### PR TITLE
Remove events from Otel Kubernetes General Dashboard

### DIFF
--- a/packages/kubernetes_otel/changelog.yml
+++ b/packages/kubernetes_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.0.5"
+  changes:
+    - description: Remove events from overview dashboard
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/11435
 - version: "0.0.4"
   changes:
     - description: Update format_spec to target 3.3.0

--- a/packages/kubernetes_otel/changelog.yml
+++ b/packages/kubernetes_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove events from overview dashboard
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/11435
+      link: https://github.com/elastic/integrations/pull/11451
 - version: "0.0.4"
   changes:
     - description: Update format_spec to target 3.3.0

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-cluster-overview.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-cluster-overview.json
@@ -117,12 +117,12 @@
                 },
                 "gridData": {
                     "h": 8,
-                    "i": "42314208-b335-435d-8a60-51f8ba7ba1f4",
+                    "i": "565acaa6-6a64-470e-a010-29004cb12359",
                     "w": 5,
                     "x": 0,
                     "y": 0
                 },
-                "panelIndex": "42314208-b335-435d-8a60-51f8ba7ba1f4",
+                "panelIndex": "565acaa6-6a64-470e-a010-29004cb12359",
                 "type": "visualization"
             },
             {
@@ -216,12 +216,12 @@
                 },
                 "gridData": {
                     "h": 4,
-                    "i": "9e64b0ef-52e1-4a05-9757-49e055cdcb35",
+                    "i": "c0c242f5-2181-40fe-b528-c99916ccc0f2",
                     "w": 8,
                     "x": 5,
                     "y": 0
                 },
-                "panelIndex": "9e64b0ef-52e1-4a05-9757-49e055cdcb35",
+                "panelIndex": "c0c242f5-2181-40fe-b528-c99916ccc0f2",
                 "title": "",
                 "type": "lens"
             },
@@ -511,12 +511,12 @@
                 },
                 "gridData": {
                     "h": 8,
-                    "i": "bd3914d9-a15c-42c1-844d-14ffd8c72c47",
+                    "i": "8560ee90-bc32-4277-b414-38d6b26d5ec3",
                     "w": 18,
                     "x": 13,
                     "y": 0
                 },
-                "panelIndex": "bd3914d9-a15c-42c1-844d-14ffd8c72c47",
+                "panelIndex": "8560ee90-bc32-4277-b414-38d6b26d5ec3",
                 "title": "CPU Usage",
                 "type": "lens"
             },
@@ -803,12 +803,12 @@
                 },
                 "gridData": {
                     "h": 8,
-                    "i": "37cf1481-5ec6-4812-82cd-a96af4b42b24",
+                    "i": "46f56bad-4469-42c3-adfd-a2eb0adddf48",
                     "w": 17,
                     "x": 31,
                     "y": 0
                 },
-                "panelIndex": "37cf1481-5ec6-4812-82cd-a96af4b42b24",
+                "panelIndex": "46f56bad-4469-42c3-adfd-a2eb0adddf48",
                 "title": "Memory Usage",
                 "type": "lens"
             },
@@ -819,11 +819,6 @@
                             {
                                 "id": "metrics-*",
                                 "name": "indexpattern-datasource-layer-894781bd-2933-418c-b883-1f758794a45d",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "d632b895-3242-4f49-8d2c-ea7310b23b9a",
                                 "type": "index-pattern"
                             }
                         ],
@@ -852,6 +847,7 @@
                                             },
                                             "ignoreGlobalFilters": false,
                                             "incompleteColumns": {},
+                                            "indexPatternId": "metrics-*",
                                             "sampling": 1
                                         }
                                     }
@@ -905,12 +901,12 @@
                 },
                 "gridData": {
                     "h": 4,
-                    "i": "382b2dfc-a59d-41e7-8ccf-b21065436bde",
+                    "i": "4d038941-1dcf-4e33-97fc-4c8efb2e5704",
                     "w": 8,
                     "x": 5,
                     "y": 4
                 },
-                "panelIndex": "382b2dfc-a59d-41e7-8ccf-b21065436bde",
+                "panelIndex": "4d038941-1dcf-4e33-97fc-4c8efb2e5704",
                 "title": "",
                 "type": "lens"
             },
@@ -1089,12 +1085,12 @@
                 },
                 "gridData": {
                     "h": 8,
-                    "i": "82d3764e-d42b-40e9-9ab0-8be50eec7342",
+                    "i": "b482677d-7f22-4bd5-9c6b-75191b609a59",
                     "w": 8,
                     "x": 5,
                     "y": 8
                 },
-                "panelIndex": "82d3764e-d42b-40e9-9ab0-8be50eec7342",
+                "panelIndex": "b482677d-7f22-4bd5-9c6b-75191b609a59",
                 "title": "Nodes Status",
                 "type": "lens"
             },
@@ -1341,12 +1337,12 @@
                 },
                 "gridData": {
                     "h": 8,
-                    "i": "3f292d84-a6bc-4013-9813-8e8af16c7b00",
+                    "i": "a12294e3-7272-4e2a-8f19-dac28cf4d7d3",
                     "w": 12,
                     "x": 13,
                     "y": 8
                 },
-                "panelIndex": "3f292d84-a6bc-4013-9813-8e8af16c7b00",
+                "panelIndex": "a12294e3-7272-4e2a-8f19-dac28cf4d7d3",
                 "title": "Top CPU intensive Nodes",
                 "type": "lens"
             },
@@ -1593,12 +1589,12 @@
                 },
                 "gridData": {
                     "h": 8,
-                    "i": "82b79a44-8403-473b-aad2-88bd0a482dab",
+                    "i": "05d37a34-85e5-4a94-a769-cf5d4edd92db",
                     "w": 12,
                     "x": 25,
                     "y": 8
                 },
-                "panelIndex": "82b79a44-8403-473b-aad2-88bd0a482dab",
+                "panelIndex": "05d37a34-85e5-4a94-a769-cf5d4edd92db",
                 "title": "Top Memory intensive Nodes",
                 "type": "lens"
             },
@@ -1849,12 +1845,12 @@
                 },
                 "gridData": {
                     "h": 8,
-                    "i": "16a1f347-4978-418b-927a-c222631fa4a2",
+                    "i": "a3ecd1c4-a760-46f5-9ba1-a78d3752736e",
                     "w": 11,
                     "x": 37,
                     "y": 8
                 },
-                "panelIndex": "16a1f347-4978-418b-927a-c222631fa4a2",
+                "panelIndex": "a3ecd1c4-a760-46f5-9ba1-a78d3752736e",
                 "title": "Top Filesystem Utilization intensive Nodes",
                 "type": "lens"
             },
@@ -1880,7 +1876,7 @@
                         "description": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "### Workload overview\n***",
+                            "markdown": "#### Workload overview\n",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -1890,12 +1886,12 @@
                 },
                 "gridData": {
                     "h": 4,
-                    "i": "9eea475d-b033-4325-ad01-3a3c60527086",
+                    "i": "0b9c37e4-91a4-4ed2-95be-f626eac313c3",
                     "w": 48,
                     "x": 0,
                     "y": 16
                 },
-                "panelIndex": "9eea475d-b033-4325-ad01-3a3c60527086",
+                "panelIndex": "0b9c37e4-91a4-4ed2-95be-f626eac313c3",
                 "type": "visualization"
             },
             {
@@ -2085,12 +2081,12 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "1b2327f8-4439-4ec0-978a-c828d1cbba5b",
+                    "i": "847c1e72-2ee2-4dbe-8964-faef69312458",
                     "w": 11,
                     "x": 0,
                     "y": 20
                 },
-                "panelIndex": "1b2327f8-4439-4ec0-978a-c828d1cbba5b",
+                "panelIndex": "847c1e72-2ee2-4dbe-8964-faef69312458",
                 "title": "Container Restarts by Pod and Reason",
                 "type": "lens"
             },
@@ -2350,12 +2346,12 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "77769608-f62f-4fe7-8e97-6e6632194112",
+                    "i": "4fed4a49-ae6f-4ba6-8272-1ac5eb5acbab",
                     "w": 8,
                     "x": 11,
                     "y": 20
                 },
-                "panelIndex": "77769608-f62f-4fe7-8e97-6e6632194112",
+                "panelIndex": "4fed4a49-ae6f-4ba6-8272-1ac5eb5acbab",
                 "title": "Pods",
                 "type": "lens"
             },
@@ -2560,12 +2556,12 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "d0cb6744-1f80-471f-a3a8-95384514e659",
+                    "i": "b0d9f784-87ec-4032-a680-80b79e131c90",
                     "w": 7,
                     "x": 19,
                     "y": 20
                 },
-                "panelIndex": "d0cb6744-1f80-471f-a3a8-95384514e659",
+                "panelIndex": "b0d9f784-87ec-4032-a680-80b79e131c90",
                 "title": "Deployments",
                 "type": "lens"
             },
