### PR TITLE
[ti_*] Fix `labels.is_ioc_transform_source` values

### DIFF
--- a/packages/ti_abusech/changelog.yml
+++ b/packages/ti_abusech/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.3"
+  changes:
+    - description: Fix labels.is_ioc_transform_source values
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11231
 - version: "2.3.2"
   changes:
     - description: Add missing fields in transform

--- a/packages/ti_abusech/data_stream/malware/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_abusech/data_stream/malware/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_abusech/data_stream/malware/fields/is-ioc-transform-source.yml
+++ b/packages/ti_abusech/data_stream/malware/fields/is-ioc-transform-source.yml
@@ -1,4 +1,0 @@
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_abusech/data_stream/malwarebazaar/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_abusech/data_stream/malwarebazaar/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_abusech/data_stream/malwarebazaar/fields/is-ioc-transform-source.yml
+++ b/packages/ti_abusech/data_stream/malwarebazaar/fields/is-ioc-transform-source.yml
@@ -1,4 +1,0 @@
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_abusech/data_stream/threatfox/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_abusech/data_stream/threatfox/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_abusech/data_stream/threatfox/fields/is-ioc-transform-source.yml
+++ b/packages/ti_abusech/data_stream/threatfox/fields/is-ioc-transform-source.yml
@@ -1,4 +1,0 @@
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_abusech/data_stream/url/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_abusech/data_stream/url/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_abusech/data_stream/url/fields/is-ioc-transform-source.yml
+++ b/packages/ti_abusech/data_stream/url/fields/is-ioc-transform-source.yml
@@ -1,4 +1,0 @@
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_abusech/docs/README.md
+++ b/packages/ti_abusech/docs/README.md
@@ -54,7 +54,7 @@ The AbuseCH URL data_stream retrieves full list of active threat intelligence in
 | host.os.codename | OS codename, if any. | keyword |
 | input.type | Type of Filebeat input. | keyword |
 | labels.interval | User-configured value for `Interval` setting. This is used in calculation of indicator expiration time. | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | log.flags | Flags for the log file. | keyword |
 | log.offset | Offset of the entry in the log file. | long |
 | threat.feed.dashboard_id | Dashboard ID used for Kibana CTI UI | constant_keyword |
@@ -89,7 +89,7 @@ The AbuseCH malware data_stream retrieves threat intelligence indicators from th
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
 | input.type | Type of Filebeat input. | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | log.flags | Flags for the log file. | keyword |
 | log.offset | Offset of the entry in the log file. | long |
 | threat.feed.dashboard_id | Dashboard ID used for Kibana CTI UI | constant_keyword |
@@ -136,7 +136,7 @@ The AbuseCH malwarebazaar data_stream retrieves threat intelligence indicators f
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
 | input.type | Type of Filebeat input. | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | log.flags | Flags for the log file. | keyword |
 | log.offset | Offset of the entry in the log file. | long |
 | threat.feed.dashboard_id | Dashboard ID used for Kibana CTI UI | constant_keyword |
@@ -172,7 +172,7 @@ The AbuseCH threatfox data_stream retrieves threat intelligence indicators from 
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
 | input.type | Type of Filebeat input. | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | log.flags | Flags for the log file. | keyword |
 | log.offset | Offset of the entry in the log file. | long |
 | threat.feed.dashboard_id | Dashboard ID used for Kibana CTI UI | constant_keyword |

--- a/packages/ti_abusech/elasticsearch/transform/latest_malware/fields/fields.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_malware/fields/fields.yml
@@ -30,8 +30,3 @@
       type: keyword
       description: |
         The configured expiration duration.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_abusech/elasticsearch/transform/latest_malware/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_malware/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_abusech/elasticsearch/transform/latest_malware/transform.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_malware/transform.yml
@@ -14,7 +14,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_abusech_latest.dest_malware-2"
+  index: "logs-ti_abusech_latest.dest_malware-3"
   aliases:
     - alias: "logs-ti_abusech_latest.malware"
       move_on_creation: true
@@ -38,4 +38,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0

--- a/packages/ti_abusech/elasticsearch/transform/latest_malwarebazaar/fields/fields.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_malwarebazaar/fields/fields.yml
@@ -102,8 +102,3 @@
       type: keyword
       description: |
         The configured expiration duration.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_abusech/elasticsearch/transform/latest_malwarebazaar/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_malwarebazaar/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_abusech/elasticsearch/transform/latest_malwarebazaar/transform.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_malwarebazaar/transform.yml
@@ -14,7 +14,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_abusech_latest.dest_malwarebazaar-2"
+  index: "logs-ti_abusech_latest.dest_malwarebazaar-3"
   aliases:
     - alias: "logs-ti_abusech_latest.malwarebazaar"
       move_on_creation: true
@@ -38,4 +38,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0

--- a/packages/ti_abusech/elasticsearch/transform/latest_threatfox/fields/fields.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_threatfox/fields/fields.yml
@@ -34,8 +34,3 @@
       type: keyword
       description: |
         The configured expiration duration.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_abusech/elasticsearch/transform/latest_threatfox/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_threatfox/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_abusech/elasticsearch/transform/latest_threatfox/transform.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_threatfox/transform.yml
@@ -14,7 +14,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_abusech_latest.dest_threatfox-2"
+  index: "logs-ti_abusech_latest.dest_threatfox-3"
   aliases:
     - alias: "logs-ti_abusech_latest.threatfox"
       move_on_creation: true
@@ -37,4 +37,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0

--- a/packages/ti_abusech/elasticsearch/transform/latest_url/fields/fields.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_url/fields/fields.yml
@@ -60,8 +60,3 @@
 - name: labels.interval
   type: keyword
   description: User-configured value for `Interval` setting. This is used in calculation of indicator expiration time.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_abusech/elasticsearch/transform/latest_url/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_url/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_abusech/elasticsearch/transform/latest_url/transform.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_url/transform.yml
@@ -14,7 +14,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_abusech_latest.dest_url-2"
+  index: "logs-ti_abusech_latest.dest_url-3"
   aliases:
     - alias: "logs-ti_abusech_latest.url"
       move_on_creation: true
@@ -37,4 +37,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0

--- a/packages/ti_abusech/manifest.yml
+++ b/packages/ti_abusech/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_abusech
 title: AbuseCH
-version: "2.3.2"
+version: "2.3.3"
 description: Ingest threat intelligence indicators from URL Haus, Malware Bazaar, and Threat Fox feeds with Elastic Agent.
 type: integration
 format_version: "3.0.3"

--- a/packages/ti_anomali/changelog.yml
+++ b/packages/ti_anomali/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.3"
+  changes:
+    - description: Fix labels.is_ioc_transform_source values
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11231
 - version: "1.22.2"
   changes:
     - description: Add missing fields in transform

--- a/packages/ti_anomali/data_stream/threatstream/fields/fields.yml
+++ b/packages/ti_anomali/data_stream/threatstream/fields/fields.yml
@@ -100,7 +100,3 @@
       type: date
       description: >-
         Date when IOC was deleted/expired.
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_anomali/data_stream/threatstream/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_anomali/data_stream/threatstream/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_anomali/docs/README.md
+++ b/packages/ti_anomali/docs/README.md
@@ -173,7 +173,7 @@ An example event for `threatstream` looks as following:
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
 | input.type | Type of Filebeat input. | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | log.flags | Flags for the log file. | keyword |
 | log.offset | Offset of the entry in the log file. | long |
 | threat.feed.dashboard_id | Dashboard ID used for Kibana CTI UI | constant_keyword |

--- a/packages/ti_anomali/elasticsearch/transform/latest_ioc/fields/fields.yml
+++ b/packages/ti_anomali/elasticsearch/transform/latest_ioc/fields/fields.yml
@@ -504,9 +504,3 @@
       example: "stretch"
       description: >
         OS codename, if any.
-
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_anomali/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_anomali/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_anomali/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_anomali/elasticsearch/transform/latest_ioc/transform.yml
@@ -9,7 +9,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_anomali_latest.threatstream-4"
+  index: "logs-ti_anomali_latest.threatstream-3"
   aliases:
     - alias: "logs-ti_anomali_latest.threatstream"
       move_on_creation: true

