### PR TITLE
Fix changelog in network traffic

### DIFF
--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,12 +1,20 @@
 # newer versions go on top
-- version: "1.31.1"
+- version: "1.32.1"
   changes:
-    - description: Add `event.module` to datastreams
+    - description: Add `event.module` to datastreams.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/10800
 - version: "1.32.0"
   changes:
-    - description: Set `map_to_ecs` to enabled by default
+    - description: event.module is not included in datastreams, this is an unexpected regression.
+      type: breaking-change
+      link: https://github.com/elastic/integrations/pull/10800
+- version: "1.31.1"
+  changes:
+    - description: Add `event.module` to datastreams.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10800
+    - description: Set `map_to_ecs` to enabled by default.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/10785
 - version: "1.31.0"

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: network_traffic
 title: Network Packet Capture
-version: "1.31.1"
+version: "1.32.1"
 description: Capture and analyze network traffic from a host with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
1.31.1 was released after 1.32.0, including more changes than 1.32.0. Upgrading to 1.32.0 actually causes regression as there is one change that is not included.

Adjust the changelog to represent the current state of packages, and release a new 1.32.1 version that includes the latest changes.

We detected this issue in https://github.com/elastic/package-spec/pull/808, adding validations to try to prevent this kind of problems.