@@ -2770,12 +2766,12 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "21b3c490-4103-4688-a863-f61a16a740f3",
+                    "i": "07d8f733-24cc-4bc7-ac6a-1350ad739cab",
                     "w": 7,
                     "x": 26,
                     "y": 20
                 },
-                "panelIndex": "21b3c490-4103-4688-a863-f61a16a740f3",
+                "panelIndex": "07d8f733-24cc-4bc7-ac6a-1350ad739cab",
                 "title": "DaemonSets",
                 "type": "lens"
             },
@@ -2980,12 +2976,12 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "bb0e342f-51f5-462d-8631-7057ca0177fb",
+                    "i": "ff9b77e4-34ec-4223-a216-43eb6a0d7ad9",
                     "w": 7,
                     "x": 33,
                     "y": 20
                 },
-                "panelIndex": "bb0e342f-51f5-462d-8631-7057ca0177fb",
+                "panelIndex": "ff9b77e4-34ec-4223-a216-43eb6a0d7ad9",
                 "title": "StatefulSets",
                 "type": "lens"
             },
@@ -3190,12 +3186,12 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "3876a0a5-d5be-47bf-94f9-8786cd4468e4",
+                    "i": "7baf7d45-0dc2-462e-8470-f05da3237ed1",
                     "w": 8,
                     "x": 40,
                     "y": 20
                 },
-                "panelIndex": "3876a0a5-d5be-47bf-94f9-8786cd4468e4",
+                "panelIndex": "7baf7d45-0dc2-462e-8470-f05da3237ed1",
                 "title": "ReplicaSets",
                 "type": "lens"
             },
@@ -3394,12 +3390,12 @@
                 },
                 "gridData": {
                     "h": 10,
-                    "i": "88e35c29-c9c4-4833-8799-09b9bff429c3",
+                    "i": "b034b10a-14fa-442a-a5a7-89d489e841a1",
                     "w": 11,
                     "x": 0,
                     "y": 26
                 },
-                "panelIndex": "88e35c29-c9c4-4833-8799-09b9bff429c3",
+                "panelIndex": "b034b10a-14fa-442a-a5a7-89d489e841a1",
                 "title": "Top CPU intensive pods per Node",
                 "type": "lens"
             },
@@ -3589,12 +3585,12 @@
                 },
                 "gridData": {
                     "h": 10,
-                    "i": "cb282228-0c99-4602-85e7-a8ccd16aa3b2",
+                    "i": "8af1e96b-1733-4024-9386-52fe04932f27",
                     "w": 12,
                     "x": 11,
                     "y": 26
                 },
-                "panelIndex": "cb282228-0c99-4602-85e7-a8ccd16aa3b2",
+                "panelIndex": "8af1e96b-1733-4024-9386-52fe04932f27",
                 "title": "Top CPU intensive pods per Pod Limit",
                 "type": "lens"
             },
@@ -3784,12 +3780,12 @@
                 },
                 "gridData": {
                     "h": 10,
-                    "i": "d1c65daf-d8ad-4962-bc5d-ad57878d11c4",
+                    "i": "b2b48493-2faa-4f71-b897-4601e806d1c7",
                     "w": 13,
                     "x": 23,
                     "y": 26
                 },
-                "panelIndex": "d1c65daf-d8ad-4962-bc5d-ad57878d11c4",
+                "panelIndex": "b2b48493-2faa-4f71-b897-4601e806d1c7",
                 "title": "Top Memory intensive pods per Node",
                 "type": "lens"
             },
@@ -3978,12 +3974,12 @@
                 },
                 "gridData": {
                     "h": 10,
-                    "i": "96d4b289-0888-475c-8063-29e01e1ea2fe",
+                    "i": "c3437c7b-2c2b-4b40-a6c9-0372274b6428",
                     "w": 12,
                     "x": 36,
                     "y": 26
                 },
-                "panelIndex": "96d4b289-0888-475c-8063-29e01e1ea2fe",
+                "panelIndex": "c3437c7b-2c2b-4b40-a6c9-0372274b6428",
                 "title": "Top Memory intensive pods per Pod Limit",
                 "type": "lens"
             },
@@ -4021,12 +4017,12 @@
                 },
                 "gridData": {
                     "h": 8,
-                    "i": "82800889-cae6-4bb5-9d18-d1954bc3abd9",
+                    "i": "ca9941d7-1eb9-43b0-b4bc-05dcf4ab52c5",
                     "w": 5,
                     "x": 0,
                     "y": 8
                 },
-                "panelIndex": "82800889-cae6-4bb5-9d18-d1954bc3abd9",
+                "panelIndex": "ca9941d7-1eb9-43b0-b4bc-05dcf4ab52c5",
                 "title": "",
                 "type": "visualization"
             }
@@ -4036,99 +4032,94 @@
         "version": 2
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-10-17T12:14:58.803Z",
+    "created_at": "2024-10-17T12:45:25.446Z",
     "created_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0",
     "id": "kubernetes_otel-cluster-overview",
     "managed": false,
     "references": [
         {
             "id": "metrics-*",
-            "name": "9e64b0ef-52e1-4a05-9757-49e055cdcb35:indexpattern-datasource-layer-894781bd-2933-418c-b883-1f758794a45d",
+            "name": "c0c242f5-2181-40fe-b528-c99916ccc0f2:indexpattern-datasource-layer-894781bd-2933-418c-b883-1f758794a45d",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "bd3914d9-a15c-42c1-844d-14ffd8c72c47:indexpattern-datasource-layer-54494aa2-197e-42d6-a8ef-0072655ca351",
+            "name": "8560ee90-bc32-4277-b414-38d6b26d5ec3:indexpattern-datasource-layer-54494aa2-197e-42d6-a8ef-0072655ca351",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "bd3914d9-a15c-42c1-844d-14ffd8c72c47:indexpattern-datasource-layer-dba09ccc-6ec6-443b-8620-1eac10077772",
+            "name": "8560ee90-bc32-4277-b414-38d6b26d5ec3:indexpattern-datasource-layer-dba09ccc-6ec6-443b-8620-1eac10077772",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "37cf1481-5ec6-4812-82cd-a96af4b42b24:indexpattern-datasource-layer-54494aa2-197e-42d6-a8ef-0072655ca351",
+            "name": "46f56bad-4469-42c3-adfd-a2eb0adddf48:indexpattern-datasource-layer-54494aa2-197e-42d6-a8ef-0072655ca351",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "37cf1481-5ec6-4812-82cd-a96af4b42b24:indexpattern-datasource-layer-dba09ccc-6ec6-443b-8620-1eac10077772",
+            "name": "46f56bad-4469-42c3-adfd-a2eb0adddf48:indexpattern-datasource-layer-dba09ccc-6ec6-443b-8620-1eac10077772",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "382b2dfc-a59d-41e7-8ccf-b21065436bde:indexpattern-datasource-layer-894781bd-2933-418c-b883-1f758794a45d",
+            "name": "4d038941-1dcf-4e33-97fc-4c8efb2e5704:indexpattern-datasource-layer-894781bd-2933-418c-b883-1f758794a45d",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "382b2dfc-a59d-41e7-8ccf-b21065436bde:d632b895-3242-4f49-8d2c-ea7310b23b9a",
+            "name": "b482677d-7f22-4bd5-9c6b-75191b609a59:indexpattern-datasource-layer-b5e4cee3-e558-4805-b276-673a7ebff8f0",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "82d3764e-d42b-40e9-9ab0-8be50eec7342:indexpattern-datasource-layer-b5e4cee3-e558-4805-b276-673a7ebff8f0",
+            "name": "a12294e3-7272-4e2a-8f19-dac28cf4d7d3:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "3f292d84-a6bc-4013-9813-8e8af16c7b00:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
+            "name": "05d37a34-85e5-4a94-a769-cf5d4edd92db:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "82b79a44-8403-473b-aad2-88bd0a482dab:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
+            "name": "a3ecd1c4-a760-46f5-9ba1-a78d3752736e:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "16a1f347-4978-418b-927a-c222631fa4a2:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
+            "name": "a3ecd1c4-a760-46f5-9ba1-a78d3752736e:1b04b540-39ae-4cfd-8088-34a4bf3d5654",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "16a1f347-4978-418b-927a-c222631fa4a2:1b04b540-39ae-4cfd-8088-34a4bf3d5654",
+            "name": "847c1e72-2ee2-4dbe-8964-faef69312458:indexpattern-datasource-layer-57a8eb42-6f2c-4112-9d6c-c03d982c569e",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "1b2327f8-4439-4ec0-978a-c828d1cbba5b:indexpattern-datasource-layer-57a8eb42-6f2c-4112-9d6c-c03d982c569e",
+            "name": "847c1e72-2ee2-4dbe-8964-faef69312458:0e11ca27-40f5-4300-b885-17ade4895220",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "1b2327f8-4439-4ec0-978a-c828d1cbba5b:0e11ca27-40f5-4300-b885-17ade4895220",
+            "name": "b034b10a-14fa-442a-a5a7-89d489e841a1:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "88e35c29-c9c4-4833-8799-09b9bff429c3:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+            "name": "8af1e96b-1733-4024-9386-52fe04932f27:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "cb282228-0c99-4602-85e7-a8ccd16aa3b2:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+            "name": "b2b48493-2faa-4f71-b897-4601e806d1c7:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "d1c65daf-d8ad-4962-bc5d-ad57878d11c4:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "96d4b289-0888-475c-8063-29e01e1ea2fe:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+            "name": "c3437c7b-2c2b-4b40-a6c9-0372274b6428:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
             "type": "index-pattern"
         },
         {

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-cluster-overview.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-cluster-overview.json
@@ -87,13 +87,11 @@
         "panelsJSON": [
             {
                 "embeddableConfig": {
-                    "description": "",
                     "enhancements": {
                         "dynamicActions": {
                             "events": []
                         }
                     },
-                    "hidePanelTitles": true,
                     "savedVis": {
                         "data": {
                             "aggs": [],
@@ -109,7 +107,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "### Cluster overview\n***",
+                            "markdown": "#### Cluster overview",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -118,14 +116,13 @@
                     }
                 },
                 "gridData": {
-                    "h": 10,
-                    "i": "3028c1e3-c28d-4a0e-973a-1d0400d8ca99",
-                    "w": 3,
+                    "h": 8,
+                    "i": "42314208-b335-435d-8a60-51f8ba7ba1f4",
+                    "w": 5,
                     "x": 0,
                     "y": 0
                 },
-                "panelIndex": "3028c1e3-c28d-4a0e-973a-1d0400d8ca99",
-                "title": "",
+                "panelIndex": "42314208-b335-435d-8a60-51f8ba7ba1f4",
                 "type": "visualization"
             },
             {
@@ -218,13 +215,13 @@
                     "hidePanelTitles": true
                 },
                 "gridData": {
-                    "h": 5,
-                    "i": "418e39a1-f843-4083-9efa-81940fd778cf",
-                    "w": 4,
-                    "x": 3,
+                    "h": 4,
+                    "i": "9e64b0ef-52e1-4a05-9757-49e055cdcb35",
+                    "w": 8,
+                    "x": 5,
                     "y": 0
                 },
-                "panelIndex": "418e39a1-f843-4083-9efa-81940fd778cf",
+                "panelIndex": "9e64b0ef-52e1-4a05-9757-49e055cdcb35",
                 "title": "",
                 "type": "lens"
             },
@@ -513,13 +510,13 @@
                     "enhancements": {}
                 },
                 "gridData": {
-                    "h": 10,
-                    "i": "2c06e3e7-e9d9-46ef-866c-7073c31216f1",
-                    "w": 21,
-                    "x": 7,
+                    "h": 8,
+                    "i": "bd3914d9-a15c-42c1-844d-14ffd8c72c47",
+                    "w": 18,
+                    "x": 13,
                     "y": 0
                 },
-                "panelIndex": "2c06e3e7-e9d9-46ef-866c-7073c31216f1",
+                "panelIndex": "bd3914d9-a15c-42c1-844d-14ffd8c72c47",
                 "title": "CPU Usage",
                 "type": "lens"
             },
@@ -805,13 +802,13 @@
                     "enhancements": {}
                 },
                 "gridData": {
-                    "h": 10,
-                    "i": "f93cbfa7-623a-4056-a14c-d94a64a8d772",
-                    "w": 20,
-                    "x": 28,
+                    "h": 8,
+                    "i": "37cf1481-5ec6-4812-82cd-a96af4b42b24",
+                    "w": 17,
+                    "x": 31,
                     "y": 0
                 },