--- a/packages/ti_anomali/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_anomali/elasticsearch/transform/latest_ioc/transform.yml
@@ -9,7 +9,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_anomali_latest.threatstream-2"
+  index: "logs-ti_anomali_latest.threatstream-4"
   aliases:
     - alias: "logs-ti_anomali_latest.threatstream"
       move_on_creation: true
@@ -32,4 +32,4 @@ retention_policy:
 _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
-  fleet_transform_version: 0.3.0
+  fleet_transform_version: 0.4.0

--- a/packages/ti_anomali/manifest.yml
+++ b/packages/ti_anomali/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_anomali
 title: Anomali
-version: "1.22.2"
+version: "1.22.3"
 description: Ingest threat intelligence indicators from Anomali with Elastic Agent.
 type: integration
 format_version: 3.0.2

--- a/packages/ti_cif3/changelog.yml
+++ b/packages/ti_cif3/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.3"
+  changes:
+    - description: Fix labels.is_ioc_transform_source values
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11231
 - version: "1.14.2"
   changes:
     - description: Add missing fields in transform

--- a/packages/ti_cif3/data_stream/feed/fields/fields.yml
+++ b/packages/ti_cif3/data_stream/feed/fields/fields.yml
@@ -112,7 +112,3 @@
       type: keyword
       description: |
         The configured expiration duration.
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_cif3/data_stream/feed/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_cif3/data_stream/feed/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_cif3/docs/README.md
+++ b/packages/ti_cif3/docs/README.md
@@ -75,7 +75,7 @@ CIFv3 `confidence` field values (0..10) are converted to ECS confidence (None, L
 | event.dataset | Event dataset | constant_keyword |
 | event.module | Name of the module this data is coming from. | constant_keyword |
 | input.type | Type of Filebeat input. | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | log.flags | Flags for the log file. | keyword |
 | log.offset | Offset of the entry in the log file. | long |
 | threat.feed.name | Display friendly feed name | constant_keyword |

--- a/packages/ti_cif3/elasticsearch/transform/latest_threat/fields/fields.yml
+++ b/packages/ti_cif3/elasticsearch/transform/latest_threat/fields/fields.yml
@@ -112,8 +112,3 @@
       type: keyword
       description: |
         The configured expiration duration.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_cif3/elasticsearch/transform/latest_threat/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_cif3/elasticsearch/transform/latest_threat/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_cif3/elasticsearch/transform/latest_threat/transform.yml
+++ b/packages/ti_cif3/elasticsearch/transform/latest_threat/transform.yml
@@ -14,7 +14,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_cif3_latest.dest_feed-2"
+  index: "logs-ti_cif3_latest.dest_feed-3"
   aliases:
     - alias: "logs-ti_cif3_latest.feed"
       move_on_creation: true
@@ -40,4 +40,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0

--- a/packages/ti_cif3/manifest.yml
+++ b/packages/ti_cif3/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: ti_cif3
 title: "Collective Intelligence Framework v3"
-version: "1.14.2"
+version: "1.14.3"
 description: "Ingest threat indicators from a Collective Intelligence Framework v3 instance with Elastic Agent."
 type: integration
 categories:

--- a/packages/ti_crowdstrike/changelog.yml
+++ b/packages/ti_crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.7"
+  changes:
+    - description: Fix labels.is_ioc_transform_source values
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11231
 - version: "1.1.6"
   changes:
     - description: Fix intel pagination bug due to cursor formatting

--- a/packages/ti_crowdstrike/data_stream/intel/fields/fields.yml
+++ b/packages/ti_crowdstrike/data_stream/intel/fields/fields.yml
@@ -87,7 +87,3 @@
     - name: vulnerabilities
       type: keyword
       description: Information related to vulnerabilities associated with the Intel Indicator.
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: 'true'
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_crowdstrike/data_stream/intel/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_crowdstrike/data_stream/intel/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_crowdstrike/data_stream/ioc/fields/fields.yml
+++ b/packages/ti_crowdstrike/data_stream/ioc/fields/fields.yml
@@ -57,7 +57,3 @@
     - name: value
       type: ip
       description: The specific value of the indicator.
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: 'true'
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_crowdstrike/data_stream/ioc/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_crowdstrike/data_stream/ioc/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_crowdstrike/docs/README.md
+++ b/packages/ti_crowdstrike/docs/README.md
@@ -263,7 +263,7 @@ An example event for `intel` looks as following:
 | event.dataset | Event dataset. | constant_keyword |
 | event.module | Event module. | constant_keyword |
 | input.type | Type of filebeat input. | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | log.offset | Log offset. | long |
 | threat.feed.name | Display friendly feed name. | constant_keyword |
 | threat.indicator.first_seen | The date and time when intelligence source first reported sighting this indicator. | date |
@@ -424,7 +424,7 @@ An example event for `ioc` looks as following:
 | event.dataset | Event dataset. | constant_keyword |
 | event.module | Event module. | constant_keyword |
 | input.type | Type of filebeat input. | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | log.offset | Log offset. | long |
 | threat.feed.name | Display friendly feed name. | constant_keyword |
 | threat.indicator.first_seen | The date and time when intelligence source first reported sighting this indicator. | date |

--- a/packages/ti_crowdstrike/elasticsearch/transform/latest_intel/fields/fields.yml
+++ b/packages/ti_crowdstrike/elasticsearch/transform/latest_intel/fields/fields.yml
@@ -87,8 +87,3 @@
     - name: vulnerabilities
       type: keyword
       description: Information related to vulnerabilities associated with the Intel Indicator.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_crowdstrike/elasticsearch/transform/latest_intel/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_crowdstrike/elasticsearch/transform/latest_intel/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_crowdstrike/elasticsearch/transform/latest_intel/transform.yml
+++ b/packages/ti_crowdstrike/elasticsearch/transform/latest_intel/transform.yml
@@ -9,7 +9,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_crowdstrike_latest.dest_intel-2"
+  index: "logs-ti_crowdstrike_latest.dest_intel-3"
   aliases:
     - alias: "logs-ti_crowdstrike_latest.intel"
       move_on_creation: true
@@ -33,4 +33,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0

--- a/packages/ti_crowdstrike/elasticsearch/transform/latest_ioc/fields/fields.yml
+++ b/packages/ti_crowdstrike/elasticsearch/transform/latest_ioc/fields/fields.yml
@@ -57,8 +57,3 @@
     - name: value
       type: ip
       description: The specific value of the indicator.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_crowdstrike/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_crowdstrike/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_crowdstrike/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_crowdstrike/elasticsearch/transform/latest_ioc/transform.yml
@@ -9,7 +9,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_crowdstrike_latest.dest_ioc-2"
+  index: "logs-ti_crowdstrike_latest.dest_ioc-3"
   aliases:
     - alias: "logs-ti_crowdstrike_latest.ioc"
       move_on_creation: true
@@ -33,4 +33,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0

--- a/packages/ti_crowdstrike/kibana/dashboard/ti_crowdstrike-37a9ef30-9993-11ee-9b44-fd906664033c.json
+++ b/packages/ti_crowdstrike/kibana/dashboard/ti_crowdstrike-37a9ef30-9993-11ee-9b44-fd906664033c.json
@@ -47,12 +47,14 @@
                                         "index": "logs-*",
                                         "key": "labels.is_ioc_transform_source",
                                         "negate": true,
-                                        "type": "exists",
-                                        "value": "exists"
+                                        "params": {
+                                            "query": "true"
+                                        },
+                                        "type": "phrase"
                                     },
                                     "query": {
-                                        "exists": {
-                                            "field": "labels.is_ioc_transform_source"
+                                        "match_phrase": {
+                                            "labels.is_ioc_transform_source": "true"
                                         }
                                     }
                                 }

--- a/packages/ti_crowdstrike/kibana/dashboard/ti_crowdstrike-b81b5020-9e64-11ee-9777-1d1f44d25bb5.json
+++ b/packages/ti_crowdstrike/kibana/dashboard/ti_crowdstrike-b81b5020-9e64-11ee-9777-1d1f44d25bb5.json
@@ -47,12 +47,14 @@
                                         "index": "logs-*",
                                         "key": "labels.is_ioc_transform_source",
                                         "negate": true,
