### PR TITLE
cel: Add `xsd` configuration option to input.

### DIFF
--- a/packages/cel/agent/input/input.yml.hbs
+++ b/packages/cel/agent/input/input.yml.hbs
@@ -21,6 +21,11 @@ regexp:
   {{regexp}}
 {{/if}}
 
+{{#if xsd}}
+xsd:
+  {{xsd}}
+{{/if}}
+
 {{#if username}}
 auth.basic.user: {{username}}
 {{/if}}

--- a/packages/cel/changelog.yml
+++ b/packages/cel/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.13.0"
+  changes:
+    - description: Add xsd configuration option inside input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.12.0"
   changes:
     - description: ECS version updated to 8.11.0. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/cel/changelog.yml
+++ b/packages/cel/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add xsd configuration option inside input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/11602
 - version: "1.12.0"
   changes:
     - description: ECS version updated to 8.11.0. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/cel/manifest.yml
+++ b/packages/cel/manifest.yml
@@ -96,7 +96,7 @@ policy_templates:
         description: |
           The XSD needed for correct parsing and ingestion of XML documents using decode_xml CEL extension.
           More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#xsd-cel).
-        show_user: true
+        show_user: false
         multi: false
         required: false
         default: |

--- a/packages/cel/manifest.yml
+++ b/packages/cel/manifest.yml
@@ -3,7 +3,7 @@ name: cel
 title: Custom API using Common Expression Language
 description: Collect custom events from an API with Elastic agent
 type: input
-version: "1.12.0"
+version: "1.13.0"
 categories:
   - custom
 conditions:
@@ -90,6 +90,27 @@ policy_templates:
         default: |
           #products: '(?i)(Elasticsearch|Beats|Logstash|Kibana)'
           #solutions: '(?i)(Search|Observability|Security)'
+      - name: xsd
+        type: textarea
+        title: XML Schema Definitions (XSD) for XML documents.
+        description: |
+          The XSD needed for correct parsing and ingestion of XML documents using decode_xml CEL extension.
+          More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#xsd-cel).
+        show_user: true
+        multi: false
+        required: false
+        default: |
+          # order: |
+          #   <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+          #     <xs:element name="order">
+          #       <xs:complexType>
+          #         <xs:sequence>
+          #           <xs:element name="sender" type="xs:string"/>
+          #           <xs:element name="address">
+          #             <xs:complexType>
+          #               <xs:sequence>
+          #                 <xs:element name="name" type="xs:string"/>
+          #                 <xs:element name="company" type="xs:string"/>
       - name: username
         type: text
         title: Basic Auth Username


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
Adds `xsd` configuration option to input.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
<img width="364" alt="Screenshot 2024-10-31 at 5 31 38 PM" src="https://github.com/user-attachments/assets/674211ca-7641-44e0-a6fb-7ce12c4ee89a">
