### PR TITLE
o365: Fix the handling of duplicated field QueryTime

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.6.5"
+  changes:
+    - description: Fix the processing of duplicated QueryTime in Data field.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11499
 - version: "2.6.4"
   changes:
     - description: Remove in-program template snippets and format CEL code.

--- a/packages/o365/data_stream/audit/_dev/test/pipeline/test-data-duplicated-querytime-events.json
+++ b/packages/o365/data_stream/audit/_dev/test/pipeline/test-data-duplicated-querytime-events.json
@@ -1,0 +1,43 @@
+{
+    "events": [
+        {
+            "event": {
+                "original": "{\"AlertEntityId\":\"asr@testsiem.onmicrosoft.com\",\"AlertId\":\"5ba6e029-8b6e-13bd-b800-08d7b180173c\",\"AlertLinks\":[{\"AlertLinkHref\":\"http://example.net/alert\"},{\"AlertLinkHref\":\"http://example.net/info\"}],\"AlertType\":\"System\",\"Category\":\"AccessGovernance\",\"Comments\":\"New alert\",\"CreationTime\":\"2020-02-14T19:00:00\",\"Data\":\"{\\\"etype\\\":\\\"User\\\",\\\"eid\\\":\\\"asr@testsiem.onmicrosoft.com\\\",\\\"tid\\\":\\\"b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd\\\",\\\"ts\\\":\\\"2020-02-14T18:54:45.0000000Z\\\",\\\"te\\\":\\\"2020-02-14T18:54:45.0000000Z\\\",\\\"op\\\":\\\"GrantAdminPermission\\\",\\\"tdc\\\":\\\"1\\\",\\\"suid\\\":\\\"asr@testsiem.onmicrosoft.com\\\",\\\"ut\\\":\\\"Admin\\\",\\\"lon\\\":\\\"GrantAdminPermission\\\",\\\"Entities\\\":[{\\\"QueryTime\\\":\\\"2024-09-30T06:16:41.7320497Z\\\",\\\"QueryTime\":\\\"9/30/2024 6:16:41 AM\\\"}]}\",\"EntityType\":\"User\",\"Id\":\"448854d7-81f6-4a06-d31a-08d7b1c1fb2f\",\"Name\":\"Elevation of Exchange admin privilege\",\"ObjectId\":\"asr@testsiem.onmicrosoft.com\",\"Operation\":\"AlertEntityGenerated\",\"OrganizationId\":\"b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd\",\"PolicyId\":\"17d51759-88e1-40c1-8df3-20bcf2e43057\",\"RecordType\":64,\"ResultStatus\":\"Succeeded\",\"Severity\":\"Low\",\"Source\":\"Office 365 Security \\u0026 Compliance\",\"Status\":\"Active\",\"UserId\":\"SecurityComplianceAlerts\",\"UserKey\":\"SecurityComplianceAlerts\",\"UserType\":4,\"Version\":1,\"Workload\":\"SecurityComplianceCenter\"}"
+            },
+            "o365audit": {
+                "AlertEntityId": "asr@testsiem.onmicrosoft.com",
+                "AlertId": "5ba6e029-8b6e-13bd-b800-08d7b180173c",
+                "AlertLinks": [
+                    {
+                        "AlertLinkHref": "http://example.net/alert"
+                    },
+                    {
+                        "AlertLinkHref": "http://example.net/info"
+                    }
+                ],
+                "AlertType": "System",
+                "Category": "AccessGovernance",
+                "Comments": "New alert",
+                "CreationTime": "2020-02-14T19:00:00",
+                "Data": "{\"etype\":\"User\",\"eid\":\"asr@testsiem.onmicrosoft.com\",\"tid\":\"b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd\",\"ts\":\"2020-02-14T18:54:45.0000000Z\",\"te\":\"2020-02-14T18:54:45.0000000Z\",\"op\":\"GrantAdminPermission\",\"tdc\":\"1\",\"suid\":\"asr@testsiem.onmicrosoft.com\",\"ut\":\"Admin\",\"lon\":\"GrantAdminPermission\",\"Entities\":[{\"QueryTime\":\"2024-09-30T06:16:41.7320497Z\",\"QueryTime\":\"9/30/2024 6:16:41 AM\"}]}",
+                "EntityType": "User",
+                "Id": "448854d7-81f6-4a06-d31a-08d7b1c1fb2f",
+                "Name": "Elevation of Exchange admin privilege",
+                "ObjectId": "asr@testsiem.onmicrosoft.com",
+                "Operation": "AlertEntityGenerated",
+                "OrganizationId": "b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd",
+                "PolicyId": "17d51759-88e1-40c1-8df3-20bcf2e43057",
+                "RecordType": 64,
+                "ResultStatus": "Succeeded",
+                "Severity": "Low",
+                "Source": "Office 365 Security \u0026 Compliance",
+                "Status": "Active",
+                "UserId": "SecurityComplianceAlerts",
+                "UserKey": "SecurityComplianceAlerts",
+                "UserType": 4,
+                "Version": 1,
+                "Workload": "SecurityComplianceCenter"
+            }
+        }
+    ]
+}