-                                        "type": "exists",
-                                        "value": "exists"
+                                        "params": {
+                                            "query": "true"
+                                        },
+                                        "type": "phrase"
                                     },
                                     "query": {
-                                        "exists": {
-                                            "field": "labels.is_ioc_transform_source"
+                                        "match_phrase": {
+                                            "labels.is_ioc_transform_source": "true"
                                         }
                                     }
                                 }

--- a/packages/ti_crowdstrike/manifest.yml
+++ b/packages/ti_crowdstrike/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_crowdstrike
 title: CrowdStrike Falcon Intelligence
-version: "1.1.6"
+version: "1.1.7"
 description: Collect logs from CrowdStrike Falcon Intelligence with Elastic Agent.
 type: integration
 categories:

--- a/packages/ti_custom/changelog.yml
+++ b/packages/ti_custom/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Fix labels.is_ioc_transform_source values
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11231
 - version: "0.1.0"
   changes:
     - description: Initial release of Custom Threat Intelligence package

--- a/packages/ti_custom/data_stream/indicator/fields/ioc-transform-source.yml
+++ b/packages/ti_custom/data_stream/indicator/fields/ioc-transform-source.yml
@@ -1,4 +1,0 @@
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: 'true'
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_custom/data_stream/indicator/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_custom/data_stream/indicator/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_custom/docs/README.md
+++ b/packages/ti_custom/docs/README.md
@@ -183,7 +183,7 @@ An example event for `indicator` looks as following:
 | event.dataset | Event dataset | constant_keyword |
 | event.module | Event module | constant_keyword |
 | input.type | Input type | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | log.file.device_id | ID of the device containing the filesystem where the file resides. | keyword |
 | log.file.inode | Inode number of the log file. | keyword |
 | log.file.path | Path to the log file. | keyword |

--- a/packages/ti_custom/elasticsearch/transform/latest_ioc/fields/ioc-transform-source.yml
+++ b/packages/ti_custom/elasticsearch/transform/latest_ioc/fields/ioc-transform-source.yml
@@ -1,4 +1,0 @@
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: 'true'
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_custom/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_custom/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_custom/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_custom/elasticsearch/transform/latest_ioc/transform.yml
@@ -8,7 +8,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: logs-ti_custom_latest.indicator-4
+  index: logs-ti_custom_latest.indicator-3
   aliases:
     - alias: logs-ti_custom_latest.indicator
       move_on_creation: true

--- a/packages/ti_custom/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_custom/elasticsearch/transform/latest_ioc/transform.yml
@@ -8,7 +8,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: logs-ti_custom_latest.indicator-2
+  index: logs-ti_custom_latest.indicator-4
   aliases:
     - alias: logs-ti_custom_latest.indicator
       move_on_creation: true
@@ -31,4 +31,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.3.0
+  fleet_transform_version: 0.4.0

--- a/packages/ti_custom/manifest.yml
+++ b/packages/ti_custom/manifest.yml
@@ -3,7 +3,7 @@ name: ti_custom
 title: Custom Threat Intelligence
 description: Ingest threat intelligence data in STIX 2.1 format with Elastic Agent
 type: integration
-version: 0.1.0
+version: 0.1.1
 categories:
   - custom
   - security

--- a/packages/ti_cybersixgill/changelog.yml
+++ b/packages/ti_cybersixgill/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.30.3"
+  changes:
+    - description: Fix labels.is_ioc_transform_source values
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11231
 - version: "1.30.2"
   changes:
     - description: Add missing fields in transform

