### PR TITLE
[cisco_ftd] Fix parsing issues with message IDs 210007, 305013, and 302023

### DIFF
--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.4.1"
+  changes:
+    - description: "Fix parsing issues with message IDs 210007, 305013, and 302023."
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.4.0"
   changes:
     - description: "Allow @custom pipeline access to event.original without setting preserve_original_event."

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log
@@ -21,3 +21,6 @@ May  5 17:51:17 dev01: %FTD-4-313005: No matching connection for ICMP error mess
 <163>%FTD-3-305006: regular translation creation failed for icmp src any:81.2.69.195 dst WAN-PROV:81.2.69.200 (type 3, code 0)
 <164>%FTD-4-113042: Non-HTTP connection from WAN-PROV:10.1.10.16/61002 to LAN:10.1.8.22/444 denied by redirect filter; only HTTP connections are supported for redirection.
 <164>Jul 16 2024 12:30:30: %FTD-4-722051: Group <ADM-AnyConnectGroup> User <Test User 1> IP <1.128.0.10> IPv4 Address <1.128.0.20> IPv6 address <::> assigned to session
+<164>Jul 16 2024 12:30:30: %FTD-5-305013: Asymmetric NAT rules matched for forward and reverse flows; Connection for protocol 47 src outside.int:175.16.199.1 dst inside.int:216.160.83.56 denied due to NAT reverse path failure
+<164>Jul 16 2024 12:30:30: %FTD-6-302023: Teardown director TCP connection for INSIDE:192.168.2.2/49001 to OUTSIDE:81.2.69.195/443 duration 0:00:30 forwarded bytes 0 Cluster flow with CLU closed on owner
+<164>Jul 16 2024 12:30:30: %FTD-6-302023: Teardown backup TCP connection for INSIDE:192.168.2.2/49001 to OUTSIDE:81.2.69.195/443 duration 0:00:12 forwarded bytes 5282 Cluster flow with CLU closed on owner

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log-expected.json
@@ -1779,6 +1779,253 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2024-07-16T12:30:30.000Z",
+            "cisco": {
+                "ftd": {
+                    "destination_interface": "inside.int",
+                    "source_interface": "outside.int"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "305013",
+                "kind": "event",
+                "original": "<164>Jul 16 2024 12:30:30: %FTD-5-305013: Asymmetric NAT rules matched for forward and reverse flows; Connection for protocol 47 src outside.int:175.16.199.1 dst inside.int:216.160.83.56 denied due to NAT reverse path failure",
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "facility": {
+                        "code": 20
+                    },
+                    "priority": 164,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "network": {
+                "iana_number": "47"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "inside.int"
+                    }
+                },
+                "ingress": {
+                    "interface": {
+                        "name": "outside.int"
+                    }
+                },
+                "product": "ftd",
+                "type": "idps",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-07-16T12:30:30.000Z",
+            "cisco": {
+                "ftd": {
+                    "destination_interface": "OUTSIDE",
+                    "source_interface": "INSIDE"
+                }
+            },
+            "destination": {
+                "address": "81.2.69.195",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.195",
+                "port": 443
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "302023",
+                "duration": 30000000000,
+                "end": "2024-07-16T12:30:30.000Z",
+                "kind": "event",
+                "original": "<164>Jul 16 2024 12:30:30: %FTD-6-302023: Teardown director TCP connection for INSIDE:192.168.2.2/49001 to OUTSIDE:81.2.69.195/443 duration 0:00:30 forwarded bytes 0 Cluster flow with CLU closed on owner",
+                "reason": "Cluster flow with CLU closed on owner",
+                "severity": 6,
+                "start": "2024-07-16T12:30:00.000Z",
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 20
+                    },
+                    "priority": 164,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "network": {
+                "bytes": 0,
+                "community_id": "1:i+psADbWmOtDAm9HJcmOsYQTd+c=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "OUTSIDE"
+                    }
+                },
+                "ingress": {
+                    "interface": {
+                        "name": "INSIDE"
+                    }
+                },
+                "product": "ftd",
+                "type": "idps",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "ip": [
+                    "192.168.2.2",
+                    "81.2.69.195"
+                ]
+            },
+            "source": {
+                "address": "192.168.2.2",
+                "ip": "192.168.2.2",
+                "port": 49001
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-07-16T12:30:30.000Z",
+            "cisco": {
+                "ftd": {
+                    "destination_interface": "OUTSIDE",
+                    "source_interface": "INSIDE"
+                }
+            },
+            "destination": {
+                "address": "81.2.69.195",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.195",
+                "port": 443
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "302023",
+                "duration": 12000000000,
+                "end": "2024-07-16T12:30:30.000Z",
+                "kind": "event",
+                "original": "<164>Jul 16 2024 12:30:30: %FTD-6-302023: Teardown backup TCP connection for INSIDE:192.168.2.2/49001 to OUTSIDE:81.2.69.195/443 duration 0:00:12 forwarded bytes 5282 Cluster flow with CLU closed on owner",
+                "reason": "Cluster flow with CLU closed on owner",
+                "severity": 6,
+                "start": "2024-07-16T12:30:18.000Z",
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 20
+                    },
+                    "priority": 164,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "network": {
+                "bytes": 5282,
+                "community_id": "1:i+psADbWmOtDAm9HJcmOsYQTd+c=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "OUTSIDE"
+                    }
+                },
+                "ingress": {
+                    "interface": {
+                        "name": "INSIDE"
+                    }
+                },
+                "product": "ftd",
+                "type": "idps",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "ip": [
+                    "192.168.2.2",
+                    "81.2.69.195"
+                ]
+            },
+            "source": {
+                "address": "192.168.2.2",
+                "ip": "192.168.2.2",
+                "port": 49001
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -411,7 +411,7 @@ processors:
       description: "210007"
       tag: "210007"
       patterns:
-        - "^LU allocate xlate failed for %{TYPE:_temp_.cisco.translation_type} %{WORD:network.protocol} translation from %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST:source.address}/%{NUMBER:source.port} \\(%{IPORHOST:_temp_.cisco.mapped_source_ip}/%{NUMBER:_temp_.cisco.mapped_source_port}\\) to %{NOTCOLON:_temp_.cisco.destination_interface}:%{IPORHOST:destination.address}/%{NUMBER:destination.port} \\(%{IPORHOST:_temp_.cisco.mapped_destination_ip}/%{NUMBER:_temp_.cisco.mapped_destination_port}\\)$"
+        - "^LU allocate xlate failed for %{TYPE:_temp_.cisco.translation_type} %{WORD:network.protocol} translation from %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST:source.address}/%{NUMBER:source.port} \\(%{IPORHOST:_temp_.cisco.mapped_source_ip}/%{NUMBER:_temp_.cisco.mapped_source_port}\\) to %{NOTCOLON:_temp_.cisco.destination_interface}:%{IPORHOST:destination.address}/%{NUMBER:destination.port} \\(%{IPORHOST:_temp_.cisco.mapped_destination_ip}/%{NUMBER:_temp_.cisco.mapped_destination_port}\\)"
       pattern_definitions:
         NOTCOLON: "[^:]*"
         IPORHOST: "(?:%{IP}|%{HOSTNAME})"
@@ -482,7 +482,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '302023'"
       field: "message"
       description: "302023"
-      pattern: "Teardown stub %{network.transport} connection for %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} duration %{_temp_.duration_hms} forwarded bytes %{network.bytes} %{event.reason}"
+      pattern: "Teardown %{->} %{network.transport} connection for %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} duration %{_temp_.duration_hms} forwarded bytes %{network.bytes} %{event.reason}"
   - grok:
       if: "ctx._temp_.cisco.message_id == '304001'"
       field: "message"
@@ -511,7 +511,8 @@ processors:
       description: "305013"
       tag: "305013"
       patterns:
-        - "^Asymmetric NAT rules matched for forward and reverse flows; Connection for %{NOTSPACE:network.transport} src %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST}/%{NUMBER:source.port}(\\(%{NOTSPACE:source.user.name}\\))? dst %{NOTCOLON:_temp_.cisco.destination_interface}:%{IPORHOST}/%{NUMBER:destination.port} denied due to NAT reverse path failure$"
+        - "^Asymmetric NAT rules matched for forward and reverse flows; Connection for protocol %{NOTSPACE:network.iana_number} src %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST}(?:/%{NUMBER:source.port})?(?:\\(%{NOTSPACE:source.user.name}\\))? dst %{NOTCOLON:_temp_.cisco.destination_interface}:%{IPORHOST}(?:/%{NUMBER:destination.port})? denied due to NAT reverse path failure"
+        - "^Asymmetric NAT rules matched for forward and reverse flows; Connection for %{NOTSPACE:network.transport} src %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST}(?:/%{NUMBER:source.port})?(?:\\(%{NOTSPACE:source.user.name}\\))? dst %{NOTCOLON:_temp_.cisco.destination_interface}:%{IPORHOST}(?:/%{NUMBER:destination.port})? denied due to NAT reverse path failure"
       pattern_definitions:
         NOTCOLON: "[^:]*"
   - dissect:

--- a/packages/cisco_ftd/manifest.yml
+++ b/packages/cisco_ftd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ftd
 title: Cisco FTD
-version: "3.4.0"
+version: "3.4.1"
 description: Collect logs from Cisco FTD with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- Tolerate trailing spaces/characters for message ID 210007
- Allow additional actions for message ID 302023
- Support IANA number protocols for message ID 305013

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages/cisco_ftd
elastic-package test
```

## Related issues

- Closes #10478