### PR TITLE
[Jamf Protect] Minor changes to the pipeline_event_authentication

### DIFF
--- a/packages/jamf_protect/changelog.yml
+++ b/packages/jamf_protect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.6.3"
+  changes:
+    - description: Fixed itemMap for pipeline_event_authentication in Telemetry. Wront integer values were mapped.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11284
 - version: "2.6.2"
   changes:
     - description: Use triple-brace Mustache templating when referencing variables in ingest pipelines.

--- a/packages/jamf_protect/changelog.yml
+++ b/packages/jamf_protect/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "2.6.3"
   changes:
-    - description: Fixed itemMap for pipeline_event_authentication in Telemetry. Wront integer values were mapped.
+    - description: Fixed itemMap for pipeline_event_authentication in Telemetry. Wrong integer values were mapped.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/11284
+      link: https://github.com/elastic/integrations/pull/11575
 - version: "2.6.2"
   changes:
     - description: Use triple-brace Mustache templating when referencing variables in ingest pipelines.

--- a/packages/jamf_protect/data_stream/alerts/sample_event.json
+++ b/packages/jamf_protect/data_stream/alerts/sample_event.json
@@ -1,24 +1,24 @@
 {
-    "@timestamp": "2024-09-04T07:30:39.656Z",
+    "@timestamp": "2024-10-29T15:33:09.283Z",
     "agent": {
-        "ephemeral_id": "75181666-4505-45af-90dd-156c8f2e1306",
-        "id": "81686acf-dfab-47d7-9dbe-c5e404724032",
-        "name": "elastic-agent-92357",
+        "ephemeral_id": "671ffaef-2f9c-40c3-bc44-8f7dd8f41bf3",
+        "id": "fffef289-536c-44b3-8a3a-7edce9a79be4",
+        "name": "elastic-agent-79065",
         "type": "filebeat",
-        "version": "8.13.0"
+        "version": "8.14.3"
     },
     "data_stream": {
         "dataset": "jamf_protect.alerts",
-        "namespace": "22598",
+        "namespace": "64311",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "81686acf-dfab-47d7-9dbe-c5e404724032",
+        "id": "fffef289-536c-44b3-8a3a-7edce9a79be4",
         "snapshot": false,
-        "version": "8.13.0"
+        "version": "8.14.3"
     },
     "event": {
         "action": "CustomURLHandlerCreation",
@@ -29,7 +29,7 @@
         ],
         "dataset": "jamf_protect.alerts",
         "id": "6bdb0697-6d07-47bc-a37d-6c3348a5d953",
-        "ingested": "2024-09-04T07:30:49Z",
+        "ingested": "2024-10-29T15:33:10Z",
         "kind": "alert",
         "provider": "Jamf Protect",
         "reason": "Application that uses custom url handler created",

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_authentication.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_authentication.yml
@@ -47,8 +47,8 @@ processors:
         lang: painless
         params:
             itemTypeMap:
-                '0': machine_unlock
-                '1': auth_prompt
+                '1': machine_unlock
+                '2': auth_prompt
         source: >
             if (ctx.jamf_protect?.telemetry?.event?.authentication?.data?.auto_unlock != null) {
                 String itemType = ctx.jamf_protect.telemetry.event.authentication.data.auto_unlock.type.toString();

--- a/packages/jamf_protect/data_stream/telemetry/sample_event.json
+++ b/packages/jamf_protect/data_stream/telemetry/sample_event.json
@@ -1,15 +1,15 @@
 {
-    "@timestamp": "2024-09-04T07:32:31.324Z",
+    "@timestamp": "2024-10-29T15:34:50.724Z",
     "agent": {
-        "ephemeral_id": "b8187d5d-0325-40c6-ade8-0779fa3be88a",
-        "id": "be948a10-ee85-46d4-a496-ca5c5117936d",
-        "name": "elastic-agent-10576",
+        "ephemeral_id": "15f81264-c6eb-4699-bab6-6aa64dfd43aa",
+        "id": "f70df138-4dc9-4972-8510-57226731f5a0",
+        "name": "elastic-agent-91650",
         "type": "filebeat",
-        "version": "8.13.0"
+        "version": "8.14.3"
     },
     "data_stream": {
         "dataset": "jamf_protect.telemetry",
-        "namespace": "51899",
+        "namespace": "55238",
         "type": "logs"
     },
     "device": {
@@ -20,9 +20,9 @@
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "be948a10-ee85-46d4-a496-ca5c5117936d",
+        "id": "f70df138-4dc9-4972-8510-57226731f5a0",
         "snapshot": false,
-        "version": "8.13.0"
+        "version": "8.14.3"
     },
     "event": {
         "action": "exec",
@@ -33,7 +33,7 @@
         "code": "9",
         "dataset": "jamf_protect.telemetry",
         "id": "CDB31202-8CB4-4C72-A9C6-7F494CD5F598",
-        "ingested": "2024-09-04T07:32:41Z",
+        "ingested": "2024-10-29T15:34:51Z",
         "kind": "event",
         "provider": "Jamf Protect",
         "reason": "A new process has been executed",

--- a/packages/jamf_protect/data_stream/telemetry_legacy/sample_event.json
+++ b/packages/jamf_protect/data_stream/telemetry_legacy/sample_event.json
@@ -1,24 +1,24 @@
 {
     "@timestamp": "2024-02-06T16:01:34.442Z",
     "agent": {
-        "ephemeral_id": "3ab8d2c5-d0cf-47b1-bcb8-aed03b164c2f",
-        "id": "144fa4ee-8c64-4fae-b5e7-9d83ff01f18c",
-        "name": "elastic-agent-88537",
+        "ephemeral_id": "ccaeefb1-5a10-4513-b5ce-6a0164246d8e",
+        "id": "73ad9852-7454-451c-968f-1975d2e363ca",
+        "name": "elastic-agent-48532",
         "type": "filebeat",
-        "version": "8.13.0"
+        "version": "8.14.3"
     },
     "data_stream": {
         "dataset": "jamf_protect.telemetry_legacy",
-        "namespace": "35800",
+        "namespace": "50605",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "144fa4ee-8c64-4fae-b5e7-9d83ff01f18c",
+        "id": "73ad9852-7454-451c-968f-1975d2e363ca",
         "snapshot": false,
-        "version": "8.13.0"
+        "version": "8.14.3"
     },
     "error": {
         "code": "0"
@@ -31,7 +31,7 @@
         ],
         "code": "43190",
         "dataset": "jamf_protect.telemetry_legacy",
-        "ingested": "2024-09-04T07:34:34Z",
+        "ingested": "2024-10-29T15:39:41Z",
         "kind": "event",
         "outcome": "success",
         "type": [

--- a/packages/jamf_protect/data_stream/web_threat_events/sample_event.json
+++ b/packages/jamf_protect/data_stream/web_threat_events/sample_event.json
@@ -1,15 +1,15 @@
 {
-    "@timestamp": "2024-09-04T07:36:11.911Z",
+    "@timestamp": "2024-10-29T15:41:26.096Z",
     "agent": {
-        "ephemeral_id": "b7f943fb-c06d-4222-93bd-358288578b26",
-        "id": "4470df0e-f5ad-4b31-9480-44c2ad6ae7b3",
-        "name": "elastic-agent-80181",
+        "ephemeral_id": "e88ac039-e2c1-4189-b7ef-f8fa987d1edc",
+        "id": "e64da853-f2f4-4421-b48f-87613b992b84",
+        "name": "elastic-agent-68255",
         "type": "filebeat",
-        "version": "8.13.2"
+        "version": "8.14.3"
     },
     "data_stream": {
         "dataset": "jamf_protect.web_threat_events",
-        "namespace": "37455",
+        "namespace": "25188",
         "type": "logs"
     },
     "destination": {
@@ -21,9 +21,9 @@
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "4470df0e-f5ad-4b31-9480-44c2ad6ae7b3",
+        "id": "e64da853-f2f4-4421-b48f-87613b992b84",
         "snapshot": false,
-        "version": "8.13.2"
+        "version": "8.14.3"
     },
     "event": {
         "action": "Detected",
@@ -33,7 +33,7 @@
         ],
         "dataset": "jamf_protect.web_threat_events",
         "id": "013b15c9-8f62-4bf1-948a-d82367af2a10",
-        "ingested": "2024-09-04T07:36:21Z",
+        "ingested": "2024-10-29T15:41:27Z",
         "kind": "alert",
         "provider": "Jamf Protect",
         "reason": "Sideloaded App",

--- a/packages/jamf_protect/data_stream/web_traffic_events/sample_event.json
+++ b/packages/jamf_protect/data_stream/web_traffic_events/sample_event.json
@@ -1,15 +1,15 @@
 {
-    "@timestamp": "2024-09-04T07:38:01.195Z",
+    "@timestamp": "2024-10-29T15:44:14.195Z",
     "agent": {
-        "ephemeral_id": "77808a3e-9a5a-4ce3-a074-f2cdaa7d0a03",
-        "id": "94e5efaa-97be-4d20-9330-c38adb3f3ebd",
-        "name": "elastic-agent-25706",
+        "ephemeral_id": "8e610613-0597-4898-8f02-f6ee4bca6af8",
+        "id": "a93c9dd6-0141-4441-8f5e-c6d1999c4351",
+        "name": "elastic-agent-59905",
         "type": "filebeat",
-        "version": "8.13.2"
+        "version": "8.14.3"
     },
     "data_stream": {
         "dataset": "jamf_protect.web_traffic_events",
-        "namespace": "39208",
+        "namespace": "79225",
         "type": "logs"
     },
     "dns": {
@@ -28,9 +28,9 @@
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "94e5efaa-97be-4d20-9330-c38adb3f3ebd",
+        "id": "a93c9dd6-0141-4441-8f5e-c6d1999c4351",
         "snapshot": false,
-        "version": "8.13.2"
+        "version": "8.14.3"
     },
     "event": {
         "action": "DNS Lookup",
@@ -40,7 +40,7 @@
             "network"
         ],
         "dataset": "jamf_protect.web_traffic_events",
-        "ingested": "2024-09-04T07:38:11Z",
+        "ingested": "2024-10-29T15:44:15Z",
         "kind": "event",
         "outcome": [
             "success"

--- a/packages/jamf_protect/docs/README.md
+++ b/packages/jamf_protect/docs/README.md
@@ -112,26 +112,26 @@ An example event for `alerts` looks as following:
 
 ```json
 {
-    "@timestamp": "2024-09-04T07:30:39.656Z",
+    "@timestamp": "2024-10-29T15:33:09.283Z",
     "agent": {
-        "ephemeral_id": "75181666-4505-45af-90dd-156c8f2e1306",
-        "id": "81686acf-dfab-47d7-9dbe-c5e404724032",
-        "name": "elastic-agent-92357",
+        "ephemeral_id": "671ffaef-2f9c-40c3-bc44-8f7dd8f41bf3",
+        "id": "fffef289-536c-44b3-8a3a-7edce9a79be4",
+        "name": "elastic-agent-79065",
         "type": "filebeat",
-        "version": "8.13.0"
+        "version": "8.14.3"
     },
     "data_stream": {
         "dataset": "jamf_protect.alerts",
-        "namespace": "22598",
+        "namespace": "64311",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "81686acf-dfab-47d7-9dbe-c5e404724032",
+        "id": "fffef289-536c-44b3-8a3a-7edce9a79be4",
         "snapshot": false,
-        "version": "8.13.0"
+        "version": "8.14.3"
     },
     "event": {
         "action": "CustomURLHandlerCreation",
@@ -142,7 +142,7 @@ An example event for `alerts` looks as following:
         ],
         "dataset": "jamf_protect.alerts",
         "id": "6bdb0697-6d07-47bc-a37d-6c3348a5d953",
-        "ingested": "2024-09-04T07:30:49Z",
+        "ingested": "2024-10-29T15:33:10Z",
         "kind": "alert",
         "provider": "Jamf Protect",
         "reason": "Application that uses custom url handler created",
@@ -304,17 +304,17 @@ An example event for `telemetry` looks as following:
 
 ```json
 {
-    "@timestamp": "2024-09-04T07:32:31.324Z",
+    "@timestamp": "2024-10-29T15:34:50.724Z",
     "agent": {
-        "ephemeral_id": "b8187d5d-0325-40c6-ade8-0779fa3be88a",
-        "id": "be948a10-ee85-46d4-a496-ca5c5117936d",
-        "name": "elastic-agent-10576",
+        "ephemeral_id": "15f81264-c6eb-4699-bab6-6aa64dfd43aa",
+        "id": "f70df138-4dc9-4972-8510-57226731f5a0",
+        "name": "elastic-agent-91650",
         "type": "filebeat",
-        "version": "8.13.0"
+        "version": "8.14.3"
     },
     "data_stream": {
         "dataset": "jamf_protect.telemetry",
-        "namespace": "51899",
+        "namespace": "55238",
         "type": "logs"
     },
     "device": {
@@ -325,9 +325,9 @@ An example event for `telemetry` looks as following:
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "be948a10-ee85-46d4-a496-ca5c5117936d",
+        "id": "f70df138-4dc9-4972-8510-57226731f5a0",
         "snapshot": false,
-        "version": "8.13.0"
+        "version": "8.14.3"
     },
     "event": {
         "action": "exec",
@@ -338,7 +338,7 @@ An example event for `telemetry` looks as following:
         "code": "9",
         "dataset": "jamf_protect.telemetry",
         "id": "CDB31202-8CB4-4C72-A9C6-7F494CD5F598",
-        "ingested": "2024-09-04T07:32:41Z",
+        "ingested": "2024-10-29T15:34:51Z",
         "kind": "event",
         "provider": "Jamf Protect",
         "reason": "A new process has been executed",
@@ -600,17 +600,17 @@ An example event for `web_threat_events` looks as following:
 
 ```json
 {
-    "@timestamp": "2024-09-04T07:36:11.911Z",
+    "@timestamp": "2024-10-29T15:41:26.096Z",
     "agent": {
-        "ephemeral_id": "b7f943fb-c06d-4222-93bd-358288578b26",
-        "id": "4470df0e-f5ad-4b31-9480-44c2ad6ae7b3",
-        "name": "elastic-agent-80181",
+        "ephemeral_id": "e88ac039-e2c1-4189-b7ef-f8fa987d1edc",
+        "id": "e64da853-f2f4-4421-b48f-87613b992b84",
+        "name": "elastic-agent-68255",
         "type": "filebeat",
-        "version": "8.13.2"
+        "version": "8.14.3"
     },
     "data_stream": {
         "dataset": "jamf_protect.web_threat_events",
-        "namespace": "37455",
+        "namespace": "25188",
         "type": "logs"
     },
     "destination": {
@@ -622,9 +622,9 @@ An example event for `web_threat_events` looks as following:
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "4470df0e-f5ad-4b31-9480-44c2ad6ae7b3",
+        "id": "e64da853-f2f4-4421-b48f-87613b992b84",
         "snapshot": false,
-        "version": "8.13.2"
+        "version": "8.14.3"
     },
     "event": {
         "action": "Detected",
@@ -634,7 +634,7 @@ An example event for `web_threat_events` looks as following:
         ],
         "dataset": "jamf_protect.web_threat_events",
         "id": "013b15c9-8f62-4bf1-948a-d82367af2a10",
-        "ingested": "2024-09-04T07:36:21Z",
+        "ingested": "2024-10-29T15:41:27Z",
         "kind": "alert",
         "provider": "Jamf Protect",
         "reason": "Sideloaded App",
@@ -727,17 +727,17 @@ An example event for `web_traffic_events` looks as following:
 
 ```json
 {
-    "@timestamp": "2024-09-04T07:38:01.195Z",
+    "@timestamp": "2024-10-29T15:44:14.195Z",
     "agent": {
-        "ephemeral_id": "77808a3e-9a5a-4ce3-a074-f2cdaa7d0a03",
-        "id": "94e5efaa-97be-4d20-9330-c38adb3f3ebd",
-        "name": "elastic-agent-25706",
+        "ephemeral_id": "8e610613-0597-4898-8f02-f6ee4bca6af8",
+        "id": "a93c9dd6-0141-4441-8f5e-c6d1999c4351",
+        "name": "elastic-agent-59905",
         "type": "filebeat",
-        "version": "8.13.2"
+        "version": "8.14.3"
     },
     "data_stream": {
         "dataset": "jamf_protect.web_traffic_events",
-        "namespace": "39208",
+        "namespace": "79225",
         "type": "logs"
     },
     "dns": {
@@ -756,9 +756,9 @@ An example event for `web_traffic_events` looks as following:
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "94e5efaa-97be-4d20-9330-c38adb3f3ebd",
+        "id": "a93c9dd6-0141-4441-8f5e-c6d1999c4351",
         "snapshot": false,
-        "version": "8.13.2"
+        "version": "8.14.3"
     },
     "event": {
         "action": "DNS Lookup",
@@ -768,7 +768,7 @@ An example event for `web_traffic_events` looks as following:
             "network"
         ],
         "dataset": "jamf_protect.web_traffic_events",
-        "ingested": "2024-09-04T07:38:11Z",
+        "ingested": "2024-10-29T15:44:15Z",
         "kind": "event",
         "outcome": [
             "success"

--- a/packages/jamf_protect/manifest.yml
+++ b/packages/jamf_protect/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: jamf_protect
 title: Jamf Protect
-version: "2.6.2"
+version: "2.6.3"
 description: Receives events from Jamf Protect with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Type of change:
- bigfix

## Proposed commit message

- Minor bug fix to the itemType for `jamf_protect.telemetry.authentication_auto_unlock_type` on the `pipeline_event_authentication.yaml`, the integer values were wrong.
 - integer values are not exposed in developer documentation, only in xCode header files. https://developer.apple.com/documentation/endpointsecurity/es_auto_unlock_type_t

```
typedef enum {
	/// Unlock the machine using Apple Watch.
	ES_AUTO_UNLOCK_MACHINE_UNLOCK = 1,
	/// Approve an authorization prompt using Apple Watch.
	ES_AUTO_UNLOCK_AUTH_PROMPT = 2
} es_auto_unlock_type_t;
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally
`elastic-package test system`

```
2024/10/29 16:45:41  INFO Write container logs to file: /Users/thijs.xhaflaire/Documents/GitHub/Elastic/integrations/build/container-logs/elastic-agent-1730216741120038000.log
--- Test results for package: jamf_protect - START ---
╭──────────────┬────────────────────┬───────────┬───────────────┬────────┬───────────────╮
│ PACKAGE      │ DATA STREAM        │ TEST TYPE │ TEST NAME     │ RESULT │  TIME ELAPSED │
├──────────────┼────────────────────┼───────────┼───────────────┼────────┼───────────────┤
│ jamf_protect │ alerts             │ system    │ http-endpoint │ PASS   │ 56.873213333s │
│ jamf_protect │ telemetry          │ system    │ http-endpoint │ PASS   │ 54.519301459s │
│ jamf_protect │ telemetry_legacy   │ system    │ http-endpoint │ PASS   │     57.86671s │
│ jamf_protect │ web_threat_events  │ system    │ http-endpoint │ PASS   │ 57.404558917s │
│ jamf_protect │ web_traffic_events │ system    │ http-endpoint │ PASS   │ 59.156538042s │
╰──────────────┴────────────────────┴───────────┴───────────────┴────────┴───────────────╯
--- Test results for package: jamf_protect - END   ---
Done
```