--- a/packages/ti_cybersixgill/data_stream/threat/fields/fields.yml
+++ b/packages/ti_cybersixgill/data_stream/threat/fields/fields.yml
@@ -37,7 +37,3 @@
       type: keyword
       description: |
         The configured expiration duration.
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_cybersixgill/data_stream/threat/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_cybersixgill/data_stream/threat/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_cybersixgill/docs/README.md
+++ b/packages/ti_cybersixgill/docs/README.md
@@ -41,7 +41,7 @@ To facilitate IOC expiration, source datastream-backed indices `.ds-logs-ti_cybe
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
 | input.type | Input type. | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | threat.feed.dashboard_id | Dashboard ID used for Kibana CTI UI | constant_keyword |
 | threat.feed.name | Display friendly feed name | constant_keyword |
 | threat.indicator.first_seen | The date and time when intelligence source first reported sighting this indicator. | date |

--- a/packages/ti_cybersixgill/elasticsearch/transform/latest_ioc/fields/fields.yml
+++ b/packages/ti_cybersixgill/elasticsearch/transform/latest_ioc/fields/fields.yml
@@ -37,8 +37,3 @@
       type: keyword
       description: |
         The configured expiration duration.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_cybersixgill/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_cybersixgill/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_cybersixgill/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_cybersixgill/elasticsearch/transform/latest_ioc/transform.yml
@@ -9,7 +9,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_cybersixgill_latest.dest_threat-2"
+  index: "logs-ti_cybersixgill_latest.dest_threat-3"
   aliases:
     - alias: "logs-ti_cybersixgill_latest.threat"
       move_on_creation: true
@@ -34,4 +34,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0

--- a/packages/ti_cybersixgill/kibana/dashboard/ti_cybersixgill-63c9fee0-5bea-11ec-9302-152fd766c738.json
+++ b/packages/ti_cybersixgill/kibana/dashboard/ti_cybersixgill-63c9fee0-5bea-11ec-9302-152fd766c738.json
@@ -78,11 +78,14 @@
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[3].meta.index",
                             "key": "labels.is_ioc_transform_source",
                             "negate": true,
-                            "type": "exists"
+                            "params": {
+                                "query": "true"
+                            },
+                            "type": "phrase"
                         },
                         "query": {
-                            "exists": {
-                                "field": "labels.is_ioc_transform_source"
+                            "match_phrase": {
+                                "labels.is_ioc_transform_source": "true"
                             }
                         }
                     }

--- a/packages/ti_cybersixgill/kibana/dashboard/ti_cybersixgill-717013b0-5bed-11ec-9302-152fd766c738.json
+++ b/packages/ti_cybersixgill/kibana/dashboard/ti_cybersixgill-717013b0-5bed-11ec-9302-152fd766c738.json
@@ -78,11 +78,14 @@
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[3].meta.index",
                             "key": "labels.is_ioc_transform_source",
                             "negate": true,
-                            "type": "exists"
+                            "params": {
+                                "query": "true"
+                            },
+                            "type": "phrase"
                         },
                         "query": {
-                            "exists": {
-                                "field": "labels.is_ioc_transform_source"
+                            "match_phrase": {
+                                "labels.is_ioc_transform_source": "true"
                             }
                         }
                     }

--- a/packages/ti_cybersixgill/kibana/dashboard/ti_cybersixgill-c75353f0-5be8-11ec-9302-152fd766c738.json
+++ b/packages/ti_cybersixgill/kibana/dashboard/ti_cybersixgill-c75353f0-5be8-11ec-9302-152fd766c738.json
@@ -57,11 +57,14 @@
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[2].meta.index",
                             "key": "labels.is_ioc_transform_source",
                             "negate": true,
-                            "type": "exists"
+                            "params": {
+                                "query": "true"
+                            },
+                            "type": "phrase"
                         },
                         "query": {
-                            "exists": {
-                                "field": "labels.is_ioc_transform_source"
+                            "match_phrase": {
+                                "labels.is_ioc_transform_source": "true"
                             }
                         }
                     }

--- a/packages/ti_cybersixgill/manifest.yml
+++ b/packages/ti_cybersixgill/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_cybersixgill
 title: Cybersixgill
-version: "1.30.2"
+version: "1.30.3"
 description: Ingest threat intelligence indicators from Cybersixgill with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/ti_eclecticiq/changelog.yml
+++ b/packages/ti_eclecticiq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.3"
+  changes:
+    - description: Fix labels.is_ioc_transform_source values
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11231
 - version: "1.2.2"
   changes:
     - description: Add missing fields in transform

--- a/packages/ti_eclecticiq/data_stream/threat/fields/fields.yml
+++ b/packages/ti_eclecticiq/data_stream/threat/fields/fields.yml
@@ -8,7 +8,3 @@
     - name: deleted_at
       type: date
       description: Date when observable was removed from dataset
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_eclecticiq/data_stream/threat/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_eclecticiq/data_stream/threat/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_eclecticiq/docs/README.md
+++ b/packages/ti_eclecticiq/docs/README.md
@@ -278,7 +278,7 @@ An example event for `threat` looks as following:
 | event.dataset | Event dataset | constant_keyword |
 | event.module | Event module | constant_keyword |
 | input.type | Input type | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | threat.feed.name | Display friendly feed name | constant_keyword |
 | threat.indicator.first_seen | The date and time when intelligence source first reported sighting this indicator. | date |
 | threat.indicator.last_seen | The date and time when intelligence source last reported sighting this indicator. | date |

--- a/packages/ti_eclecticiq/elasticsearch/transform/latest_ioc/fields/fields.yml
+++ b/packages/ti_eclecticiq/elasticsearch/transform/latest_ioc/fields/fields.yml
@@ -11,8 +11,3 @@
     - name: deleted_at
       type: date
       description: Date when observable was removed from dataset
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_eclecticiq/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_eclecticiq/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_eclecticiq/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_eclecticiq/elasticsearch/transform/latest_ioc/transform.yml
@@ -8,7 +8,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_eclecticiq_latest.threat-2"
+  index: "logs-ti_eclecticiq_latest.threat-3"
 latest:
   unique_key:
     - event.dataset
@@ -28,4 +28,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0

--- a/packages/ti_eclecticiq/manifest.yml
+++ b/packages/ti_eclecticiq/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_eclecticiq
 title: EclecticIQ
-version: "1.2.2"
+version: "1.2.3"
 description: Ingest threat intelligence from EclecticIQ with Elastic Agent
 type: integration
 categories:

--- a/packages/ti_eset/changelog.yml
+++ b/packages/ti_eset/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.4"
+  changes:
+    - description: Fix labels.is_ioc_transform_source values
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11231
 - version: "1.2.3"
   changes:
     - description: Add missing fields in transform

--- a/packages/ti_eset/data_stream/apt/fields/fields.yml
+++ b/packages/ti_eset/data_stream/apt/fields/fields.yml
@@ -31,7 +31,3 @@
       type: date
       description: >-
         Event expiration date.
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: 'true'
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_eset/data_stream/apt/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_eset/data_stream/apt/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_eset/data_stream/botnet/fields/fields.yml
+++ b/packages/ti_eset/data_stream/botnet/fields/fields.yml
@@ -15,7 +15,3 @@
       type: keyword
       description: >-
         Threat labels.
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: 'true'
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_eset/data_stream/botnet/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_eset/data_stream/botnet/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_eset/data_stream/cc/fields/fields.yml
+++ b/packages/ti_eset/data_stream/cc/fields/fields.yml
@@ -15,7 +15,3 @@
       type: keyword
       description: >-
         Threat labels.
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: 'true'
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_eset/data_stream/cc/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_eset/data_stream/cc/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_eset/data_stream/domains/fields/fields.yml
+++ b/packages/ti_eset/data_stream/domains/fields/fields.yml
@@ -15,7 +15,3 @@
       type: keyword
       description: >-
         Threat labels.
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: 'true'
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_eset/data_stream/domains/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_eset/data_stream/domains/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_eset/data_stream/files/fields/fields.yml
+++ b/packages/ti_eset/data_stream/files/fields/fields.yml
@@ -15,7 +15,3 @@
       type: keyword
       description: >-
         Threat labels.
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: 'true'
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_eset/data_stream/files/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_eset/data_stream/files/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_eset/data_stream/ip/fields/fields.yml
+++ b/packages/ti_eset/data_stream/ip/fields/fields.yml
@@ -15,7 +15,3 @@
       type: keyword
       description: >-
         Threat labels.
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: 'true'
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_eset/data_stream/ip/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_eset/data_stream/ip/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_eset/data_stream/url/fields/fields.yml
+++ b/packages/ti_eset/data_stream/url/fields/fields.yml
@@ -15,7 +15,3 @@
       type: keyword
       description: >-
         Threat labels.
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: 'true'
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_eset/data_stream/url/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_eset/data_stream/url/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_eset/docs/README.md
+++ b/packages/ti_eset/docs/README.md
@@ -108,7 +108,7 @@ refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-a
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
 | input.type | Input type. | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | threat.indicator.first_seen | The date and time when intelligence source first reported sighting this indicator. | date |
 | threat.indicator.last_seen | The date and time when intelligence source last reported sighting this indicator. | date |
 | threat.indicator.modified_at | The date and time when intelligence source last modified information for this indicator. | date |
@@ -212,7 +212,7 @@ An example event for `botnet` looks as following:
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
 | input.type | Input type. | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | threat.indicator.first_seen | The date and time when intelligence source first reported sighting this indicator. | date |
 | threat.indicator.last_seen | The date and time when intelligence source last reported sighting this indicator. | date |
 | threat.indicator.modified_at | The date and time when intelligence source last modified information for this indicator. | date |
@@ -312,7 +312,7 @@ An example event for `cc` looks as following:
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
 | input.type | Input type. | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | threat.indicator.first_seen | The date and time when intelligence source first reported sighting this indicator. | date |
 | threat.indicator.last_seen | The date and time when intelligence source last reported sighting this indicator. | date |
 | threat.indicator.modified_at | The date and time when intelligence source last modified information for this indicator. | date |
@@ -413,7 +413,7 @@ An example event for `domains` looks as following:
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
 | input.type | Input type. | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | threat.indicator.first_seen | The date and time when intelligence source first reported sighting this indicator. | date |
 | threat.indicator.last_seen | The date and time when intelligence source last reported sighting this indicator. | date |
 | threat.indicator.modified_at | The date and time when intelligence source last modified information for this indicator. | date |
@@ -517,7 +517,7 @@ An example event for `files` looks as following:
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
 | input.type | Input type. | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | threat.indicator.first_seen | The date and time when intelligence source first reported sighting this indicator. | date |
 | threat.indicator.last_seen | The date and time when intelligence source last reported sighting this indicator. | date |
 | threat.indicator.modified_at | The date and time when intelligence source last modified information for this indicator. | date |
@@ -618,7 +618,7 @@ An example event for `ip` looks as following:
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
 | input.type | Input type. | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | threat.indicator.first_seen | The date and time when intelligence source first reported sighting this indicator. | date |
 | threat.indicator.last_seen | The date and time when intelligence source last reported sighting this indicator. | date |
 | threat.indicator.modified_at | The date and time when intelligence source last modified information for this indicator. | date |
@@ -720,7 +720,7 @@ An example event for `apt` looks as following:
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
 | input.type | Input type. | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | threat.indicator.first_seen | The date and time when intelligence source first reported sighting this indicator. | date |
 | threat.indicator.last_seen | The date and time when intelligence source last reported sighting this indicator. | date |
 | threat.indicator.modified_at | The date and time when intelligence source last modified information for this indicator. | date |

--- a/packages/ti_eset/elasticsearch/transform/apt_latest_ioc/fields/fields.yml
+++ b/packages/ti_eset/elasticsearch/transform/apt_latest_ioc/fields/fields.yml
@@ -31,8 +31,3 @@
       type: date
       description: >-
         Event expiration date.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_eset/elasticsearch/transform/apt_latest_ioc/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_eset/elasticsearch/transform/apt_latest_ioc/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_eset/elasticsearch/transform/apt_latest_ioc/transform.yml
+++ b/packages/ti_eset/elasticsearch/transform/apt_latest_ioc/transform.yml
@@ -1,9 +1,9 @@
 _meta:
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0
   managed: true
 description: Latest ESET APT IoC data
 dest:
-  index: logs-ti_eset_latest.dest_apt-2
+  index: logs-ti_eset_latest.dest_apt-3
   aliases:
     - alias: logs-ti_eset_latest.apt
       move_on_creation: true

--- a/packages/ti_eset/elasticsearch/transform/botnet_latest_ioc/fields/fields.yml
+++ b/packages/ti_eset/elasticsearch/transform/botnet_latest_ioc/fields/fields.yml
@@ -15,8 +15,3 @@
       type: keyword
       description: >-
         Threat labels.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_eset/elasticsearch/transform/botnet_latest_ioc/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_eset/elasticsearch/transform/botnet_latest_ioc/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_eset/elasticsearch/transform/botnet_latest_ioc/transform.yml
+++ b/packages/ti_eset/elasticsearch/transform/botnet_latest_ioc/transform.yml
@@ -1,9 +1,9 @@
 _meta:
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0
   managed: true
 description: Latest ESET Botnet IoC data
 dest:
-  index: logs-ti_eset_latest.dest_botnet-2
+  index: logs-ti_eset_latest.dest_botnet-3
   aliases:
     - alias: logs-ti_eset_latest.botnet
       move_on_creation: true

--- a/packages/ti_eset/elasticsearch/transform/cc_latest_ioc/fields/fields.yml
+++ b/packages/ti_eset/elasticsearch/transform/cc_latest_ioc/fields/fields.yml
@@ -15,8 +15,3 @@
       type: keyword
       description: >-
         Threat labels.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_eset/elasticsearch/transform/cc_latest_ioc/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_eset/elasticsearch/transform/cc_latest_ioc/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_eset/elasticsearch/transform/cc_latest_ioc/transform.yml
+++ b/packages/ti_eset/elasticsearch/transform/cc_latest_ioc/transform.yml
@@ -1,9 +1,9 @@
 _meta:
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0
   managed: true
 description: Latest ESET C&C IoC data
 dest:
-  index: logs-ti_eset_latest.dest_cc-2
+  index: logs-ti_eset_latest.dest_cc-3
   aliases:
     - alias: logs-ti_eset_latest.cc
       move_on_creation: true

--- a/packages/ti_eset/elasticsearch/transform/domains_latest_ioc/fields/fields.yml
+++ b/packages/ti_eset/elasticsearch/transform/domains_latest_ioc/fields/fields.yml
@@ -15,8 +15,3 @@
       type: keyword
       description: >-
         Threat labels.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_eset/elasticsearch/transform/domains_latest_ioc/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_eset/elasticsearch/transform/domains_latest_ioc/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_eset/elasticsearch/transform/domains_latest_ioc/transform.yml
+++ b/packages/ti_eset/elasticsearch/transform/domains_latest_ioc/transform.yml
@@ -1,9 +1,9 @@
 _meta:
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0
   managed: true
 description: Latest ESET Domains IoC data
 dest:
-  index: logs-ti_eset_latest.dest_domains-2
+  index: logs-ti_eset_latest.dest_domains-3
   aliases:
     - alias: logs-ti_eset_latest.domains
       move_on_creation: true

--- a/packages/ti_eset/elasticsearch/transform/files_latest_ioc/fields/fields.yml
+++ b/packages/ti_eset/elasticsearch/transform/files_latest_ioc/fields/fields.yml
@@ -15,8 +15,3 @@
       type: keyword
       description: >-
         Threat labels.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_eset/elasticsearch/transform/files_latest_ioc/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_eset/elasticsearch/transform/files_latest_ioc/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_eset/elasticsearch/transform/files_latest_ioc/transform.yml
+++ b/packages/ti_eset/elasticsearch/transform/files_latest_ioc/transform.yml
@@ -1,9 +1,9 @@
 _meta:
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0
   managed: true
 description: Latest ESET Files IoC data
 dest:
-  index: logs-ti_eset_latest.dest_files-2
+  index: logs-ti_eset_latest.dest_files-3
   aliases:
     - alias: logs-ti_eset_latest.files
       move_on_creation: true

--- a/packages/ti_eset/elasticsearch/transform/ip_latest_ioc/fields/fields.yml
+++ b/packages/ti_eset/elasticsearch/transform/ip_latest_ioc/fields/fields.yml
@@ -15,8 +15,3 @@
       type: keyword
       description: >-
         Threat labels.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_eset/elasticsearch/transform/ip_latest_ioc/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_eset/elasticsearch/transform/ip_latest_ioc/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_eset/elasticsearch/transform/ip_latest_ioc/transform.yml
+++ b/packages/ti_eset/elasticsearch/transform/ip_latest_ioc/transform.yml
@@ -1,9 +1,9 @@
 _meta:
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0
   managed: true
 description: Latest ESET IP IoC data
 dest:
-  index: logs-ti_eset_latest.dest_ip-2
+  index: logs-ti_eset_latest.dest_ip-3
   aliases:
     - alias: logs-ti_eset_latest.ip
       move_on_creation: true

--- a/packages/ti_eset/elasticsearch/transform/url_latest_ioc/fields/fields.yml
+++ b/packages/ti_eset/elasticsearch/transform/url_latest_ioc/fields/fields.yml
@@ -15,8 +15,3 @@
       type: keyword
       description: >-
         Threat labels.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_eset/elasticsearch/transform/url_latest_ioc/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_eset/elasticsearch/transform/url_latest_ioc/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_eset/elasticsearch/transform/url_latest_ioc/transform.yml
+++ b/packages/ti_eset/elasticsearch/transform/url_latest_ioc/transform.yml
@@ -1,9 +1,9 @@
 _meta:
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0
   managed: true
 description: Latest ESET URL IoC data
 dest:
-  index: logs-ti_eset_latest.dest_url-2
+  index: logs-ti_eset_latest.dest_url-3
   aliases:
     - alias: logs-ti_eset_latest.url
       move_on_creation: true

--- a/packages/ti_eset/manifest.yml
+++ b/packages/ti_eset/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_eset
 title: "ESET Threat Intelligence"
-version: "1.2.3"
+version: "1.2.4"
 description: "Ingest threat intelligence indicators from ESET Threat Intelligence with Elastic Agent."
 type: integration
 categories:

--- a/packages/ti_maltiverse/changelog.yml
+++ b/packages/ti_maltiverse/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.2.3"
+  changes:
+    - description: Fix labels.is_ioc_transform_source values
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11231
 - version: "1.2.2"
   changes:
     - description: Add missing fields in transform

--- a/packages/ti_maltiverse/data_stream/indicator/fields/base-fields.yml
+++ b/packages/ti_maltiverse/data_stream/indicator/fields/base-fields.yml
@@ -13,10 +13,6 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.
 - name: event.module
   type: constant_keyword
   description: Event module

--- a/packages/ti_maltiverse/data_stream/indicator/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_maltiverse/data_stream/indicator/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_maltiverse/docs/README.md
+++ b/packages/ti_maltiverse/docs/README.md
@@ -30,7 +30,7 @@ Both, the data_stream and the _latest index have applied expiration through ILM 
 | event.dataset | Event dataset | constant_keyword |
 | event.module | Event module | constant_keyword |
 | input.type | Input type. | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | maltiverse.address | registered address | keyword |
 | maltiverse.address.address | Multi-field of `maltiverse.address`. | match_only_text |
 | maltiverse.as_name | AS registered name | keyword |

--- a/packages/ti_maltiverse/elasticsearch/transform/latest/fields/fields.yml
+++ b/packages/ti_maltiverse/elasticsearch/transform/latest/fields/fields.yml
@@ -381,8 +381,3 @@
       type: keyword
     - name: urlchecksum
       type: keyword
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_maltiverse/elasticsearch/transform/latest/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_maltiverse/elasticsearch/transform/latest/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_maltiverse/elasticsearch/transform/latest/transform.yml
+++ b/packages/ti_maltiverse/elasticsearch/transform/latest/transform.yml
@@ -9,7 +9,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_maltiverse_latest.indicator-2"
+  index: "logs-ti_maltiverse_latest.indicator-3"
 latest:
   unique_key:
     - event.dataset
@@ -29,4 +29,4 @@ retention_policy:
 _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0

--- a/packages/ti_maltiverse/manifest.yml
+++ b/packages/ti_maltiverse/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_maltiverse
 title: Maltiverse
-version: "1.2.2"
+version: "1.2.3"
 description: Ingest threat intelligence indicators from Maltiverse feeds with Elastic Agent
 type: integration
 format_version: 3.0.2

--- a/packages/ti_misp/changelog.yml
+++ b/packages/ti_misp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.35.3"
+  changes:
+    - description: Fix labels.is_ioc_transform_source values
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11231
 - version: "1.35.2"
   changes:
     - description: Add missing fields in transform

--- a/packages/ti_misp/data_stream/threat_attributes/fields/fields.yml
+++ b/packages/ti_misp/data_stream/threat_attributes/fields/fields.yml
@@ -294,8 +294,3 @@
           type: flattened
           description: >
             List of attributes of the object in which the attribute is attached.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: Field indicating if the document is a source for the transform. This field is not added to destination indices to facilitate easier filtering of indicators for indicator match rules.

--- a/packages/ti_misp/data_stream/threat_attributes/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_misp/data_stream/threat_attributes/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_misp/docs/README.md
+++ b/packages/ti_misp/docs/README.md
@@ -248,7 +248,7 @@ To facilitate IOC expiration, source datastream-backed indices `.ds-logs-ti_misp
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
 | input.type | Type of Filebeat input. | keyword |
