### PR TITLE
[squid] Reorder processors to ensure more fields are extracted

### DIFF
--- a/packages/squid/changelog.yml
+++ b/packages/squid/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Reorder processors to ensure more fields are extracted if a url parsing error occurs.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.0.0"
   changes:
     - description: Add dashboard and improve documentation. Release integration as GA.

--- a/packages/squid/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/squid/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -88,22 +88,6 @@ processors:
       target_field: destination.bytes
       ignore_missing: true
 
-  - rename:
-      tag: move_http_method
-      field: _tmp.method
-      target_field: http.request.method
-      ignore_missing: true
-  - uri_parts:
-      tag: uri_parts
-      field: _tmp.url
-      if: ctx.http?.request?.method != 'CONNECT'
-      ignore_missing: true
-  - rename:
-      tag: move_connect_hostport
-      field: _tmp.url
-      target_field: url.original
-      if: ctx._tmp?.url != null && ctx.http?.request?.method == 'CONNECT'
-
   - set:
       tag: set_event_outcome_success
       field: event.outcome
@@ -141,6 +125,55 @@ processors:
       field: _tmp.peer_host
       target_field: destination.address
       ignore_missing: true
+
+  - geoip:
+      tag: geoip_source_ip
+      field: source.ip
+      target_field: source.geo
+      ignore_missing: true
+  - geoip:
+      tag: geoip_source_as
+      database_file: GeoLite2-ASN.mmdb
+      field: source.ip
+      target_field: source.as
+      properties:
+        - asn
+        - organization_name
+      ignore_missing: true
+  - rename:
+      tag: rename_source_as_asn
+      field: source.as.asn
+      target_field: source.as.number
+      ignore_missing: true
+  - rename:
+      tag: rename_source_as_organization_name
+      field: source.as.organization_name
+      target_field: source.as.organization.name
+      ignore_missing: true
+
+  - append:
+      tag: append_related_source_ip
+      field: related.ip
+      value: '{{{source.ip}}}'
+      allow_duplicates: false
+      if: ctx.source?.ip != null
+
+  - rename:
+      tag: move_http_method
+      field: _tmp.method
+      target_field: http.request.method
+      ignore_missing: true
+  - uri_parts:
+      tag: uri_parts
+      field: _tmp.url
+      if: ctx.http?.request?.method != 'CONNECT'
+      ignore_missing: true
+  - rename:
+      tag: move_connect_hostport
+      field: _tmp.url
+      target_field: url.original
+      if: ctx._tmp?.url != null && ctx.http?.request?.method == 'CONNECT'
+
   - set:
       tag: set_url_destination_address
       field: destination.address
@@ -156,23 +189,9 @@ processors:
       ignore_missing: true
 
   - geoip:
-      tag: geoip_source_ip
-      field: source.ip
-      target_field: source.geo
-      ignore_missing: true
-  - geoip:
       tag: geoip_destination_ip
       field: destination.ip
       target_field: destination.geo
-      ignore_missing: true
-  - geoip:
-      tag: geoip_source_as
-      database_file: GeoLite2-ASN.mmdb
-      field: source.ip
-      target_field: source.as
-      properties:
-        - asn
-        - organization_name
       ignore_missing: true
   - geoip:
       tag: geoip_destination_as
@@ -183,16 +202,7 @@ processors:
         - asn
         - organization_name
       ignore_missing: true
-  - rename:
-      tag: rename_source_as_asn
-      field: source.as.asn
-      target_field: source.as.number
-      ignore_missing: true
-  - rename:
-      tag: rename_source_as_organization_name
-      field: source.as.organization_name
-      target_field: source.as.organization.name
-      ignore_missing: true
+
   - rename:
       tag: rename_destination_as_asn
       field: destination.as.asn
@@ -216,12 +226,6 @@ processors:
       value: '{{{url.domain}}}'
       allow_duplicates: false
       if: ctx.url?.domain != null
-  - append:
-      tag: append_related_source_ip
-      field: related.ip
-      value: '{{{source.ip}}}'
-      allow_duplicates: false
-      if: ctx.source?.ip != null
   - append:
       tag: append_related_destination_ip
       field: related.ip

--- a/packages/squid/manifest.yml
+++ b/packages/squid/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: squid
 title: Squid Proxy
-version: "1.0.0"
+version: "1.0.1"
 description: Collect and parse logs from Squid devices with Elastic Agent.
 categories:
   - network


### PR DESCRIPTION
## Proposed commit message

- Reorder processors to ensure more fields are extracted if a url parsing error occurs.
- Add remove processor to failure handler to ensure tmp fields are removed

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #10951 
