### PR TITLE
[Cloud Security] increase transfom retention_policy to 90 days for Wiz

### DIFF
--- a/packages/wiz/changelog.yml
+++ b/packages/wiz/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "1.9.0-preview05"
   changes:
-    - description: Increase retention on transfroms
+    - description: Increase retention on transfroms to 90 days.
       type: enhancement
-      link: tbd
+      link: https://github.com/elastic/integrations/pull/11393
 - version: "1.9.0-preview04"
   changes:
     - description: Update vulnerabilities mappings and ingest pipeline for better support in CDR.

--- a/packages/wiz/changelog.yml
+++ b/packages/wiz/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.0-preview05"
+  changes:
+    - description: Increase retention on transfroms
+      type: enhancement
+      link: tbd
 - version: "1.9.0-preview04"
   changes:
     - description: Update vulnerabilities mappings and ingest pipeline for better support in CDR.

--- a/packages/wiz/elasticsearch/transform/latest_cdr_misconfigurations/transform.yml
+++ b/packages/wiz/elasticsearch/transform/latest_cdr_misconfigurations/transform.yml
@@ -20,7 +20,7 @@ sync:
 retention_policy:
   time:
     field: "@timestamp"
-    max_age: 26h
+    max_age: 90d
 settings:
   unattended: true
 _meta:

--- a/packages/wiz/elasticsearch/transform/latest_cdr_vulnerabilities/transform.yml
+++ b/packages/wiz/elasticsearch/transform/latest_cdr_vulnerabilities/transform.yml
@@ -24,7 +24,7 @@ sync:
 retention_policy:
   time:
     field: "@timestamp"
-    max_age: 3d
+    max_age: 90d
 _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.

--- a/packages/wiz/manifest.yml
+++ b/packages/wiz/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: wiz
 title: Wiz
-version: "1.9.0-preview04"
+version: "1.9.0-preview05"
 description: Collect logs from Wiz with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Increase retention policy to 90 days on Wiz transforms to cater for how Wiz evaluates environments for posture. In contrast to native CSP integration Wiz doesn't do regular full re-evaluation of customer environments, that's why short retention period mean customers having only a small slice of their posture. The change will go together with documentation on how to get more complete view for the posture using longer initial interval setting value

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Build and install integration, ingest some data from Wiz, check that latest index contains documents without 90d period

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/security-team/issues/10683 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