-                "panelIndex": "f93cbfa7-623a-4056-a14c-d94a64a8d772",
+                "panelIndex": "37cf1481-5ec6-4812-82cd-a96af4b42b24",
                 "title": "Memory Usage",
                 "type": "lens"
             },
@@ -907,55 +904,15 @@
                     "hidePanelTitles": true
                 },
                 "gridData": {
-                    "h": 5,
-                    "i": "13964c54-c02c-4e60-91e9-742f6024c373",
-                    "w": 4,
-                    "x": 3,
-                    "y": 5
+                    "h": 4,
+                    "i": "382b2dfc-a59d-41e7-8ccf-b21065436bde",
+                    "w": 8,
+                    "x": 5,
+                    "y": 4
                 },
-                "panelIndex": "13964c54-c02c-4e60-91e9-742f6024c373",
+                "panelIndex": "382b2dfc-a59d-41e7-8ccf-b21065436bde",
                 "title": "",
                 "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "hidePanelTitles": true,
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "params": {
-                            "fontSize": 12,
-                            "markdown": "### Node overview\n***",
-                            "openLinksInNewTab": false
-                        },
-                        "title": "",
-                        "type": "markdown",
-                        "uiState": {}
-                    }
-                },
-                "gridData": {
-                    "h": 9,
-                    "i": "84789c1a-890f-4248-b265-a7cc7265c2a9",
-                    "w": 3,
-                    "x": 0,
-                    "y": 10
-                },
-                "panelIndex": "84789c1a-890f-4248-b265-a7cc7265c2a9",
-                "type": "visualization"
             },
             {
                 "embeddableConfig": {
@@ -1131,13 +1088,13 @@
                     "enhancements": {}
                 },
                 "gridData": {
-                    "h": 9,
-                    "i": "b83e8093-e4fd-4f0f-8f52-74b1e5600cbf",
-                    "w": 4,
-                    "x": 3,
-                    "y": 10
+                    "h": 8,
+                    "i": "82d3764e-d42b-40e9-9ab0-8be50eec7342",
+                    "w": 8,
+                    "x": 5,
+                    "y": 8
                 },
-                "panelIndex": "b83e8093-e4fd-4f0f-8f52-74b1e5600cbf",
+                "panelIndex": "82d3764e-d42b-40e9-9ab0-8be50eec7342",
                 "title": "Nodes Status",
                 "type": "lens"
             },
@@ -1383,13 +1340,13 @@
                     "enhancements": {}
                 },
                 "gridData": {
-                    "h": 9,
-                    "i": "58dfa3d6-c91b-4868-974a-d405db499dcb",
-                    "w": 14,
-                    "x": 7,
-                    "y": 10
+                    "h": 8,
+                    "i": "3f292d84-a6bc-4013-9813-8e8af16c7b00",
+                    "w": 12,
+                    "x": 13,
+                    "y": 8
                 },
-                "panelIndex": "58dfa3d6-c91b-4868-974a-d405db499dcb",
+                "panelIndex": "3f292d84-a6bc-4013-9813-8e8af16c7b00",
                 "title": "Top CPU intensive Nodes",
                 "type": "lens"
             },
@@ -1635,13 +1592,13 @@
                     "enhancements": {}
                 },
                 "gridData": {
-                    "h": 9,
-                    "i": "5396b322-e988-4902-9be8-df6d1bf738d1",
-                    "w": 14,
-                    "x": 21,
-                    "y": 10
+                    "h": 8,
+                    "i": "82b79a44-8403-473b-aad2-88bd0a482dab",
+                    "w": 12,
+                    "x": 25,
+                    "y": 8
                 },
-                "panelIndex": "5396b322-e988-4902-9be8-df6d1bf738d1",
+                "panelIndex": "82b79a44-8403-473b-aad2-88bd0a482dab",
                 "title": "Top Memory intensive Nodes",
                 "type": "lens"
             },
@@ -1891,13 +1848,13 @@
                     "enhancements": {}
                 },
                 "gridData": {
-                    "h": 9,
-                    "i": "93fcf7c5-9f87-4d8f-8582-5df16d4c5603",
-                    "w": 13,
-                    "x": 35,
-                    "y": 10
+                    "h": 8,
+                    "i": "16a1f347-4978-418b-927a-c222631fa4a2",
+                    "w": 11,
+                    "x": 37,
+                    "y": 8
                 },
-                "panelIndex": "93fcf7c5-9f87-4d8f-8582-5df16d4c5603",
+                "panelIndex": "16a1f347-4978-418b-927a-c222631fa4a2",
                 "title": "Top Filesystem Utilization intensive Nodes",
                 "type": "lens"
             },
@@ -1932,13 +1889,13 @@
                     }
                 },
                 "gridData": {
-                    "h": 5,
-                    "i": "6c896981-187f-4f2d-9956-08318ef2ae2e",
+                    "h": 4,
+                    "i": "9eea475d-b033-4325-ad01-3a3c60527086",
                     "w": 48,
                     "x": 0,
-                    "y": 19
+                    "y": 16
                 },
