### PR TITLE
[azure_metrics] Enable subobjects: false on azure.resource.tags.*

### DIFF
--- a/packages/azure_metrics/data_stream/compute_vm/_dev/test/pipeline/test-azure-metrics-compute-vm.json
+++ b/packages/azure_metrics/data_stream/compute_vm/_dev/test/pipeline/test-azure-metrics-compute-vm.json
@@ -81,7 +81,8 @@
                     "group": "obs-infrastructure",
                     "tags": {
                         "vmtest1": "value3",
-                        "vmtest": "value1, value 2"
+                        "vmtest": "value1, value 2",
+                        "i.contain.dots": "value4"
                     }
                 },
                 "namespace": "Microsoft.Compute/virtualMachines",

--- a/packages/azure_metrics/data_stream/compute_vm/_dev/test/pipeline/test-azure-metrics-compute-vm.json-expected.json
+++ b/packages/azure_metrics/data_stream/compute_vm/_dev/test/pipeline/test-azure-metrics-compute-vm.json-expected.json
@@ -30,7 +30,8 @@
                     "name": "obstestmemleak",
                     "tags": {
                         "vmtest": "value1, value 2",
-                        "vmtest1": "value3"
+                        "vmtest1": "value3",
+                        "i.contain.dots": "value4"
                     },
                     "type": "Microsoft.Compute/virtualMachines"
                 },

--- a/packages/azure_metrics/data_stream/compute_vm/fields/package-fields.yml
+++ b/packages/azure_metrics/data_stream/compute_vm/fields/package-fields.yml
@@ -39,6 +39,7 @@
           type: object
           object_type: keyword
           object_type_mapping_type: "*"
+          subobjects: false
           description: >
             Azure resource tags.
 

--- a/packages/azure_metrics/data_stream/compute_vm_scaleset/_dev/test/pipeline/test-azure-metrics-compute-vm-scaleset.json
+++ b/packages/azure_metrics/data_stream/compute_vm_scaleset/_dev/test/pipeline/test-azure-metrics-compute-vm-scaleset.json
@@ -71,7 +71,11 @@
                     "name": "obswinvmss",
                     "id": "/subscriptions/70bd6e77-4b1e-4835-8896-db77b8eef364/resourceGroups/obs-infrastructure/providers/Microsoft.Compute/virtualMachineScaleSets/obswinvmss",
                     "type": "Microsoft.Compute/virtualMachineScaleSets",
-                    "group": "obs-infrastructure"
+                    "group": "obs-infrastructure",
+                    "tags": {
+                        "vmtest1": "value1",
+                        "i.contain.dots": "value2"
+                    }                    
                 },
                 "namespace": "Microsoft.Compute/virtualMachineScaleSets"
             }

--- a/packages/azure_metrics/data_stream/compute_vm_scaleset/_dev/test/pipeline/test-azure-metrics-compute-vm-scaleset.json-expected.json
+++ b/packages/azure_metrics/data_stream/compute_vm_scaleset/_dev/test/pipeline/test-azure-metrics-compute-vm-scaleset.json-expected.json
@@ -16,7 +16,11 @@
                     "group": "obs-infrastructure",
                     "id": "/subscriptions/70bd6e77-4b1e-4835-8896-db77b8eef364/resourceGroups/obs-infrastructure/providers/Microsoft.Compute/virtualMachineScaleSets/obswinvmss",
                     "name": "obswinvmss",
-                    "type": "Microsoft.Compute/virtualMachineScaleSets"
+                    "type": "Microsoft.Compute/virtualMachineScaleSets",
+                    "tags": {
+                        "vmtest1": "value1",
+                        "i.contain.dots": "value2"
+                    }                       
                 },
                 "subscription_id": "70bd6e77-4b1e-4835-8896-db77b8eef364",
                 "timegrain": "PT5M"

--- a/packages/azure_metrics/data_stream/compute_vm_scaleset/fields/package-fields.yml
+++ b/packages/azure_metrics/data_stream/compute_vm_scaleset/fields/package-fields.yml
@@ -39,6 +39,7 @@
           type: object
           object_type: keyword
           object_type_mapping_type: "*"
+          subobjects: false
           description: >
             Azure resource tags.
 

--- a/packages/azure_metrics/data_stream/container_instance/_dev/test/pipeline/test-azure-metrics-container-instance.json
+++ b/packages/azure_metrics/data_stream/container_instance/_dev/test/pipeline/test-azure-metrics-container-instance.json
@@ -63,7 +63,8 @@
                     "id": "/subscriptions/70bd6e77-4b1e-4835-8896-db77b8eef364/resourceGroups/obs-infrastructure/providers/Microsoft.ContainerInstance/containerGroups/testcontainergroup",
                     "type": "Microsoft.ContainerInstance/containerGroups",
                     "tags": {
-                        "tag1": "value1"
+                        "tag1": "value1",
+                        "i.contain.dots": "value2"
                     },
                     "group": "obs-infrastructure"
                 },

