### PR TITLE
Allow system package to be installed on 9.0.0+ as well

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.62.0"
+  changes:
+    - description: Allow package to be installed with Kibana 9.0.0+
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/11334
 - version: "1.61.0"
   changes:
     - description: Tighten IPv4 extraction from IPv4-mapped IPv6 addresses.

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -8,7 +8,7 @@ categories:
   - os_system
 conditions:
   kibana:
-    version: "^8.13.0"
+    version: "^8.13.0 || ^9.0.0"
 screenshots:
   - src: /img/system-overview.png
     title: system overview

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: system
 title: System
-version: "1.61.0"
+version: "1.62.0"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

This change allows the `system` package to be installed on 9.0.0+ as well.

See also https://github.com/elastic/elastic-package/blob/main/docs/howto/stack_version_support.md#support-for-multiple-majors.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

