### PR TITLE
[AuditdManager] Reverting Session Data option

### DIFF
--- a/packages/auditd_manager/_dev/build/docs/README.md
+++ b/packages/auditd_manager/_dev/build/docs/README.md
@@ -5,21 +5,11 @@ is a part of the Linux kernel.
 
 This integration is available only for Linux.
 
-## Session View powered by Auditd Manager
+## Session View powered by Auditd Manager [BETA]
 
-The Auditd Manager is one of the integrations that can power the [Session View](https://www.elastic.co/guide/en/security/current/session-view.html) utility for the Elastic Security Platform. This feature provides a visual representation of session and process execution data, organized according to the Linux process model to help you investigate process, user, and service activity on your Linux infrastructure.
+The `add_session_metadata` processor for Auditd Manager powers the [Session View](https://www.elastic.co/guide/en/security/current/session-view.html) utility for the Elastic Security Platform.
 
-### Enabling Session Data Capture
-
-There are two ways to enable session data capture for the Session View feature:
-
-#### Method 1: Using the Toggle Switch (Recommended)
-
-1. Navigate to the Auditd Manager integration configuration in Kibana.
-2. Locate the "Session data" toggle switch.
-3. Turn the switch on to enable session data capture.
-
-#### Method 2: Manual Configuration
+To enable the `add_session_metadata` processor for Auditd Manager: 
 
 1. Navigate to the Auditd Manager integration configuration in Kibana.
 2. Add the `add_session_metadata` processor configuration under the **Processors** section of Advanced options.
@@ -38,13 +28,6 @@ There are two ways to enable session data capture for the Session View feature:
 ```
 
 Changes are applied automatically, and you do not have to restart the service.
-
-### Important Notes
-
-- Using the toggle switch (Method 1) automatically applies these configurations, making it the simpler option for most users.
-- When enabling session data capture, be aware that it will collect extended process data, which may have privacy and storage implications.
-- You can disable session data capture at any time by turning off the toggle switch or removing the manual configurations.
-- If you switch between methods or disable the feature, ensure that any conflicting configurations are removed to avoid unexpected behaviour.
 
 ## How it works
 

--- a/packages/auditd_manager/changelog.yml
+++ b/packages/auditd_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.1"
+  changes:
+    - description: "Reverting Session data option"
+      type: fix
+      link: https://github.com/elastic/integrations/issues/11336
 - version: "1.18.0"
   changes:
     - description: "Added Session data option"

--- a/packages/auditd_manager/changelog.yml
+++ b/packages/auditd_manager/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: "Reverting Session data option"
       type: fix
-      link: https://github.com/elastic/integrations/issues/11336
+      link: https://github.com/elastic/integrations/issues/11420
 - version: "1.18.0"
   changes:
     - description: "Added Session data option"

--- a/packages/auditd_manager/changelog.yml
+++ b/packages/auditd_manager/changelog.yml
@@ -2,7 +2,7 @@
 - version: "1.18.1"
   changes:
     - description: "Reverting Session data option"
-      type: fix
+      type: bugfix
       link: https://github.com/elastic/integrations/issues/11420
 - version: "1.18.0"
   changes:

--- a/packages/auditd_manager/data_stream/auditd/agent/stream/auditd.yml.hbs
+++ b/packages/auditd_manager/data_stream/auditd/agent/stream/auditd.yml.hbs
@@ -7,17 +7,8 @@ socket_type: '{{socket_type}}'
 immutable: {{immutable}}
 resolve_ids: {{resolve_ids}}
 failure_mode: {{failure_mode}}
-{{#if session_data}}
-audit_rules: "{{escape_multiline_string audit_rules}}
-{{escape_multiline_string "
-# Session data audit rules
--a always,exit -F arch=b64 -S execve,execveat -k exec
--a always,exit -F arch=b64 -S exit_group
--a always,exit -F arch=b64 -S setsid"}}"
-{{else}}
 {{#if audit_rules}}
 audit_rules: {{escape_string audit_rules}}
-{{/if}}
 {{/if}}
 {{#if audit_rule_files.length}}
 audit_rule_files:
@@ -42,12 +33,4 @@ publisher_pipeline.disable_host: true
 {{#if processors}}
 processors:
 {{processors}}
-{{#if session_data}}
-{{session_data_processors}}
-{{/if}}
-{{else}}
-{{#if session_data}}
-processors:
-{{session_data_processors}}
-{{/if}}
 {{/if}}

--- a/packages/auditd_manager/data_stream/auditd/manifest.yml
+++ b/packages/auditd_manager/data_stream/auditd/manifest.yml
@@ -33,19 +33,6 @@ streams:
 
           If `auto` is selected, `elastic-agent` will attempt to use multicast sockets, falling
           back to unicast if multicast is not available.
-      - name: session_data
-        type: bool
-        title: Session data
-        show_user: true
-        multi: false
-        default: false
-        description: |
-          Turn this on to capture the extended process data required for Session View. 
-          Session View provides you a visual representation of session and process execution data.
-          
-          Session View data is organized according to the Linux process model to help you 
-          investigate process, user, and service activity on your Linux infrastructure.
-          [Learn more](https://www.elastic.co/guide/en/security/current/session-view.html) 
       - name: immutable
         type: bool
         title: Immutable
@@ -190,14 +177,3 @@ streams:
         description: |
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata.
           This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
-      - name: session_data_processors
-        type: yaml
-        title: Session data processors
-        required: false
-        show_user: false
-        multi: false
-        description: |
-          These processors will be appended to the processors configuration if Session Data is enabled.
-        default: >2-
-            - add_session_metadata:
-               backend: "auto"

--- a/packages/auditd_manager/docs/README.md
+++ b/packages/auditd_manager/docs/README.md
@@ -5,21 +5,11 @@ is a part of the Linux kernel.
 
 This integration is available only for Linux.
 
-## Session View powered by Auditd Manager
+## Session View powered by Auditd Manager [BETA]
 
-The Auditd Manager is one of the integrations that can power the [Session View](https://www.elastic.co/guide/en/security/current/session-view.html) utility for the Elastic Security Platform. This feature provides a visual representation of session and process execution data, organized according to the Linux process model to help you investigate process, user, and service activity on your Linux infrastructure.
+The `add_session_metadata` processor for Auditd Manager powers the [Session View](https://www.elastic.co/guide/en/security/current/session-view.html) utility for the Elastic Security Platform.
 
-### Enabling Session Data Capture
-
-There are two ways to enable session data capture for the Session View feature:
-
-#### Method 1: Using the Toggle Switch (Recommended)
-
-1. Navigate to the Auditd Manager integration configuration in Kibana.
-2. Locate the "Session data" toggle switch.
-3. Turn the switch on to enable session data capture.
-
-#### Method 2: Manual Configuration
+To enable the `add_session_metadata` processor for Auditd Manager: 
 
 1. Navigate to the Auditd Manager integration configuration in Kibana.
 2. Add the `add_session_metadata` processor configuration under the **Processors** section of Advanced options.
@@ -38,13 +28,6 @@ There are two ways to enable session data capture for the Session View feature:
 ```
 
 Changes are applied automatically, and you do not have to restart the service.
-
-### Important Notes
-
-- Using the toggle switch (Method 1) automatically applies these configurations, making it the simpler option for most users.
-- When enabling session data capture, be aware that it will collect extended process data, which may have privacy and storage implications.
-- You can disable session data capture at any time by turning off the toggle switch or removing the manual configurations.
-- If you switch between methods or disable the feature, ensure that any conflicting configurations are removed to avoid unexpected behaviour.
 
 ## How it works
 

--- a/packages/auditd_manager/manifest.yml
+++ b/packages/auditd_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: auditd_manager
 title: "Auditd Manager"
-version: "1.18.0"
+version: "1.18.1"
 description: "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel."
 type: integration
 categories:

--- a/packages/auditd_manager/manifest.yml
+++ b/packages/auditd_manager/manifest.yml
@@ -9,7 +9,7 @@ categories:
   - auditd
 conditions:
   kibana:
-    version: "^8.16.0 || ^9.0.0"
+    version: "^8.16.0"
 screenshots:
   - src: /img/overview.png
     title: Overview Dashboard


### PR DESCRIPTION
## Proposed commit message

This PR reverts the Session Data option introduced on [this](https://github.com/elastic/integrations/pull/11336) PR.

The revert is needed because the `1.8.0` version relies on the `escape_multiline_string` helper that was introduced in Kibana in [this](https://github.com/elastic/kibana/pull/195159) PR. 

It fixes the error below when attempting to save the Auditd Manager integration version `1.8.0` in Serverless environments that don't contain the [Kibana](https://github.com/elastic/kibana/pull/195159) changes:

![image](https://github.com/user-attachments/assets/6ecd42a3-a50e-4c82-a551-1c47eace712b)

Reasoning:

1.8.0 manifest was set to be enabled Starting on Kibana 8.16+, but serverless release cadences follow a different cadence and it's on version 9.0.0 already, therefore  [this Kibana PR](https://github.com/elastic/integrations/pull/11336) must be deployed on serverless in order to `escape_multiline_string` be available.


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

