### PR TITLE
o365: Add missing `resource.timeout` to CEL input.

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add missing resource_timeout to CEL input.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1111
+      link: https://github.com/elastic/integrations/pull/11342
 - version: "2.6.1"
   changes:
     - description: Use triple-brace Mustache templating when referencing variables in ingest pipelines.

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.6.2"
+  changes:
+    - description: Add missing resource_timeout to CEL input.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1111
 - version: "2.6.1"
   changes:
     - description: Use triple-brace Mustache templating when referencing variables in ingest pipelines.

--- a/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
@@ -20,6 +20,9 @@ resource.url: {{url}}
 resource.ssl: 
   {{resource_ssl}}
 {{/if}}
+{{#if resource_timeout}}
+resource.timeout: {{resource_timeout}}
+{{/if}}
 {{#if resource_proxy_url}}
 resource.proxy_url: {{resource_proxy_url}}
 {{/if}}

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft Office 365
-version: "2.6.1"
+version: "2.6.2"
 description: Collect logs from Microsoft Office 365 with Elastic Agent.
 type: integration
 format_version: "3.0.2"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
Add missing `resource.timeout` to CEL input.

Although the parameter `resource_timeout` is defined in `manifest.yml`, 
it is missing from the input file. This PR adds `resource.timeout` to input.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

