### PR TITLE
[Cloud Security][Cloud Security Posture] Bump package

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -13,7 +13,7 @@
   changes:
     - description: Bump package to include new kibana condition
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/10479
+      link: https://github.com/elastic/integrations/pull/11274
 - version: "1.11.0-preview08"
   changes:
     - description: Change gcp.credentials.json secret to true

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -9,6 +9,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "1.11.0-preview09"
+  changes:
+    - description: Bump package to include new kibana condition
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10479
 - version: "1.11.0-preview08"
   changes:
     - description: Change gcp.credentials.json secret to true

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.11.0-preview08"
+version: "1.11.0-preview09"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION


## Proposed commit message

https://github.com/elastic/integrations/pull/11252 updated the kibana condition to include `^9.0.0` but did not add a changelog entry or bump the package version. this is what this PR does.
