### PR TITLE
Tolerate existing event.timezone in fortimail and fortiproxy

### DIFF
--- a/packages/fortinet_fortimail/changelog.yml
+++ b/packages/fortinet_fortimail/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.13.1"
+  changes:
+    - description: Tolerate existing event.timezone value.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.13.0"
   changes:
     - description: Update package spec to 3.0.3.

--- a/packages/fortinet_fortimail/changelog.yml
+++ b/packages/fortinet_fortimail/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Tolerate existing event.timezone value.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/11606
 - version: "2.13.0"
   changes:
     - description: Update package spec to 3.0.3.

--- a/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -55,11 +55,11 @@ processors:
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - rename:
-      field: _conf.tz_offset
-      target_field: event.timezone
+  - set:
+      field: event.timezone
+      copy_from: _conf.tz_offset
       if: ctx._conf?.tz_offset != null && ctx._conf.tz_offset != 'local'
-      ignore_missing: true
+      ignore_empty_value: true
   - rename:
       field: temp.date
       target_field: fortinet_fortimail.log.date

--- a/packages/fortinet_fortimail/manifest.yml
+++ b/packages/fortinet_fortimail/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_fortimail
 title: Fortinet FortiMail
-version: "2.13.0"
+version: "2.13.1"
 description: Collect logs from Fortinet FortiMail instances with Elastic Agent.
 type: integration
 format_version: "3.0.3"

--- a/packages/fortinet_fortiproxy/changelog.yml
+++ b/packages/fortinet_fortiproxy/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Tolerate existing event.timezone value.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/11606
 - version: "1.0.0"
   changes:
     - description: Release package as GA.

--- a/packages/fortinet_fortiproxy/changelog.yml
+++ b/packages/fortinet_fortiproxy/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Tolerate existing event.timezone value.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.0.0"
   changes:
     - description: Release package as GA.

--- a/packages/fortinet_fortiproxy/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet_fortiproxy/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -95,11 +95,11 @@ processors:
 # ------------------------------------------------------------------------------
 # Date and Time.
 
-  - rename:
-      tag: rename_timezone
-      target_field: event.timezone
-      field: _fields_.tz
-      ignore_missing: true
+  - set:
+      tag: set_timezone
+      field: event.timezone
+      copy_from: _fields_.tz
+      ignore_empty_value: true
   - set:
       tag: set_temp_timestamp_with_tz
       field: '_temp_.timestamp'
@@ -120,6 +120,7 @@ processors:
       field:
         - _fields_.date
         - _fields_.time
+        - _fields_.tz
         - message
 
 # ------------------------------------------------------------------------------

--- a/packages/fortinet_fortiproxy/manifest.yml
+++ b/packages/fortinet_fortiproxy/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.3
 name: fortinet_fortiproxy
 title: "Fortinet FortiProxy"
-version: 1.0.0
+version: 1.0.1
 description: "Collect logs from Fortinet FortiProxy with Elastic Agent."
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- Change rename to set processor when setting event.timezone
- In certain situations, an add_locale processor may have run on the agent and this will set event.timezone.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- ~~[ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

## How to test this PR locally

```
cd packages/fortinet_fortimail
elastic-package test

cd packages/fortinet_fortiproxy
elastic-package test
```
