### PR TITLE
[checkpoint] Drop support for EOL OS version R80.X

### DIFF
--- a/packages/checkpoint/_dev/build/docs/README.md
+++ b/packages/checkpoint/_dev/build/docs/README.md
@@ -22,7 +22,7 @@ You will need one or more Check Point Firewall appliances to monitor.
 
 ### Compatibility
 
-This integration has been tested against Check Point Log Exporter on R80.X and R81.X.
+This integration has been tested against Check Point Log Exporter on R81.X.
 
 ## Setup
 

--- a/packages/checkpoint/changelog.yml
+++ b/packages/checkpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.34.0"
+  changes:
+    - description: Drop support for EOL OS version R80.X
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.33.1"
   changes:
     - description: Improve normalization of user.name field

--- a/packages/checkpoint/changelog.yml
+++ b/packages/checkpoint/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Drop support for EOL OS version R80.X
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/11263
 - version: "1.33.1"
   changes:
     - description: Improve normalization of user.name field

--- a/packages/checkpoint/docs/README.md
+++ b/packages/checkpoint/docs/README.md
@@ -22,7 +22,7 @@ You will need one or more Check Point Firewall appliances to monitor.
 
 ### Compatibility
 
-This integration has been tested against Check Point Log Exporter on R80.X and R81.X.
+This integration has been tested against Check Point Log Exporter on R81.X.
 
 ## Setup
 

--- a/packages/checkpoint/manifest.yml
+++ b/packages/checkpoint/manifest.yml
@@ -1,6 +1,6 @@
 name: checkpoint
 title: Check Point
-version: "1.33.1"
+version: "1.34.0"
 description: Collect logs from Check Point with Elastic Agent.
 type: integration
 format_version: "3.0.3"


### PR DESCRIPTION
## Proposed commit message

- Documentation update to remove EOL OS version R80.X from the list of supported versions.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- ~~[ ] I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- #10977
