### PR TITLE
[carbon_black_cloud] Fix alert_v7 CEL pagination logic

### DIFF
--- a/packages/carbon_black_cloud/changelog.yml
+++ b/packages/carbon_black_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.4"
+  changes:
+    - description: Fix alert_v7 CEL pagination logic.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11259
 - version: "2.5.3"
   changes:
     - description: Fix timestamp type when using cursor value.

--- a/packages/carbon_black_cloud/data_stream/alert_v7/agent/stream/cel.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/alert_v7/agent/stream/cel.yml.hbs
@@ -18,6 +18,7 @@ state:
     api_key: '{{custom_api_secret_key}}/{{custom_api_id}}'
     want_more: false
     initial_interval: {{initial_interval}}
+    rows_per_page: 100
 redact:
     fields:
         - api_key
@@ -43,6 +44,7 @@ program: |-
   					"start": string(range.start < range.end ? range.start : range.end),
   					"end": string(range.end),
   				}),
+          "rows": state.rows_per_page,
   				"sort": [{"field": "backend_update_timestamp", "order": "ASC"}],
   			}.encode_json(),
   		}
@@ -69,7 +71,7 @@ program: |-
   					:
   						state.?cursor.last_backend_update_timestamp,
   				},
-  				"want_more": body.?num_found != body.?num_available,
+  				"want_more": body.num_found > state.rows_per_page,
   			}
   		)
   	:

--- a/packages/carbon_black_cloud/manifest.yml
+++ b/packages/carbon_black_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: carbon_black_cloud
 title: VMware Carbon Black Cloud
-version: "2.5.3"
+version: "2.5.4"
 description: Collect logs from VMWare Carbon Black Cloud with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[carbon_black_cloud] Fix alert_v7 CEL pagination logic

When using the CEL input for the `alert_v7` data stream, data would
load very slowly for two reason:

- The page size defaulted to 20 results.
- The `want_more` flag was incorrectly set to false.

The response body has the fields `num_found` and `num_available`.
The `num_found` field gives the total number of results matching the query.
The `num_available` filed is equal to `min(num_found, 10000)`.

Now `want_more` is true if `num_found` is less than the page size, so it
will keep fetching more until less than a full page of results are found.

The page size is increased from 20 (the default) to 100.
```

## Testing

I tested this manually.

When no results are found, the `num_found` field is returned with the value `0`, so the pagination condition can assume it is always there.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).