### PR TITLE
[Auditd Manager] Add Session Data option

### DIFF
--- a/packages/auditd_manager/_dev/build/docs/README.md
+++ b/packages/auditd_manager/_dev/build/docs/README.md
@@ -5,11 +5,21 @@ is a part of the Linux kernel.
 
 This integration is available only for Linux.
 
-## Session View powered by Auditd Manager [BETA]
+## Session View powered by Auditd Manager
 
-The `add_session_metadata` processor for Auditd Manager powers the [Session View](https://www.elastic.co/guide/en/security/current/session-view.html) utility for the Elastic Security Platform.
+The Auditd Manager is one of the integrations that can power the [Session View](https://www.elastic.co/guide/en/security/current/session-view.html) utility for the Elastic Security Platform. This feature provides a visual representation of session and process execution data, organized according to the Linux process model to help you investigate process, user, and service activity on your Linux infrastructure.
 
-To enable the `add_session_metadata` processor for Auditd Manager: 
+### Enabling Session Data Capture
+
+There are two ways to enable session data capture for the Session View feature:
+
+#### Method 1: Using the Toggle Switch (Recommended)
+
+1. Navigate to the Auditd Manager integration configuration in Kibana.
+2. Locate the "Session data" toggle switch.
+3. Turn the switch on to enable session data capture.
+
+#### Method 2: Manual Configuration
 
 1. Navigate to the Auditd Manager integration configuration in Kibana.
 2. Add the `add_session_metadata` processor configuration under the **Processors** section of Advanced options.
@@ -28,6 +38,13 @@ To enable the `add_session_metadata` processor for Auditd Manager:
 ```
 
 Changes are applied automatically, and you do not have to restart the service.
+
+### Important Notes
+
+- Using the toggle switch (Method 1) automatically applies these configurations, making it the simpler option for most users.
+- When enabling session data capture, be aware that it will collect extended process data, which may have privacy and storage implications.
+- You can disable session data capture at any time by turning off the toggle switch or removing the manual configurations.
+- If you switch between methods or disable the feature, ensure that any conflicting configurations are removed to avoid unexpected behaviour.
 
 ## How it works
 

--- a/packages/auditd_manager/changelog.yml
+++ b/packages/auditd_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.2"
+  changes:
+    - description: "Added Session data option"
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/11420
 - version: "1.18.1"
   changes:
     - description: "Reverting Session data option"

--- a/packages/auditd_manager/changelog.yml
+++ b/packages/auditd_manager/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: "Added Session data option"
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/11420
+      link: https://github.com/elastic/integrations/pull/11500
 - version: "1.18.1"
   changes:
     - description: "Reverting Session data option"

--- a/packages/auditd_manager/data_stream/auditd/_dev/test/policy/test-default.expected
+++ b/packages/auditd_manager/data_stream/auditd/_dev/test/policy/test-default.expected
@@ -1,0 +1,42 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: auditd_manager
+      name: test-default-auditd_manager
+      streams:
+        - backlog_limit: 8192
+          backpressure_strategy: auto
+          condition: ${host.platform} == 'linux'
+          data_stream:
+            dataset: auditd_manager.auditd
+            type: logs
+          failure_mode: silent
+          immutable: false
+          include_raw_message: true
+          include_warnings: false
+          rate_limit: 0
+          resolve_ids: true
+          socket_type: ""
+          tags:
+            - auditd_manager-auditd
+          type: audit/auditd
+      type: audit/auditd
+      use_output: default
+namespaces: []
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-auditd_manager.auditd-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references: []

--- a/packages/auditd_manager/data_stream/auditd/_dev/test/policy/test-default.yml
+++ b/packages/auditd_manager/data_stream/auditd/_dev/test/policy/test-default.yml
@@ -1,0 +1,2 @@
+data_stream:
+  vars:

--- a/packages/auditd_manager/data_stream/auditd/_dev/test/policy/test-session-viewer-with-audit-rules-and-processors.expected
+++ b/packages/auditd_manager/data_stream/auditd/_dev/test/policy/test-session-viewer-with-audit-rules-and-processors.expected
@@ -1,0 +1,57 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: auditd_manager
+      name: test-session-viewer-with-audit-rules-and-processors-auditd_manager
+      streams:
+        - audit_rules: |-
+            # Session data audit rules
+            -a always,exit -F arch=b64 -S execve,execveat -k exec
+            -a always,exit -F arch=b64 -S exit_group
+            -a always,exit -F arch=b64 -S setsid
+            # Unauthorized access attempts to files (unsuccessful).
+            -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access
+            -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access
+            -a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access
+            -a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access
+          backlog_limit: 8192
+          backpressure_strategy: auto
+          condition: ${host.platform} == 'linux'
+          data_stream:
+            dataset: auditd_manager.auditd
+            type: logs
+          failure_mode: silent
+          immutable: false
+          include_raw_message: true
+          include_warnings: false
+          processors:
+            - test_metadata:
+                mode: full
+            - add_session_metadata:
+                backend: auto
+          rate_limit: 0
+          resolve_ids: true
+          socket_type: ""
+          tags:
+            - auditd_manager-auditd
+          type: audit/auditd
+      type: audit/auditd
+      use_output: default
+namespaces: []
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-auditd_manager.auditd-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references: []

--- a/packages/auditd_manager/data_stream/auditd/_dev/test/policy/test-session-viewer-with-audit-rules-and-processors.yml
+++ b/packages/auditd_manager/data_stream/auditd/_dev/test/policy/test-session-viewer-with-audit-rules-and-processors.yml
@@ -1,0 +1,6 @@
+data_stream:
+  vars:
+    session_data: true
+    session_data_processors: "  - add_session_metadata:\n     backend: \"auto\""
+    processors: "  - test_metadata:\n     mode: \"full\""
+    audit_rules: "# Unauthorized access attempts to files (unsuccessful).\n-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access\n-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access\n-a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access\n-a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access"

--- a/packages/auditd_manager/data_stream/auditd/_dev/test/policy/test-session-viewer-with-audit-rules.expected
+++ b/packages/auditd_manager/data_stream/auditd/_dev/test/policy/test-session-viewer-with-audit-rules.expected
@@ -1,0 +1,55 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: auditd_manager
+      name: test-session-viewer-with-audit-rules-auditd_manager
+      streams:
+        - audit_rules: |-
+            # Session data audit rules
+            -a always,exit -F arch=b64 -S execve,execveat -k exec
+            -a always,exit -F arch=b64 -S exit_group
+            -a always,exit -F arch=b64 -S setsid
+            # Unauthorized access attempts to files (unsuccessful).
+            -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access
+            -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access
+            -a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access
+            -a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access
+          backlog_limit: 8192
+          backpressure_strategy: auto
+          condition: ${host.platform} == 'linux'
+          data_stream:
+            dataset: auditd_manager.auditd
+            type: logs
+          failure_mode: silent
+          immutable: false
+          include_raw_message: true
+          include_warnings: false
+          processors:
+            - add_session_metadata:
+                backend: auto
+          rate_limit: 0
+          resolve_ids: true
+          socket_type: ""
+          tags:
+            - auditd_manager-auditd
+          type: audit/auditd
+      type: audit/auditd
+      use_output: default
+namespaces: []
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-auditd_manager.auditd-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references: []

--- a/packages/auditd_manager/data_stream/auditd/_dev/test/policy/test-session-viewer-with-audit-rules.yml
+++ b/packages/auditd_manager/data_stream/auditd/_dev/test/policy/test-session-viewer-with-audit-rules.yml
@@ -1,0 +1,5 @@
+data_stream:
+  vars:
+    session_data: true
+    session_data_processors: "  - add_session_metadata:\n     backend: \"auto\""
+    audit_rules: "# Unauthorized access attempts to files (unsuccessful).\n-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access\n-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access\n-a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access\n-a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access"

--- a/packages/auditd_manager/data_stream/auditd/_dev/test/policy/test-session-viewer-with-processors.expected
+++ b/packages/auditd_manager/data_stream/auditd/_dev/test/policy/test-session-viewer-with-processors.expected
@@ -1,0 +1,52 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: auditd_manager
+      name: test-session-viewer-with-processors-auditd_manager
+      streams:
+        - audit_rules: |
+            # Session data audit rules
+            -a always,exit -F arch=b64 -S execve,execveat -k exec
+            -a always,exit -F arch=b64 -S exit_group
+            -a always,exit -F arch=b64 -S setsid
+          backlog_limit: 8192
+          backpressure_strategy: auto
+          condition: ${host.platform} == 'linux'
+          data_stream:
+            dataset: auditd_manager.auditd
+            type: logs
+          failure_mode: silent
+          immutable: false
+          include_raw_message: true
+          include_warnings: false
+          processors:
+            - test_metadata:
+                mode: full
+            - add_session_metadata:
+                backend: auto
+          rate_limit: 0
+          resolve_ids: true
+          socket_type: ""
+          tags:
+            - auditd_manager-auditd
+          type: audit/auditd
+      type: audit/auditd
+      use_output: default
+namespaces: []
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-auditd_manager.auditd-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references: []

--- a/packages/auditd_manager/data_stream/auditd/_dev/test/policy/test-session-viewer-with-processors.yml
+++ b/packages/auditd_manager/data_stream/auditd/_dev/test/policy/test-session-viewer-with-processors.yml
@@ -1,0 +1,5 @@
+data_stream:
+  vars:
+    session_data: true
+    session_data_processors: "  - add_session_metadata:\n     backend: \"auto\""
+    processors: "  - test_metadata:\n     mode: \"full\""

--- a/packages/auditd_manager/data_stream/auditd/_dev/test/policy/test-session-viewer.expected
+++ b/packages/auditd_manager/data_stream/auditd/_dev/test/policy/test-session-viewer.expected
@@ -1,0 +1,50 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: auditd_manager
+      name: test-session-viewer-auditd_manager
+      streams:
+        - audit_rules: |
+            # Session data audit rules
+            -a always,exit -F arch=b64 -S execve,execveat -k exec
+            -a always,exit -F arch=b64 -S exit_group
+            -a always,exit -F arch=b64 -S setsid
+          backlog_limit: 8192
+          backpressure_strategy: auto
+          condition: ${host.platform} == 'linux'
+          data_stream:
+            dataset: auditd_manager.auditd
+            type: logs
+          failure_mode: silent
+          immutable: false
+          include_raw_message: true
+          include_warnings: false
+          processors:
+            - add_session_metadata:
+                backend: auto
+          rate_limit: 0
+          resolve_ids: true
+          socket_type: ""
+          tags:
+            - auditd_manager-auditd
+          type: audit/auditd
+      type: audit/auditd
+      use_output: default
+namespaces: []
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-auditd_manager.auditd-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references: []

--- a/packages/auditd_manager/data_stream/auditd/_dev/test/policy/test-session-viewer.yml
+++ b/packages/auditd_manager/data_stream/auditd/_dev/test/policy/test-session-viewer.yml
@@ -1,0 +1,4 @@
+data_stream:
+  vars:
+    session_data: true
+    session_data_processors: "  - add_session_metadata:\n     backend: \"auto\""

--- a/packages/auditd_manager/data_stream/auditd/agent/stream/auditd.yml.hbs
+++ b/packages/auditd_manager/data_stream/auditd/agent/stream/auditd.yml.hbs
@@ -7,8 +7,16 @@ socket_type: '{{socket_type}}'
 immutable: {{immutable}}
 resolve_ids: {{resolve_ids}}
 failure_mode: {{failure_mode}}
+{{#if session_data}}
+audit_rules: "{{escape_multiline_string "# Session data audit rules
+-a always,exit -F arch=b64 -S execve,execveat -k exec
+-a always,exit -F arch=b64 -S exit_group
+-a always,exit -F arch=b64 -S setsid
+"}}{{escape_multiline_string audit_rules}}"
+{{else}}
 {{#if audit_rules}}
 audit_rules: {{escape_string audit_rules}}
+{{/if}}
 {{/if}}
 {{#if audit_rule_files.length}}
 audit_rule_files:
@@ -33,4 +41,12 @@ publisher_pipeline.disable_host: true
 {{#if processors}}
 processors:
 {{processors}}
+{{#if session_data}}
+{{session_data_processors}}
+{{/if}}
+{{else}}
+{{#if session_data}}
+processors:
+{{session_data_processors}}
+{{/if}}
 {{/if}}

--- a/packages/auditd_manager/data_stream/auditd/manifest.yml
+++ b/packages/auditd_manager/data_stream/auditd/manifest.yml
@@ -33,6 +33,19 @@ streams:
 
           If `auto` is selected, `elastic-agent` will attempt to use multicast sockets, falling
           back to unicast if multicast is not available.
+      - name: session_data
+        type: bool
+        title: Session data
+        show_user: true
+        multi: false
+        default: false
+        description: |
+          Turn this on to capture the extended process data required for Session View. 
+          Session View provides you a visual representation of session and process execution data.
+          
+          Session View data is organized according to the Linux process model to help you 
+          investigate process, user, and service activity on your Linux infrastructure.
+          [Learn more](https://www.elastic.co/guide/en/security/current/session-view.html) 
       - name: immutable
         type: bool
         title: Immutable
@@ -177,3 +190,14 @@ streams:
         description: |
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata.
           This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: session_data_processors
+        type: yaml
+        title: Session data processors
+        required: false
+        show_user: false
+        multi: false
+        description: |
+          These processors will be appended to the processors configuration if Session Data is enabled.
+        default: >2-
+            - add_session_metadata:
+               backend: "auto"

--- a/packages/auditd_manager/docs/README.md
+++ b/packages/auditd_manager/docs/README.md
@@ -5,11 +5,21 @@ is a part of the Linux kernel.
 
 This integration is available only for Linux.
 
-## Session View powered by Auditd Manager [BETA]
+## Session View powered by Auditd Manager
 
-The `add_session_metadata` processor for Auditd Manager powers the [Session View](https://www.elastic.co/guide/en/security/current/session-view.html) utility for the Elastic Security Platform.
+The Auditd Manager is one of the integrations that can power the [Session View](https://www.elastic.co/guide/en/security/current/session-view.html) utility for the Elastic Security Platform. This feature provides a visual representation of session and process execution data, organized according to the Linux process model to help you investigate process, user, and service activity on your Linux infrastructure.
 
-To enable the `add_session_metadata` processor for Auditd Manager: 
+### Enabling Session Data Capture
+
+There are two ways to enable session data capture for the Session View feature:
+
+#### Method 1: Using the Toggle Switch (Recommended)
+
+1. Navigate to the Auditd Manager integration configuration in Kibana.
+2. Locate the "Session data" toggle switch.
+3. Turn the switch on to enable session data capture.
+
+#### Method 2: Manual Configuration
 
 1. Navigate to the Auditd Manager integration configuration in Kibana.
 2. Add the `add_session_metadata` processor configuration under the **Processors** section of Advanced options.
@@ -28,6 +38,13 @@ To enable the `add_session_metadata` processor for Auditd Manager:
 ```
 
 Changes are applied automatically, and you do not have to restart the service.
+
+### Important Notes
+
+- Using the toggle switch (Method 1) automatically applies these configurations, making it the simpler option for most users.
+- When enabling session data capture, be aware that it will collect extended process data, which may have privacy and storage implications.
+- You can disable session data capture at any time by turning off the toggle switch or removing the manual configurations.
+- If you switch between methods or disable the feature, ensure that any conflicting configurations are removed to avoid unexpected behaviour.
 
 ## How it works
 

--- a/packages/auditd_manager/manifest.yml
+++ b/packages/auditd_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: auditd_manager
 title: "Auditd Manager"
-version: "1.18.1"
+version: "1.18.2"
 description: "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel."
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- Updating Auditd Manager manifest to include Session Data option starting from Kibana version 8.16.0.
- Updated logic in the `hbs` file to append Session Data Audit Rules and Session Data Processors when Session Data is selected.
- Updated documentation to include both manual and Toggle Switch options

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have tested it in Serverless
- [x] I have added the necessary automated tests
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).



## How to test this PR locally

To test these changes, go to Kibana -> Integrations -> Create new integration -> upload it as a .zip; and upload the following package:

[auditd_manager-1.18.2.zip](https://github.com/user-attachments/files/17498523/auditd_manager-1.18.2.zip)


## Related issues

- Closes https://github.com/elastic/security-team/issues/10830

## Screenshots

Session Data Switcher

<img width="1657" alt="image" src="https://github.com/user-attachments/assets/4a6480f0-27a6-4d6f-9528-a9c43b1e7553">

Docs

![image](https://github.com/user-attachments/assets/0388fc56-7851-43af-bf87-730ad619a6cb)

Policy Tests Included

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/b0fe14d3-505a-4471-a134-4b7592321555">

