### PR TITLE
[Elastic Connectors] Add index name as input var

### DIFF
--- a/packages/elastic_connectors/agent/input/github.yml.hbs
+++ b/packages/elastic_connectors/agent/input/github.yml.hbs
@@ -1,1 +1,4 @@
 service_type: github
+{{#if connector_name}}
+connector_name: {{connector_name}}
+{{/if}}

--- a/packages/elastic_connectors/agent/input/google_drive.yml.hbs
+++ b/packages/elastic_connectors/agent/input/google_drive.yml.hbs
@@ -1,1 +1,4 @@
 service_type: google_drive
+{{#if connector_name}}
+connector_name: {{connector_name}}
+{{/if}}

--- a/packages/elastic_connectors/changelog.yml
+++ b/packages/elastic_connectors/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: 0.0.2
   changes:
-    - description: Add index_name as the connector input variable
+    - description: Add connector_name as the connector input variable
       type: enhancement
       link: https://github.com/elastic/integrations/pull/11267
 - version: 0.0.1

--- a/packages/elastic_connectors/changelog.yml
+++ b/packages/elastic_connectors/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: 0.0.2
   changes:
-    - description: WIP....
+    - description: Add index_name as the connector input variable
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1234
+      link: https://github.com/elastic/integrations/pull/11267
 - version: 0.0.1
   changes:
     - description: Initial draft of the package

--- a/packages/elastic_connectors/changelog.yml
+++ b/packages/elastic_connectors/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.0.2
+  changes:
+    - description: WIP....
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1234
 - version: 0.0.1
   changes:
     - description: Initial draft of the package

--- a/packages/elastic_connectors/manifest.yml
+++ b/packages/elastic_connectors/manifest.yml
@@ -42,7 +42,8 @@ policy_templates:
         title: GitHub & GitHub Enterprise Server Connector
         description: Connectors syncs data from an original data source to an Elasticsearch index.
         vars:
-          - name: connector_name
+          - &connector_name
+            name: connector_name
             type: text
             title: Connector Name
             required: true
@@ -68,12 +69,7 @@ policy_templates:
         title: Google Drive Connector
         description: Connectors syncs data from an original data source to an Elasticsearch index.
         vars:
-          - name: connector_name
-            type: text
-            title: Connector Name
-            required: true
-            show_user: false
-            description: Connector name to identify the connector in the UI
+          - <<: *connector_name
             default: "[Elastic-managed] Google Drive Connector"
         template_path: google_drive.yml.hbs
 

--- a/packages/elastic_connectors/manifest.yml
+++ b/packages/elastic_connectors/manifest.yml
@@ -42,13 +42,13 @@ policy_templates:
         title: GitHub & GitHub Enterprise Server Connector
         description: Connectors syncs data from an original data source to an Elasticsearch index.
         vars:
-          - name: index_name
+          - name: connector_name
             type: text
-            title: Index Name
+            title: Connector Name
             required: true
             show_user: false
-            description: This index will hold your data source content, and is optimized with default field mappings for relevant search experiences. Give your index a unique name.
-            default: content-
+            description: Connector name to identify the connector in the UI
+            default: "[Elastic-managed] Github Connector"
         template_path: github.yml.hbs
   - name: google_drive
     title: Google Drive Connector
@@ -68,13 +68,13 @@ policy_templates:
         title: Google Drive Connector
         description: Connectors syncs data from an original data source to an Elasticsearch index.
         vars:
-          - name: index_name
+          - name: connector_name
             type: text
-            title: Index Name
+            title: Connector Name
             required: true
             show_user: false
-            description: This index will hold your data source content, and is optimized with default field mappings for relevant search experiences. Give your index a unique name.
-            default: content-
+            description: Connector name to identify the connector in the UI
+            default: "[Elastic-managed] Google Drive Connector"
         template_path: google_drive.yml.hbs
 
 owner:

--- a/packages/elastic_connectors/manifest.yml
+++ b/packages/elastic_connectors/manifest.yml
@@ -37,6 +37,7 @@ policy_templates:
         enabled: false
       agentless:
         enabled: true
+    multiple: false
     inputs:
       - type: connectors-py
         title: GitHub & GitHub Enterprise Server Connector
@@ -46,10 +47,9 @@ policy_templates:
             name: connector_name
             type: text
             title: Connector Name
-            required: true
-            show_user: false
+            required: false
+            show_user: false # TODO: Change to true once this is fixed https://github.com/elastic/kibana/issues/194310
             description: Connector name to identify the connector in the UI
-            default: "[Elastic-managed] Github Connector"
         template_path: github.yml.hbs
   - name: google_drive
     title: Google Drive Connector
@@ -64,13 +64,13 @@ policy_templates:
         enabled: false
       agentless:
         enabled: true
+    multiple: false
     inputs:
       - type: connectors-py
         title: Google Drive Connector
         description: Connectors syncs data from an original data source to an Elasticsearch index.
         vars:
           - <<: *connector_name
-            default: "[Elastic-managed] Google Drive Connector"
         template_path: google_drive.yml.hbs
 
 owner:

--- a/packages/elastic_connectors/manifest.yml
+++ b/packages/elastic_connectors/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: elastic_connectors
 title: "Elastic Connectors"
-version: 0.0.1
+version: 0.0.2
 source:
   license: "Elastic-2.0"
 description: "Sync data from source to the Elasticsearch index."
@@ -28,7 +28,7 @@ policy_templates:
     title: GitHub & GitHub Enterprise Server Connector
     icons:
       - src: /img/service_type/github.svg
-        title: Google Drive logo
+        title: GitHub logo
         size: 32x32
         type: image/svg+xml
     description: Use a connector to sync data from your GitHub data source.
@@ -37,11 +37,18 @@ policy_templates:
         enabled: false
       agentless:
         enabled: true
-    multiple: false
     inputs:
       - type: connectors-py
         title: GitHub & GitHub Enterprise Server Connector
         description: Connectors syncs data from an original data source to an Elasticsearch index.
+        vars:
+          - name: index_name
+            type: text
+            title: Index Name
+            required: true
+            show_user: false
+            description: This index will hold your data source content, and is optimized with default field mappings for relevant search experiences. Give your index a unique name.
+            default: content-
         template_path: github.yml.hbs
   - name: google_drive
     title: Google Drive Connector
@@ -56,12 +63,20 @@ policy_templates:
         enabled: false
       agentless:
         enabled: true
-    multiple: false
     inputs:
       - type: connectors-py
         title: Google Drive Connector
         description: Connectors syncs data from an original data source to an Elasticsearch index.
+        vars:
+          - name: index_name
+            type: text
+            title: Index Name
+            required: true
+            show_user: false
+            description: This index will hold your data source content, and is optimized with default field mappings for relevant search experiences. Give your index a unique name.
+            default: content-
         template_path: google_drive.yml.hbs
+
 owner:
   github: elastic/search-extract-and-transform
   type: elastic


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Add connector_name as input variable

Update connector package definition to pass `connector_name` as input variable for the package logic. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Test the final version of this package def e2e (ping @jedrazb for exact steps if needed)

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

- Since agentless package is not public yet, ping @jedrazb for steps


## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->

<img width="600" alt="Screenshot 2024-10-03 at 17 14 09" src="https://github.com/user-attachments/assets/ac9937c0-ef03-4047-82d9-0522aaaa63af">

