### PR TITLE
Change format_spec in the kubernetes_otel package to 3.3.0

### DIFF
--- a/packages/kubernetes_otel/changelog.yml
+++ b/packages/kubernetes_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.0.4"
+  changes:
+    - description: Update format_spec to target 3.3.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/11435
 - version: "0.0.3"
   changes:
     - description: Add a link to the onboarding flow, fix the package logo

--- a/packages/kubernetes_otel/manifest.yml
+++ b/packages/kubernetes_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.0
 name: kubernetes_otel
 title: "Kubernetes OpenTelemetry Assets"
-version: 0.0.3
+version: 0.0.4
 description: "Utilise the pre-built dashboard for OTel-native metrics and events collected from a Kubernetes cluster"
 type: content
 categories:

--- a/packages/kubernetes_otel/manifest.yml
+++ b/packages/kubernetes_otel/manifest.yml
@@ -1,4 +1,4 @@
-format_version: 3.4.0
+format_version: 3.3.0
 name: kubernetes_otel
 title: "Kubernetes OpenTelemetry Assets"
 version: 0.0.3


### PR DESCRIPTION
Change `format_spec` in the `kubernetes_otel` package to 3.3.0 as support for content packages is added to `3.3.0`. 

Related to https://github.com/elastic/package-spec/pull/818