-                "panelIndex": "6c896981-187f-4f2d-9956-08318ef2ae2e",
+                "panelIndex": "9eea475d-b033-4325-ad01-3a3c60527086",
                 "type": "visualization"
             },
             {
@@ -2123,16 +2080,17 @@
                         "type": "lens",
                         "visualizationType": "lnsXY"
                     },
+                    "description": "No values in specific Visualisation means that no Pod restarts took place for the specific time range",
                     "enhancements": {}
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "c793c718-7819-4d53-951a-7d664d381307",
+                    "i": "1b2327f8-4439-4ec0-978a-c828d1cbba5b",
                     "w": 11,
                     "x": 0,
-                    "y": 24
+                    "y": 20
                 },
-                "panelIndex": "c793c718-7819-4d53-951a-7d664d381307",
+                "panelIndex": "1b2327f8-4439-4ec0-978a-c828d1cbba5b",
                 "title": "Container Restarts by Pod and Reason",
                 "type": "lens"
             },
@@ -2392,12 +2350,12 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "f9265c18-5920-476c-b904-8464fd77c7fc",
+                    "i": "77769608-f62f-4fe7-8e97-6e6632194112",
                     "w": 8,
                     "x": 11,
-                    "y": 24
+                    "y": 20
                 },
-                "panelIndex": "f9265c18-5920-476c-b904-8464fd77c7fc",
+                "panelIndex": "77769608-f62f-4fe7-8e97-6e6632194112",
                 "title": "Pods",
                 "type": "lens"
             },
@@ -2602,12 +2560,12 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "65c1c7a7-c469-4edf-af4b-c02567330684",
+                    "i": "d0cb6744-1f80-471f-a3a8-95384514e659",
                     "w": 7,
                     "x": 19,
-                    "y": 24
+                    "y": 20
                 },
-                "panelIndex": "65c1c7a7-c469-4edf-af4b-c02567330684",
+                "panelIndex": "d0cb6744-1f80-471f-a3a8-95384514e659",
                 "title": "Deployments",
                 "type": "lens"
             },
@@ -2812,12 +2770,12 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "e04f410d-0aff-407c-9c42-c80de6966138",
+                    "i": "21b3c490-4103-4688-a863-f61a16a740f3",
                     "w": 7,
                     "x": 26,
-                    "y": 24
+                    "y": 20
                 },
-                "panelIndex": "e04f410d-0aff-407c-9c42-c80de6966138",
+                "panelIndex": "21b3c490-4103-4688-a863-f61a16a740f3",
                 "title": "DaemonSets",
                 "type": "lens"
             },
@@ -3022,12 +2980,12 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "ce6c9ec3-8f98-4249-8ec0-7590b499f0d5",
+                    "i": "bb0e342f-51f5-462d-8631-7057ca0177fb",
                     "w": 7,
                     "x": 33,
-                    "y": 24
+                    "y": 20
                 },
-                "panelIndex": "ce6c9ec3-8f98-4249-8ec0-7590b499f0d5",
+                "panelIndex": "bb0e342f-51f5-462d-8631-7057ca0177fb",
                 "title": "StatefulSets",
                 "type": "lens"
             },
@@ -3232,12 +3190,12 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "79bd8ed6-bf0a-41ba-97ca-af560f5ce552",
+                    "i": "3876a0a5-d5be-47bf-94f9-8786cd4468e4",
                     "w": 8,
                     "x": 40,
-                    "y": 24
+                    "y": 20
                 },
-                "panelIndex": "79bd8ed6-bf0a-41ba-97ca-af560f5ce552",
+                "panelIndex": "3876a0a5-d5be-47bf-94f9-8786cd4468e4",
                 "title": "ReplicaSets",
                 "type": "lens"
             },
@@ -3415,13 +3373,16 @@
                                 },
                                 "preferredSeriesType": "bar_horizontal",
                                 "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": false,
+                                    "x": false,
+                                    "yLeft": true,
                                     "yRight": true
                                 },
                                 "title": "Empty XY chart",
                                 "valueLabels": "show",
-                                "xTitle": "% CPU Node"
+                                "xTitle": "% CPU Node",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                }
                             }
                         },
                         "title": "",
@@ -3433,12 +3394,12 @@
                 },
                 "gridData": {
                     "h": 10,
-                    "i": "136b58d1-1483-42a1-9fda-c99adf0792c5",
+                    "i": "88e35c29-c9c4-4833-8799-09b9bff429c3",
                     "w": 11,
                     "x": 0,
-                    "y": 30
+                    "y": 26
                 },
-                "panelIndex": "136b58d1-1483-42a1-9fda-c99adf0792c5",
+                "panelIndex": "88e35c29-c9c4-4833-8799-09b9bff429c3",
                 "title": "Top CPU intensive pods per Node",
                 "type": "lens"
             },
@@ -3610,7 +3571,7 @@
                                 },
                                 "preferredSeriesType": "bar_horizontal",
                                 "tickLabelsVisibilitySettings": {
-                                    "x": true,
+                                    "x": false,
                                     "yLeft": false,
                                     "yRight": true
                                 },
@@ -3628,12 +3589,12 @@
                 },
                 "gridData": {
                     "h": 10,
-                    "i": "be5a9424-c970-40d1-bb23-60f3d4d24cc9",
+                    "i": "cb282228-0c99-4602-85e7-a8ccd16aa3b2",
                     "w": 12,
                     "x": 11,
-                    "y": 30
+                    "y": 26
                 },
-                "panelIndex": "be5a9424-c970-40d1-bb23-60f3d4d24cc9",
+                "panelIndex": "cb282228-0c99-4602-85e7-a8ccd16aa3b2",
                 "title": "Top CPU intensive pods per Pod Limit",
                 "type": "lens"
             },
@@ -3805,7 +3766,7 @@
                                 },
                                 "preferredSeriesType": "bar_horizontal",
                                 "tickLabelsVisibilitySettings": {
-                                    "x": true,
+                                    "x": false,
                                     "yLeft": false,
                                     "yRight": true
                                 },
@@ -3823,12 +3784,12 @@
                 },
                 "gridData": {
                     "h": 10,
-                    "i": "9c8dc773-0432-43d5-9a87-57986054e0b0",
+                    "i": "d1c65daf-d8ad-4962-bc5d-ad57878d11c4",
                     "w": 13,
                     "x": 23,
-                    "y": 30
+                    "y": 26
                 },
-                "panelIndex": "9c8dc773-0432-43d5-9a87-57986054e0b0",
+                "panelIndex": "d1c65daf-d8ad-4962-bc5d-ad57878d11c4",
                 "title": "Top Memory intensive pods per Node",
                 "type": "lens"
             },
@@ -3995,7 +3956,7 @@
                                 },
                                 "preferredSeriesType": "bar_horizontal",
                                 "tickLabelsVisibilitySettings": {
-                                    "x": true,
+                                    "x": false,
                                     "yLeft": false,
                                     "yRight": true
                                 },
@@ -4017,114 +3978,157 @@
                 },
                 "gridData": {
                     "h": 10,
-                    "i": "6b564db2-f6f7-4bf4-8fab-534b6bb47c55",
+                    "i": "96d4b289-0888-475c-8063-29e01e1ea2fe",
                     "w": 12,
                     "x": 36,
-                    "y": 30
+                    "y": 26
                 },
-                "panelIndex": "6b564db2-f6f7-4bf4-8fab-534b6bb47c55",
+                "panelIndex": "96d4b289-0888-475c-8063-29e01e1ea2fe",
                 "title": "Top Memory intensive pods per Pod Limit",
                 "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "description": "",
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "hidePanelTitles": true,
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
+                        "description": "",
+                        "id": "",
+                        "params": {
+                            "fontSize": 12,
+                            "markdown": "#### Node overview",
+                            "openLinksInNewTab": false
+                        },
+                        "title": "",
+                        "type": "markdown",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "82800889-cae6-4bb5-9d18-d1954bc3abd9",
+                    "w": 5,
+                    "x": 0,
+                    "y": 8
+                },
+                "panelIndex": "82800889-cae6-4bb5-9d18-d1954bc3abd9",
+                "title": "",
+                "type": "visualization"
             }
         ],
         "timeRestore": false,
