### PR TITLE
[Bug] Fix 400 bad request in localhost_access.*.log causing dissect failure on pipeline.

### DIFF
--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: "Prevent 400 within access log causing failure in dissect."
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11515
 - version: "1.8.0"
   changes:
     - description: "Allow @custom pipeline access to event.original without setting preserve_original_event."

--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.8.1"
   changes:
-    - description: "Prevent 400 within access log causing failure in dissect."
+    - description: "Fix 400 bad request within access log causing pipeline failure."
       type: bugfix
       link: https://github.com/elastic/integrations/pull/11515
 - version: "1.8.0"

--- a/packages/apache_tomcat/data_stream/access/_dev/test/pipeline/test-access.log
+++ b/packages/apache_tomcat/data_stream/access/_dev/test/pipeline/test-access.log
@@ -8,5 +8,3 @@
 81.2.69.144 - admin [02/Mar/2023:19:01:17 +0530] "GET /manager/status HTTP/1.1" 200 4654 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36
 81.2.69.144 - admin [02/Mar/2023:19:02:25 +0530] "GET / HTTP/1.1" 200 11235
 81.2.69.144 - - [24/Oct/2024:14:18:49 +1100] "-" 400 - 81.2.69.145 + 0.000 "-" "-" X-Forwarded-For="-"
-
-

--- a/packages/apache_tomcat/data_stream/access/_dev/test/pipeline/test-access.log
+++ b/packages/apache_tomcat/data_stream/access/_dev/test/pipeline/test-access.log
@@ -7,3 +7,6 @@
 81.2.69.144 - admin [02/Mar/2023:18:58:17 +0530] "POST /host-manager/images/asf-logo.svg HTTP/1.1" 200 20486 81.2.69.145 - "http://localhost:8080/host-manager/html" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36" X-Forwarded-For=""
 81.2.69.144 - admin [02/Mar/2023:19:01:17 +0530] "GET /manager/status HTTP/1.1" 200 4654 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36
 81.2.69.144 - admin [02/Mar/2023:19:02:25 +0530] "GET / HTTP/1.1" 200 11235
+81.2.69.144 - - [24/Oct/2024:14:18:49 +1100] "-" 400 - 81.2.69.145 + 0.000 "-" "-" X-Forwarded-For="-"
+
+

--- a/packages/apache_tomcat/data_stream/access/_dev/test/pipeline/test-access.log-expected.json
+++ b/packages/apache_tomcat/data_stream/access/_dev/test/pipeline/test-access.log-expected.json
@@ -650,9 +650,6 @@
         },
         {
             "@timestamp": "2024-10-24T03:18:49.000Z",
-            "ecs": {
-                "version": "8.11.0"
-            },
             "apache_tomcat": {
                 "access": {
                     "http": {
@@ -665,6 +662,21 @@
                     },
                     "connection_status": "+"
                 }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "web"
+                ],
+                "type": [
+                    "access"
+                ],
+                "kind": "event",
+                "module": "apache_tomcat",
+                "original": "81.2.69.144 - - [24/Oct/2024:14:18:49 +1100] \"-\" 400 - 81.2.69.145 + 0.000 \"-\" \"-\" X-Forwarded-For=\"-\"",
+                "outcome": "failure"
             },
             "related": {
                 "ip": [
@@ -683,17 +695,9 @@
             "source": {
                 "ip": "81.2.69.144"
             },
-            "event": {
-                "category": [
-                    "web"
-                ],
-                "type": [
-                    "access"
-                ],
-                "kind": "event",
-                "outcome": "failure",
-                "module": "apache_tomcat"
-            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "user_agent": {
                 "original": "-"
             }

--- a/packages/apache_tomcat/data_stream/access/_dev/test/pipeline/test-access.log-expected.json
+++ b/packages/apache_tomcat/data_stream/access/_dev/test/pipeline/test-access.log-expected.json
@@ -647,6 +647,56 @@
                 "original": "/",
                 "path": "/"
             }
+        },
+        {
+            "@timestamp": "2024-10-24T03:18:49.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "apache_tomcat": {
+                "access": {
+                    "http": {
+                        "useragent": "-",
+                        "ident": "-"
+                    },
+                    "response_time": 0,
+                    "ip": {
+                        "local": "81.2.69.145"
+                    },
+                    "connection_status": "+"
+                }
+            },
+            "related": {
+                "ip": [
+                    "81.2.69.144",
+                    "81.2.69.145"
+                ]
+            },
+            "http": {
+                "request": {
+                    "referrer": "-"
+                },
+                "response": {
+                    "status_code": 400
+                }
+            },
+            "source": {
+                "ip": "81.2.69.144"
+            },
+            "event": {
+                "category": [
+                    "web"
+                ],
+                "type": [
+                    "access"
+                ],
+                "kind": "event",
+                "outcome": "failure",
+                "module": "apache_tomcat"
+            },
+            "user_agent": {
+                "original": "-"
+            }
         }
     ]
 }

