### PR TITLE
Deprecate experimental third-party API import option

### DIFF
--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.26.0"
+  changes:
+    - description: "Deprecate third-party REST API import option."
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.25.0"
   changes:
     - description: "Allow configuration of ignoring older events in apache access log datastream."

--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: "Deprecate third-party REST API import option."
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/11524
 - version: "1.25.0"
   changes:
     - description: "Allow configuration of ignoring older events in apache access log datastream."

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.4
 name: apache
 title: Apache HTTP Server
-version: "1.25.0"
+version: "1.26.0"
 source:
   license: Elastic-2.0
 description: Collect logs and metrics from Apache servers with Elastic Agent.
@@ -45,8 +45,8 @@ policy_templates:
             required: false
             show_user: false
       - type: httpjson
-        title: Collect logs from third-party REST API (experimental)
-        description: Collect logs from third-party REST API (experimental)
+        title: Collect logs from third-party REST API (deprecated)
+        description: Collect logs from third-party REST API (deprecated)
         vars:
           - name: url
             type: text

--- a/packages/nginx/changelog.yml
+++ b/packages/nginx/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Deprecate third-party REST API import option.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/11524
 - version: "1.23.0"
   changes:
     - description: Add processor support for stubstatus data stream.

--- a/packages/nginx/changelog.yml
+++ b/packages/nginx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.24.0"
+  changes:
+    - description: Deprecate third-party REST API import option.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.23.0"
   changes:
     - description: Add processor support for stubstatus data stream.

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: nginx
 title: Nginx
-version: "1.23.0"
+version: "1.24.0"
 description: Collect logs and metrics from Nginx HTTP servers with Elastic Agent.
 type: integration
 categories:
@@ -39,8 +39,8 @@ policy_templates:
         title: Collect logs from Nginx instances
         description: Collecting Nginx access and error logs
       - type: httpjson
-        title: Collect logs from third-party REST API (experimental)
-        description: Collect logs from third-party REST API (experimental)
+        title: Collect logs from third-party REST API (deprecated)
+        description: Collect logs from third-party REST API (deprecated)
         vars:
           - name: url
             type: text

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Deprecate third-party REST API import option.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/11524
 - version: "1.61.1"
   changes:
     - description: Parse `winlog.event_data.AccessList` and `winlog.event_data.AccessMask` into a list of values

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.62.0"
+  changes:
+    - description: Deprecate third-party REST API import option.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.61.1"
   changes:
     - description: Parse `winlog.event_data.AccessList` and `winlog.event_data.AccessMask` into a list of values

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: system
 title: System
-version: "1.61.1"
+version: "1.62.0"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:
@@ -46,8 +46,8 @@ policy_templates:
             show_user: true
             description: The proc filesystem base directory.
       - type: httpjson
-        title: Collect logs from third-party REST API (experimental)
-        description: Collect logs from third-party REST API (experimental)
+        title: Collect logs from third-party REST API (deprecated)
+        description: Collect logs from third-party REST API (deprecated)
         vars:
           - name: url
             type: text

--- a/packages/windows/_dev/build/docs/README.md
+++ b/packages/windows/_dev/build/docs/README.md
@@ -38,7 +38,7 @@ see the {{ url "getting-started-observability" "Getting started" }} guide.
 
 Note: Because the Windows integration always applies to the local server, the `hosts` config option is not needed.
 
-### Ingesting Windows Events via Splunk
+### Ingesting Windows Events via Splunk (Deprecated)
 
 This integration allows you to seamlessly ingest data from a Splunk Enterprise instance.
 The integration uses the {{ url "filebeat-input-httpjson" "`httpjson` input" }} in Elastic Agent to run a Splunk search via the Splunk REST API and then extract the raw event from the results.

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Deprecate third-party REST API import option.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/11524
 - version: "2.2.0"
   changes:
     - description: Improve Windows Defender ECS mappings and make data stream GA

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.0"
+  changes:
+    - description: Deprecate third-party REST API import option.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.2.0"
   changes:
     - description: Improve Windows Defender ECS mappings and make data stream GA

--- a/packages/windows/docs/README.md
+++ b/packages/windows/docs/README.md
@@ -38,7 +38,7 @@ see the [Getting started](https://www.elastic.co/guide/en/welcome-to-elastic/cur
 
 Note: Because the Windows integration always applies to the local server, the `hosts` config option is not needed.
 
-### Ingesting Windows Events via Splunk
+### Ingesting Windows Events via Splunk (Deprecated)
 
 This integration allows you to seamlessly ingest data from a Splunk Enterprise instance.
 The integration uses the [`httpjson` input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html) in Elastic Agent to run a Splunk search via the Splunk REST API and then extract the raw event from the results.

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 2.2.0
+version: 2.3.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:
@@ -38,8 +38,8 @@ policy_templates:
         title: Collect Windows perfmon and service metrics
         description: Collecting perfmon and service metrics from Windows instances
       - type: httpjson
-        title: Collect logs from third-party REST API (experimental)
-        description: Collect logs from third-party REST API (experimental)
+        title: Collect logs from third-party REST API (deprecated)
+        description: Collect logs from third-party REST API (deprecated)
         vars:
           - name: url
             type: text

--- a/packages/zeek/changelog.yml
+++ b/packages/zeek/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Deprecate third-party REST API import option.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/11524
 - version: "2.24.4"
   changes:
     - description: Use triple-brace Mustache templating when referencing variables in ingest pipelines.

--- a/packages/zeek/changelog.yml
+++ b/packages/zeek/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.25.0"
+  changes:
+    - description: Deprecate third-party REST API import option.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.24.4"
   changes:
     - description: Use triple-brace Mustache templating when referencing variables in ingest pipelines.

--- a/packages/zeek/manifest.yml
+++ b/packages/zeek/manifest.yml
@@ -1,6 +1,6 @@
 name: zeek
 title: Zeek
-version: "2.24.4"
+version: "2.25.0"
 description: Collect logs from Zeek with Elastic Agent.
 type: integration
 icons:
@@ -39,8 +39,8 @@ policy_templates:
               - /opt/zeek/logs/current
               - /usr/local/var/spool/zeek
       - type: httpjson
-        title: Collect logs from third-party REST API (experimental)
-        description: Collect logs from third-party REST API (experimental)
+        title: Collect logs from third-party REST API (deprecated)
+        description: Collect logs from third-party REST API (deprecated)
         vars:
           - name: url
             type: text


### PR DESCRIPTION
## Proposed commit message

- Deprecated the experimental third-party API (Splunk) import option in apache, nginx, system, windows, and zeek packages.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- ~~[ ] I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- ~~[ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

## Related issues

- Closes #11502

## Screenshots

![Screenshot 2024-10-25 at 2 54 50 PM](https://github.com/user-attachments/assets/ffc81a6a-ee98-41f9-9bb7-0ff4fcab4579)