--- a/packages/azure_metrics/data_stream/container_instance/_dev/test/pipeline/test-azure-metrics-container-instance.json-expected.json
+++ b/packages/azure_metrics/data_stream/container_instance/_dev/test/pipeline/test-azure-metrics-container-instance.json-expected.json
@@ -17,7 +17,8 @@
                     "id": "/subscriptions/70bd6e77-4b1e-4835-8896-db77b8eef364/resourceGroups/obs-infrastructure/providers/Microsoft.ContainerInstance/containerGroups/testcontainergroup",
                     "name": "testcontainergroup",
                     "tags": {
-                        "tag1": "value1"
+                        "tag1": "value1",
+                        "i.contain.dots": "value2"
                     },
                     "type": "Microsoft.ContainerInstance/containerGroups"
                 },

--- a/packages/azure_metrics/data_stream/container_registry/fields/package-fields.yml
+++ b/packages/azure_metrics/data_stream/container_registry/fields/package-fields.yml
@@ -39,6 +39,7 @@
           type: object
           object_type: keyword
           object_type_mapping_type: "*"
+          subobjects: false
           description: >
             Azure resource tags.
 

--- a/packages/azure_metrics/data_stream/container_service/_dev/test/pipeline/test-azure-container-service.json
+++ b/packages/azure_metrics/data_stream/container_service/_dev/test/pipeline/test-azure-container-service.json
@@ -94,7 +94,8 @@
                     "type": "Microsoft.ContainerService/managedClusters",
                     "group": "test_group",
                     "tags": {
-                        "custodian_status": "Resource does not meet policy: delete@2023/09/26"
+                        "custodian_status": "Resource does not meet policy: delete@2023/09/26",
+                        "i.contain.dots": "value2"
                     }
                 },
                 "namespace": "Microsoft.ContainerService/managedClusters",

--- a/packages/azure_metrics/data_stream/container_service/_dev/test/pipeline/test-azure-container-service.json-expected.json
+++ b/packages/azure_metrics/data_stream/container_service/_dev/test/pipeline/test-azure-container-service.json-expected.json
@@ -26,7 +26,8 @@
                     "id": "/subscriptions/a2960656-390f-47b5-a154-b048d34ab096/resourceGroups/test_group/providers/Microsoft.ContainerService/managedClusters/test",
                     "name": "test",
                     "tags": {
-                        "custodian_status": "Resource does not meet policy: delete@2023/09/26"
+                        "custodian_status": "Resource does not meet policy: delete@2023/09/26",
+                        "i.contain.dots": "value2"
                     },
                     "type": "Microsoft.ContainerService/managedClusters"
                 },

--- a/packages/azure_metrics/data_stream/container_service/fields/package-fields.yml
+++ b/packages/azure_metrics/data_stream/container_service/fields/package-fields.yml
@@ -39,6 +39,7 @@
           type: object
           object_type: keyword
           object_type_mapping_type: "*"
+          subobjects: false
           description: >
             Azure resource tags.
 

--- a/packages/azure_metrics/data_stream/database_account/fields/package-fields.yml
+++ b/packages/azure_metrics/data_stream/database_account/fields/package-fields.yml
@@ -39,6 +39,7 @@
           type: object
           object_type: keyword
           object_type_mapping_type: "*"
+          subobjects: false
           description: >
             Azure resource tags.
 

--- a/packages/azure_metrics/data_stream/monitor/fields/package-fields.yml
+++ b/packages/azure_metrics/data_stream/monitor/fields/package-fields.yml
@@ -39,6 +39,7 @@
           type: object
           object_type: keyword
           object_type_mapping_type: "*"
+          subobjects: false
           description: >
             Azure resource tags.
 

--- a/packages/azure_metrics/data_stream/storage_account/fields/package-fields.yml
+++ b/packages/azure_metrics/data_stream/storage_account/fields/package-fields.yml
@@ -39,6 +39,7 @@
           type: object
           object_type: keyword
           object_type_mapping_type: "*"
+          subobjects: false
           description: >
             Azure resource tags.
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Update `azure.resource.tags` mapping setting `subobjects: true`.

On Azure, users can set tag names with dots. When a tag name contains a dot, Elasticsearch expands the dots in the name into an object value, creating a conflict with the expected mapping. 

This change allow users to index documents like this:

```
POST metrics-azure.monitor-pr11345/_doc
{
  "@timestamp": "2024-10-07T12:29:24+02:00",
  "azure": {
    "resource": {
      "id": "795166f8-3743-48dc-9d2e-3807f0375679",
      "tags": {
        "a": 1,
        "tag.with.dots": "value"
      }
    }
  }
}
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


<!-- Recommended
## Author's Checklist
Add a checklist of things that are required to be reviewed in order to have the PR approved
- [ ] 
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/integrations/issues/11343


<!-- Optional
## Screenshots
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
