### PR TITLE
Remove visualizations team from PR reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,7 +69,7 @@
 /packages/aws/data_stream/route53_resolver_logs @elastic/security-service-integrations
 /packages/aws/data_stream/vpcflow @elastic/security-service-integrations
 /packages/aws/data_stream/waf @elastic/security-service-integrations
-/packages/aws/kibana @elastic/obs-ds-hosted-services @elastic/kibana-visualizations @elastic/obs-infraobs-integrations
+/packages/aws/kibana @elastic/obs-ds-hosted-services @elastic/obs-infraobs-integrations
 /packages/aws/manifest.yml @elastic/obs-ds-hosted-services @elastic/security-service-integrations @elastic/obs-infraobs-integrations
 /packages/aws_bedrock @elastic/security-service-integrations
 /packages/aws_logs @elastic/obs-ds-hosted-services
@@ -254,7 +254,7 @@
 /packages/keycloak @elastic/security-service-integrations
 /packages/kibana @elastic/stack-monitoring
 /packages/kubernetes @elastic/obs-cloudnative-monitoring
-/packages/kubernetes/kibana @elastic/obs-cloudnative-monitoring @elastic/kibana-visualizations
+/packages/kubernetes/kibana @elastic/obs-cloudnative-monitoring
 /packages/kubernetes_otel @elastic/obs-cloudnative-monitoring
 /packages/lastpass @elastic/security-service-integrations
 /packages/linux @elastic/elastic-agent-data-plane

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,6 +33,7 @@ The text here and the PR title will be subject to the PR review process.
 - [ ] I have verified that all data streams collect metrics or logs.
 - [ ] I have added an entry to my package's `changelog.yml` file.
 - [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
+- [ ] I have verified that any added dashboard complies with Kibana's [Dashbaord good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
 
 ## Author's Checklist
 


### PR DESCRIPTION
The Kibana visualization team is not currently adding a lot of value in the PR review process, due to the lack of context and the lack of time/effort we can spend on that.
The initial reason why we where part of the PR reviews was to support the migration and use of Lens visualizations.
Right now I don't see anymore the need for this step and our PR check is usually unnecessary.

I've removed our team from being pinged about Kibana dashboard integration changes.
I've also added a check in the checklist that I believe is useful: it gives the link for the dashboard good practices in data visualization, that we believe are useful when developing and designing new integration dashboards.
If you feel the need of more or direct help in that, please contact the @elastic/kibana-visualizations team here or on Slack.
