### PR TITLE
[cisco_duo] Make the rate limit configurable

### DIFF
--- a/packages/cisco_duo/changelog.yml
+++ b/packages/cisco_duo/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.0.5"
+  changes:
+    - description: Make the rate limit configurable.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11471
 - version: "2.0.4"
   changes:
     - description: Fix auth CEL cursor handling.

--- a/packages/cisco_duo/data_stream/admin/agent/stream/httpjson.yml.hbs
+++ b/packages/cisco_duo/data_stream/admin/agent/stream/httpjson.yml.hbs
@@ -6,7 +6,7 @@ request.tracer.maxbackups: 5
 {{/if}}
 request.method: GET
 request.url: {{hostname}}/admin/v1/logs/administrator
-request.rate_limit.limit: "0.5"
+request.rate_limit.limit: "{{rate_limit}}"
 request.transforms:
   - set:
       target: url.params.mintime

--- a/packages/cisco_duo/data_stream/auth/agent/stream/cel.yml.hbs
+++ b/packages/cisco_duo/data_stream/auth/agent/stream/cel.yml.hbs
@@ -2,7 +2,7 @@ config_version: 2
 interval: {{interval}}
 resource.url: {{hostname}}
 resource.rate_limit.burst: 1
-resource.rate_limit.limit: 0.5
+resource.rate_limit.limit: {{rate_limit}}
 
 {{#if enable_request_tracer}}
 resource.tracer.filename: "../../logs/cel/http-request-trace-*.ndjson"

--- a/packages/cisco_duo/data_stream/auth/agent/stream/httpjson.yml.hbs
+++ b/packages/cisco_duo/data_stream/auth/agent/stream/httpjson.yml.hbs
@@ -6,7 +6,7 @@ request.tracer.maxbackups: 5
 {{/if}}
 request.method: GET
 request.url: {{hostname}}/admin/v2/logs/authentication
-request.rate_limit.limit: "0.5"
+request.rate_limit.limit: "{{rate_limit}}"
 request.transforms:
   - set:
       target: url.params.limit

--- a/packages/cisco_duo/data_stream/offline_enrollment/agent/stream/httpjson.yml.hbs
+++ b/packages/cisco_duo/data_stream/offline_enrollment/agent/stream/httpjson.yml.hbs
@@ -6,7 +6,7 @@ request.tracer.filename: "../../logs/httpjson/http-request-trace-*.ndjson"
 request.tracer.maxbackups: 5
 {{/if}}
 request.url: {{hostname}}/admin/v1/logs/offline_enrollment
-request.rate_limit.limit: "0.5"
+request.rate_limit.limit: "{{rate_limit}}"
 request.transforms:
   - set:
       target: url.params.mintime

--- a/packages/cisco_duo/data_stream/summary/agent/stream/httpjson.yml.hbs
+++ b/packages/cisco_duo/data_stream/summary/agent/stream/httpjson.yml.hbs
@@ -6,7 +6,7 @@ request.tracer.maxbackups: 5
 {{/if}}
 request.method: GET
 request.url: {{hostname}}/admin/v1/info/summary
-request.rate_limit.limit: "0.5"
+request.rate_limit.limit: "{{rate_limit}}"
 request.transforms:
   - set:
       target: header.Date

--- a/packages/cisco_duo/data_stream/telephony/agent/stream/httpjson.yml.hbs
+++ b/packages/cisco_duo/data_stream/telephony/agent/stream/httpjson.yml.hbs
@@ -6,7 +6,7 @@ request.tracer.maxbackups: 5
 {{/if}}
 request.method: GET
 request.url: {{hostname}}/admin/v1/logs/telephony
-request.rate_limit.limit: "0.5"
+request.rate_limit.limit: "{{rate_limit}}"
 request.transforms:
   - set:
       target: url.params.mintime

--- a/packages/cisco_duo/data_stream/telephony_v2/agent/stream/cel.yml.hbs
+++ b/packages/cisco_duo/data_stream/telephony_v2/agent/stream/cel.yml.hbs
@@ -2,7 +2,7 @@ config_version: 2
 interval: {{interval}}
 resource.url: {{hostname}}
 resource.rate_limit.burst: 1
-resource.rate_limit.limit: 0.5
+resource.rate_limit.limit: {{rate_limit}}
 
 {{#if enable_request_tracer}}
 resource.tracer.filename: "../../logs/cel/http-request-trace-*.ndjson"

--- a/packages/cisco_duo/manifest.yml
+++ b/packages/cisco_duo/manifest.yml
@@ -48,13 +48,6 @@ policy_templates:
             title: Hostname
             description: Hostname for the Cisco Duo Admin API (Add https:// before the hostname).
             required: true
-          - name: enable_request_tracer
-            type: bool
-            title: Enable request tracing
-            multi: false
-            required: false
-            show_user: false
-            description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
           - name: integration_key
             type: text
             title: Integration Key
@@ -74,6 +67,21 @@ policy_templates:
             required: true
             show_user: true
             default: 1m
+          - name: rate_limit
+            type: text
+            title: Rate limit
+            description: "The maximum per endpoint request rate, in requests per second (e.g. 0.5 reqs/sec for 30 reqs/min)."
+            default: "0.5"
+            multi: false
+            required: true
+            show_user: false
+          - name: enable_request_tracer
+            type: bool
+            title: Enable request tracing
+            multi: false
+            required: false
+            show_user: false
+            description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
         title: Collect Cisco Duo logs via API v1
         description: Collect Cisco Duo Administrator, Offline Enrollment, Summary, and Telephony (legacy) logs
       - type: cel
@@ -83,13 +91,6 @@ policy_templates:
             title: Hostname
             description: Hostname for the Cisco Duo Admin API. All API methods use your API hostname, https://api-XXXXXXXX.duosecurity.com. Obtain this value from the Duo Admin Panel and use it exactly as shown there.
             required: true
-          - name: enable_request_tracer
-            type: bool
-            title: Enable request tracing
-            multi: false
-            required: false
-            show_user: false
-            description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
           - name: integration_key
             type: text
             title: Integration Key
@@ -109,6 +110,21 @@ policy_templates:
             required: true
             show_user: true
             default: 1m
+          - name: rate_limit
+            type: text
+            title: Rate limit
+            description: "The maximum per endpoint request rate, in requests per second (e.g. 0.5 reqs/sec for 30 reqs/min)."
+            default: "0.5"
+            multi: false
+            required: true
+            show_user: false
+          - name: enable_request_tracer
+            type: bool
+            title: Enable request tracing
+            multi: false
+            required: false
+            show_user: false
+            description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
         title: Collect Cisco Duo logs via API v2
         description: Collect Cisco Duo Authentication, and Telephony logs
 owner:

--- a/packages/cisco_duo/manifest.yml
+++ b/packages/cisco_duo/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cisco_duo
 title: Cisco Duo
-version: "2.0.4"
+version: "2.0.5"
 description: Collect logs from Cisco Duo with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[cisco_duo] Make rate limit configurable
```

Also moves `show_user: false` variables to the end of the list in the manifest.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Relates #11405