--- a/packages/o365/data_stream/audit/_dev/test/pipeline/test-data-duplicated-querytime-events.json-expected.json
+++ b/packages/o365/data_stream/audit/_dev/test/pipeline/test-data-duplicated-querytime-events.json-expected.json
@@ -1,0 +1,100 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2020-02-14T19:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "AlertEntityGenerated",
+                "category": [
+                    "web"
+                ],
+                "code": "AirInvestigation",
+                "id": "448854d7-81f6-4a06-d31a-08d7b1c1fb2f",
+                "kind": "event",
+                "original": "{\"AlertEntityId\":\"asr@testsiem.onmicrosoft.com\",\"AlertId\":\"5ba6e029-8b6e-13bd-b800-08d7b180173c\",\"AlertLinks\":[{\"AlertLinkHref\":\"http://example.net/alert\"},{\"AlertLinkHref\":\"http://example.net/info\"}],\"AlertType\":\"System\",\"Category\":\"AccessGovernance\",\"Comments\":\"New alert\",\"CreationTime\":\"2020-02-14T19:00:00\",\"Data\":\"{\\\"etype\\\":\\\"User\\\",\\\"eid\\\":\\\"asr@testsiem.onmicrosoft.com\\\",\\\"tid\\\":\\\"b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd\\\",\\\"ts\\\":\\\"2020-02-14T18:54:45.0000000Z\\\",\\\"te\\\":\\\"2020-02-14T18:54:45.0000000Z\\\",\\\"op\\\":\\\"GrantAdminPermission\\\",\\\"tdc\\\":\\\"1\\\",\\\"suid\\\":\\\"asr@testsiem.onmicrosoft.com\\\",\\\"ut\\\":\\\"Admin\\\",\\\"lon\\\":\\\"GrantAdminPermission\\\",\\\"Entities\\\":[{\\\"QueryTime\\\":\\\"2024-09-30T06:16:41.7320497Z\\\",\\\"QueryTime\":\\\"9/30/2024 6:16:41 AM\\\"}]}\",\"EntityType\":\"User\",\"Id\":\"448854d7-81f6-4a06-d31a-08d7b1c1fb2f\",\"Name\":\"Elevation of Exchange admin privilege\",\"ObjectId\":\"asr@testsiem.onmicrosoft.com\",\"Operation\":\"AlertEntityGenerated\",\"OrganizationId\":\"b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd\",\"PolicyId\":\"17d51759-88e1-40c1-8df3-20bcf2e43057\",\"RecordType\":64,\"ResultStatus\":\"Succeeded\",\"Severity\":\"Low\",\"Source\":\"Office 365 Security \\u0026 Compliance\",\"Status\":\"Active\",\"UserId\":\"SecurityComplianceAlerts\",\"UserKey\":\"SecurityComplianceAlerts\",\"UserType\":4,\"Version\":1,\"Workload\":\"SecurityComplianceCenter\"}",
+                "outcome": "success",
+                "provider": "SecurityComplianceCenter",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "id": "b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd",
+                "name": "mytenant.onmicrosoft.com"
+            },
+            "o365": {
+                "audit": {
+                    "AlertEntityId": "asr@testsiem.onmicrosoft.com",
+                    "AlertId": "5ba6e029-8b6e-13bd-b800-08d7b180173c",
+                    "AlertLinks": [
+                        "http://example.net/alert",
+                        "http://example.net/info"
+                    ],
+                    "AlertType": "System",
+                    "Category": "AccessGovernance",
+                    "Comments": "New alert",
+                    "CreationTime": "2020-02-14T19:00:00",
+                    "Data": {
+                        "eid": "asr@testsiem.onmicrosoft.com",
+                        "etype": "User",
+                        "flattened": {
+                            "Entities": [
+                                {
+                                    "QueryTime": "2024-09-30T06:16:41.7320497Z"
+                                }
+                            ],
+                            "eid": "asr@testsiem.onmicrosoft.com",
+                            "etype": "User",
+                            "lon": "GrantAdminPermission",
+                            "op": "GrantAdminPermission",
+                            "suid": "asr@testsiem.onmicrosoft.com",
+                            "tdc": "1",
+                            "te": "2020-02-14T18:54:45.0000000Z",
+                            "tid": "b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd",
+                            "ts": "2020-02-14T18:54:45.0000000Z",
+                            "ut": "Admin"
+                        },
+                        "lon": "GrantAdminPermission",
+                        "op": "GrantAdminPermission",
+                        "suid": "asr@testsiem.onmicrosoft.com",
+                        "tdc": "1",
+                        "te": "2020-02-14T18:54:45.000Z",
+                        "tid": "b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd",
+                        "ts": "2020-02-14T18:54:45.000Z",
+                        "ut": "Admin"
+                    },
+                    "EntityType": "User",
+                    "Name": "Elevation of Exchange admin privilege",
+                    "ObjectId": "asr@testsiem.onmicrosoft.com",
+                    "PolicyId": "17d51759-88e1-40c1-8df3-20bcf2e43057",
+                    "RecordType": "64",
+                    "ResultStatus": "Succeeded",
+                    "Severity": "Low",
+                    "Source": "Office 365 Security & Compliance",
+                    "Status": "Active",
+                    "UserId": "SecurityComplianceAlerts",
+                    "UserKey": "SecurityComplianceAlerts",
+                    "UserType": "4",
+                    "Version": "1"
+                }
+            },
+            "organization": {
+                "id": "b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd",
+                "name": "mytenant.onmicrosoft.com"
+            },
+            "related": {
+                "user": [
+                    "asr@testsiem.onmicrosoft.com"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "id": "SecurityComplianceAlerts"
+            }
+        }
+    ]
+}