-        "title": "[OTEL][Metrics Kubernetes] Cluster Overview (1)",
+        "title": "[OTEL][Metrics Kubernetes] Cluster Overview",
         "version": 2
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-10-17T11:10:00.109Z",
+    "created_at": "2024-10-17T12:14:58.803Z",
     "created_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0",
     "id": "kubernetes_otel-cluster-overview",
     "managed": false,
     "references": [
         {
             "id": "metrics-*",
-            "name": "418e39a1-f843-4083-9efa-81940fd778cf:indexpattern-datasource-layer-894781bd-2933-418c-b883-1f758794a45d",
+            "name": "9e64b0ef-52e1-4a05-9757-49e055cdcb35:indexpattern-datasource-layer-894781bd-2933-418c-b883-1f758794a45d",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "2c06e3e7-e9d9-46ef-866c-7073c31216f1:indexpattern-datasource-layer-54494aa2-197e-42d6-a8ef-0072655ca351",
+            "name": "bd3914d9-a15c-42c1-844d-14ffd8c72c47:indexpattern-datasource-layer-54494aa2-197e-42d6-a8ef-0072655ca351",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "2c06e3e7-e9d9-46ef-866c-7073c31216f1:indexpattern-datasource-layer-dba09ccc-6ec6-443b-8620-1eac10077772",
+            "name": "bd3914d9-a15c-42c1-844d-14ffd8c72c47:indexpattern-datasource-layer-dba09ccc-6ec6-443b-8620-1eac10077772",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "f93cbfa7-623a-4056-a14c-d94a64a8d772:indexpattern-datasource-layer-54494aa2-197e-42d6-a8ef-0072655ca351",
+            "name": "37cf1481-5ec6-4812-82cd-a96af4b42b24:indexpattern-datasource-layer-54494aa2-197e-42d6-a8ef-0072655ca351",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "f93cbfa7-623a-4056-a14c-d94a64a8d772:indexpattern-datasource-layer-dba09ccc-6ec6-443b-8620-1eac10077772",
+            "name": "37cf1481-5ec6-4812-82cd-a96af4b42b24:indexpattern-datasource-layer-dba09ccc-6ec6-443b-8620-1eac10077772",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "13964c54-c02c-4e60-91e9-742f6024c373:indexpattern-datasource-layer-894781bd-2933-418c-b883-1f758794a45d",
+            "name": "382b2dfc-a59d-41e7-8ccf-b21065436bde:indexpattern-datasource-layer-894781bd-2933-418c-b883-1f758794a45d",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "13964c54-c02c-4e60-91e9-742f6024c373:d632b895-3242-4f49-8d2c-ea7310b23b9a",
+            "name": "382b2dfc-a59d-41e7-8ccf-b21065436bde:d632b895-3242-4f49-8d2c-ea7310b23b9a",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "b83e8093-e4fd-4f0f-8f52-74b1e5600cbf:indexpattern-datasource-layer-b5e4cee3-e558-4805-b276-673a7ebff8f0",
+            "name": "82d3764e-d42b-40e9-9ab0-8be50eec7342:indexpattern-datasource-layer-b5e4cee3-e558-4805-b276-673a7ebff8f0",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "58dfa3d6-c91b-4868-974a-d405db499dcb:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
+            "name": "3f292d84-a6bc-4013-9813-8e8af16c7b00:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "5396b322-e988-4902-9be8-df6d1bf738d1:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
+            "name": "82b79a44-8403-473b-aad2-88bd0a482dab:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "93fcf7c5-9f87-4d8f-8582-5df16d4c5603:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
+            "name": "16a1f347-4978-418b-927a-c222631fa4a2:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "93fcf7c5-9f87-4d8f-8582-5df16d4c5603:1b04b540-39ae-4cfd-8088-34a4bf3d5654",
+            "name": "16a1f347-4978-418b-927a-c222631fa4a2:1b04b540-39ae-4cfd-8088-34a4bf3d5654",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "c793c718-7819-4d53-951a-7d664d381307:indexpattern-datasource-layer-57a8eb42-6f2c-4112-9d6c-c03d982c569e",
+            "name": "1b2327f8-4439-4ec0-978a-c828d1cbba5b:indexpattern-datasource-layer-57a8eb42-6f2c-4112-9d6c-c03d982c569e",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "c793c718-7819-4d53-951a-7d664d381307:0e11ca27-40f5-4300-b885-17ade4895220",
+            "name": "1b2327f8-4439-4ec0-978a-c828d1cbba5b:0e11ca27-40f5-4300-b885-17ade4895220",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "136b58d1-1483-42a1-9fda-c99adf0792c5:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+            "name": "88e35c29-c9c4-4833-8799-09b9bff429c3:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "be5a9424-c970-40d1-bb23-60f3d4d24cc9:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+            "name": "cb282228-0c99-4602-85e7-a8ccd16aa3b2:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "9c8dc773-0432-43d5-9a87-57986054e0b0:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+            "name": "d1c65daf-d8ad-4962-bc5d-ad57878d11c4:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "6b564db2-f6f7-4bf4-8fab-534b6bb47c55:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+            "name": "96d4b289-0888-475c-8063-29e01e1ea2fe:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
             "type": "index-pattern"
         },
         {

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-cluster-overview.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-cluster-overview.json
@@ -4128,11 +4128,6 @@
             "type": "index-pattern"
         },
         {
-            "id": "kubernetes_otel-fleet-shared-tag-kubernetes_otel-dfd505f6-fc02-5c53-adc7-148425d7972c-default",
-            "name": "tag-ref-fleet-shared-tag-kubernetes_otel-dfd505f6-fc02-5c53-adc7-148425d7972c-default",
-            "type": "tag"
-        },
-        {
             "id": "metrics-*",
             "name": "controlGroup_a01727d6-1aa3-4918-91ca-9059f18d9222:optionsListDataView",
             "type": "index-pattern"

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-cluster-overview.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-cluster-overview.json
@@ -119,12 +119,12 @@
                 },
                 "gridData": {
                     "h": 10,
-                    "i": "fae0c591-74a9-47d2-9a70-6755790806a1",
+                    "i": "3028c1e3-c28d-4a0e-973a-1d0400d8ca99",
                     "w": 3,
                     "x": 0,
                     "y": 0
                 },
-                "panelIndex": "fae0c591-74a9-47d2-9a70-6755790806a1",
+                "panelIndex": "3028c1e3-c28d-4a0e-973a-1d0400d8ca99",
                 "title": "",
                 "type": "visualization"
             },
@@ -219,12 +219,12 @@
                 },
                 "gridData": {
                     "h": 5,
-                    "i": "eeac2e1e-8980-4606-8b00-b75e73204c3f",
+                    "i": "418e39a1-f843-4083-9efa-81940fd778cf",
                     "w": 4,
                     "x": 3,
                     "y": 0
                 },
-                "panelIndex": "eeac2e1e-8980-4606-8b00-b75e73204c3f",
+                "panelIndex": "418e39a1-f843-4083-9efa-81940fd778cf",
                 "title": "",
                 "type": "lens"
             },
@@ -514,12 +514,12 @@
                 },
                 "gridData": {
                     "h": 10,
-                    "i": "e37f26c5-4007-4cd7-aa4a-1d409c990752",
+                    "i": "2c06e3e7-e9d9-46ef-866c-7073c31216f1",
                     "w": 21,
                     "x": 7,
                     "y": 0
                 },
-                "panelIndex": "e37f26c5-4007-4cd7-aa4a-1d409c990752",
+                "panelIndex": "2c06e3e7-e9d9-46ef-866c-7073c31216f1",
                 "title": "CPU Usage",
                 "type": "lens"
             },
@@ -806,12 +806,12 @@
                 },
                 "gridData": {
                     "h": 10,
-                    "i": "8ec1e48e-9d3a-4ac8-a36d-139302785d83",
+                    "i": "f93cbfa7-623a-4056-a14c-d94a64a8d772",
                     "w": 20,
                     "x": 28,
                     "y": 0
                 },
-                "panelIndex": "8ec1e48e-9d3a-4ac8-a36d-139302785d83",
+                "panelIndex": "f93cbfa7-623a-4056-a14c-d94a64a8d772",
                 "title": "Memory Usage",
                 "type": "lens"
             },
@@ -908,12 +908,12 @@
                 },
                 "gridData": {
                     "h": 5,
-                    "i": "33c4c965-846e-41bb-8457-8e8a3fe04e2c",
+                    "i": "13964c54-c02c-4e60-91e9-742f6024c373",
                     "w": 4,
                     "x": 3,
                     "y": 5
                 },
-                "panelIndex": "33c4c965-846e-41bb-8457-8e8a3fe04e2c",
+                "panelIndex": "13964c54-c02c-4e60-91e9-742f6024c373",
                 "title": "",
                 "type": "lens"
             },
@@ -949,12 +949,12 @@
                 },
                 "gridData": {
                     "h": 9,
-                    "i": "f45328dc-848b-4096-ae8f-87d775729b08",
+                    "i": "84789c1a-890f-4248-b265-a7cc7265c2a9",
                     "w": 3,
                     "x": 0,
                     "y": 10
                 },
-                "panelIndex": "f45328dc-848b-4096-ae8f-87d775729b08",
+                "panelIndex": "84789c1a-890f-4248-b265-a7cc7265c2a9",
                 "type": "visualization"
             },
             {
@@ -1132,12 +1132,12 @@
                 },
                 "gridData": {
                     "h": 9,
-                    "i": "7a508a02-dfab-43cb-84f4-682ea5d1c483",
+                    "i": "b83e8093-e4fd-4f0f-8f52-74b1e5600cbf",
                     "w": 4,
                     "x": 3,
                     "y": 10
                 },
