### PR TITLE
[windows] Defender - Fix pipeline for Path and add missing fields.

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.1"
+  changes:
+    - description: Fix improper parsing of Path for Windows Defender, add more winlog fields
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9999999
 - version: "2.2.0"
   changes:
     - description: Improve Windows Defender ECS mappings and make data stream GA

--- a/packages/windows/data_stream/windows_defender/_dev/test/pipeline/test-events-windows-defender-events.json
+++ b/packages/windows/data_stream/windows_defender/_dev/test/pipeline/test-events-windows-defender-events.json
@@ -13,7 +13,7 @@
             "log": {
                 "level": "Warning"
             },
-            "message": "Microsoft Defender Antivirus has detected malware or other potentially unwanted software.\r\n For more information please see the following:\r\nhttps://go.microsoft.com/fwlink/?linkid=37020\u0026name=Virus:DOS/EICAR_Test_File\u0026threatid=2147519003\u0026enterprise=0\r\n \tName: Virus:DOS/EICAR_Test_File\r\n \tID: 2147519003\r\n \tSeverity: Severe\r\n \tCategory: Virus\r\n \tPath: file:_C:\\Users\\nicpe\\OneDrive\\Desktop\\eicar.com\r\n \tDetection Origin: Local machine\r\n \tDetection Type: Concrete\r\n \tDetection Source: Real-Time Protection\r\n \tUser: el33t-b00k-1\\nicpe\r\n \tProcess Name: C:\\Users\\nicpe\\AppData\\Local\\Microsoft\\OneDrive\\OneDrive.exe\r\n \tSecurity intelligence Version: AV: 1.413.419.0, AS: 1.413.419.0, NIS: 1.413.419.0\r\n \tEngine Version: AM: 1.1.24050.5, NIS: 1.1.24050.5",
+            "message": "Microsoft Defender Antivirus has detected malware or other potentially unwanted software.\r\n For more information please see the following:\r\nhttps://go.microsoft.com/fwlink/?linkid=37020\u0026name=Virus:DOS/EICAR_Test_File\u0026threatid=2147519003\u0026enterprise=0\r\n \tName: Virus:DOS/EICAR_Test_File\r\n \tID: 2147519003\r\n \tSeverity: Severe\r\n \tCategory: Virus\r\n \tPath: file:_C:\\Users\\topsy\\OneDrive\\Desktop\\eat_more_yams.exe\r\n \tDetection Origin: Local machine\r\n \tDetection Type: Concrete\r\n \tDetection Source: Real-Time Protection\r\n \tUser: el33t-b00k-1\\topsy\r\n \tProcess Name: C:\\Users\\topsy\\AppData\\Local\\Microsoft\\OneDrive\\OneDrive.exe\r\n \tSecurity intelligence Version: AV: 1.413.419.0, AS: 1.413.419.0, NIS: 1.413.419.0\r\n \tEngine Version: AM: 1.1.24050.5, NIS: 1.1.24050.5",
             "winlog": {
                 "activity_id": "5f4a9fb7-8bb9-4d46-a5af-b880cefca3c1",
                 "channel": "Microsoft-Windows-Windows Defender/Operational",
@@ -35,6 +35,78 @@
                     "Threat_ID": "2147519003",
                     "Detection_ID": "{21A294A2-FE84-4DE0-B1D0-47D6DCD4DA9A}",
                     "Path": "file:_C:\\Users\\Topsy\\Desktop\\eat_more_yams.exe",
+                    "Source_Name": "System",
+                    "Origin_ID": "1",
+                    "Type_Name": "Concrete",
+                    "Action_ID": "9",
+                    "Source_ID": "2",
+                    "Product_Name": "Microsoft Defender Antivirus",
+                    "Category_Name": "Virus",
+                    "Status_Code": "1",
+                    "Threat_Name": "Virus:DOS/EICAR_Test_File",
+                    "Origin_Name": "Local machine",
+                    "Severity_ID": "5",
+                    "State": "1",
+                    "Severity_Name": "Severe",
+                    "Execution_ID": "1",
+                    "Product_Version": "4.18.24080.9",
+                    "Engine_Version": "AM: 1.1.24080.9, NIS: 1.1.24080.9",
+                    "Type_ID": "0"
+                },
+                "event_id": "1116",
+                "level": "Warning",
+                "opcode": "Info",
+                "process": {
+                    "pid": 7676,
+                    "thread": {
+                        "id": 29468
+                    }
+                },
+                "provider_guid": "11cd958a-c507-4ef3-b3f2-5fd9dfbd2c78",
+                "provider_name": "Microsoft-Windows-Windows Defender",
+                "record_id": "5646",
+                "time_created": "2024-06-21T01:21:15.1310609Z",
+                "user": {
+                    "identifier": "S-1-5-18",
+                    "name": "Topsy"
+                },
+                "version": 0
+            }
+        },{
+            "@timestamp": "2024-06-21T01:21:15.1310609Z",
+            "event": {
+                "code": "1116",
+                "kind": "event",
+                "provider": "Microsoft-Windows-Windows Defender"
+            },
+            "host": {
+                "name": "el33t-b00k-1"
+            },
+            "log": {
+                "level": "Warning"
+            },
+            "message": "Microsoft Defender Antivirus has detected malware or other potentially unwanted software.\r\n For more information please see the following:\r\nhttps://go.microsoft.com/fwlink/?linkid=37020\u0026name=Virus:DOS/EICAR_Test_File\u0026threatid=2147519003\u0026enterprise=0\r\n \tName: Virus:DOS/EICAR_Test_File\r\n \tID: 2147519003\r\n \tSeverity: Severe\r\n \tCategory: Virus\r\n \tPath: file:_C:\\Users\\topsy\\OneDrive\\Desktop\\eat_more_yams.com; process:_pid: 1337\r\n \tDetection Origin: Local machine\r\n \tDetection Type: Concrete\r\n \tDetection Source: Real-Time Protection\r\n \tUser: el33t-b00k-1\\topsy\r\n \tProcess Name: C:\\Users\\topsy\\AppData\\Local\\Microsoft\\OneDrive\\OneDrive.exe\r\n \tSecurity intelligence Version: AV: 1.413.419.0, AS: 1.413.419.0, NIS: 1.413.419.0\r\n \tEngine Version: AM: 1.1.24050.5, NIS: 1.1.24050.5",
+            "winlog": {
+                "activity_id": "5f4a9fb7-8bb9-4d46-a5af-b880cefca3c1",
+                "channel": "Microsoft-Windows-Windows Defender/Operational",
+                "computer_name": "el33t-b00k-1",
+                "event_data": {
+                    "Detection_User": "NT AUTHORITY\\SYSTEM",
+                    "Execution_Name": "Suspended",
+                    "Detection_Time": "2024-09-26T16:04:49.772Z",
+                    "Error_Description": "The operation completed successfully. ",
+                    "Error_Code": "0x00000000",
+                    "Action_Name": "Not Applicable",
+                    "FWLink": "https://go.microsoft.com/fwlink/?linkid=37020&name=Virus:DOS/EICAR_Test_File&threatid=2147519003&enterprise=1",
+                    "Post_Clean_Status": "0",
+                    "Category_ID": "42",
+                    "Additional_Actions_String": "No additional actions required",
+                    "Additional_Actions_ID": "0",
+                    "Pre_Execution_Status": "0",
+                    "Security_intelligence_Version": "AV: 1.419.183.0, AS: 1.419.183.0, NIS: 1.419.183.0",
+                    "Threat_ID": "2147519003",
+                    "Detection_ID": "{21A294A2-FE84-4DE0-B1D0-47D6DCD4DA9A}",
+                    "Path": "file:_C:\\Users\\Topsy\\Desktop\\eat_more_yams.exe; process:_pid: 31337",
                     "Source_Name": "System",
                     "Origin_ID": "1",
                     "Type_Name": "Concrete",
@@ -286,7 +358,7 @@
             "log": {
                 "level": "Information"
             },
-            "message": "Microsoft Defender Antivirus has taken action to protect this machine from malware or other potentially unwanted software.\r\n For more information please see the following:\r\nhttps://go.microsoft.com/fwlink/?linkid=37020\u0026name=Virus:DOS/EICAR_Test_File\u0026threatid=2147519003\u0026enterprise=0\r\n \tName: Virus:DOS/EICAR_Test_File\r\n \tID: 2147519003\r\n \tSeverity: Severe\r\n \tCategory: Virus\r\n \tPath: file:_C:\\Users\\nicpe\\OneDrive\\Desktop\\eicar.com\r\n \tDetection Origin: Local machine\r\n \tDetection Type: Concrete\r\n \tDetection Source: Real-Time Protection\r\n \tUser: NT AUTHORITY\\SYSTEM\r\n \tProcess Name: C:\\Users\\nicpe\\AppData\\Local\\Microsoft\\OneDrive\\OneDrive.exe\r\n \tAction: Quarantine\r\n \tAction Status:  No additional actions required\r\n \tError Code: 0x00000000\r\n \tError description: The operation completed successfully. \r\n \tSecurity intelligence Version: AV: 1.413.419.0, AS: 1.413.419.0, NIS: 1.413.419.0\r\n \tEngine Version: AM: 1.1.24050.5, NIS: 1.1.24050.5",
+            "message": "Microsoft Defender Antivirus has taken action to protect this machine from malware or other potentially unwanted software.\r\n For more information please see the following:\r\nhttps://go.microsoft.com/fwlink/?linkid=37020\u0026name=Virus:DOS/EICAR_Test_File\u0026threatid=2147519003\u0026enterprise=0\r\n \tName: Virus:DOS/EICAR_Test_File\r\n \tID: 2147519003\r\n \tSeverity: Severe\r\n \tCategory: Virus\r\n \tPath: file:_C:\\Users\\topsy\\OneDrive\\Desktop\\eat_more_yams.exe\r\n \tDetection Origin: Local machine\r\n \tDetection Type: Concrete\r\n \tDetection Source: Real-Time Protection\r\n \tUser: NT AUTHORITY\\SYSTEM\r\n \tProcess Name: C:\\Users\\topsy\\AppData\\Local\\Microsoft\\OneDrive\\OneDrive.exe\r\n \tAction: Quarantine\r\n \tAction Status:  No additional actions required\r\n \tError Code: 0x00000000\r\n \tError description: The operation completed successfully. \r\n \tSecurity intelligence Version: AV: 1.413.419.0, AS: 1.413.419.0, NIS: 1.413.419.0\r\n \tEngine Version: AM: 1.1.24050.5, NIS: 1.1.24050.5",
             "winlog": {
                 "activity_id": "",
                 "channel": "Microsoft-Windows-Windows Defender/Operational",
@@ -309,6 +381,80 @@
                     "Remediation_User": "NT AUTHORITY\\SYSTEM",
                     "Detection_ID": "{21A294A2-FE84-4DE0-B1D0-47D6DCD4DA9A}",
                     "Path": "file:_C:\\Users\\Topsy\\Desktop\\eat_more_yams.exe",
+                    "Source_Name": "System",
+                    "Origin_ID": "1",
+                    "Type_Name": "Concrete",
+                    "Action_ID": "2",
+                    "Product_Name": "Microsoft Defender Antivirus",
+                    "Source_ID": "2",
+                    "Category_Name": "Virus",
+                    "Status_Code": "3",
+                    "Threat_Name": "Virus:DOS/EICAR_Test_File",
+                    "Origin_Name": "Local machine",
+                    "Severity_ID": "5",
+                    "State": "2",
+                    "Severity_Name": "Severe",
+                    "Execution_ID": "1",
+                    "Product_Version": "4.18.24080.9",
+                    "Engine_Version": "AM: 1.1.24080.9, NIS: 1.1.24080.9",
+                    "Type_ID": "0"
+                },
+                "event_id": "1117",
+                "level": "Information",
+                "opcode": "Info",
+                "process": {
+                    "pid": 7676,
+                    "thread": {
+                        "id": 29468
+                    }
+                },
+                "provider_guid": "11cd958a-c507-4ef3-b3f2-5fd9dfbd2c78",
+                "provider_name": "Microsoft-Windows-Windows Defender",
+                "record_id": "5647",
+                "time_created": "2024-06-21T01:21:15.2279837Z",
+                "user": {
+                    "identifier": "S-1-5-18",
+                    "name": "Topsy"
+                },
+                "version": 0
+            }
+        },
+        {
+            "@timestamp": "2024-06-21T01:21:15.2279837Z",
+            "event": {
+                "code": "1117",
+                "kind": "event",
+                "provider": "Microsoft-Windows-Windows Defender"
+            },
+            "host": {
+                "name": "el33t-b00k-1"
+            },
+            "log": {
+                "level": "Information"
+            },
+            "message": "Microsoft Defender Antivirus has taken action to protect this machine from malware or other potentially unwanted software.\r\n For more information please see the following:\r\nhttps://go.microsoft.com/fwlink/?linkid=37020\u0026name=Virus:DOS/EICAR_Test_File\u0026threatid=2147519003\u0026enterprise=0\r\n \tName: Virus:DOS/EICAR_Test_File\r\n \tID: 2147519003\r\n \tSeverity: Severe\r\n \tCategory: Virus\r\n \tPath: file:_C:\\Users\\topsy\\OneDrive\\Desktop\\eat_more_yams.exe; process:_pid: 1337\r\n \tDetection Origin: Local machine\r\n \tDetection Type: Concrete\r\n \tDetection Source: Real-Time Protection\r\n \tUser: NT AUTHORITY\\SYSTEM\r\n \tProcess Name: C:\\Users\\topsy\\AppData\\Local\\Microsoft\\OneDrive\\OneDrive.exe\r\n \tAction: Quarantine\r\n \tAction Status:  No additional actions required\r\n \tError Code: 0x00000000\r\n \tError description: The operation completed successfully. \r\n \tSecurity intelligence Version: AV: 1.413.419.0, AS: 1.413.419.0, NIS: 1.413.419.0\r\n \tEngine Version: AM: 1.1.24050.5, NIS: 1.1.24050.5",
+            "winlog": {
+                "activity_id": "",
+                "channel": "Microsoft-Windows-Windows Defender/Operational",
+                "computer_name": "el33t-b00k-1",
+                "event_data": {
+                    "Detection_User": "NT AUTHORITY\\SYSTEM",
+                    "Execution_Name": "Suspended",
+                    "Detection_Time": "2024-09-26T16:04:49.772Z",
+                    "Error_Description": "The operation completed successfully. ",
+                    "Error_Code": "0x00000000",
+                    "Action_Name": "Quarantine",
+                    "FWLink": "https://go.microsoft.com/fwlink/?linkid=37020&name=Virus:DOS/EICAR_Test_File&threatid=2147519003&enterprise=1",
+                    "Post_Clean_Status": "0",
+                    "Category_ID": "42",
+                    "Additional_Actions_String": "No additional actions required",
+                    "Additional_Actions_ID": "0",
+                    "Pre_Execution_Status": "0",
+                    "Security_intelligence_Version": "AV: 1.419.183.0, AS: 1.419.183.0, NIS: 1.419.183.0",
+                    "Threat_ID": "2147519003",
+                    "Remediation_User": "NT AUTHORITY\\SYSTEM",
+                    "Detection_ID": "{21A294A2-FE84-4DE0-B1D0-47D6DCD4DA9A}",
+                    "Path": "file:_C:\\Users\\Topsy\\Desktop\\eat_more_yams.exe; process:_pid: 1337",
                     "Source_Name": "System",
                     "Origin_ID": "1",
                     "Type_Name": "Concrete",

--- a/packages/windows/data_stream/windows_defender/_dev/test/pipeline/test-events-windows-defender-events.json-expected.json
+++ b/packages/windows/data_stream/windows_defender/_dev/test/pipeline/test-events-windows-defender-events.json-expected.json
@@ -30,7 +30,7 @@
             "log": {
                 "level": "Warning"
             },
-            "message": "Microsoft Defender Antivirus has detected malware or other potentially unwanted software.\r\n For more information please see the following:\r\nhttps://go.microsoft.com/fwlink/?linkid=37020&name=Virus:DOS/EICAR_Test_File&threatid=2147519003&enterprise=0\r\n \tName: Virus:DOS/EICAR_Test_File\r\n \tID: 2147519003\r\n \tSeverity: Severe\r\n \tCategory: Virus\r\n \tPath: file:_C:\\Users\\nicpe\\OneDrive\\Desktop\\eicar.com\r\n \tDetection Origin: Local machine\r\n \tDetection Type: Concrete\r\n \tDetection Source: Real-Time Protection\r\n \tUser: el33t-b00k-1\\nicpe\r\n \tProcess Name: C:\\Users\\nicpe\\AppData\\Local\\Microsoft\\OneDrive\\OneDrive.exe\r\n \tSecurity intelligence Version: AV: 1.413.419.0, AS: 1.413.419.0, NIS: 1.413.419.0\r\n \tEngine Version: AM: 1.1.24050.5, NIS: 1.1.24050.5",
+            "message": "Microsoft Defender Antivirus has detected malware or other potentially unwanted software.\r\n For more information please see the following:\r\nhttps://go.microsoft.com/fwlink/?linkid=37020&name=Virus:DOS/EICAR_Test_File&threatid=2147519003&enterprise=0\r\n \tName: Virus:DOS/EICAR_Test_File\r\n \tID: 2147519003\r\n \tSeverity: Severe\r\n \tCategory: Virus\r\n \tPath: file:_C:\\Users\\topsy\\OneDrive\\Desktop\\eat_more_yams.exe\r\n \tDetection Origin: Local machine\r\n \tDetection Type: Concrete\r\n \tDetection Source: Real-Time Protection\r\n \tUser: el33t-b00k-1\\topsy\r\n \tProcess Name: C:\\Users\\topsy\\AppData\\Local\\Microsoft\\OneDrive\\OneDrive.exe\r\n \tSecurity intelligence Version: AV: 1.413.419.0, AS: 1.413.419.0, NIS: 1.413.419.0\r\n \tEngine Version: AM: 1.1.24050.5, NIS: 1.1.24050.5",
             "user": {
                 "domain": "NT AUTHORITY",
                 "name": "SYSTEM"
@@ -58,6 +58,100 @@
                     "Origin_ID": "1",
                     "Origin_Name": "Local machine",
                     "Path": "file:_C:\\Users\\Topsy\\Desktop\\eat_more_yams.exe",
+                    "Post_Clean_Status": "0",
+                    "Pre_Execution_Status": "0",
+                    "Product_Name": "Microsoft Defender Antivirus",
+                    "Product_Version": "4.18.24080.9",
+                    "Security_intelligence_Version": "AV: 1.419.183.0, AS: 1.419.183.0, NIS: 1.419.183.0",
+                    "Severity_ID": "5",
+                    "Severity_Name": "Severe",
+                    "Source_ID": "2",
+                    "Source_Name": "System",
+                    "State": "1",
+                    "Status_Code": "1",
+                    "Threat_ID": "2147519003",
+                    "Threat_Name": "Virus:DOS/EICAR_Test_File",
+                    "Type_ID": "0",
+                    "Type_Name": "Concrete"
+                },
+                "event_id": "1116",
+                "level": "Warning",
+                "opcode": "Info",
+                "process": {
+                    "pid": 7676,
+                    "thread": {
+                        "id": 29468
+                    }
+                },
+                "provider_guid": "11cd958a-c507-4ef3-b3f2-5fd9dfbd2c78",
+                "provider_name": "Microsoft-Windows-Windows Defender",
+                "record_id": "5646",
+                "time_created": "2024-06-21T01:21:15.1310609Z",
+                "user": {
+                    "identifier": "S-1-5-18",
+                    "name": "Topsy"
+                },
+                "version": 0
+            }
+        },
+        {
+            "@timestamp": "2024-06-21T01:21:15.131Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "malware-detected",
+                "category": [
+                    "malware"
+                ],
+                "code": "1116",
+                "kind": "event",
+                "outcome": "success",
+                "provider": "Microsoft-Windows-Windows Defender",
+                "reference": "https://go.microsoft.com/fwlink/?linkid=37020&name=Virus:DOS/EICAR_Test_File&threatid=2147519003&enterprise=1",
+                "type": [
+                    "info"
+                ]
+            },
+            "file": {
+                "extension": "exe",
+                "name": "eat_more_yams.exe",
+                "path": "C:\\Users\\Topsy\\Desktop\\eat_more_yams.exe"
+            },
+            "host": {
+                "name": "el33t-b00k-1"
+            },
+            "log": {
+                "level": "Warning"
+            },
+            "message": "Microsoft Defender Antivirus has detected malware or other potentially unwanted software.\r\n For more information please see the following:\r\nhttps://go.microsoft.com/fwlink/?linkid=37020&name=Virus:DOS/EICAR_Test_File&threatid=2147519003&enterprise=0\r\n \tName: Virus:DOS/EICAR_Test_File\r\n \tID: 2147519003\r\n \tSeverity: Severe\r\n \tCategory: Virus\r\n \tPath: file:_C:\\Users\\topsy\\OneDrive\\Desktop\\eat_more_yams.com; process:_pid: 1337\r\n \tDetection Origin: Local machine\r\n \tDetection Type: Concrete\r\n \tDetection Source: Real-Time Protection\r\n \tUser: el33t-b00k-1\\topsy\r\n \tProcess Name: C:\\Users\\topsy\\AppData\\Local\\Microsoft\\OneDrive\\OneDrive.exe\r\n \tSecurity intelligence Version: AV: 1.413.419.0, AS: 1.413.419.0, NIS: 1.413.419.0\r\n \tEngine Version: AM: 1.1.24050.5, NIS: 1.1.24050.5",
+            "user": {
+                "domain": "NT AUTHORITY",
+                "name": "SYSTEM"
+            },
+            "winlog": {
+                "activity_id": "5f4a9fb7-8bb9-4d46-a5af-b880cefca3c1",
+                "channel": "Microsoft-Windows-Windows Defender/Operational",
+                "computer_name": "el33t-b00k-1",
+                "event_data": {
+                    "Action_ID": "9",
+                    "Action_Name": "Not Applicable",
+                    "Additional_Actions_ID": "0",
+                    "Additional_Actions_String": "No additional actions required",
+                    "Category_ID": "42",
+                    "Category_Name": "Virus",
+                    "Detection_ID": "{21A294A2-FE84-4DE0-B1D0-47D6DCD4DA9A}",
+                    "Detection_Time": "2024-09-26T16:04:49.772Z",
+                    "Detection_User": "NT AUTHORITY\\SYSTEM",
+                    "Engine_Version": "AM: 1.1.24080.9, NIS: 1.1.24080.9",
+                    "Error_Code": "0x00000000",
+                    "Error_Description": "The operation completed successfully. ",
+                    "Execution_ID": "1",
+                    "Execution_Name": "Suspended",
+                    "FWLink": "https://go.microsoft.com/fwlink/?linkid=37020&name=Virus:DOS/EICAR_Test_File&threatid=2147519003&enterprise=1",
+                    "Origin_ID": "1",
+                    "Origin_Name": "Local machine",
+                    "Path": "file:_C:\\Users\\Topsy\\Desktop\\eat_more_yams.exe; process:_pid: 31337",
                     "Post_Clean_Status": "0",
                     "Pre_Execution_Status": "0",
                     "Product_Name": "Microsoft Defender Antivirus",
@@ -360,7 +454,7 @@
             "log": {
                 "level": "Information"
             },
-            "message": "Microsoft Defender Antivirus has taken action to protect this machine from malware or other potentially unwanted software.\r\n For more information please see the following:\r\nhttps://go.microsoft.com/fwlink/?linkid=37020&name=Virus:DOS/EICAR_Test_File&threatid=2147519003&enterprise=0\r\n \tName: Virus:DOS/EICAR_Test_File\r\n \tID: 2147519003\r\n \tSeverity: Severe\r\n \tCategory: Virus\r\n \tPath: file:_C:\\Users\\nicpe\\OneDrive\\Desktop\\eicar.com\r\n \tDetection Origin: Local machine\r\n \tDetection Type: Concrete\r\n \tDetection Source: Real-Time Protection\r\n \tUser: NT AUTHORITY\\SYSTEM\r\n \tProcess Name: C:\\Users\\nicpe\\AppData\\Local\\Microsoft\\OneDrive\\OneDrive.exe\r\n \tAction: Quarantine\r\n \tAction Status:  No additional actions required\r\n \tError Code: 0x00000000\r\n \tError description: The operation completed successfully. \r\n \tSecurity intelligence Version: AV: 1.413.419.0, AS: 1.413.419.0, NIS: 1.413.419.0\r\n \tEngine Version: AM: 1.1.24050.5, NIS: 1.1.24050.5",
+            "message": "Microsoft Defender Antivirus has taken action to protect this machine from malware or other potentially unwanted software.\r\n For more information please see the following:\r\nhttps://go.microsoft.com/fwlink/?linkid=37020&name=Virus:DOS/EICAR_Test_File&threatid=2147519003&enterprise=0\r\n \tName: Virus:DOS/EICAR_Test_File\r\n \tID: 2147519003\r\n \tSeverity: Severe\r\n \tCategory: Virus\r\n \tPath: file:_C:\\Users\\topsy\\OneDrive\\Desktop\\eat_more_yams.exe\r\n \tDetection Origin: Local machine\r\n \tDetection Type: Concrete\r\n \tDetection Source: Real-Time Protection\r\n \tUser: NT AUTHORITY\\SYSTEM\r\n \tProcess Name: C:\\Users\\topsy\\AppData\\Local\\Microsoft\\OneDrive\\OneDrive.exe\r\n \tAction: Quarantine\r\n \tAction Status:  No additional actions required\r\n \tError Code: 0x00000000\r\n \tError description: The operation completed successfully. \r\n \tSecurity intelligence Version: AV: 1.413.419.0, AS: 1.413.419.0, NIS: 1.413.419.0\r\n \tEngine Version: AM: 1.1.24050.5, NIS: 1.1.24050.5",
             "user": {
                 "domain": "NT AUTHORITY",
                 "name": "SYSTEM"
@@ -388,6 +482,101 @@
                     "Origin_ID": "1",
                     "Origin_Name": "Local machine",
                     "Path": "file:_C:\\Users\\Topsy\\Desktop\\eat_more_yams.exe",
+                    "Post_Clean_Status": "0",
+                    "Pre_Execution_Status": "0",
+                    "Product_Name": "Microsoft Defender Antivirus",
+                    "Product_Version": "4.18.24080.9",
+                    "Remediation_User": "NT AUTHORITY\\SYSTEM",
+                    "Security_intelligence_Version": "AV: 1.419.183.0, AS: 1.419.183.0, NIS: 1.419.183.0",
+                    "Severity_ID": "5",
+                    "Severity_Name": "Severe",
+                    "Source_ID": "2",
+                    "Source_Name": "System",
+                    "State": "2",
+                    "Status_Code": "3",
+                    "Threat_ID": "2147519003",
+                    "Threat_Name": "Virus:DOS/EICAR_Test_File",
+                    "Type_ID": "0",
+                    "Type_Name": "Concrete"
+                },
+                "event_id": "1117",
+                "level": "Information",
+                "opcode": "Info",
+                "process": {
+                    "pid": 7676,
+                    "thread": {
+                        "id": 29468
+                    }
+                },
+                "provider_guid": "11cd958a-c507-4ef3-b3f2-5fd9dfbd2c78",
+                "provider_name": "Microsoft-Windows-Windows Defender",
+                "record_id": "5647",
+                "time_created": "2024-06-21T01:21:15.2279837Z",
+                "user": {
+                    "identifier": "S-1-5-18",
+                    "name": "Topsy"
+                },
+                "version": 0
+            }
+        },
+        {
+            "@timestamp": "2024-06-21T01:21:15.227Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "malware-quarantined",
+                "category": [
+                    "malware"
+                ],
+                "code": "1117",
+                "kind": "event",
+                "outcome": "success",
+                "provider": "Microsoft-Windows-Windows Defender",
+                "reference": "https://go.microsoft.com/fwlink/?linkid=37020&name=Virus:DOS/EICAR_Test_File&threatid=2147519003&enterprise=1",
+                "type": [
+                    "info"
+                ]
+            },
+            "file": {
+                "extension": "exe",
+                "name": "eat_more_yams.exe",
+                "path": "C:\\Users\\Topsy\\Desktop\\eat_more_yams.exe"
+            },
+            "host": {
+                "name": "el33t-b00k-1"
+            },
+            "log": {
+                "level": "Information"
+            },
+            "message": "Microsoft Defender Antivirus has taken action to protect this machine from malware or other potentially unwanted software.\r\n For more information please see the following:\r\nhttps://go.microsoft.com/fwlink/?linkid=37020&name=Virus:DOS/EICAR_Test_File&threatid=2147519003&enterprise=0\r\n \tName: Virus:DOS/EICAR_Test_File\r\n \tID: 2147519003\r\n \tSeverity: Severe\r\n \tCategory: Virus\r\n \tPath: file:_C:\\Users\\topsy\\OneDrive\\Desktop\\eat_more_yams.exe; process:_pid: 1337\r\n \tDetection Origin: Local machine\r\n \tDetection Type: Concrete\r\n \tDetection Source: Real-Time Protection\r\n \tUser: NT AUTHORITY\\SYSTEM\r\n \tProcess Name: C:\\Users\\topsy\\AppData\\Local\\Microsoft\\OneDrive\\OneDrive.exe\r\n \tAction: Quarantine\r\n \tAction Status:  No additional actions required\r\n \tError Code: 0x00000000\r\n \tError description: The operation completed successfully. \r\n \tSecurity intelligence Version: AV: 1.413.419.0, AS: 1.413.419.0, NIS: 1.413.419.0\r\n \tEngine Version: AM: 1.1.24050.5, NIS: 1.1.24050.5",
+            "user": {
+                "domain": "NT AUTHORITY",
+                "name": "SYSTEM"
+            },
+            "winlog": {
+                "activity_id": "",
+                "channel": "Microsoft-Windows-Windows Defender/Operational",
+                "computer_name": "el33t-b00k-1",
+                "event_data": {
+                    "Action_ID": "2",
+                    "Action_Name": "Quarantine",
+                    "Additional_Actions_ID": "0",
+                    "Additional_Actions_String": "No additional actions required",
+                    "Category_ID": "42",
+                    "Category_Name": "Virus",
+                    "Detection_ID": "{21A294A2-FE84-4DE0-B1D0-47D6DCD4DA9A}",
+                    "Detection_Time": "2024-09-26T16:04:49.772Z",
+                    "Detection_User": "NT AUTHORITY\\SYSTEM",
+                    "Engine_Version": "AM: 1.1.24080.9, NIS: 1.1.24080.9",
+                    "Error_Code": "0x00000000",
+                    "Error_Description": "The operation completed successfully. ",
+                    "Execution_ID": "1",
+                    "Execution_Name": "Suspended",
+                    "FWLink": "https://go.microsoft.com/fwlink/?linkid=37020&name=Virus:DOS/EICAR_Test_File&threatid=2147519003&enterprise=1",
+                    "Origin_ID": "1",
+                    "Origin_Name": "Local machine",
+                    "Path": "file:_C:\\Users\\Topsy\\Desktop\\eat_more_yams.exe; process:_pid: 1337",
                     "Post_Clean_Status": "0",
                     "Pre_Execution_Status": "0",
                     "Product_Name": "Microsoft Defender Antivirus",

--- a/packages/windows/data_stream/windows_defender/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/windows_defender/elasticsearch/ingest_pipeline/default.yml
@@ -157,17 +157,15 @@ processors:
 
     ## File Fields
 
-  - gsub:
-      field: "winlog.event_data.Path"
-      pattern: ".*:_"
-      replacement: ""
-      target_field: "file.path"
+  - grok:
+      field: winlog.event_data.Path
+      patterns:
+        - "file:_(?<file.path>[^;]+)(; process:_pid:%{NUMBER:process.pid})?"
       ignore_missing: true
-  - gsub:
-      field: "winlog.event_data.FileName"
-      pattern: ".*:_"
-      replacement: ""
-      target_field: "file.path"
+  - grok:
+      field: winlog.event_data.FileName
+      patterns:
+        - 'file:_(?<file.path>[^;]+)(; process:_pid:%{NUMBER:process.pid})?'
       ignore_missing: true
   - set:
       field: "file.path"

--- a/packages/windows/data_stream/windows_defender/fields/winlog.yml
+++ b/packages/windows/data_stream/windows_defender/fields/winlog.yml
@@ -308,6 +308,102 @@
           type: keyword
         - name: RTP_state
           type: keyword
+        - name: Action_ID
+          type: keyword
+        - name: Action_Name
+          type: keyword
+        - name: Additional_Actions_ID
+          type: keyword
+        - name: Additional_Actions_String
+          type: keyword
+        - name: Category_ID
+          type: keyword
+        - name: Category_Name
+          type: keyword
+        - name: Current_Engine_Version
+          type: keyword
+        - name: Current_security_intelligence_Version
+          type: keyword
+        - name: Detection_ID
+          type: keyword
+        - name: Detection_Time
+          type: date
+        - name: Detection_User
+          type: keyword
+        - name: Domain
+          type: keyword
+        - name: Engine_Version
+          type: keyword
+        - name: Error_Code
+          type: keyword
+        - name: Error_Description
+          type: keyword
+        - name: Execution_ID
+          type: keyword
+        - name: Execution_Name
+          type: keyword
+        - name: FWLink
+          type: keyword
+        - name: Origin_ID
+          type: keyword
+        - name: Origin_Name
+          type: keyword
+        - name: Post_Clean_Status
+          type: keyword
+        - name: Pre_Execution_Status
+          type: keyword
+        - name: Previous_Engine_Version
+          type: keyword
+        - name: Previous_security_intelligence_Version
+          type: keyword
+        - name: Product_Version
+          type: keyword
+        - name: Remediation_User
+          type: keyword
+        - name: SID
+          type: keyword
+        - name: Scan_ID
+          type: keyword
+        - name: Scan_Parameters
+          type: keyword
+        - name: Scan_Parameters_Index
+          type: keyword
+        - name: Scan_Type
+          type: keyword
+        - name: Scan_Type_Index
+          type: keyword
+        - name: Security_intelligence_Type
+          type: keyword
+        - name: Security_intelligence_Type_Index
+          type: keyword
+        - name: Security_intelligence_Version
+          type: keyword
+        - name: Security_intelligence_version
+          type: keyword
+        - name: Severity_ID
+          type: keyword
+        - name: Severity_Name
+          type: keyword
+        - name: Source_ID
+          type: keyword
+        - name: Source_Name
+          type: keyword
+        - name: Status_Code
+          type: keyword
+        - name: Threat_ID
+          type: keyword
+        - name: Threat_Name
+          type: keyword
+        - name: Type_ID
+          type: keyword
+        - name: Type_Name
+          type: keyword
+        - name: Update_Type
+          type: keyword
+        - name: Update_Type_Index
+          type: keyword
+        - name: User
+          type: keyword
 
     - name: event_id
       type: keyword

--- a/packages/windows/data_stream/windows_defender/sample_event.json
+++ b/packages/windows/data_stream/windows_defender/sample_event.json
@@ -1,24 +1,24 @@
 {
     "@timestamp": "2024-09-25T19:30:20.339Z",
     "agent": {
-        "ephemeral_id": "8b5286b8-9d5e-4a19-921b-48b6cdf2881d",
-        "id": "1f365586-06e0-4a4b-8787-c5c088f44de5",
-        "name": "elastic-agent-28855",
+        "ephemeral_id": "d0fee858-3b2f-4e5d-9fbb-204845903e8a",
+        "id": "757d65b4-4801-45c8-ad21-82958af8fd34",
+        "name": "elastic-agent-80630",
         "type": "filebeat",
-        "version": "8.15.1"
+        "version": "8.15.3"
     },
     "data_stream": {
         "dataset": "windows.windows_defender",
-        "namespace": "39980",
+        "namespace": "71160",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "1f365586-06e0-4a4b-8787-c5c088f44de5",
+        "id": "757d65b4-4801-45c8-ad21-82958af8fd34",
         "snapshot": false,
-        "version": "8.15.1"
+        "version": "8.15.3"
     },
     "event": {
         "action": "malware-quarantined",
@@ -27,9 +27,9 @@
             "malware"
         ],
         "code": "1117",
-        "created": "2024-09-26T15:59:35.718Z",
+        "created": "2024-10-27T18:11:49.634Z",
         "dataset": "windows.windows_defender",
-        "ingested": "2024-09-26T15:59:38Z",
+        "ingested": "2024-10-27T18:11:52Z",
         "kind": "event",
         "original": "<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Windows Defender' Guid='{11cd958a-c507-4ef3-b3f2-5fd9dfbd2c78}'/><EventID>1117</EventID><Version>0</Version><Level>4</Level><Task>0</Task><Opcode>0</Opcode><Keywords>0x8000000000000000</Keywords><TimeCreated SystemTime='2024-09-25T19:30:20.3397185Z'/><EventRecordID>22399</EventRecordID><Correlation ActivityID='{e8e94442-2856-4bab-a775-454654f7ec59}'/><Execution ProcessID='3168' ThreadID='13904'/><Channel>Microsoft-Windows-Windows Defender/Operational</Channel><Computer>el33t-b00k-1.org.local</Computer><Security UserID='S-1-5-18'/></System><EventData><Data Name='Product Name'>Microsoft Defender Antivirus</Data><Data Name='Product Version'>4.18.24080.9</Data><Data Name='Detection ID'>{4E4D1D41-19CC-4EE2-BDB0-950A07B81378}</Data><Data Name='Detection Time'>2024-09-25T19:29:38.198Z</Data><Data Name='Unused'></Data><Data Name='Unused2'></Data><Data Name='Threat ID'>2147680291</Data><Data Name='Threat Name'>Trojan:Win32/Detplock</Data><Data Name='Severity ID'>5</Data><Data Name='Severity Name'>Severe</Data><Data Name='Category ID'>8</Data><Data Name='Category Name'>Trojan</Data><Data Name='FWLink'>https://go.microsoft.com/fwlink/?linkid=37020&amp;name=Trojan:Win32/Detplock&amp;threatid=2147680291&amp;enterprise=1</Data><Data Name='Status Code'>3</Data><Data Name='Status Description'></Data><Data Name='State'>2</Data><Data Name='Source ID'>3</Data><Data Name='Source Name'>Real-Time Protection</Data><Data Name='Process Name'>C:\\Program Files\\Notepad++\\notepad++.exe</Data><Data Name='Detection User'>ORG\\Topsy</Data><Data Name='Unused3'></Data><Data Name='Path'>file:_C:\\Users\\Topsy\\Desktop\\eat_dem_yams.exe</Data><Data Name='Origin ID'>1</Data><Data Name='Origin Name'>Local machine</Data><Data Name='Execution ID'>1</Data><Data Name='Execution Name'>Suspended</Data><Data Name='Type ID'>8</Data><Data Name='Type Name'>FastPath</Data><Data Name='Pre Execution Status'>0</Data><Data Name='Action ID'>2</Data><Data Name='Action Name'>Quarantine</Data><Data Name='Unused4'></Data><Data Name='Error Code'>0x00000000</Data><Data Name='Error Description'>The operation completed successfully. </Data><Data Name='Unused5'></Data><Data Name='Post Clean Status'>0</Data><Data Name='Additional Actions ID'>0</Data><Data Name='Additional Actions String'>No additional actions required</Data><Data Name='Remediation User'>NT AUTHORITY\\SYSTEM</Data><Data Name='Unused6'></Data><Data Name='Security intelligence Version'>AV: 1.419.163.0, AS: 1.419.163.0, NIS: 1.419.163.0</Data><Data Name='Engine Version'>AM: 1.1.24080.9, NIS: 1.1.24080.9</Data></EventData><RenderingInfo Culture='en-US'><Message>Microsoft Defender Antivirus has taken action to protect this machine from malware or other potentially unwanted software.&#13;&#10; For more information please see the following:&#13;&#10;https://go.microsoft.com/fwlink/?linkid=37020&amp;name=Trojan:Win32/Detplock&amp;threatid=2147680291&amp;enterprise=1&#13;&#10; &#9;Name: Trojan:Win32/Detplock&#13;&#10; &#9;ID: 2147680291&#13;&#10; &#9;Severity: Severe&#13;&#10; &#9;Category: Trojan&#13;&#10; &#9;Path: file:_C:\\Users\\Topsy\\Desktop\\eat_dem_yams.exe&#13;&#10; &#9;Detection Origin: Local machine&#13;&#10; &#9;Detection Type: FastPath&#13;&#10; &#9;Detection Source: Real-Time Protection&#13;&#10; &#9;User: NT AUTHORITY\\SYSTEM&#13;&#10; &#9;Process Name: C:\\Program Files\\Notepad++\\notepad++.exe&#13;&#10; &#9;Action: Quarantine&#13;&#10; &#9;Action Status:  No additional actions required&#13;&#10; &#9;Error Code: 0x00000000&#13;&#10; &#9;Error description: The operation completed successfully. &#13;&#10; &#9;Security intelligence Version: AV: 1.419.163.0, AS: 1.419.163.0, NIS: 1.419.163.0&#13;&#10; &#9;Engine Version: AM: 1.1.24080.9, NIS: 1.1.24080.9</Message><Level>Information</Level><Opcode>Info</Opcode><Provider>Microsoft-Windows-Windows Defender</Provider></RenderingInfo></Event>",
         "outcome": "success",

--- a/packages/windows/docs/README.md
+++ b/packages/windows/docs/README.md
@@ -2811,24 +2811,24 @@ An example event for `windows_defender` looks as following:
 {
     "@timestamp": "2024-09-25T19:30:20.339Z",
     "agent": {
-        "ephemeral_id": "8b5286b8-9d5e-4a19-921b-48b6cdf2881d",
-        "id": "1f365586-06e0-4a4b-8787-c5c088f44de5",
-        "name": "elastic-agent-28855",
+        "ephemeral_id": "d0fee858-3b2f-4e5d-9fbb-204845903e8a",
+        "id": "757d65b4-4801-45c8-ad21-82958af8fd34",
+        "name": "elastic-agent-80630",
         "type": "filebeat",
-        "version": "8.15.1"
+        "version": "8.15.3"
     },
     "data_stream": {
         "dataset": "windows.windows_defender",
-        "namespace": "39980",
+        "namespace": "71160",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "1f365586-06e0-4a4b-8787-c5c088f44de5",
+        "id": "757d65b4-4801-45c8-ad21-82958af8fd34",
         "snapshot": false,
-        "version": "8.15.1"
+        "version": "8.15.3"
     },
     "event": {
         "action": "malware-quarantined",
@@ -2837,9 +2837,9 @@ An example event for `windows_defender` looks as following:
             "malware"
         ],
         "code": "1117",
-        "created": "2024-09-26T15:59:35.718Z",
+        "created": "2024-10-27T18:11:49.634Z",
         "dataset": "windows.windows_defender",
-        "ingested": "2024-09-26T15:59:38Z",
+        "ingested": "2024-10-27T18:11:52Z",
         "kind": "event",
         "original": "<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Windows Defender' Guid='{11cd958a-c507-4ef3-b3f2-5fd9dfbd2c78}'/><EventID>1117</EventID><Version>0</Version><Level>4</Level><Task>0</Task><Opcode>0</Opcode><Keywords>0x8000000000000000</Keywords><TimeCreated SystemTime='2024-09-25T19:30:20.3397185Z'/><EventRecordID>22399</EventRecordID><Correlation ActivityID='{e8e94442-2856-4bab-a775-454654f7ec59}'/><Execution ProcessID='3168' ThreadID='13904'/><Channel>Microsoft-Windows-Windows Defender/Operational</Channel><Computer>el33t-b00k-1.org.local</Computer><Security UserID='S-1-5-18'/></System><EventData><Data Name='Product Name'>Microsoft Defender Antivirus</Data><Data Name='Product Version'>4.18.24080.9</Data><Data Name='Detection ID'>{4E4D1D41-19CC-4EE2-BDB0-950A07B81378}</Data><Data Name='Detection Time'>2024-09-25T19:29:38.198Z</Data><Data Name='Unused'></Data><Data Name='Unused2'></Data><Data Name='Threat ID'>2147680291</Data><Data Name='Threat Name'>Trojan:Win32/Detplock</Data><Data Name='Severity ID'>5</Data><Data Name='Severity Name'>Severe</Data><Data Name='Category ID'>8</Data><Data Name='Category Name'>Trojan</Data><Data Name='FWLink'>https://go.microsoft.com/fwlink/?linkid=37020&amp;name=Trojan:Win32/Detplock&amp;threatid=2147680291&amp;enterprise=1</Data><Data Name='Status Code'>3</Data><Data Name='Status Description'></Data><Data Name='State'>2</Data><Data Name='Source ID'>3</Data><Data Name='Source Name'>Real-Time Protection</Data><Data Name='Process Name'>C:\\Program Files\\Notepad++\\notepad++.exe</Data><Data Name='Detection User'>ORG\\Topsy</Data><Data Name='Unused3'></Data><Data Name='Path'>file:_C:\\Users\\Topsy\\Desktop\\eat_dem_yams.exe</Data><Data Name='Origin ID'>1</Data><Data Name='Origin Name'>Local machine</Data><Data Name='Execution ID'>1</Data><Data Name='Execution Name'>Suspended</Data><Data Name='Type ID'>8</Data><Data Name='Type Name'>FastPath</Data><Data Name='Pre Execution Status'>0</Data><Data Name='Action ID'>2</Data><Data Name='Action Name'>Quarantine</Data><Data Name='Unused4'></Data><Data Name='Error Code'>0x00000000</Data><Data Name='Error Description'>The operation completed successfully. </Data><Data Name='Unused5'></Data><Data Name='Post Clean Status'>0</Data><Data Name='Additional Actions ID'>0</Data><Data Name='Additional Actions String'>No additional actions required</Data><Data Name='Remediation User'>NT AUTHORITY\\SYSTEM</Data><Data Name='Unused6'></Data><Data Name='Security intelligence Version'>AV: 1.419.163.0, AS: 1.419.163.0, NIS: 1.419.163.0</Data><Data Name='Engine Version'>AM: 1.1.24080.9, NIS: 1.1.24080.9</Data></EventData><RenderingInfo Culture='en-US'><Message>Microsoft Defender Antivirus has taken action to protect this machine from malware or other potentially unwanted software.&#13;&#10; For more information please see the following:&#13;&#10;https://go.microsoft.com/fwlink/?linkid=37020&amp;name=Trojan:Win32/Detplock&amp;threatid=2147680291&amp;enterprise=1&#13;&#10; &#9;Name: Trojan:Win32/Detplock&#13;&#10; &#9;ID: 2147680291&#13;&#10; &#9;Severity: Severe&#13;&#10; &#9;Category: Trojan&#13;&#10; &#9;Path: file:_C:\\Users\\Topsy\\Desktop\\eat_dem_yams.exe&#13;&#10; &#9;Detection Origin: Local machine&#13;&#10; &#9;Detection Type: FastPath&#13;&#10; &#9;Detection Source: Real-Time Protection&#13;&#10; &#9;User: NT AUTHORITY\\SYSTEM&#13;&#10; &#9;Process Name: C:\\Program Files\\Notepad++\\notepad++.exe&#13;&#10; &#9;Action: Quarantine&#13;&#10; &#9;Action Status:  No additional actions required&#13;&#10; &#9;Error Code: 0x00000000&#13;&#10; &#9;Error description: The operation completed successfully. &#13;&#10; &#9;Security intelligence Version: AV: 1.419.163.0, AS: 1.419.163.0, NIS: 1.419.163.0&#13;&#10; &#9;Engine Version: AM: 1.1.24080.9, NIS: 1.1.24080.9</Message><Level>Information</Level><Opcode>Info</Opcode><Provider>Microsoft-Windows-Windows Defender</Provider></RenderingInfo></Event>",
         "outcome": "success",
@@ -2963,6 +2963,10 @@ An example event for `windows_defender` looks as following:
 | winlog.event_data.AS_security_intelligence_version |  | keyword |
 | winlog.event_data.AV_security_intelligence_creation_time |  | date |
 | winlog.event_data.AV_security_intelligence_version |  | keyword |
+| winlog.event_data.Action_ID |  | keyword |
+| winlog.event_data.Action_Name |  | keyword |
+| winlog.event_data.Additional_Actions_ID |  | keyword |
+| winlog.event_data.Additional_Actions_String |  | keyword |
 | winlog.event_data.AuthenticationPackageName |  | keyword |
 | winlog.event_data.BM_state |  | keyword |
 | winlog.event_data.Binary |  | keyword |
@@ -2970,24 +2974,38 @@ An example event for `windows_defender` looks as following:
 | winlog.event_data.BootMode |  | keyword |
 | winlog.event_data.BootType |  | keyword |
 | winlog.event_data.BuildVersion |  | keyword |
+| winlog.event_data.Category_ID |  | keyword |
+| winlog.event_data.Category_Name |  | keyword |
 | winlog.event_data.Company |  | keyword |
 | winlog.event_data.CorruptionActionState |  | keyword |
 | winlog.event_data.CreationUtcTime |  | keyword |
+| winlog.event_data.Current_Engine_Version |  | keyword |
+| winlog.event_data.Current_security_intelligence_Version |  | keyword |
 | winlog.event_data.Description |  | keyword |
 | winlog.event_data.Detail |  | keyword |
+| winlog.event_data.Detection_ID |  | keyword |
+| winlog.event_data.Detection_Time |  | date |
+| winlog.event_data.Detection_User |  | keyword |
 | winlog.event_data.DeviceName |  | keyword |
 | winlog.event_data.DeviceNameLength |  | keyword |
 | winlog.event_data.DeviceTime |  | keyword |
 | winlog.event_data.DeviceVersionMajor |  | keyword |
 | winlog.event_data.DeviceVersionMinor |  | keyword |
+| winlog.event_data.Domain |  | keyword |
 | winlog.event_data.DriveName |  | keyword |
 | winlog.event_data.DriverName |  | keyword |
 | winlog.event_data.DriverNameLength |  | keyword |
 | winlog.event_data.DwordVal |  | keyword |
+| winlog.event_data.Engine_Version |  | keyword |
 | winlog.event_data.Engine_up-to-date |  | keyword |
 | winlog.event_data.Engine_version |  | keyword |
 | winlog.event_data.EntryCount |  | keyword |
+| winlog.event_data.Error_Code |  | keyword |
+| winlog.event_data.Error_Description |  | keyword |
+| winlog.event_data.Execution_ID |  | keyword |
+| winlog.event_data.Execution_Name |  | keyword |
 | winlog.event_data.ExtraInfo |  | keyword |
+| winlog.event_data.FWLink |  | keyword |
 | winlog.event_data.FailureName |  | keyword |
 | winlog.event_data.FailureNameLength |  | keyword |
 | winlog.event_data.FileVersion |  | keyword |
@@ -3038,13 +3056,19 @@ An example event for `windows_defender` looks as following:
 | winlog.event_data.OA_state |  | keyword |
 | winlog.event_data.OldSchemeGuid |  | keyword |
 | winlog.event_data.OldTime |  | keyword |
+| winlog.event_data.Origin_ID |  | keyword |
+| winlog.event_data.Origin_Name |  | keyword |
 | winlog.event_data.OriginalFileName |  | keyword |
 | winlog.event_data.Path |  | keyword |
 | winlog.event_data.PerformanceImplementation |  | keyword |
 | winlog.event_data.Platform_up-to-date |  | keyword |
 | winlog.event_data.Platform_version |  | keyword |
+| winlog.event_data.Post_Clean_Status |  | keyword |
+| winlog.event_data.Pre_Execution_Status |  | keyword |
 | winlog.event_data.PreviousCreationUtcTime |  | keyword |
 | winlog.event_data.PreviousTime |  | keyword |
+| winlog.event_data.Previous_Engine_Version |  | keyword |
+| winlog.event_data.Previous_security_intelligence_Version |  | keyword |
 | winlog.event_data.PrivilegeList |  | keyword |
 | winlog.event_data.ProcessId |  | keyword |
 | winlog.event_data.ProcessName |  | keyword |
@@ -3052,25 +3076,42 @@ An example event for `windows_defender` looks as following:
 | winlog.event_data.ProcessPid |  | keyword |
 | winlog.event_data.Product |  | keyword |
 | winlog.event_data.Product_Name |  | keyword |
+| winlog.event_data.Product_Version |  | keyword |
 | winlog.event_data.Product_status |  | keyword |
 | winlog.event_data.PuaCount |  | keyword |
 | winlog.event_data.PuaPolicyId |  | keyword |
 | winlog.event_data.QfeVersion |  | keyword |
 | winlog.event_data.RTP_state |  | keyword |
 | winlog.event_data.Reason |  | keyword |
+| winlog.event_data.Remediation_User |  | keyword |
+| winlog.event_data.SID |  | keyword |
+| winlog.event_data.Scan_ID |  | keyword |
+| winlog.event_data.Scan_Parameters |  | keyword |
+| winlog.event_data.Scan_Parameters_Index |  | keyword |
+| winlog.event_data.Scan_Type |  | keyword |
+| winlog.event_data.Scan_Type_Index |  | keyword |
 | winlog.event_data.SchemaVersion |  | keyword |
 | winlog.event_data.ScriptBlockText |  | keyword |
+| winlog.event_data.Security_intelligence_Type |  | keyword |
+| winlog.event_data.Security_intelligence_Type_Index |  | keyword |
+| winlog.event_data.Security_intelligence_Version |  | keyword |
+| winlog.event_data.Security_intelligence_version |  | keyword |
 | winlog.event_data.ServiceName |  | keyword |
 | winlog.event_data.ServiceVersion |  | keyword |
+| winlog.event_data.Severity_ID |  | keyword |
+| winlog.event_data.Severity_Name |  | keyword |
 | winlog.event_data.ShutdownActionType |  | keyword |
 | winlog.event_data.ShutdownEventCode |  | keyword |
 | winlog.event_data.ShutdownReason |  | keyword |
 | winlog.event_data.Signature |  | keyword |
 | winlog.event_data.SignatureStatus |  | keyword |
 | winlog.event_data.Signed |  | keyword |
+| winlog.event_data.Source_ID |  | keyword |
+| winlog.event_data.Source_Name |  | keyword |
 | winlog.event_data.StartTime |  | keyword |
 | winlog.event_data.State |  | keyword |
 | winlog.event_data.Status |  | keyword |
+| winlog.event_data.Status_Code |  | keyword |
 | winlog.event_data.StopTime |  | keyword |
 | winlog.event_data.SubjectDomainName |  | keyword |
 | winlog.event_data.SubjectLogonId |  | keyword |
@@ -3085,8 +3126,15 @@ An example event for `windows_defender` looks as following:
 | winlog.event_data.TargetUserName |  | keyword |
 | winlog.event_data.TargetUserSid |  | keyword |
 | winlog.event_data.TerminalSessionId |  | keyword |
+| winlog.event_data.Threat_ID |  | keyword |
+| winlog.event_data.Threat_Name |  | keyword |
 | winlog.event_data.TokenElevationType |  | keyword |
 | winlog.event_data.TransmittedServices |  | keyword |
+| winlog.event_data.Type_ID |  | keyword |
+| winlog.event_data.Type_Name |  | keyword |
+| winlog.event_data.Update_Type |  | keyword |
+| winlog.event_data.Update_Type_Index |  | keyword |
+| winlog.event_data.User |  | keyword |
 | winlog.event_data.UserSid |  | keyword |
 | winlog.event_data.Version |  | keyword |
 | winlog.event_data.Workstation |  | keyword |

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 2.2.0
+version: 2.2.1
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
It was reported in the community that the File Path will sometimes contain a process pid which is not currently processor correctly (see screenshots). This PR will resolve this issue and also add more fields that were missed in the last update.

Convo started here: https://elasticstack.slack.com/archives/C018PDGK6JU/p1729764392118379?thread_ts=1729593410.515049&cid=C018PDGK6JU

- Bug

This will improve the integration further.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues


## Screenshots
![image](https://github.com/user-attachments/assets/d8842317-c37c-424e-9c94-218822e7a36c)
![image](https://github.com/user-attachments/assets/13005bff-7134-46ee-934f-f7e91eb2474f)
