### PR TITLE
[cisco_duo] Set request rate limits

### DIFF
--- a/packages/cisco_duo/changelog.yml
+++ b/packages/cisco_duo/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.0.3"
+  changes:
+    - description: Set request rate limits
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11441
 - version: "2.0.2"
   changes:
     - description: Return response body when a non-200 HTTP status is returned by the API.

--- a/packages/cisco_duo/changelog.yml
+++ b/packages/cisco_duo/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.0.3"
   changes:
-    - description: Set request rate limits
+    - description: Set request rate limits.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/11441
 - version: "2.0.2"

--- a/packages/cisco_duo/data_stream/admin/agent/stream/httpjson.yml.hbs
+++ b/packages/cisco_duo/data_stream/admin/agent/stream/httpjson.yml.hbs
@@ -6,6 +6,7 @@ request.tracer.maxbackups: 5
 {{/if}}
 request.method: GET
 request.url: {{hostname}}/admin/v1/logs/administrator
+request.rate_limit.limit: "0.5"
 request.transforms:
   - set:
       target: url.params.mintime

--- a/packages/cisco_duo/data_stream/auth/agent/stream/cel.yml.hbs
+++ b/packages/cisco_duo/data_stream/auth/agent/stream/cel.yml.hbs
@@ -1,6 +1,8 @@
 config_version: 2
 interval: {{interval}}
 resource.url: {{hostname}}
+resource.rate_limit.burst: 1
+resource.rate_limit.limit: 0.5
 
 {{#if enable_request_tracer}}
 resource.tracer.filename: "../../logs/cel/http-request-trace-*.ndjson"

--- a/packages/cisco_duo/data_stream/auth/agent/stream/httpjson.yml.hbs
+++ b/packages/cisco_duo/data_stream/auth/agent/stream/httpjson.yml.hbs
@@ -6,6 +6,7 @@ request.tracer.maxbackups: 5
 {{/if}}
 request.method: GET
 request.url: {{hostname}}/admin/v2/logs/authentication
+request.rate_limit.limit: "0.5"
 request.transforms:
   - set:
       target: url.params.limit

--- a/packages/cisco_duo/data_stream/offline_enrollment/agent/stream/httpjson.yml.hbs
+++ b/packages/cisco_duo/data_stream/offline_enrollment/agent/stream/httpjson.yml.hbs
@@ -6,6 +6,7 @@ request.tracer.filename: "../../logs/httpjson/http-request-trace-*.ndjson"
 request.tracer.maxbackups: 5
 {{/if}}
 request.url: {{hostname}}/admin/v1/logs/offline_enrollment
+request.rate_limit.limit: "0.5"
 request.transforms:
   - set:
       target: url.params.mintime

--- a/packages/cisco_duo/data_stream/summary/agent/stream/httpjson.yml.hbs
+++ b/packages/cisco_duo/data_stream/summary/agent/stream/httpjson.yml.hbs
@@ -6,6 +6,7 @@ request.tracer.maxbackups: 5
 {{/if}}
 request.method: GET
 request.url: {{hostname}}/admin/v1/info/summary
+request.rate_limit.limit: "0.5"
 request.transforms:
   - set:
       target: header.Date

--- a/packages/cisco_duo/data_stream/telephony/agent/stream/httpjson.yml.hbs
+++ b/packages/cisco_duo/data_stream/telephony/agent/stream/httpjson.yml.hbs
@@ -6,6 +6,7 @@ request.tracer.maxbackups: 5
 {{/if}}
 request.method: GET
 request.url: {{hostname}}/admin/v1/logs/telephony
+request.rate_limit.limit: "0.5"
 request.transforms:
   - set:
       target: url.params.mintime

--- a/packages/cisco_duo/data_stream/telephony_v2/agent/stream/cel.yml.hbs
+++ b/packages/cisco_duo/data_stream/telephony_v2/agent/stream/cel.yml.hbs
@@ -1,6 +1,8 @@
 config_version: 2
 interval: {{interval}}
 resource.url: {{hostname}}
+resource.rate_limit.burst: 1
+resource.rate_limit.limit: 0.5
 
 {{#if enable_request_tracer}}
 resource.tracer.filename: "../../logs/cel/http-request-trace-*.ndjson"

--- a/packages/cisco_duo/manifest.yml
+++ b/packages/cisco_duo/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cisco_duo
 title: Cisco Duo
-version: "2.0.2"
+version: "2.0.3"
 description: Collect logs from Cisco Duo with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[cisco_duo] Set request rate limits

The Duo Admin API has rate limiting. It doesn't return rate limit
headers, but it does enforce limits with HTTP 429 responses.

For some endpoints, the API documentation specifies "a rate limit of 50
calls per minute". This as also been observed on the authentication
logs endpoint.

This changes sets a limit of 0.5 calls/second or 30 calls per minute
for all data streams and inputs.

HTTP 429 responses continue to be treated as errors.

API documentation: https://duo.com/docs/adminapi
```

I considered returning `{ "events": [], "want_more": false }` when a 429 response is received, however, with the new settings we expect to never exceed the limit, and if the limit is repeatedly exceeded, treating it as an error will help with troubleshooting.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)