-                "panelIndex": "7a508a02-dfab-43cb-84f4-682ea5d1c483",
+                "panelIndex": "b83e8093-e4fd-4f0f-8f52-74b1e5600cbf",
                 "title": "Nodes Status",
                 "type": "lens"
             },
@@ -1384,12 +1384,12 @@
                 },
                 "gridData": {
                     "h": 9,
-                    "i": "acc7e28f-cfc7-4d27-a904-332aac864a4d",
+                    "i": "58dfa3d6-c91b-4868-974a-d405db499dcb",
                     "w": 14,
                     "x": 7,
                     "y": 10
                 },
-                "panelIndex": "acc7e28f-cfc7-4d27-a904-332aac864a4d",
+                "panelIndex": "58dfa3d6-c91b-4868-974a-d405db499dcb",
                 "title": "Top CPU intensive Nodes",
                 "type": "lens"
             },
@@ -1636,12 +1636,12 @@
                 },
                 "gridData": {
                     "h": 9,
-                    "i": "a73b59f6-e7fe-495d-85b9-455ea1dc92eb",
+                    "i": "5396b322-e988-4902-9be8-df6d1bf738d1",
                     "w": 14,
                     "x": 21,
                     "y": 10
                 },
-                "panelIndex": "a73b59f6-e7fe-495d-85b9-455ea1dc92eb",
+                "panelIndex": "5396b322-e988-4902-9be8-df6d1bf738d1",
                 "title": "Top Memory intensive Nodes",
                 "type": "lens"
             },
@@ -1892,12 +1892,12 @@
                 },
                 "gridData": {
                     "h": 9,
-                    "i": "d57f55a8-e2a3-49aa-9e6d-fc3a92b2b787",
+                    "i": "93fcf7c5-9f87-4d8f-8582-5df16d4c5603",
                     "w": 13,
                     "x": 35,
                     "y": 10
                 },
-                "panelIndex": "d57f55a8-e2a3-49aa-9e6d-fc3a92b2b787",
+                "panelIndex": "93fcf7c5-9f87-4d8f-8582-5df16d4c5603",
                 "title": "Top Filesystem Utilization intensive Nodes",
                 "type": "lens"
             },
@@ -1933,12 +1933,12 @@
                 },
                 "gridData": {
                     "h": 5,
-                    "i": "16feda9a-92ab-4315-8a34-d9a8711d1a48",
+                    "i": "6c896981-187f-4f2d-9956-08318ef2ae2e",
                     "w": 48,
                     "x": 0,
                     "y": 19
                 },
-                "panelIndex": "16feda9a-92ab-4315-8a34-d9a8711d1a48",
+                "panelIndex": "6c896981-187f-4f2d-9956-08318ef2ae2e",
                 "type": "visualization"
             },
             {
@@ -2127,12 +2127,12 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "7cd4d107-fcfc-4a07-bb63-d3a9862f0e96",
+                    "i": "c793c718-7819-4d53-951a-7d664d381307",
                     "w": 11,
                     "x": 0,
                     "y": 24
                 },
-                "panelIndex": "7cd4d107-fcfc-4a07-bb63-d3a9862f0e96",
+                "panelIndex": "c793c718-7819-4d53-951a-7d664d381307",
                 "title": "Container Restarts by Pod and Reason",
                 "type": "lens"
             },
@@ -2392,12 +2392,12 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "d0ed3566-1892-4f18-af9f-1c328d5cbc9f",
+                    "i": "f9265c18-5920-476c-b904-8464fd77c7fc",
                     "w": 8,
                     "x": 11,
                     "y": 24
                 },
-                "panelIndex": "d0ed3566-1892-4f18-af9f-1c328d5cbc9f",
+                "panelIndex": "f9265c18-5920-476c-b904-8464fd77c7fc",
                 "title": "Pods",
                 "type": "lens"
             },
@@ -2602,12 +2602,12 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "c74c1060-fc08-4ea5-8695-dc98be09fef8",
+                    "i": "65c1c7a7-c469-4edf-af4b-c02567330684",
                     "w": 7,
                     "x": 19,
                     "y": 24
                 },
-                "panelIndex": "c74c1060-fc08-4ea5-8695-dc98be09fef8",
+                "panelIndex": "65c1c7a7-c469-4edf-af4b-c02567330684",
                 "title": "Deployments",
                 "type": "lens"
             },
@@ -2812,12 +2812,12 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "210d13ba-78aa-4711-a29d-5f1ef0d0f3de",
+                    "i": "e04f410d-0aff-407c-9c42-c80de6966138",
                     "w": 7,
                     "x": 26,
                     "y": 24
                 },
-                "panelIndex": "210d13ba-78aa-4711-a29d-5f1ef0d0f3de",
+                "panelIndex": "e04f410d-0aff-407c-9c42-c80de6966138",
                 "title": "DaemonSets",
                 "type": "lens"
             },
@@ -3022,12 +3022,12 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "b44849ce-b976-487c-bb1e-bfc975eac5ed",
+                    "i": "ce6c9ec3-8f98-4249-8ec0-7590b499f0d5",
                     "w": 7,
                     "x": 33,
                     "y": 24
                 },
-                "panelIndex": "b44849ce-b976-487c-bb1e-bfc975eac5ed",
+                "panelIndex": "ce6c9ec3-8f98-4249-8ec0-7590b499f0d5",
                 "title": "StatefulSets",
                 "type": "lens"
             },
@@ -3232,12 +3232,12 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "5f44ed28-c686-46bd-9e53-d849489060c5",
+                    "i": "79bd8ed6-bf0a-41ba-97ca-af560f5ce552",
                     "w": 8,
                     "x": 40,
                     "y": 24
                 },
-                "panelIndex": "5f44ed28-c686-46bd-9e53-d849489060c5",
+                "panelIndex": "79bd8ed6-bf0a-41ba-97ca-af560f5ce552",
                 "title": "ReplicaSets",
                 "type": "lens"
             },
@@ -3433,12 +3433,12 @@
                 },
                 "gridData": {
                     "h": 10,
-                    "i": "53ef9b2d-f968-4ab7-858e-20b4b9171157",
+                    "i": "136b58d1-1483-42a1-9fda-c99adf0792c5",
                     "w": 11,
                     "x": 0,
                     "y": 30
                 },
-                "panelIndex": "53ef9b2d-f968-4ab7-858e-20b4b9171157",
+                "panelIndex": "136b58d1-1483-42a1-9fda-c99adf0792c5",
                 "title": "Top CPU intensive pods per Node",
                 "type": "lens"
             },
@@ -3628,12 +3628,12 @@
                 },
                 "gridData": {
                     "h": 10,
-                    "i": "49683e76-f892-40b8-9299-9558ff44103b",
+                    "i": "be5a9424-c970-40d1-bb23-60f3d4d24cc9",
                     "w": 12,
                     "x": 11,
                     "y": 30
                 },
-                "panelIndex": "49683e76-f892-40b8-9299-9558ff44103b",
+                "panelIndex": "be5a9424-c970-40d1-bb23-60f3d4d24cc9",
                 "title": "Top CPU intensive pods per Pod Limit",
                 "type": "lens"
             },
@@ -3823,12 +3823,12 @@
                 },
                 "gridData": {
                     "h": 10,
-                    "i": "020a7985-baa4-4b7b-9136-ab0357bb83c8",
+                    "i": "9c8dc773-0432-43d5-9a87-57986054e0b0",
                     "w": 13,
                     "x": 23,
                     "y": 30
                 },
-                "panelIndex": "020a7985-baa4-4b7b-9136-ab0357bb83c8",
+                "panelIndex": "9c8dc773-0432-43d5-9a87-57986054e0b0",
                 "title": "Top Memory intensive pods per Node",
                 "type": "lens"
             },
@@ -4017,726 +4017,120 @@
                 },
                 "gridData": {
                     "h": 10,
-                    "i": "67779719-91a4-4a68-b7fe-7bc7eef837af",
+                    "i": "6b564db2-f6f7-4bf4-8fab-534b6bb47c55",
                     "w": 12,
                     "x": 36,
                     "y": 30
                 },
