### PR TITLE
[osquery_manager] Add mappings for ECS email fields

### DIFF
--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.1"
+  changes:
+    - description: Add mappings for ECS email fields
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.14.0"
   changes:
     - description: Update schema for osquery 5.13.1

--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.14.1"
+- version: "1.15.0"
   changes:
     - description: Add mappings for ECS email fields
       type: enhancement

--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add mappings for ECS email fields
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/11583
 - version: "1.14.0"
   changes:
     - description: Update schema for osquery 5.13.1

--- a/packages/osquery_manager/data_stream/result/fields/ecs.yml
+++ b/packages/osquery_manager/data_stream/result/fields/ecs.yml
@@ -70,11 +70,57 @@
 - external: ecs
   name: dns.resolved_ip
 - external: ecs
+  name: email.attachments
+- external: ecs
+  name: email.attachments.file.extension
+- external: ecs
+  name: email.attachments.file.hash.md5
+- external: ecs
+  name: email.attachments.file.hash.sha1
+- external: ecs
+  name: email.attachments.file.hash.sha256
+- external: ecs
+  name: email.attachments.file.hash.sha384
+- external: ecs
+  name: email.attachments.file.hash.sha512
+- external: ecs
+  name: email.attachments.file.hash.ssdeep
+- external: ecs
+  name: email.attachments.file.hash.tlsh
+- external: ecs
+  name: email.attachments.file.mime_type
+- external: ecs
+  name: email.attachments.file.name
+- external: ecs
   name: email.attachments.file.size
+- external: ecs
+  name: email.bcc.address
+- external: ecs
+  name: email.cc.address
+- external: ecs
+  name: email.content_type
 - external: ecs
   name: email.delivery_timestamp
 - external: ecs
+  name: email.direction
+- external: ecs
+  name: email.from.address
+- external: ecs
+  name: email.local_id
+- external: ecs
+  name: email.message_id
+- external: ecs
   name: email.origination_timestamp
+- external: ecs
+  name: email.reply_to.address
+- external: ecs
+  name: email.sender.address
+- external: ecs
+  name: email.subject
+- external: ecs
+  name: email.to.address
+- external: ecs
+  name: email.x_mailer
 - external: ecs
   name: event.created
 - external: ecs

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: osquery_manager
 title: Osquery Manager
-version: 1.14.1
+version: 1.15.0
 description: Deploy Osquery with Elastic Agent, then run and schedule queries in Kibana
 type: integration
 categories:

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: osquery_manager
 title: Osquery Manager
-version: 1.14.0
+version: 1.14.1
 description: Deploy Osquery with Elastic Agent, then run and schedule queries in Kibana
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Add mappings for ECS email fields

This addresses one of the issues with email subfields mapping specifically `email.attachments` ECS field was not specified in the package before, resulting with invalid auto generated object mapping instead of the nested field. 
Adding all of the ECS email fields mappings with this change. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## Screenshots

<img width="1239" alt="Screenshot 2024-10-29 at 6 15 41 PM" src="https://github.com/user-attachments/assets/0acc51c3-4302-4987-9f0d-711dce6f204d">

<img width="1364" alt="Screenshot 2024-10-29 at 6 15 29 PM" src="https://github.com/user-attachments/assets/429bd0bf-de4f-4b54-84b1-ee50df2bfbc0">