-| labels.is_ioc_transform_source | Field indicating if the document is a source for the transform. This field is not added to destination indices to facilitate easier filtering of indicators for indicator match rules. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | log.flags | Flags for the log file. | keyword |
 | log.offset | Offset of the entry in the log file. | long |
 | misp.attribute.category | The category of the attribute. For example "Network Activity". | keyword |

--- a/packages/ti_misp/elasticsearch/transform/latest_ioc/fields/fields.yml
+++ b/packages/ti_misp/elasticsearch/transform/latest_ioc/fields/fields.yml
@@ -294,9 +294,3 @@
           type: flattened
           description: >
             List of attributes of the object in which the attribute is attached.
-
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_misp/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_misp/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_misp/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_misp/elasticsearch/transform/latest_ioc/transform.yml
@@ -9,7 +9,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_misp_latest.dest_threat_attributes-2"
+  index: "logs-ti_misp_latest.dest_threat_attributes-3"
   aliases:
     - alias: "logs-ti_misp_latest.threat_attributes"
       move_on_creation: true
@@ -33,4 +33,4 @@ retention_policy:
 _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0

--- a/packages/ti_misp/manifest.yml
+++ b/packages/ti_misp/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_misp
 title: MISP
-version: "1.35.2"
+version: "1.35.3"
 description: Ingest threat intelligence indicators from MISP platform with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/ti_opencti/changelog.yml
