### PR TITLE
[IBM MQ integration package] Update the compatibility section

### DIFF
--- a/packages/ibmmq/_dev/build/docs/README.md
+++ b/packages/ibmmq/_dev/build/docs/README.md
@@ -28,7 +28,7 @@ Note:
 
 ## Compatibility
 
-This integration has been tested against `IBM MQ v9.1` and `IBM MQ v9.2`. The ibmmq `qmgr` data stream is compatible with a containerized distribution of IBM MQ (since version 9.1.0).
+This integration has been tested against IBM MQ v9.1 and IBM MQ v9.2. The ibmmq qmgr data stream is currently only compatible with a [containerized distribution of IBM MQ](https://hub.docker.com/r/ibmcom/mq). 
 
 ## Prerequisites
 

--- a/packages/ibmmq/_dev/build/docs/README.md
+++ b/packages/ibmmq/_dev/build/docs/README.md
@@ -28,7 +28,7 @@ Note:
 
 ## Compatibility
 
-This integration has been tested against IBM MQ v9.1 and IBM MQ v9.2. Currently, the `ibmmq qmgr` data stream is only compatible with a [containerized distribution of IBM MQ](https://hub.docker.com/r/ibmcom/mq). 
+This integration has been tested against IBM MQ v9.1 and IBM MQ v9.2. Currently, the `ibmmq qmgr` data stream is only compatible with the containerized versions of IBM MQ, such as those available from [IBM Cloud Container Registry](https://icr.io/) or [Docker Hub](https://hub.docker.com/r/ibmcom/mq). 
 
 ## Prerequisites
 

--- a/packages/ibmmq/_dev/build/docs/README.md
+++ b/packages/ibmmq/_dev/build/docs/README.md
@@ -28,7 +28,7 @@ Note:
 
 ## Compatibility
 
-This integration has been tested against IBM MQ v9.1 and IBM MQ v9.2. The ibmmq qmgr data stream is currently only compatible with a [containerized distribution of IBM MQ](https://hub.docker.com/r/ibmcom/mq). 
+This integration has been tested against IBM MQ v9.1 and IBM MQ v9.2. Currently, the `ibmmq qmgr` data stream is only compatible with a [containerized distribution of IBM MQ](https://hub.docker.com/r/ibmcom/mq). 
 
 ## Prerequisites
 

--- a/packages/ibmmq/changelog.yml
+++ b/packages/ibmmq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.1"
+  changes:
+    - description: Update the IBM MQ compatibility section.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/11492
 - version: "1.4.0"
   changes:
     - description: ECS version updated to 8.11.0. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/ibmmq/docs/README.md
+++ b/packages/ibmmq/docs/README.md
@@ -28,7 +28,7 @@ Note:
 
 ## Compatibility
 
-This integration has been tested against `IBM MQ v9.1` and `IBM MQ v9.2`. The ibmmq `qmgr` data stream is compatible with a containerized distribution of IBM MQ (since version 9.1.0).
+This integration has been tested against IBM MQ v9.1 and IBM MQ v9.2. The ibmmq qmgr data stream is currently only compatible with a [containerized distribution of IBM MQ](https://hub.docker.com/r/ibmcom/mq). 
 
 ## Prerequisites
 

--- a/packages/ibmmq/docs/README.md
+++ b/packages/ibmmq/docs/README.md
@@ -28,7 +28,7 @@ Note:
 
 ## Compatibility
 
-This integration has been tested against IBM MQ v9.1 and IBM MQ v9.2. Currently, the `ibmmq qmgr` data stream is only compatible with a [containerized distribution of IBM MQ](https://hub.docker.com/r/ibmcom/mq). 
+This integration has been tested against IBM MQ v9.1 and IBM MQ v9.2. Currently, the `ibmmq qmgr` data stream is only compatible with the containerized versions of IBM MQ, such as those available from [IBM Cloud Container Registry](https://icr.io/) or [Docker Hub](https://hub.docker.com/r/ibmcom/mq). 
 
 ## Prerequisites
 

--- a/packages/ibmmq/docs/README.md
+++ b/packages/ibmmq/docs/README.md
@@ -28,7 +28,7 @@ Note:
 
 ## Compatibility
 
-This integration has been tested against IBM MQ v9.1 and IBM MQ v9.2. The ibmmq qmgr data stream is currently only compatible with a [containerized distribution of IBM MQ](https://hub.docker.com/r/ibmcom/mq). 
+This integration has been tested against IBM MQ v9.1 and IBM MQ v9.2. Currently, the `ibmmq qmgr` data stream is only compatible with a [containerized distribution of IBM MQ](https://hub.docker.com/r/ibmcom/mq). 
 
 ## Prerequisites
 

--- a/packages/ibmmq/manifest.yml
+++ b/packages/ibmmq/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: ibmmq
 title: IBM MQ
-version: "1.4.0"
+version: "1.4.1"
 source:
   license: Elastic-2.0
 description: Collect logs and metrics from IBM MQ with Elastic Agent.


### PR DESCRIPTION
This PR updates the Compatibility section for IBM MQ integration package with the supported official container images.

Closes https://github.com/elastic/integration-docs/issues/559