--- a/packages/o365/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/o365/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -1154,9 +1154,20 @@ processors:
       field: o365audit.YammerNetworkId
       type: string
       ignore_missing: true
+  - gsub:
+      field: o365audit.Data
+      pattern: ',\"QueryTime\":\"[0-9\/]+\s[0-9]+:[0-9]+:[0-9]+\s[AP]M\"|\"QueryTime\":\"[0-9\/]+\s[0-9]+:[0-9]+:[0-9]+\s[AP]M\",'
+      replacement: ""
+      if: ctx.o365audit?.containsKey('Data') == true && ctx.o365audit?.RecordType == '64'
+      tag: gsub_remove_duplicated_querytime
   - json:
       field: o365audit.Data
       if: ctx.o365audit?.containsKey('Data') == true
+      on_failure:
+        - remove:
+            field: o365audit.Data
+            ignore_missing: true
+            description: remove_malformed_data
   - rename:
       field: o365audit.Data
       target_field: o365audit.Data.flattened

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft Office 365
-version: "2.6.4"
+version: "2.6.5"
 description: Collect logs from Microsoft Office 365 with Elastic Agent.
 type: integration
 format_version: "3.0.2"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

For some unknown reason we couldn't find out, some events from O365 introduces a malformed JSON object by adding a duplicated `QueryTime` field. The pattern this issue follows is:
- It only affects events with `RecordType == 64`
- The undesired `QueryTime` field doesn't follow ISO8601 format.

So the pipeline fails with:
```
"error": {
      "message": [
        "Duplicate field 'QueryTime'\n at [Source: (String)\"{\"Version\":\"3.0\",\"VendorName\":\"Microsoft\"...\"[truncated 11497 chars]; line: 1, column: 5099]"
      ]
}
```

To fix the error it was added a `gsub` processor that attempts to find the undesired `QueryTime` field and removed from the whole `Data` object. In addition, to prevent other similar issues, added a `on_failure` case when decoding the `Data` field which generally contains unknown fields.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/integrations/issues/9920