--- a/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -33,6 +33,10 @@ processors:
       if: _tmp.dissect_request != '-'
       field: _tmp.dissect_request
       pattern: '%{http.request.method} %{url.original} HTTP/%{http.version}'
+      on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag fail-{{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - grok:
       field: _tmp.sourceorusername
       tag: 'grok_parse_log_sourceoruser'

--- a/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -24,11 +24,15 @@ processors:
   - dissect:
       field: event.original
       tag: 'dissect_event_original'
-      pattern: '%{_tmp.sourceorusername} %{apache_tomcat.access.http.ident} %{apache_tomcat.access.http.useragent} [%{_tmp.timestamp}] "%{http.request.method} %{url.original} HTTP/%{http.version}" %{_tmp.dissectgrok}'
+      pattern: '%{_tmp.sourceorusername} %{apache_tomcat.access.http.ident} %{apache_tomcat.access.http.useragent} [%{_tmp.timestamp}] "%{_tmp.dissect_request}" %{_tmp.dissectgrok}'
       on_failure:
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag fail-{{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - dissect:
+      if: _tmp.dissect_request != '-'
+      field: _tmp.dissect_request
+      pattern: '%{http.request.method} %{url.original} HTTP/%{http.version}'
   - grok:
       field: _tmp.sourceorusername
       tag: 'grok_parse_log_sourceoruser'

--- a/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -30,9 +30,9 @@ processors:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag fail-{{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - dissect:
-      if: _tmp.dissect_request != '-'
       field: _tmp.dissect_request
       pattern: '%{http.request.method} %{url.original} HTTP/%{http.version}'
+      if: ctx._tmp.dissect_request != '-'
       on_failure:
         - append:
             field: error.message

--- a/packages/apache_tomcat/manifest.yml
+++ b/packages/apache_tomcat/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: apache_tomcat
 title: Apache Tomcat
-version: "1.8.0"
+version: "1.8.1"
 description: Collect and parse logs and metrics from Apache Tomcat servers with Elastic Agent.
 categories: ["web", "observability"]
 type: integration


### PR DESCRIPTION
## Proposed commit message
Fix 400 bad request in localhost_access.*.log causing dissect failure on pipeline.

This change seeks to resolve defect #11514, where the dissect will fail in the event that a 400 bad request occurs by modify the ingest pipeline for Apache Tomcat localhost access logs. 

The pipeline currently does not cater for a null (-) %r, First line of the request (method and request URI) see [Tomcat 9 - Access Logging](https://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#Access_Logging).

To resolve this, the %r will be split out as a whole and dissected again in the event it's not null (-).

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist
- [x] Added 400 test case to Integration Log sample.
- [x] Updated pipeline within ECE and tested using log samples within integration tests. 
- [x] Updated Test Cases and results to expected vaules.

## How to test this PR locally

- Cloned existing pipeline "logs-apache_tomcat.access.1.5.1" within ECE deployment and modified to add in dissects and tested using the following records: 

Input Docs:
``` json
[
  {
    "_index": "index",
    "_id": "id",
    "_source": {
      "message": "81.2.69.144 - admin [02/Mar/2023:18:58:17 +0530] \"POST /host-manager/images/asf-logo.svg HTTP/1.1\" 200 20486 81.2.69.145 + 400 \"http://localhost:8080/host-manager/html\" \"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36\" X-Forwarded-For=\"127.0.0.1, 127.0.0.2\""
    }
  },
  {
    "_index": "index",
    "_id": "id",
    "_source": {
      "message": "81.2.69.144 - admin [02/Mar/2023:18:58:17 +0530] \"POST /host-manager/images/asf-logo.svg HTTP/1.1\" 302 - 81.2.69.145 + 400 \"http://localhost:8080/host-manager/html\" \"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36\" X-Forwarded-For=\"127.0.0.1, 127.0.0.2\""
    }
  },
  {
    "_index": "index",
    "_id": "id",
    "_source": {
      "message": "81.2.69.144 - admin [02/Mar/2023:18:58:17 +0530] \"POST /host-manager/images/asf-logo.svg HTTP/1.1\" 200 20486 X 400 \"http://localhost:8080/host-manager/html\" \"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36\" X-Forwarded-For=\"127.0.0.1\""
    }
  },
  {
    "_index": "index",
    "_id": "id",
    "_source": {
      "message": "81.2.69.144 - admin [02/Mar/2023:18:58:17 +0530] \"POST /host-manager/images/asf-logo.svg HTTP/1.1\" 200 20486 50 \"http://localhost:8080/host-manager/html\" \"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36\" X-Forwarded-For=\"\""
    }
  },
  {
    "_index": "index",
    "_id": "id",
    "_source": {
      "message": "81.2.69.144 - admin [02/Mar/2023:18:58:17 +0530] \"POST /host-manager/images/asf-logo.svg HTTP/1.1\" 200 20486 81.2.69.145 40 \"http://localhost:8080/host-manager/html\" \"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36\" X-Forwarded-For=\"127.0.0.1, 127.0.0.3\""
    }
  },
  {
    "_index": "index",
    "_id": "id",
    "_source": {
      "message": "81.2.69.144 - admin [02/Mar/2023:18:58:17 +0530] \"POST /host-manager/images/asf-logo.svg HTTP/1.1\" 200 20486 \"http://localhost:8080/host-manager/html\" \"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36\" X-Forwarded-For=\"\""
    }
  },
  {
    "_index": "index",
    "_id": "id",
    "_source": {
      "message": "81.2.69.144 - admin [02/Mar/2023:18:58:17 +0530] \"POST /host-manager/images/asf-logo.svg HTTP/1.1\" 200 20486 81.2.69.145 - \"http://localhost:8080/host-manager/html\" \"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36\" X-Forwarded-For=\"\""
    }
  },
  {
    "_index": "index",
    "_id": "id",
    "_source": {
      "message": "81.2.69.144 - admin [02/Mar/2023:19:01:17 +0530] \"GET /manager/status HTTP/1.1\" 200 4654 \"-\" \"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"
    }
  },
  {
    "_index": "index",
    "_id": "id",
    "_source": {
      "message": "81.2.69.144 - admin [02/Mar/2023:19:02:25 +0530] \"GET / HTTP/1.1\" 200 11235"
    }
  },
  {
    "_index": "index",
    "_id": "id",
    "_source": {
      "message": "81.2.69.144 - - [24/Oct/2024:14:18:49 +1100] \"-\" 400 - 81.2.69.145 + 0.000 \"-\" \"-\" X-Forwarded-For=\"-\""
    }
  }
]
```
Results: 
``` json
{
  "docs": [
    {
      "doc": {
        "_index": "index",
        "_version": "-3",
        "_id": "id",
        "_source": {
          "@timestamp": "2023-03-02T13:28:17.000Z",
          "ecs": {
            "version": "8.7.0"
          },
          "apache_tomcat": {
            "access": {
              "http": {
                "useragent": "admin",
                "ident": "-"
              },
              "response_time": 400,
              "ip": {
                "local": "81.2.69.145"
              },
              "connection_status": "+"
            }
          },
          "related": {
            "ip": [
              "81.2.69.144",
              "81.2.69.145",
              "127.0.0.1",
              "127.0.0.2"
            ]
          },
          "destination": {
            "bytes": 20486
          },
          "http": {
            "request": {
              "method": "POST",
              "referrer": "http://localhost:8080/host-manager/html"
            },
            "version": "1.1",
            "response": {
              "status_code": 200
            }
          },
          "client": {
            "ip": [
              "127.0.0.1",
              "127.0.0.2"
            ]
          },
          "source": {
            "ip": "81.2.69.144"
          },
          "event": {
            "category": [
              "web"
            ],
            "type": [
              "access"
            ],
            "kind": "event",
            "outcome": "success",
            "module": "apache_tomcat"
          },
          "url": {
            "path": "/host-manager/images/asf-logo.svg",
            "extension": "svg",
            "original": "/host-manager/images/asf-logo.svg"
          },
          "user_agent": {
            "name": "Chrome",
            "original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
            "os": {
              "name": "Windows",
              "version": "10",
              "full": "Windows 10"
            },
            "device": {
              "name": "Other"
            },
            "version": "109.0.0.0"
          }
        },
        "_ingest": {
          "_value": null,
          "timestamp": "2024-10-24T23:59:02.240317575Z"
        }
      }
    },
    {
      "doc": {
        "_index": "index",
        "_version": "-3",
        "_id": "id",
        "_source": {
          "@timestamp": "2023-03-02T13:28:17.000Z",
          "ecs": {
            "version": "8.7.0"
          },
          "apache_tomcat": {
            "access": {
              "http": {
                "useragent": "admin",
                "ident": "-"
              },
              "response_time": 400,
              "ip": {
                "local": "81.2.69.145"
              },
              "connection_status": "+"
            }
          },
          "related": {
            "ip": [
              "81.2.69.144",
              "81.2.69.145",
              "127.0.0.1",
              "127.0.0.2"
            ]
          },
          "http": {
            "request": {
              "method": "POST",
              "referrer": "http://localhost:8080/host-manager/html"
            },
            "version": "1.1",
            "response": {
              "status_code": 302
            }
          },
          "client": {
            "ip": [
              "127.0.0.1",
              "127.0.0.2"
            ]
          },
          "source": {
            "ip": "81.2.69.144"
          },
          "event": {
            "category": [
              "web"
            ],
            "type": [
              "access"
            ],
            "kind": "event",
            "outcome": "success",
            "module": "apache_tomcat"
          },
          "url": {
            "path": "/host-manager/images/asf-logo.svg",
            "extension": "svg",
            "original": "/host-manager/images/asf-logo.svg"
          },
          "user_agent": {
            "name": "Chrome",
            "original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
            "os": {
              "name": "Windows",
              "version": "10",
              "full": "Windows 10"
            },
            "device": {
              "name": "Other"
            },
            "version": "109.0.0.0"
          }
        },
        "_ingest": {
          "_value": null,
          "timestamp": "2024-10-24T23:59:02.240331968Z"
        }
      }
    },
    {
      "doc": {
        "_index": "index",
        "_version": "-3",
        "_id": "id",
        "_source": {
          "@timestamp": "2023-03-02T13:28:17.000Z",
          "ecs": {
            "version": "8.7.0"
          },
          "apache_tomcat": {
            "access": {
              "http": {
                "useragent": "admin",
                "ident": "-"
              },
              "response_time": 400,
              "connection_status": "X"
            }
          },
          "related": {
            "ip": [
              "81.2.69.144",
              "127.0.0.1"
            ]
          },
          "destination": {
            "bytes": 20486
          },
          "http": {
            "request": {
              "method": "POST",
              "referrer": "http://localhost:8080/host-manager/html"
            },
            "version": "1.1",
            "response": {
              "status_code": 200
            }
          },
          "client": {
            "ip": [
              "127.0.0.1"
            ]
          },
          "source": {
            "ip": "81.2.69.144"
          },
          "event": {
            "category": [
              "web"
            ],
            "type": [
              "access"
            ],
            "kind": "event",
            "outcome": "success",
            "module": "apache_tomcat"
          },
          "url": {
            "path": "/host-manager/images/asf-logo.svg",
            "extension": "svg",
            "original": "/host-manager/images/asf-logo.svg"
          },
          "user_agent": {
            "name": "Chrome",
            "original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
            "os": {
              "name": "Windows",
              "version": "10",
              "full": "Windows 10"
            },
            "device": {
              "name": "Other"
            },
            "version": "109.0.0.0"
          }
        },
        "_ingest": {
          "_value": null,
          "timestamp": "2024-10-24T23:59:02.240334601Z"
        }
      }
    },
    {
      "doc": {
        "_index": "index",
        "_version": "-3",
        "_id": "id",
        "_source": {
          "@timestamp": "2023-03-02T13:28:17.000Z",
          "ecs": {
            "version": "8.7.0"
          },
          "apache_tomcat": {
            "access": {
              "http": {
                "useragent": "admin",
                "ident": "-"
              },
              "response_time": 50
            }
          },
          "related": {
            "ip": [
              "81.2.69.144"
            ]
          },
          "destination": {
            "bytes": 20486
          },
          "http": {
            "request": {
              "method": "POST",
              "referrer": "http://localhost:8080/host-manager/html"
            },
            "version": "1.1",
            "response": {
              "status_code": 200
            }
          },
          "source": {
            "ip": "81.2.69.144"
          },
          "event": {
            "category": [
              "web"
            ],
            "type": [
              "access"
            ],
            "kind": "event",
            "outcome": "success",
            "module": "apache_tomcat"
          },
          "url": {
            "path": "/host-manager/images/asf-logo.svg",
            "extension": "svg",
            "original": "/host-manager/images/asf-logo.svg"
          },
          "user_agent": {
            "name": "Chrome",
            "original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
            "os": {
              "name": "Windows",
              "version": "10",
              "full": "Windows 10"
            },
            "device": {
              "name": "Other"
            },
            "version": "109.0.0.0"
          }
        },
        "_ingest": {
          "timestamp": "2024-10-24T23:59:02.240339761Z"
        }
      }
    },
    {
      "doc": {
        "_index": "index",
        "_version": "-3",
        "_id": "id",
        "_source": {
          "@timestamp": "2023-03-02T13:28:17.000Z",
          "ecs": {
            "version": "8.7.0"
          },
          "apache_tomcat": {
            "access": {
              "http": {
                "useragent": "admin",
                "ident": "-"
              },
              "response_time": 40,
              "ip": {
                "local": "81.2.69.145"
              }
            }
          },
          "related": {
            "ip": [
              "81.2.69.144",
              "81.2.69.145",
              "127.0.0.1",
              "127.0.0.3"
            ]
          },
          "destination": {
            "bytes": 20486
          },
          "http": {
            "request": {
              "method": "POST",
              "referrer": "http://localhost:8080/host-manager/html"
            },
            "version": "1.1",
            "response": {
              "status_code": 200
            }
          },
          "client": {
            "ip": [
              "127.0.0.1",
              "127.0.0.3"
            ]
          },
          "source": {
            "ip": "81.2.69.144"
          },
          "event": {
            "category": [
              "web"
            ],
            "type": [
              "access"
            ],
            "kind": "event",
            "outcome": "success",
            "module": "apache_tomcat"
          },
          "url": {
            "path": "/host-manager/images/asf-logo.svg",
            "extension": "svg",
            "original": "/host-manager/images/asf-logo.svg"
          },
          "user_agent": {
            "name": "Chrome",
            "original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
            "os": {
              "name": "Windows",
              "version": "10",
              "full": "Windows 10"
            },
            "device": {
              "name": "Other"
            },
            "version": "109.0.0.0"
          }
        },
        "_ingest": {
          "_value": null,
          "timestamp": "2024-10-24T23:59:02.2403418Z"
        }
      }
    },
    {
      "doc": {
        "_index": "index",
        "_version": "-3",
        "_id": "id",
        "_source": {
          "@timestamp": "2023-03-02T13:28:17.000Z",
          "ecs": {
            "version": "8.7.0"
          },
          "apache_tomcat": {
            "access": {
              "http": {
                "useragent": "admin",
                "ident": "-"
              }
            }
          },
          "related": {
            "ip": [
              "81.2.69.144"
            ]
          },
          "destination": {
            "bytes": 20486
          },
          "http": {
            "request": {
              "method": "POST",
              "referrer": "http://localhost:8080/host-manager/html"
            },
            "version": "1.1",
            "response": {
              "status_code": 200
            }
          },
          "source": {
            "ip": "81.2.69.144"
          },
          "event": {
            "category": [
              "web"
            ],
            "type": [
              "access"
            ],
            "kind": "event",
            "outcome": "success",
            "module": "apache_tomcat"
          },
          "url": {
            "path": "/host-manager/images/asf-logo.svg",
            "extension": "svg",
            "original": "/host-manager/images/asf-logo.svg"
          },
          "user_agent": {
            "name": "Chrome",
            "original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
            "os": {
              "name": "Windows",
              "version": "10",
              "full": "Windows 10"
            },
            "device": {
              "name": "Other"
            },
            "version": "109.0.0.0"
          }
        },
        "_ingest": {
          "timestamp": "2024-10-24T23:59:02.240343772Z"
        }
      }
    },
    {
      "doc": {
        "_index": "index",
        "_version": "-3",
        "_id": "id",
        "_source": {
          "@timestamp": "2023-03-02T13:28:17.000Z",
          "ecs": {
            "version": "8.7.0"
          },
          "apache_tomcat": {
            "access": {
              "http": {
                "useragent": "admin",
                "ident": "-"
              },
              "ip": {
                "local": "81.2.69.145"
              },
              "connection_status": "-"
            }
          },
          "related": {
            "ip": [
              "81.2.69.144",
              "81.2.69.145"
            ]
          },
          "destination": {
            "bytes": 20486
          },
          "http": {
            "request": {
              "method": "POST",
              "referrer": "http://localhost:8080/host-manager/html"
            },
            "version": "1.1",
            "response": {
              "status_code": 200
            }
          },
          "source": {
            "ip": "81.2.69.144"
          },
          "event": {
            "category": [
              "web"
            ],
            "type": [
              "access"
            ],
            "kind": "event",
            "outcome": "success",
            "module": "apache_tomcat"
          },
          "url": {
            "path": "/host-manager/images/asf-logo.svg",
            "extension": "svg",
            "original": "/host-manager/images/asf-logo.svg"
          },
          "user_agent": {
            "name": "Chrome",
            "original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
            "os": {
              "name": "Windows",
              "version": "10",
              "full": "Windows 10"
            },
            "device": {
              "name": "Other"
            },
            "version": "109.0.0.0"
          }
        },
        "_ingest": {
          "timestamp": "2024-10-24T23:59:02.240345692Z"
        }
      }
    },
    {
      "doc": {
        "_index": "index",
        "_version": "-3",
        "_id": "id",
        "_source": {
          "@timestamp": "2023-03-02T13:31:17.000Z",
          "ecs": {
            "version": "8.7.0"
          },
          "apache_tomcat": {
            "access": {
              "http": {
                "useragent": "admin",
                "ident": "-"
              }
            }
          },
          "related": {
            "ip": [
              "81.2.69.144"
            ]
          },
          "destination": {
            "bytes": 4654
          },
          "http": {
            "request": {
              "method": "GET",
              "referrer": "-"
            },
            "version": "1.1",
            "response": {
              "status_code": 200
            }
          },
          "source": {
            "ip": "81.2.69.144"
          },
          "event": {
            "category": [
              "web"
            ],
            "type": [
              "access"
            ],
            "kind": "event",
            "outcome": "success",
            "module": "apache_tomcat"
          },
          "url": {
            "path": "/manager/status",
            "original": "/manager/status"
          },
          "user_agent": {
            "name": "Chrome",
            "original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
            "os": {
              "name": "Windows",
              "version": "10",
              "full": "Windows 10"
            },
            "device": {
              "name": "Other"
            },
            "version": "109.0.0.0"
          }
        },
        "_ingest": {
          "timestamp": "2024-10-24T23:59:02.240348732Z"
        }
      }
    },
    {
      "doc": {
        "_index": "index",
        "_version": "-3",
        "_id": "id",
        "_source": {
          "@timestamp": "2023-03-02T13:32:25.000Z",
          "ecs": {
            "version": "8.7.0"
          },
          "apache_tomcat": {
            "access": {
              "http": {
                "useragent": "admin",
                "ident": "-"
              }
            }
          },
          "related": {
            "ip": [
              "81.2.69.144"
            ]
          },
          "destination": {
            "bytes": 11235
          },
          "http": {
            "request": {
              "method": "GET"
            },
            "version": "1.1",
            "response": {
              "status_code": 200
            }
          },
          "source": {
            "ip": "81.2.69.144"
          },
          "event": {
            "category": [
              "web"
            ],
            "type": [
              "access"
            ],
            "kind": "event",
            "outcome": "success",
            "module": "apache_tomcat"
          },
          "url": {
            "path": "/",
            "original": "/"
          }
        },
        "_ingest": {
          "timestamp": "2024-10-24T23:59:02.240350585Z"
        }
      }
    },
    {
      "doc": {
        "_index": "index",
        "_version": "-3",
        "_id": "id",
        "_source": {
          "@timestamp": "2024-10-24T03:18:49.000Z",
          "ecs": {
            "version": "8.7.0"
          },
          "apache_tomcat": {
            "access": {
              "http": {
                "useragent": "-",
                "ident": "-"
              },
              "response_time": 0,
              "ip": {
                "local": "81.2.69.145"
              },
              "connection_status": "+"
            }
          },
          "related": {
            "ip": [
              "81.2.69.144",
              "81.2.69.145"
            ]
          },
          "http": {
            "request": {
              "referrer": "-"
            },
            "response": {
              "status_code": 400
            }
          },
          "source": {
            "ip": "81.2.69.144"
          },
          "event": {
            "category": [
              "web"
            ],
            "type": [
              "access"
            ],
            "kind": "event",
            "outcome": "failure",
            "module": "apache_tomcat"
          },
          "user_agent": {
            "original": "-"
          }
        },
        "_ingest": {
          "timestamp": "2024-10-24T23:59:02.240352292Z"
        }
      }
    }
  ]
}
```

## Related issues

- Closes #11514 