+++ b/packages/ti_opencti/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.4"
+  changes:
+    - description: Fix labels.is_ioc_transform_source values
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11231
 - version: "2.3.3"
   changes:
     - description: Add missing fields in transform

--- a/packages/ti_opencti/data_stream/indicator/fields/ioc-transform-source.yml
+++ b/packages/ti_opencti/data_stream/indicator/fields/ioc-transform-source.yml
@@ -1,4 +1,0 @@
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: Field indicating if the document is a source for the transform. This field is not added to destination indices to facilitate easier filtering of indicators for indicator match rules.

--- a/packages/ti_opencti/data_stream/indicator/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_opencti/data_stream/indicator/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_opencti/docs/README.md
+++ b/packages/ti_opencti/docs/README.md
@@ -195,7 +195,7 @@ The documentation for ECS fields can be found at:
 | data_stream.type | Data stream type. | constant_keyword |
 | event.module | Event module | constant_keyword |
 | input.type | Input type. | keyword |
-| labels.is_ioc_transform_source | Field indicating if the document is a source for the transform. This field is not added to destination indices to facilitate easier filtering of indicators for indicator match rules. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | opencti.indicator.creator_identity_class | The type of the creator of this indicator (e.g. "organization"). | keyword |
 | opencti.indicator.detection | Whether the indicator has been detected. | boolean |
 | opencti.indicator.external_reference.description | A description for a related record in an external system. | keyword |

--- a/packages/ti_opencti/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_opencti/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_opencti/elasticsearch/transform/latest_ioc/fields/opencti.yml
+++ b/packages/ti_opencti/elasticsearch/transform/latest_ioc/fields/opencti.yml
@@ -1103,8 +1103,3 @@
             - name: publication_date
               type: date
               description: The publication date of an item of media content.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_opencti/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_opencti/elasticsearch/transform/latest_ioc/transform.yml
@@ -10,7 +10,7 @@ source:
 # that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_opencti_latest.dest_indicator-2"
+  index: "logs-ti_opencti_latest.dest_indicator-3"
   aliases:
     - alias: "logs-ti_opencti_latest.indicator"
       move_on_creation: true
@@ -34,4 +34,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during
   # package installation.
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0

--- a/packages/ti_opencti/manifest.yml
+++ b/packages/ti_opencti/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: ti_opencti
 title: OpenCTI
-version: "2.3.3"
+version: "2.3.4"
 description: "Ingest threat intelligence indicators from OpenCTI with Elastic Agent."
 type: integration
 source:

--- a/packages/ti_otx/changelog.yml
+++ b/packages/ti_otx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.25.3"
+  changes:
+    - description: Fix labels.is_ioc_transform_source values
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11231
 - version: "1.25.2"
   changes:
     - description: Add missing fields in transform

--- a/packages/ti_otx/data_stream/pulses_subscribed/fields/fields.yml
+++ b/packages/ti_otx/data_stream/pulses_subscribed/fields/fields.yml
@@ -72,7 +72,3 @@
           type: keyword
         - name: tlp
           type: keyword
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_otx/data_stream/pulses_subscribed/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_otx/data_stream/pulses_subscribed/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_otx/docs/README.md
+++ b/packages/ti_otx/docs/README.md
@@ -132,7 +132,7 @@ The following subscriptions are included by this API:
 | event.dataset | Event dataset | constant_keyword |
 | event.module | Event module | constant_keyword |
 | input.type | Type of Filebeat input. | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | log.flags | Flags for the log file. | keyword |
 | log.offset | Offset of the entry in the log file. | long |
 | otx.content |  | keyword |

--- a/packages/ti_otx/elasticsearch/transform/latest_ioc/fields/fields.yml
+++ b/packages/ti_otx/elasticsearch/transform/latest_ioc/fields/fields.yml
@@ -228,8 +228,3 @@
           type: keyword
         - name: tlp
           type: keyword
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_otx/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_otx/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_otx/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_otx/elasticsearch/transform/latest_ioc/transform.yml
@@ -9,7 +9,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_otx_latest.dest_pulses_subscribed-1"
+  index: "logs-ti_otx_latest.dest_pulses_subscribed-2"
   aliases:
     - alias: "logs-ti_otx_latest.pulses_subscribed"
       move_on_creation: true
@@ -33,4 +33,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.1.0
+  fleet_transform_version: 0.2.0

--- a/packages/ti_otx/kibana/dashboard/ti_otx-7da241a0-71f3-11ec-9910-d1ceb8a1734b.json
+++ b/packages/ti_otx/kibana/dashboard/ti_otx-7da241a0-71f3-11ec-9910-d1ceb8a1734b.json
@@ -63,11 +63,14 @@
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[2].meta.index",
                             "key": "labels.is_ioc_transform_source",
                             "negate": true,
-                            "type": "exists"
+                            "params": {
+                                "query": "true"
+                            },
+                            "type": "phrase"
                         },
                         "query": {
-                            "exists": {
-                                "field": "labels.is_ioc_transform_source"
+                            "match_phrase": {
+                                "labels.is_ioc_transform_source": "true"
                             }
                         }
                     }

--- a/packages/ti_otx/kibana/dashboard/ti_otx-83b01770-71f3-11ec-9910-d1ceb8a1734b.json
+++ b/packages/ti_otx/kibana/dashboard/ti_otx-83b01770-71f3-11ec-9910-d1ceb8a1734b.json
@@ -78,11 +78,14 @@
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[3].meta.index",
                             "key": "labels.is_ioc_transform_source",
                             "negate": true,
-                            "type": "exists"
+                            "params": {
+                                "query": "true"
+                            },
+                            "type": "phrase"
                         },
                         "query": {
-                            "exists": {
-                                "field": "labels.is_ioc_transform_source"
+                            "match_phrase": {
+                                "labels.is_ioc_transform_source": "true"
                             }
                         }
                     }