-                "panelIndex": "67779719-91a4-4a68-b7fe-7bc7eef837af",
+                "panelIndex": "6b564db2-f6f7-4bf4-8fab-534b6bb47c55",
                 "title": "Top Memory intensive pods per Pod Limit",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "hidePanelTitles": true,
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "params": {
-                            "fontSize": 12,
-                            "markdown": "### Cluster Events\n***",
-                            "openLinksInNewTab": false
-                        },
-                        "title": "",
-                        "type": "markdown",
-                        "uiState": {}
-                    }
-                },
-                "gridData": {
-                    "h": 5,
-                    "i": "bc1eea31-367b-4291-8ea1-5ab609888237",
-                    "w": 48,
-                    "x": 0,
-                    "y": 40
-                },
-                "panelIndex": "bc1eea31-367b-4291-8ea1-5ab609888237",
-                "type": "visualization"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "description": "",
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "f641ba62-c9ca-4f45-ba95-3d68c419a5a5": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "f641ba62-c9ca-4f45-ba95-3d68c419a5a5",
-                                    "name": "events-ad-hoc",
-                                    "runtimeFieldMap": {
-                                        "resource.attributes.k8s.namespace.name": {
-                                            "script": {
-                                                "source": "if (doc.containsKey('body_structured.object.regarding.kind')) {\n    if (doc['body_structured.object.regarding.kind'].value == \"Pod\") {\n        emit(doc['body_structured.object.regarding.namespace'].value);\n    }\n}"
-                                            },
-                                            "type": "keyword"
-                                        },
-                                        "resource.attributes.k8s.node.name": {
-                                            "script": {
-                                                "source": "if (doc.containsKey('body_structured.object.regarding.kind')) {\n    if (doc['body_structured.object.regarding.kind'].value == \"Node\") {\n        emit(doc['body_structured.object.regarding.name'].value);\n    }\n    if (doc['body_structured.object.regarding.kind'].value == \"Pod\") {\n        emit(doc['body_structured.object.reportingInstance'].value);\n    }\n}"
-                                            },
-                                            "type": "keyword"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "logs-*otel*"
-                                }
-                            },
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "29bf96fd-6dcd-4667-8e14-8865fb5a7e63": {
-                                            "columnOrder": [
-                                                "f5ec8d83-2794-4577-bb1c-a23f1ea9c87e",
-                                                "5f4d7cd7-5853-47c5-9fd3-bcc5a0ad5da8",
-                                                "7c4f6d0c-8079-40a9-9d8f-14983af72e56"
-                                            ],
-                                            "columns": {
-                                                "5f4d7cd7-5853-47c5-9fd3-bcc5a0ad5da8": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "7c4f6d0c-8079-40a9-9d8f-14983af72e56": {
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "body_structured.object.kind:*"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Count of body_structured.object.kind",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "body_structured.object.kind"
-                                                },
-                                                "f5ec8d83-2794-4577-bb1c-a23f1ea9c87e": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top values of body_structured.object.regarding.kind + 1 other",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "7c4f6d0c-8079-40a9-9d8f-14983af72e56",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "multi_terms"
-                                                        },
-                                                        "secondaryFields": [
-                                                            "body_structured.object.reason"
-                                                        ],
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "body_structured.object.regarding.kind"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "indexpattern": {
-                                    "layers": {}
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "field": "body_structured.object.kind",
-                                        "index": "a299f833-0fff-49b7-a790-fc61198326f9",
-                                        "key": "body_structured.object.kind",
-                                        "negate": false,
-                                        "type": "exists"
-                                    },
-                                    "query": {
-                                        "exists": {
-                                            "field": "body_structured.object.kind"
-                                        }
-                                    }
-                                },
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "field": "body_structured.object.type",
-                                        "index": "a299f833-0fff-49b7-a790-fc61198326f9",
-                                        "key": "body_structured.object.type",
-                                        "negate": true,
-                                        "params": {
-                                            "query": "Normal"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "body_structured.object.type": "Normal"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [
-                                {
-                                    "id": "f641ba62-c9ca-4f45-ba95-3d68c419a5a5",
-                                    "name": "indexpattern-datasource-layer-29bf96fd-6dcd-4667-8e14-8865fb5a7e63",
-                                    "type": "index-pattern"
-                                }
-                            ],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "7c4f6d0c-8079-40a9-9d8f-14983af72e56"
-                                        ],
-                                        "layerId": "29bf96fd-6dcd-4667-8e14-8865fb5a7e63",
-                                        "layerType": "data",
-                                        "seriesType": "bar_stacked",
-                                        "splitAccessor": "f5ec8d83-2794-4577-bb1c-a23f1ea9c87e",
-                                        "xAccessor": "5f4d7cd7-5853-47c5-9fd3-bcc5a0ad5da8"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "bar_stacked",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "Kubernetes Warning and Error Events",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "description": "",
-                    "enhancements": {}
-                },
-                "gridData": {
-                    "h": 15,
-                    "i": "c2d8c039-fc7e-4637-b2ef-ac05cd0b0b24",
-                    "w": 23,
-                    "x": 0,
-                    "y": 45
-                },
-                "panelIndex": "c2d8c039-fc7e-4637-b2ef-ac05cd0b0b24",
-                "title": "Kubernetes Warning Events",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "description": "",
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "3769faab-05d7-4801-a802-b96342983e85": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "3769faab-05d7-4801-a802-b96342983e85",
-                                    "name": "events-ad-hoc",
-                                    "runtimeFieldMap": {
-                                        "resource.attributes.k8s.namespace.name": {
-                                            "script": {
-                                                "source": "if (doc.containsKey('body_structured.object.regarding.kind')) {\n    if (doc['body_structured.object.regarding.kind'].value == \"Pod\") {\n        emit(doc['body_structured.object.regarding.namespace'].value);\n    }\n}"
-                                            },
-                                            "type": "keyword"
-                                        },
-                                        "resource.attributes.k8s.node.name": {
-                                            "script": {
-                                                "source": "if (doc.containsKey('body_structured.object.regarding.kind')) {\n    if (doc['body_structured.object.regarding.kind'].value == \"Node\") {\n        emit(doc['body_structured.object.regarding.name'].value);\n    }\n    if (doc['body_structured.object.regarding.kind'].value == \"Pod\") {\n        emit(doc['body_structured.object.reportingInstance'].value);\n    }\n}"
-                                            },
-                                            "type": "keyword"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "logs-*otel*"
-                                }
-                            },
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "4581d01c-5f91-4098-bb19-36de6b81d665": {
-                                            "columnOrder": [
-                                                "ae8cea3a-aef4-48a3-8076-9b88229ed6c6",
-                                                "e60b992c-e1f9-4351-b5f1-d05a16424ccf",
-                                                "18cb52c0-f508-4d55-b5fc-7e0e7d273486",
-                                                "8e7feb9e-b98e-492d-b1a6-16c9152dcdbd",
-                                                "c62d6c19-ac0f-42e8-a872-4996e96a4904",
-                                                "cde7d210-0d76-4a32-92b6-bdfce76aaa1b",
-                                                "bd5a95f8-2eb8-4338-8b0b-50ccb2ded899"
-                                            ],
-                                            "columns": {
-                                                "18cb52c0-f508-4d55-b5fc-7e0e7d273486": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Event Reason",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "bd5a95f8-2eb8-4338-8b0b-50ccb2ded899",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "body_structured.object.reason"
-                                                },
-                                                "8e7feb9e-b98e-492d-b1a6-16c9152dcdbd": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Resource Name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "bd5a95f8-2eb8-4338-8b0b-50ccb2ded899",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "body_structured.object.regarding.name"
-                                                },
-                                                "ae8cea3a-aef4-48a3-8076-9b88229ed6c6": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": false,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "bd5a95f8-2eb8-4338-8b0b-50ccb2ded899": {
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Unique count of body_structured.object.kind",
-                                                    "operationType": "unique_count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "body_structured.object.kind"
-                                                },
-                                                "c62d6c19-ac0f-42e8-a872-4996e96a4904": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Node",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "bd5a95f8-2eb8-4338-8b0b-50ccb2ded899",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "secondaryFields": [],
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "resource.attributes.k8s.node.name"
-                                                },
-                                                "cde7d210-0d76-4a32-92b6-bdfce76aaa1b": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Event message",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "bd5a95f8-2eb8-4338-8b0b-50ccb2ded899",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "body_structured.object.note"
-                                                },
-                                                "e60b992c-e1f9-4351-b5f1-d05a16424ccf": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Event Kind",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "bd5a95f8-2eb8-4338-8b0b-50ccb2ded899",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "body_structured.object.regarding.kind"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "indexpattern": {
-                                    "layers": {}
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "field": "body_structured.object.kind",
-                                        "index": "a299f833-0fff-49b7-a790-fc61198326f9",
-                                        "key": "body_structured.object.kind",
-                                        "negate": false,
-                                        "type": "exists"
-                                    },
-                                    "query": {
-                                        "exists": {
-                                            "field": "body_structured.object.kind"
-                                        }
-                                    }
-                                },
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "field": "body_structured.object.type",
-                                        "index": "a299f833-0fff-49b7-a790-fc61198326f9",
-                                        "key": "body_structured.object.type",
-                                        "negate": true,
-                                        "params": {
-                                            "query": "Normal"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "body_structured.object.type": "Normal"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [
-                                {
-                                    "id": "3769faab-05d7-4801-a802-b96342983e85",
-                                    "name": "indexpattern-datasource-layer-4581d01c-5f91-4098-bb19-36de6b81d665",
-                                    "type": "index-pattern"
-                                }
-                            ],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "columns": [
-                                    {
-                                        "columnId": "e60b992c-e1f9-4351-b5f1-d05a16424ccf",
-                                        "isMetric": false,
-                                        "isTransposed": false,
-                                        "width": 139.35000000000002
-                                    },
-                                    {
-                                        "columnId": "ae8cea3a-aef4-48a3-8076-9b88229ed6c6",
-                                        "isMetric": false,
-                                        "isTransposed": false,
-                                        "oneClickFilter": false,
-                                        "width": 211.68333333333334
-                                    },
-                                    {
-                                        "columnId": "bd5a95f8-2eb8-4338-8b0b-50ccb2ded899",
-                                        "hidden": true,
-                                        "isMetric": true,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "18cb52c0-f508-4d55-b5fc-7e0e7d273486",
-                                        "isMetric": false,
-                                        "isTransposed": false,
-                                        "width": 201.60000000000002
-                                    },
-                                    {
-                                        "columnId": "c62d6c19-ac0f-42e8-a872-4996e96a4904",
-                                        "hidden": false,
-                                        "isMetric": false,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "cde7d210-0d76-4a32-92b6-bdfce76aaa1b",
-                                        "isMetric": false,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "8e7feb9e-b98e-492d-b1a6-16c9152dcdbd",
-                                        "isMetric": false,
-                                        "isTransposed": false,
-                                        "width": 163.1222222222222
-                                    }
-                                ],
-                                "headerRowHeight": "single",
-                                "headerRowHeightLines": 1,
-                                "layerId": "4581d01c-5f91-4098-bb19-36de6b81d665",
-                                "layerType": "data",
-                                "paging": {
-                                    "enabled": false,
-                                    "size": 10
-                                },
-                                "rowHeight": "auto",
-                                "sorting": {
-                                    "columnId": "ae8cea3a-aef4-48a3-8076-9b88229ed6c6",
-                                    "direction": "desc"
-                                }
-                            }
-                        },
-                        "title": "Latest Warning Events",
-                        "type": "lens",
-                        "visualizationType": "lnsDatatable"
-                    },
-                    "enhancements": {}
-                },
-                "gridData": {
-                    "h": 15,
-                    "i": "7b762c59-2643-4200-8c76-ece0937e11e7",
-                    "w": 25,
-                    "x": 23,
-                    "y": 45
-                },
-                "panelIndex": "7b762c59-2643-4200-8c76-ece0937e11e7",
                 "type": "lens"
             }
         ],
         "timeRestore": false,
