### PR TITLE
aws.firewall_logs: flaky-test: Increase wait time for data.

### DIFF
--- a/packages/aws/data_stream/firewall_logs/_dev/test/system/test-default-config.yml
+++ b/packages/aws/data_stream/firewall_logs/_dev/test/system/test-default-config.yml
@@ -1,5 +1,5 @@
 input: aws-s3
-wait_for_data_timeout: 20m
+wait_for_data_timeout: 30m
 vars:
   access_key_id: "{{AWS_ACCESS_KEY_ID}}"
   secret_access_key: "{{AWS_SECRET_ACCESS_KEY}}"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
A possible fix for flaky system test. 
This PR increases wait time for data retrieval.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates: https://github.com/elastic/integrations/issues/11088