### PR TITLE
[CI] Update configuration to update LogsDB step label in daily job

### DIFF
--- a/.buildkite/pipeline.schedule-daily.yml
+++ b/.buildkite/pipeline.schedule-daily.yml
@@ -38,7 +38,7 @@ steps:
       - step: "check"
         allow_failure: false
 
-  - label: "Check integrations local stacks - Stack Version v8.16 - LogsDB"
+  - label: "Check integrations local stacks - Stack Version v8.17 - LogsDB"
     trigger: "integrations"
     build:
       env:

--- a/.github/workflows/updatecli/updatecli.d/bump-latest-8x-snapshot-version.yml
+++ b/.github/workflows/updatecli/updatecli.d/bump-latest-8x-snapshot-version.yml
@@ -60,8 +60,8 @@ targets:
     scmid: default
     spec:
       file: '.buildkite/pipeline.schedule-daily.yml'
-      matchpattern: '(Stack Version) v8\.\d+"'
-      replacepattern: 'Stack Version v{{ source "latestSnapshotMajorMinor" }}"'
+      matchpattern: '(Stack Version) v8\.\d+("| - LogsDB")'
+      replacepattern: '$1 v{{ source "latestSnapshotMajorMinor" }}$2'
 
   update-snapshot-weekly:
     name: '[updatecli] [weekly] Update latest snapshot to {{ source "latestSnapshot" }}'


### PR DESCRIPTION
## Proposed commit message

Fix updatecli automation to update also label with the Elastic stack version accordingly.

Changed that would be performed by updatecli
```diff
--- .buildkite/pipeline.schedule-daily.yml
+++ .buildkite/pipeline.schedule-daily.yml
@@ -38,7 +38,7 @@
       - step: "check"
         allow_failure: false
 
-  - label: "Check integrations local stacks - Stack Version v8.16 - LogsDB"
+  - label: "Check integrations local stacks - Stack Version v8.17 - LogsDB"
     trigger: "integrations"
     build:
       env:
```

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Perform test with updatecli configuration
- [x] Update step label as part of the PR.