--- a/packages/ti_otx/kibana/dashboard/ti_otx-8957ff80-71f3-11ec-9910-d1ceb8a1734b.json
+++ b/packages/ti_otx/kibana/dashboard/ti_otx-8957ff80-71f3-11ec-9910-d1ceb8a1734b.json
@@ -57,11 +57,14 @@
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[2].meta.index",
                             "key": "labels.is_ioc_transform_source",
                             "negate": true,
-                            "type": "exists"
+                            "params": {
+                                "query": "true"
+                            },
+                            "type": "phrase"
                         },
                         "query": {
-                            "exists": {
-                                "field": "labels.is_ioc_transform_source"
+                            "match_phrase": {
+                                "labels.is_ioc_transform_source": "true"
                             }
                         }
                     }

--- a/packages/ti_otx/kibana/dashboard/ti_otx-b8cff1d0-5bc3-11ee-b268-039dec835103.json
+++ b/packages/ti_otx/kibana/dashboard/ti_otx-b8cff1d0-5bc3-11ee-b268-039dec835103.json
@@ -57,11 +57,14 @@
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[2].meta.index",
                             "key": "labels.is_ioc_transform_source",
                             "negate": true,
-                            "type": "exists"
+                            "params": {
+                                "query": "true"
+                            },
+                            "type": "phrase"
                         },
                         "query": {
-                            "exists": {
-                                "field": "labels.is_ioc_transform_source"
+                            "match_phrase": {
+                                "labels.is_ioc_transform_source": "true"
                             }
                         }
                     }

--- a/packages/ti_otx/manifest.yml
+++ b/packages/ti_otx/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_otx
 title: AlienVault OTX
-version: "1.25.2"
+version: "1.25.3"
 description: Ingest threat intelligence indicators from AlienVault Open Threat Exchange (OTX) with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/ti_rapid7_threat_command/changelog.yml
+++ b/packages/ti_rapid7_threat_command/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.0.3"
+  changes:
+    - description: Fix labels.is_ioc_transform_source values
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11231
 - version: "2.0.2"
   changes:
     - description: Add missing fields in transform

--- a/packages/ti_rapid7_threat_command/data_stream/ioc/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_rapid7_threat_command/data_stream/ioc/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_rapid7_threat_command/data_stream/ioc/fields/is-ioc-transform-source.yml
+++ b/packages/ti_rapid7_threat_command/data_stream/ioc/fields/is-ioc-transform-source.yml
@@ -1,4 +1,0 @@
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_rapid7_threat_command/docs/README.md
+++ b/packages/ti_rapid7_threat_command/docs/README.md
@@ -345,7 +345,7 @@ An example event for `ioc` looks as following:
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
 | input.type | Input type | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | log.offset | Log offset | long |
 | rapid7.tc.ioc.deleted_at | The timestamp when indicator is (or will be) expired. | date |
 | rapid7.tc.ioc.expiration_duration | The configured expiration duration. | keyword |

--- a/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_alert/fields/fields.yml
+++ b/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_alert/fields/fields.yml
@@ -91,8 +91,3 @@
     - name: update_date
       type: date
       description: Last update date of an alert in Unix Millisecond Timestamp.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_alert/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_alert/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_alert/transform.yml
+++ b/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_alert/transform.yml
@@ -14,7 +14,7 @@ source:
 # us that ability in order to prevent having duplicate data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_rapid7_threat_command_latest.dest_alert-1"
+  index: "logs-ti_rapid7_threat_command_latest.dest_alert-2"
   aliases:
     - alias: "logs-ti_rapid7_threat_command_latest.alert"
       move_on_creation: true
@@ -37,4 +37,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.1.0
+  fleet_transform_version: 0.2.0

--- a/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_ioc/fields/fields.yml
+++ b/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_ioc/fields/fields.yml
@@ -70,8 +70,3 @@
       type: keyword
       description: |
         The configured expiration duration.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_ioc/transform.yml
@@ -17,7 +17,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_rapid7_threat_command_latest.dest_ioc-1"
+  index: "logs-ti_rapid7_threat_command_latest.dest_ioc-2"
   aliases:
     - alias: "logs-ti_rapid7_threat_command_latest.ioc"
       move_on_creation: true
@@ -40,4 +40,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.1.0
+  fleet_transform_version: 0.2.0

--- a/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_vulnerability/fields/fields.yml
+++ b/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_vulnerability/fields/fields.yml
@@ -115,8 +115,3 @@
     - name: update_date
       type: date
       description: CVE's update date in ISO 8601 format.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_vulnerability/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_vulnerability/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_vulnerability/transform.yml
+++ b/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_vulnerability/transform.yml
@@ -14,7 +14,7 @@ source:
 # us that ability in order to prevent having duplicate data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_rapid7_threat_command_latest.dest_vulnerability-1"
+  index: "logs-ti_rapid7_threat_command_latest.dest_vulnerability-2"
   aliases:
     - alias: "logs-ti_rapid7_threat_command_latest.vulnerability"
       move_on_creation: true
@@ -37,4 +37,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.1.0
+  fleet_transform_version: 0.2.0

--- a/packages/ti_rapid7_threat_command/kibana/dashboard/ti_rapid7_threat_command-20735802-0864-485a-8b6f-e138aae5900d.json
+++ b/packages/ti_rapid7_threat_command/kibana/dashboard/ti_rapid7_threat_command-20735802-0864-485a-8b6f-e138aae5900d.json
@@ -15,11 +15,14 @@
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
                             "key": "labels.is_ioc_transform_source",
                             "negate": true,
-                            "type": "exists"
+                            "params": {
+                                "query": "true"
+                            },
+                            "type": "phrase"
                         },
                         "query": {
-                            "exists": {
-                                "field": "labels.is_ioc_transform_source"
+                            "match_phrase": {
+                                "labels.is_ioc_transform_source": "true"
                             }
                         }
                     },

--- a/packages/ti_rapid7_threat_command/manifest.yml
+++ b/packages/ti_rapid7_threat_command/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: ti_rapid7_threat_command
 title: Rapid7 Threat Command
-version: "2.0.2"
+version: "2.0.3"
 description: Collect threat intelligence from Threat Command API with Elastic Agent.
 type: integration
 categories: ["security", "threat_intel"]

--- a/packages/ti_recordedfuture/changelog.yml
+++ b/packages/ti_recordedfuture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.26.3"
+  changes:
+    - description: Fix labels.is_ioc_transform_source values
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11231
 - version: "1.26.2"
   changes:
     - description: Add missing fields in transform

--- a/packages/ti_recordedfuture/data_stream/threat/fields/fields.yml
+++ b/packages/ti_recordedfuture/data_stream/threat/fields/fields.yml
@@ -44,8 +44,3 @@
       type: keyword
       description: >
         User-configured risklist.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_recordedfuture/data_stream/threat/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_recordedfuture/data_stream/threat/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_recordedfuture/docs/README.md
+++ b/packages/ti_recordedfuture/docs/README.md
@@ -167,7 +167,7 @@ An example event for `threat` looks as following:
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
 | input.type | Type of Filebeat input. | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | log.flags | Flags for the log file. | keyword |
 | log.offset | Offset of the entry in the log file. | long |
 | recordedfuture.evidence_details.criticality |  | double |

--- a/packages/ti_recordedfuture/elasticsearch/transform/latest_ioc/fields/fields.yml
+++ b/packages/ti_recordedfuture/elasticsearch/transform/latest_ioc/fields/fields.yml
@@ -44,9 +44,3 @@
       type: keyword
       description: >
         User-configured risklist.
-
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_recordedfuture/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_recordedfuture/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_recordedfuture/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_recordedfuture/elasticsearch/transform/latest_ioc/transform.yml
@@ -9,7 +9,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_recordedfuture_latest.threat-2"
+  index: "logs-ti_recordedfuture_latest.threat-4"
   aliases:
     - alias: "logs-ti_recordedfuture_latest.threat"
       move_on_creation: true
@@ -35,4 +35,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.3.0
+  fleet_transform_version: 0.4.0

