### PR TITLE
[Elastic Agent] Add data retention policy of 30d to all data streams

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.1.0"
+  changes:
+    - description: Add data retention policy of 30d to all data streams
+      type: enhancement
+      link: "https://github.com/elastic/integrations/pull/10773"
 - version: "2.0.3"
   changes:
     - description: Restore Agent errors visualisation to Elastic-Agent agent info dashboard

--- a/packages/elastic_agent/data_stream/apm_server_logs/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/apm_server_logs/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/apm_server_metrics/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/apm_server_metrics/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/auditbeat_logs/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_logs/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/auditbeat_metrics/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_metrics/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/cloud_defend_logs/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/cloud_defend_logs/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/endpoint_security_metrics/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/endpoint_security_metrics/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/endpoint_sercurity_logs/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/endpoint_sercurity_logs/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/filebeat_input_logs/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_logs/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/filebeat_input_metrics/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_metrics/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/filebeat_logs/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/filebeat_logs/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/filebeat_metrics/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/filebeat_metrics/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/fleet_server_logs/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_logs/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/fleet_server_metrics/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_metrics/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/heartbeat_logs/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_logs/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/heartbeat_metrics/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_metrics/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/metricbeat_logs/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_logs/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/metricbeat_metrics/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_metrics/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/osquerybeat_logs/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_logs/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/osquerybeat_metrics/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_metrics/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/packetbeat_logs/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_logs/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/packetbeat_metrics/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_metrics/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/pf_elastic_collector/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/pf_elastic_collector/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/pf_elastic_symbolizer/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/pf_elastic_symbolizer/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/elastic_agent/data_stream/pf_host_agent_logs/lifecycle.yml
+++ b/packages/elastic_agent/data_stream/pf_host_agent_logs/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"


### PR DESCRIPTION
## Proposed commit message

Add data retention policy of 30d to all Elastic Agent data streams

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
