### PR TITLE
[Azure docs] Clarify generic vs specialized integrations

### DIFF
--- a/packages/azure_metrics/_dev/build/docs/README.md
+++ b/packages/azure_metrics/_dev/build/docs/README.md
@@ -83,7 +83,11 @@ Check [Azure Monitor pricing](https://azure.microsoft.com/en-gb/pricing/details/
 
 A generic integration is fully customizable and can support any Azure service. There are no out-of-the-box dashboards for visualizing data, giving users complete control over the process. You must install the integration and customize the configuration before sending metrics to the data stream. You have the maximum flexibility to customize the configuration, custom pipelines, and mappings fully.
 
+To start using the generic metrics integration, enable "Collect Azure Monitor metrics" and set up your custom configuration.
+
 A specialized integration specializes in a specific Azure service and comes with a built-in configuration that provides the most appropriate mapping for each field with one or more out-of-the-box dashboards to visualize data. You cannot edit the built-in configurations. When you install the integration, you can send the metrics to the data stream, and can immediately visualize and search the data. You still have customization options like custom pipelines and mappings, but they are optional for specific needs.
+
+Specialized integrations include the Azure Virtual Machine, Storage Account, Container Registry, and other Container-related metrics integration.
 
 ## Setup
 

--- a/packages/azure_metrics/_dev/build/docs/README.md
+++ b/packages/azure_metrics/_dev/build/docs/README.md
@@ -60,7 +60,6 @@ To use this integration you will need:
 * **Azure App Registration**: You need to set up an Azure App Registration to allow the Agent to access the Azure APIs. See more details in the [Setup section](#setup).
 * **Elasticsearch and Kibana**: You need Elasticsearch to store and search your data and Kibana to visualize and manage it. You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, the [Native Azure Integration](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/elastic.elasticsearch?tab=Overview), or self-manage the Elastic Stack on your hardware.
 
-
 ### Authentication and costs
 
 **Authentication on the Azure side**
@@ -79,6 +78,12 @@ Elastic handles authentication by creating or renewing the authentication token.
 **Costs**
 Metric queries are charged based on the number of standard API calls. 
 Check [Azure Monitor pricing](https://azure.microsoft.com/en-gb/pricing/details/monitor/) for more detailsgit.
+
+## Generic vs specialized integrations
+
+A generic integration is fully customizable and can support any Azure service. There are no out-of-the-box dashboards for visualizing data, giving users complete control over the process. You must install the integration and customize the configuration before sending metrics to the data stream. You have the maximum flexibility to customize the configuration, custom pipelines, and mappings fully.
+
+A specialized integration specializes in a specific Azure service and comes with a built-in configuration that provides the most appropriate mapping for each field with one or more out-of-the-box dashboards to visualize data. You cannot edit the built-in configurations. When you install the integration, you can send the metrics to the data stream, and can immediately visualize and search the data. You still have customization options like custom pipelines and mappings, but they are optional for specific needs.
 
 ## Setup
 

--- a/packages/azure_metrics/_dev/build/docs/README.md
+++ b/packages/azure_metrics/_dev/build/docs/README.md
@@ -79,7 +79,7 @@ Elastic handles authentication by creating or renewing the authentication token.
 Metric queries are charged based on the number of standard API calls. 
 Check [Azure Monitor pricing](https://azure.microsoft.com/en-gb/pricing/details/monitor/) for more detailsgit.
 
-## Generic vs specialized integrations
+## Generic and specialized integrations
 
 A generic integration is fully customizable and can support any Azure service. There are no out-of-the-box dashboards for visualizing data, giving users complete control over the process. You must install the integration and customize the configuration before sending metrics to the data stream. You have the maximum flexibility to customize the configuration, custom pipelines, and mappings fully.
 

--- a/packages/azure_metrics/_dev/build/docs/README.md
+++ b/packages/azure_metrics/_dev/build/docs/README.md
@@ -87,7 +87,7 @@ To start using the generic metrics integration, enable "Collect Azure Monitor me
 
 A specialized integration specializes in a specific Azure service and comes with a built-in configuration that provides the most appropriate mapping for each field with one or more out-of-the-box dashboards to visualize data. You cannot edit the built-in configurations. When you install the integration, you can send the metrics to the data stream, and can immediately visualize and search the data. You still have customization options like custom pipelines and mappings, but they are optional for specific needs.
 
-Specialized integrations include the Azure Virtual Machine, Storage Account, Container Registry, and other Container-related metrics integration.
+Specialized integrations include the Azure Virtual Machine, Storage Account, Container Registry, and other Container-related metrics integrations.
 
 ## Setup
 

--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -1,3 +1,9 @@
+
+- version: "1.6.7"
+  changes:
+    - description: Clarify generic vs specialized integrations on Azure metrics pages.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/11232
 - version: "1.6.6"
   changes:
     - description: Fix capacity and count metrics visualizations in the overview, blob, table, and file storage dashboards.

--- a/packages/azure_metrics/docs/README.md
+++ b/packages/azure_metrics/docs/README.md
@@ -83,7 +83,11 @@ Check [Azure Monitor pricing](https://azure.microsoft.com/en-gb/pricing/details/
 
 A generic integration is fully customizable and can support any Azure service. There are no out-of-the-box dashboards for visualizing data, giving users complete control over the process. You must install the integration and customize the configuration before sending metrics to the data stream. You have the maximum flexibility to customize the configuration, custom pipelines, and mappings fully.
 
+To start using the generic metrics integration, enable "Collect Azure Monitor metrics" and set up your custom configuration.
+
 A specialized integration specializes in a specific Azure service and comes with a built-in configuration that provides the most appropriate mapping for each field with one or more out-of-the-box dashboards to visualize data. You cannot edit the built-in configurations. When you install the integration, you can send the metrics to the data stream, and can immediately visualize and search the data. You still have customization options like custom pipelines and mappings, but they are optional for specific needs.
+
+Specialized integrations include the Azure Virtual Machine, Storage Account, Container Registry, and other Container-related metrics integrations.
 
 ## Setup
 

--- a/packages/azure_metrics/docs/README.md
+++ b/packages/azure_metrics/docs/README.md
@@ -60,7 +60,6 @@ To use this integration you will need:
 * **Azure App Registration**: You need to set up an Azure App Registration to allow the Agent to access the Azure APIs. See more details in the [Setup section](#setup).
 * **Elasticsearch and Kibana**: You need Elasticsearch to store and search your data and Kibana to visualize and manage it. You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, the [Native Azure Integration](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/elastic.elasticsearch?tab=Overview), or self-manage the Elastic Stack on your hardware.
 
-
 ### Authentication and costs
 
 **Authentication on the Azure side**
@@ -79,6 +78,12 @@ Elastic handles authentication by creating or renewing the authentication token.
 **Costs**
 Metric queries are charged based on the number of standard API calls. 
 Check [Azure Monitor pricing](https://azure.microsoft.com/en-gb/pricing/details/monitor/) for more detailsgit.
+
+## Generic vs specialized integrations
+
+A generic integration is fully customizable and can support any Azure service. There are no out-of-the-box dashboards for visualizing data, giving users complete control over the process. You must install the integration and customize the configuration before sending metrics to the data stream. You have the maximum flexibility to customize the configuration, custom pipelines, and mappings fully.
+
+A specialized integration specializes in a specific Azure service and comes with a built-in configuration that provides the most appropriate mapping for each field with one or more out-of-the-box dashboards to visualize data. You cannot edit the built-in configurations. When you install the integration, you can send the metrics to the data stream, and can immediately visualize and search the data. You still have customization options like custom pipelines and mappings, but they are optional for specific needs.
 
 ## Setup
 

--- a/packages/azure_metrics/docs/README.md
+++ b/packages/azure_metrics/docs/README.md
@@ -79,7 +79,7 @@ Elastic handles authentication by creating or renewing the authentication token.
 Metric queries are charged based on the number of standard API calls. 
 Check [Azure Monitor pricing](https://azure.microsoft.com/en-gb/pricing/details/monitor/) for more detailsgit.
 
-## Generic vs specialized integrations
+## Generic and specialized integrations
 
 A generic integration is fully customizable and can support any Azure service. There are no out-of-the-box dashboards for visualizing data, giving users complete control over the process. You must install the integration and customize the configuration before sending metrics to the data stream. You have the maximum flexibility to customize the configuration, custom pipelines, and mappings fully.
 

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_metrics
 title: Azure Resource Metrics
-version: 1.6.6
+version: 1.6.7
 description: Collect metrics from Azure resources with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
This PR adds a section to the [Azure Resource Metrics](https://docs.elastic.co/integrations/azure_metrics) page to distinguish generic vs specialized integrations.

Fixes https://github.com/elastic/integration-docs/issues/376
