### PR TITLE
Add the security capability to the tychon package

### DIFF
--- a/packages/tychon/changelog.yml
+++ b/packages/tychon/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add the security capability, as the package needs security features.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/11284
+      link: https://github.com/elastic/integrations/pull/11308
 - version: "0.1.1"
   changes:
     - description: Use triple-brace Mustache templating when referencing variables in ingest pipelines.

--- a/packages/tychon/changelog.yml
+++ b/packages/tychon/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.1.2"
+  changes:
+    - description: Add the security capability, as the package needs security features.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11284
 - version: "0.1.1"
   changes:
     - description: Use triple-brace Mustache templating when referencing variables in ingest pipelines.

--- a/packages/tychon/manifest.yml
+++ b/packages/tychon/manifest.yml
@@ -2,7 +2,7 @@ format_version: 3.2.2
 name: tychon
 type: integration
 title: "TYCHON Agentless"
-version: 0.1.1
+version: 0.1.2
 source:
   license: "Elastic-2.0"
 description: Collect complete master endpoint datasets including vulnerability and STIG to comply with DISA endpoint requirements and C2C without adding services to your endpoints.
@@ -15,6 +15,8 @@ conditions:
     version: "^8.14.0"
   elastic:
     subscription: "basic"
+    capabilities:
+      - security
 screenshots:
   - src: /img/screenshot-v-dashboards.png
     title: Dashboards


### PR DESCRIPTION
## Proposed commit message

Add the security capability to the tychon package, this package fails to start in deployments without security plugins:
```
Error: can't install the package: could not zip-install package; API status code = 400; response body = {"statusCode":400,"error":"Bad Request","message":"Encountered 17 errors creating saved objects: [{\"type\":\"security-rule\",\"id\":\"0c5a9660-eaa9-11ee-a30d-e7740197132d\",\"error\":{\"type\":\"unsupported_type\"}},{\"type\":\"security-rule\",\"id\":\"10359860-1139-11ee-af86-538da1394f27\",\"error\":{\"type\":\"unsupported_type\"}},{\"type\":\"security-rule\",\"id\":\"2140f083-6e39-4df4-ba41-aa1f41cb81b8\",\"error\":{\"type\":\"unsupported_type\"}}...
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] ~~I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

Thanks @mrodm for reporting!