--- a/packages/ti_recordedfuture/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_recordedfuture/elasticsearch/transform/latest_ioc/transform.yml
@@ -9,7 +9,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_recordedfuture_latest.threat-4"
+  index: "logs-ti_recordedfuture_latest.threat-3"
   aliases:
     - alias: "logs-ti_recordedfuture_latest.threat"
       move_on_creation: true

--- a/packages/ti_recordedfuture/manifest.yml
+++ b/packages/ti_recordedfuture/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_recordedfuture
 title: Recorded Future
-version: "1.26.2"
+version: "1.26.3"
 description: Ingest threat intelligence indicators from Recorded Future risk lists with Elastic Agent.
 type: integration
 format_version: 3.0.2

--- a/packages/ti_threatconnect/changelog.yml
+++ b/packages/ti_threatconnect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.3"
+  changes:
+    - description: Fix labels.is_ioc_transform_source values
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11231
 - version: "1.2.2"
   changes:
     - description: Add missing fields in transform

--- a/packages/ti_threatconnect/data_stream/indicator/fields/fields.yml
+++ b/packages/ti_threatconnect/data_stream/indicator/fields/fields.yml
@@ -634,7 +634,3 @@
         - name: whois_active
           type: boolean
           description: Indicates whether the Whois feature is active for the Host Indicator.
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: 'true'
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_threatconnect/data_stream/indicator/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_threatconnect/data_stream/indicator/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_threatconnect/docs/README.md
+++ b/packages/ti_threatconnect/docs/README.md
@@ -347,7 +347,7 @@ An example event for `indicator` looks as following:
 | event.dataset | Event dataset. | constant_keyword |
 | event.module | Event module. | constant_keyword |
 | input.type | Type of filebeat input. | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | log.offset | Log offset. | long |
 | threat.feed.name | Display friendly feed name. | constant_keyword |
 | threat.indicator.first_seen | The date and time when intelligence source first reported sighting this indicator. | date |

--- a/packages/ti_threatconnect/elasticsearch/transform/latest/fields/fields.yml
+++ b/packages/ti_threatconnect/elasticsearch/transform/latest/fields/fields.yml
@@ -634,8 +634,3 @@
         - name: whois_active
           type: boolean
           description: Indicates whether the Whois feature is active for the Host Indicator.
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_threatconnect/elasticsearch/transform/latest/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_threatconnect/elasticsearch/transform/latest/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_threatconnect/elasticsearch/transform/latest/transform.yml
+++ b/packages/ti_threatconnect/elasticsearch/transform/latest/transform.yml
@@ -9,7 +9,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_threatconnect_latest.dest_indicator-2"
+  index: "logs-ti_threatconnect_latest.dest_indicator-3"
   aliases:
     - alias: "logs-ti_threatconnect_latest.indicator"
       move_on_creation: true
@@ -32,4 +32,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0

--- a/packages/ti_threatconnect/kibana/dashboard/ti_threatconnect-2d465f90-973d-11ee-839e-ef65b7014120.json
+++ b/packages/ti_threatconnect/kibana/dashboard/ti_threatconnect-2d465f90-973d-11ee-839e-ef65b7014120.json
@@ -41,12 +41,14 @@
                                         "index": "logs-*",
                                         "key": "labels.is_ioc_transform_source",
                                         "negate": true,
-                                        "type": "exists",
-                                        "value": "exists"
+                                        "params": {
+                                            "query": "true"
+                                        },
+                                        "type": "phrase"
                                     },
                                     "query": {
-                                        "exists": {
-                                            "field": "labels.is_ioc_transform_source"
+                                        "match_phrase": {
+                                            "labels.is_ioc_transform_source": "true"
                                         }
                                     }
                                 }

--- a/packages/ti_threatconnect/manifest.yml
+++ b/packages/ti_threatconnect/manifest.yml
@@ -2,7 +2,7 @@
 format_version: 3.0.3
 name: ti_threatconnect
 title: ThreatConnect
-version: "1.2.2"
+version: "1.2.3"
 description: Collects Indicators from ThreatConnect using the Elastic Agent and saves them as logs inside Elastic
 type: integration
 categories:

--- a/packages/ti_threatq/changelog.yml
+++ b/packages/ti_threatq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.28.3"
+  changes:
+    - description: Fix labels.is_ioc_transform_source values
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11231
 - version: "1.28.2"
   changes:
     - description: Add missing fields in transform

--- a/packages/ti_threatq/data_stream/threat/fields/fields.yml
+++ b/packages/ti_threatq/data_stream/threat/fields/fields.yml
@@ -73,8 +73,3 @@
       type: flattened
       description: >
         These provide additional context about an object
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators.

--- a/packages/ti_threatq/data_stream/threat/fields/is-ioc-transform-source-true.yml
+++ b/packages/ti_threatq/data_stream/threat/fields/is-ioc-transform-source-true.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "true"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_threatq/docs/README.md
+++ b/packages/ti_threatq/docs/README.md
@@ -41,7 +41,7 @@ To facilitate IOC expiration, source datastream-backed indices `.ds-logs-ti_thre
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
 | input.type | Type of Filebeat input. | keyword |
-| labels.is_ioc_transform_source | Field indicating if its the transform source for supporting IOC expiration. This field is dropped from destination indices to facilitate easier filtering of indicators. | constant_keyword |
+| labels.is_ioc_transform_source | Indicates whether an IOC is in the raw source data stream, or the in latest destination index. | constant_keyword |
 | log.flags | Flags for the log file. | keyword |
 | log.offset | Offset of the entry in the log file. | long |
 | threat.feed.dashboard_id | Dashboard ID used for Kibana CTI UI | constant_keyword |

--- a/packages/ti_threatq/elasticsearch/transform/latest_ioc/fields/fields.yml
+++ b/packages/ti_threatq/elasticsearch/transform/latest_ioc/fields/fields.yml
@@ -73,9 +73,3 @@
       type: flattened
       description: >
         These provide additional context about an object
-
-
-- name: labels.is_ioc_transform_source
-  type: constant_keyword
-  value: "true"
-  description: In the source index it indicates if the document is a source for the transform.

--- a/packages/ti_threatq/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
+++ b/packages/ti_threatq/elasticsearch/transform/latest_ioc/fields/is-ioc-transform-source-false.yml
@@ -1,0 +1,4 @@
+- name: labels.is_ioc_transform_source
+  type: constant_keyword
+  value: "false"
+  description: Indicates whether an IOC is in the raw source data stream, or the in latest destination index.

--- a/packages/ti_threatq/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_threatq/elasticsearch/transform/latest_ioc/transform.yml
@@ -9,7 +9,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_threatq_latest.dest_threat-2"
+  index: "logs-ti_threatq_latest.dest_threat-3"
   aliases:
     - alias: "logs-ti_threatq_latest.threat"
       move_on_creation: true
@@ -32,4 +32,4 @@ retention_policy:
 _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0

--- a/packages/ti_threatq/manifest.yml
+++ b/packages/ti_threatq/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_threatq
 title: ThreatQuotient
-version: "1.28.2"
+version: "1.28.3"
 description: Ingest threat intelligence indicators from ThreatQuotient with Elastic Agent.
 type: integration
 format_version: "3.0.2"


### PR DESCRIPTION
## Proposed commit message

```
[ti_*] Fix `labels.is_ioc_transform_source` values

The distinction between source and destination records was lost when
#11008 added a field definition for `labels.is_ioc_transform_source`
to the destination indices with a value of `"true"`.

Here it is restored by:
- Moving `labels.is_ioc_transform_source` field definitions into
  separate files.
- Setting the value to `"false"` in the transform destinations.
- Incrementing transform version numbers so new destination indices
  will be built with correct values.
- Adjusting dashboards to filter for not `"true"` rather than not
  exists.

Security rules already filter for not `"true"`.
```

## Extra details

The relevant security rules can be seen [here](https://github.com/search?q=repo%3Aelastic%2Fintegrations+path%3A%2F%5Epackages%5C%2Fsecurity_detection_engine%5C%2F%2F+labels.is_ioc_transform_source%3A&type=code).

Dashboards using `exists` queries could be found with the following, but have all been removed:
```
ag --json -B5 -A5 labels.is_ioc_transform_source | grep -B5 -A5 exists
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #11208