-        "title": "[OTEL][Metrics Kubernetes] Cluster Overview",
+        "title": "[OTEL][Metrics Kubernetes] Cluster Overview (1)",
         "version": 2
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-10-14T16:05:02.264Z",
+    "created_at": "2024-10-17T11:10:00.109Z",
     "created_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0",
     "id": "kubernetes_otel-cluster-overview",
     "managed": false,
     "references": [
         {
             "id": "metrics-*",
-            "name": "eeac2e1e-8980-4606-8b00-b75e73204c3f:indexpattern-datasource-layer-894781bd-2933-418c-b883-1f758794a45d",
+            "name": "418e39a1-f843-4083-9efa-81940fd778cf:indexpattern-datasource-layer-894781bd-2933-418c-b883-1f758794a45d",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "e37f26c5-4007-4cd7-aa4a-1d409c990752:indexpattern-datasource-layer-54494aa2-197e-42d6-a8ef-0072655ca351",
+            "name": "2c06e3e7-e9d9-46ef-866c-7073c31216f1:indexpattern-datasource-layer-54494aa2-197e-42d6-a8ef-0072655ca351",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "e37f26c5-4007-4cd7-aa4a-1d409c990752:indexpattern-datasource-layer-dba09ccc-6ec6-443b-8620-1eac10077772",
+            "name": "2c06e3e7-e9d9-46ef-866c-7073c31216f1:indexpattern-datasource-layer-dba09ccc-6ec6-443b-8620-1eac10077772",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "8ec1e48e-9d3a-4ac8-a36d-139302785d83:indexpattern-datasource-layer-54494aa2-197e-42d6-a8ef-0072655ca351",
+            "name": "f93cbfa7-623a-4056-a14c-d94a64a8d772:indexpattern-datasource-layer-54494aa2-197e-42d6-a8ef-0072655ca351",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "8ec1e48e-9d3a-4ac8-a36d-139302785d83:indexpattern-datasource-layer-dba09ccc-6ec6-443b-8620-1eac10077772",
+            "name": "f93cbfa7-623a-4056-a14c-d94a64a8d772:indexpattern-datasource-layer-dba09ccc-6ec6-443b-8620-1eac10077772",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "33c4c965-846e-41bb-8457-8e8a3fe04e2c:indexpattern-datasource-layer-894781bd-2933-418c-b883-1f758794a45d",
+            "name": "13964c54-c02c-4e60-91e9-742f6024c373:indexpattern-datasource-layer-894781bd-2933-418c-b883-1f758794a45d",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "33c4c965-846e-41bb-8457-8e8a3fe04e2c:d632b895-3242-4f49-8d2c-ea7310b23b9a",
+            "name": "13964c54-c02c-4e60-91e9-742f6024c373:d632b895-3242-4f49-8d2c-ea7310b23b9a",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "7a508a02-dfab-43cb-84f4-682ea5d1c483:indexpattern-datasource-layer-b5e4cee3-e558-4805-b276-673a7ebff8f0",
+            "name": "b83e8093-e4fd-4f0f-8f52-74b1e5600cbf:indexpattern-datasource-layer-b5e4cee3-e558-4805-b276-673a7ebff8f0",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "acc7e28f-cfc7-4d27-a904-332aac864a4d:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
+            "name": "58dfa3d6-c91b-4868-974a-d405db499dcb:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "a73b59f6-e7fe-495d-85b9-455ea1dc92eb:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
+            "name": "5396b322-e988-4902-9be8-df6d1bf738d1:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "d57f55a8-e2a3-49aa-9e6d-fc3a92b2b787:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
+            "name": "93fcf7c5-9f87-4d8f-8582-5df16d4c5603:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "d57f55a8-e2a3-49aa-9e6d-fc3a92b2b787:1b04b540-39ae-4cfd-8088-34a4bf3d5654",
+            "name": "93fcf7c5-9f87-4d8f-8582-5df16d4c5603:1b04b540-39ae-4cfd-8088-34a4bf3d5654",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "7cd4d107-fcfc-4a07-bb63-d3a9862f0e96:indexpattern-datasource-layer-57a8eb42-6f2c-4112-9d6c-c03d982c569e",
+            "name": "c793c718-7819-4d53-951a-7d664d381307:indexpattern-datasource-layer-57a8eb42-6f2c-4112-9d6c-c03d982c569e",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "7cd4d107-fcfc-4a07-bb63-d3a9862f0e96:0e11ca27-40f5-4300-b885-17ade4895220",
+            "name": "c793c718-7819-4d53-951a-7d664d381307:0e11ca27-40f5-4300-b885-17ade4895220",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "53ef9b2d-f968-4ab7-858e-20b4b9171157:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+            "name": "136b58d1-1483-42a1-9fda-c99adf0792c5:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "49683e76-f892-40b8-9299-9558ff44103b:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+            "name": "be5a9424-c970-40d1-bb23-60f3d4d24cc9:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "020a7985-baa4-4b7b-9136-ab0357bb83c8:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+            "name": "9c8dc773-0432-43d5-9a87-57986054e0b0:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "67779719-91a4-4a68-b7fe-7bc7eef837af:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+            "name": "6b564db2-f6f7-4bf4-8fab-534b6bb47c55:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
             "type": "index-pattern"
+        },
+        {
+            "id": "kubernetes_otel-fleet-shared-tag-kubernetes_otel-dfd505f6-fc02-5c53-adc7-148425d7972c-default",
+            "name": "tag-ref-fleet-shared-tag-kubernetes_otel-dfd505f6-fc02-5c53-adc7-148425d7972c-default",
+            "type": "tag"
         },
         {
             "id": "metrics-*",

--- a/packages/kubernetes_otel/manifest.yml
+++ b/packages/kubernetes_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.0
 name: kubernetes_otel
 title: "Kubernetes OpenTelemetry Assets"
-version: 0.0.4
+version: 0.0.5
 description: "Utilise the pre-built dashboard for OTel-native metrics and events collected from a Kubernetes cluster"
 type: content
 categories:


### PR DESCRIPTION
## Proposed commit message

WHAT: Removing the events from overview dashboard
WHY: https://github.com/elastic/opentelemetry-dev/issues/469

This version includes some resizing of visualisations in ordeto make UX more friendly to smaller display analysis
