### PR TITLE
aws.securityhub_findings: Add fields to `_source` as needed by CDR workflows

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.31.1"
+  changes:
+    - description: Add `cloud.provider`, `event.kind`, and `observer.vendor` fields to _source as needed by CDR workflows.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11
 - version: "2.31.0"
   changes:
     - description: Improve support for Cloud Detection and Response (CDR) workflows in securityhub_findings data stream.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `cloud.provider`, `event.kind`, and `observer.vendor` fields to _source as needed by CDR workflows.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/11
+      link: https://github.com/elastic/integrations/pull/11607
 - version: "2.31.0"
   changes:
     - description: Improve support for Cloud Detection and Response (CDR) workflows in securityhub_findings data stream.

--- a/packages/aws/data_stream/securityhub_findings/_dev/test/pipeline/test-securityhub-findings.log-expected.json
+++ b/packages/aws/data_stream/securityhub_findings/_dev/test/pipeline/test-securityhub-findings.log-expected.json
@@ -362,6 +362,7 @@
                     "id": "i-cafebabe",
                     "name": "i-cafebabe"
                 },
+                "provider": "aws",
                 "region": "us-east-1"
             },
             "destination": {
@@ -381,6 +382,7 @@
                     "configuration"
                 ],
                 "id": "us-west-2/111111111111/98aebb2207407c87f51e89943f12b1ef",
+                "kind": "state",
                 "original": "{\"Action\":{\"ActionType\":\"PORT_PROBE\",\"PortProbeAction\":{\"PortProbeDetails\":[{\"LocalPortDetails\":{\"Port\":80,\"PortName\":\"HTTP\"},\"LocalIpDetails\":{\"IpAddressV4\":\"1.128.0.0\"},\"RemoteIpDetails\":{\"Country\":{\"CountryName\":\"Example Country\"},\"City\":{\"CityName\":\"Example City\"},\"GeoLocation\":{\"Lon\":0,\"Lat\":0},\"Organization\":{\"AsnOrg\":\"ExampleASO\",\"Org\":\"ExampleOrg\",\"Isp\":\"ExampleISP\",\"Asn\":64496}}}],\"Blocked\":false}},\"AwsAccountId\":\"111111111111\",\"CompanyName\":\"AWS\",\"Compliance\":{\"RelatedRequirements\":[\"Req1\",\"Req2\"],\"Status\":\"PASSED\",\"StatusReasons\":[{\"ReasonCode\":\"CLOUDWATCH_ALARMS_NOT_PRESENT\",\"Description\":\"CloudWatch alarms do not exist in the account\"}]},\"Confidence\":42,\"CreatedAt\":\"2017-03-22T13:22:13.933Z\",\"Criticality\":99,\"Description\":\"The version of openssl found on instance i-abcd1234 is known to contain a vulnerability.\",\"FindingProviderFields\":{\"Confidence\":42,\"Criticality\":99,\"RelatedFindings\":[{\"ProductArn\":\"arn:aws:securityhub:us-west-2::product/aws/guardduty\",\"Id\":\"123e4567-e89b-12d3-a456-426655440000\"}],\"Severity\":{\"Label\":\"MEDIUM\",\"Original\":\"MEDIUM\"},\"Types\":[\"Software and Configuration Checks/Vulnerabilities/CVE\"]},\"FirstObservedAt\":\"2017-03-22T13:22:13.933Z\",\"GeneratorId\":\"acme-vuln-9ab348\",\"Id\":\"us-west-2/111111111111/98aebb2207407c87f51e89943f12b1ef\",\"LastObservedAt\":\"2017-03-23T13:22:13.933Z\",\"Malware\":[{\"Name\":\"Stringler\",\"Type\":\"COIN_MINER\",\"Path\":\"/usr/sbin/stringler\",\"State\":\"OBSERVED\"}],\"Network\":{\"Direction\":\"IN\",\"OpenPortRange\":{\"Begin\":443,\"End\":443},\"Protocol\":\"TCP\",\"SourceIpV4\":\"1.128.0.0\",\"SourceIpV6\":\"2a02:cf40::\",\"SourcePort\":\"42\",\"SourceDomain\":\"example1.com\",\"SourceMac\":\"00:0d:83:b1:c0:8e\",\"DestinationIpV4\":\"1.128.0.0\",\"DestinationIpV6\":\"2a02:cf40::\",\"DestinationPort\":\"80\",\"DestinationDomain\":\"example2.com\"},\"NetworkPath\":[{\"ComponentId\":\"abc-01a234bc56d8901ee\",\"ComponentType\":\"AWS::EC2::InternetGateway\",\"Egress\":{\"Destination\":{\"Address\":[\"1.128.0.0/24\"],\"PortRanges\":[{\"Begin\":443,\"End\":443}]},\"Protocol\":\"TCP\",\"Source\":{\"Address\":[\"175.16.199.1/24\"]}},\"Ingress\":{\"Destination\":{\"Address\":[\"175.16.199.1/24\"],\"PortRanges\":[{\"Begin\":443,\"End\":443}]},\"Protocol\":\"TCP\",\"Source\":{\"Address\":[\"175.16.199.1/24\"]}}}],\"Note\":{\"Text\":\"Don't forget to check under the mat.\",\"UpdatedBy\":\"jsmith\",\"UpdatedAt\":\"2018-08-31T00:15:09Z\"},\"PatchSummary\":{\"Id\":\"pb-123456789098\",\"InstalledCount\":\"100\",\"MissingCount\":\"100\",\"FailedCount\":\"0\",\"InstalledOtherCount\":\"1023\",\"InstalledRejectedCount\":\"0\",\"InstalledPendingReboot\":\"0\",\"OperationStartTime\":\"2018-09-27T23:37:31Z\",\"OperationEndTime\":\"2018-09-27T23:39:31Z\",\"RebootOption\":\"RebootIfNeeded\",\"Operation\":\"Install\"},\"Process\":{\"Name\":\"syslogd\",\"Path\":\"/usr/sbin/syslogd\",\"Pid\":12345,\"ParentPid\":56789,\"LaunchedAt\":\"2018-09-27T22:37:31Z\",\"TerminatedAt\":\"2018-09-27T23:37:31Z\"},\"ProductArn\":\"arn:aws:securityhub:us-east-1:111111111111:product/111111111111/default\",\"ProductFields\":{\"generico/secure-pro/Count\":\"6\",\"Service_Name\":\"cloudtrail.amazonaws.com\",\"aws/inspector/AssessmentTemplateName\":\"My daily CVE assessment\",\"aws/inspector/AssessmentTargetName\":\"My prod env\",\"aws/inspector/RulesPackageName\":\"Common Vulnerabilities and Exposures\"},\"ProductName\":\"Security Hub\",\"RecordState\":\"ACTIVE\",\"Region\":\"us-east-1\",\"RelatedFindings\":[{\"ProductArn\":\"arn:aws:securityhub:us-west-2::product/aws/guardduty\",\"Id\":\"123e4567-e89b-12d3-a456-426655440000\"},{\"ProductArn\":\"arn:aws:securityhub:us-west-2::product/aws/guardduty\",\"Id\":\"AcmeNerfHerder-111111111111-x189dx7824\"}],\"Remediation\":{\"Recommendation\":{\"Text\":\"Run sudo yum update and cross your fingers and toes.\",\"Url\":\"http://myfp.com/recommendations/dangerous_things_and_how_to_fix_them.html\"}},\"Resources\":[{\"Type\":\"AwsEc2Instance\",\"Id\":\"i-cafebabe\",\"Partition\":\"aws\",\"Region\":\"us-west-2\",\"Tags\":{\"billingCode\":\"Lotus-1-2-3\",\"needsPatching\":\"true\"},\"Details\":{\"IamInstanceProfileArn\":\"arn:aws:iam::123456789012:role/IamInstanceProfileArn\",\"ImageId\":\"ami-79fd7eee\",\"IpV4Addresses\":[\"175.16.199.1\"],\"IpV6Addresses\":[\"2a02:cf40::\"],\"KeyName\":\"testkey\",\"LaunchedAt\":\"2018-09-29T01:25:54Z\",\"MetadataOptions\":{\"HttpEndpoint\":\"enabled\",\"HttpProtocolIpv6\":\"enabled\",\"HttpPutResponseHopLimit\":1,\"HttpTokens\":\"optional\",\"InstanceMetadataTags\":\"disabled\"},\"NetworkInterfaces\":[{\"NetworkInterfaceId\":\"eni-e5aa89a3\"}],\"SubnetId\":\"PublicSubnet\",\"Type\":\"i3.xlarge\",\"VirtualizationType\":\"hvm\",\"VpcId\":\"TestVPCIpv6\"}}],\"Sample\":true,\"SchemaVersion\":\"2018-10-08\",\"Severity\":{\"Label\":\"CRITICAL\",\"Original\":\"8.3\"},\"SourceUrl\":\"http://threatintelweekly.org/backdoors/8888\",\"ThreatIntelIndicators\":[{\"Type\":\"IPV4_ADDRESS\",\"Value\":\"175.16.199.1\",\"Category\":\"BACKDOOR\",\"LastObservedAt\":\"2018-09-27T23:37:31Z\",\"Source\":\"Threat Intel Weekly\",\"SourceUrl\":\"http://threatintelweekly.org/backdoors/8888\"}],\"Threats\":[{\"FilePaths\":[{\"FileName\":\"b.txt\",\"FilePath\":\"/tmp/b.txt\",\"Hash\":\"sha256\",\"ResourceId\":\"arn:aws:ec2:us-west-2:123456789012:volume/vol-032f3bdd89aee112f\"}],\"ItemCount\":3,\"Name\":\"Iot.linux.mirai.vwisi\",\"Severity\":\"HIGH\"}],\"Title\":\"EC2.20 Both VPN tunnels for an AWS Site-to-Site VPN connection should be up\",\"Types\":[\"Software and Configuration Checks/Vulnerabilities/CVE\"],\"UpdatedAt\":\"2018-08-31T00:15:09Z\",\"UserDefinedFields\":{\"reviewedByCio\":\"true\",\"comeBackToLater\":\"Check this again on Monday\"},\"VerificationState\":\"UNKNOWN\",\"Vulnerabilities\":[{\"Cvss\":[{\"BaseScore\":4.7,\"BaseVector\":\"AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N\",\"Version\":\"V3\"},{\"BaseScore\":4.7,\"BaseVector\":\"AV:L/AC:M/Au:N/C:C/I:N/A:N\",\"Version\":\"V2\"}],\"Id\":\"CVE-2020-12345\",\"ReferenceUrls\":[\"http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-12418\",\"http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-17563\"],\"RelatedVulnerabilities\":[\"CVE-2020-12345\"],\"Vendor\":{\"Name\":\"Alas\",\"Url\":\"https://alas.aws.amazon.com/ALAS-2020-1337.html\",\"VendorCreatedAt\":\"2020-01-16T00:01:43Z\",\"VendorSeverity\":\"Medium\",\"VendorUpdatedAt\":\"2020-01-16T00:01:43Z\"},\"VulnerablePackages\":[{\"Architecture\":\"x86_64\",\"Epoch\":\"1\",\"Name\":\"openssl\",\"Release\":\"16.amzn2.0.3\",\"Version\":\"1.0.2k\"}]}],\"Workflow\":{\"Status\":\"NEW\"},\"WorkflowState\":\"NEW\"}",
                 "outcome": "success",
                 "type": [
@@ -393,6 +395,9 @@
             "network": {
                 "direction": "inbound",
                 "protocol": "tcp"
+            },
+            "observer": {
+                "vendor": "AWS Security Hub"
             },
             "organization": {
                 "name": "AWS"
@@ -835,6 +840,7 @@
                     "id": "i-cafebabe",
                     "name": "i-cafebabe"
                 },
+                "provider": "aws",
                 "region": "us-east-1"
             },
             "destination": {
@@ -854,6 +860,7 @@
                     "configuration"
                 ],
                 "id": "us-west-2/111111111111/98aebb2207407c87f51e89943f12b1ef",
+                "kind": "state",
                 "original": "{\"Action\":{\"ActionType\":\"PORT_PROBE\",\"PortProbeAction\":{\"PortProbeDetails\":[{\"LocalPortDetails\":{\"Port\":80,\"PortName\":\"HTTP\"},\"LocalIpDetails\":{\"IpAddressV4\":\"1.128.0.0\"},\"RemoteIpDetails\":{\"Country\":{\"CountryName\":\"Example Country\"},\"City\":{\"CityName\":\"Example City\"},\"GeoLocation\":{\"Lon\":0,\"Lat\":0},\"Organization\":{\"AsnOrg\":\"ExampleASO\",\"Org\":\"ExampleOrg\",\"Isp\":\"ExampleISP\",\"Asn\":64496}}}],\"Blocked\":false}},\"AwsAccountId\":\"111111111111\",\"CompanyName\":\"AWS\",\"Compliance\":{\"RelatedRequirements\":[\"Req1\",\"Req2\"],\"Status\":\"PASSED\",\"StatusReasons\":[{\"ReasonCode\":\"CLOUDWATCH_ALARMS_NOT_PRESENT\",\"Description\":\"CloudWatch alarms do not exist in the account\"}]},\"Confidence\":42,\"CreatedAt\":\"2017-03-22T13:22:13.933Z\",\"Criticality\":99,\"Description\":\"The version of openssl found on instance i-abcd1234 is known to contain a vulnerability.\",\"FindingProviderFields\":{\"Confidence\":42,\"Criticality\":99,\"RelatedFindings\":[{\"ProductArn\":\"arn:aws:securityhub:us-west-2::product/aws/guardduty\",\"Id\":\"123e4567-e89b-12d3-a456-426655440000\"}],\"Severity\":{\"Label\":\"MEDIUM\",\"Original\":\"MEDIUM\"},\"Types\":[\"Software and Configuration Checks/Vulnerabilities/CVE\"]},\"FirstObservedAt\":\"2017-03-22T13:22:13.933Z\",\"GeneratorId\":\"acme-vuln-9ab348\",\"Id\":\"us-west-2/111111111111/98aebb2207407c87f51e89943f12b1ef\",\"LastObservedAt\":\"2017-03-23T13:22:13.933Z\",\"Malware\":[{\"Name\":\"Stringler\",\"Type\":\"COIN_MINER\",\"Path\":\"/usr/sbin/stringler\",\"State\":\"OBSERVED\"}],\"Network\":{\"Direction\":\"IN\",\"OpenPortRange\":{\"Begin\":443,\"End\":443},\"Protocol\":\"TCP\",\"SourceIpV4\":\"1.128.0.0\",\"SourceIpV6\":\"2a02:cf40::\",\"SourcePort\":\"42\",\"SourceDomain\":\"example1.com\",\"SourceMac\":\"00:0d:83:b1:c0:8e\",\"DestinationIpV4\":\"1.128.0.0\",\"DestinationIpV6\":\"2a02:cf40::\",\"DestinationPort\":\"80\",\"DestinationDomain\":\"example2.com\"},\"NetworkPath\":[{\"ComponentId\":\"abc-01a234bc56d8901ee\",\"ComponentType\":\"AWS::EC2::InternetGateway\",\"Egress\":{\"Destination\":{\"Address\":[\"1.128.0.0/24\"],\"PortRanges\":[{\"Begin\":443,\"End\":443}]},\"Protocol\":\"TCP\",\"Source\":{\"Address\":[\"175.16.199.1/24\"]}},\"Ingress\":{\"Destination\":{\"Address\":[\"175.16.199.1/24\"],\"PortRanges\":[{\"Begin\":443,\"End\":443}]},\"Protocol\":\"TCP\",\"Source\":{\"Address\":[\"175.16.199.1/24\"]}}}],\"Note\":{\"Text\":\"Don't forget to check under the mat.\",\"UpdatedBy\":\"jsmith\",\"UpdatedAt\":\"2018-08-31T00:15:09Z\"},\"PatchSummary\":{\"Id\":\"pb-123456789098\",\"InstalledCount\":\"100\",\"MissingCount\":\"100\",\"FailedCount\":\"0\",\"InstalledOtherCount\":\"1023\",\"InstalledRejectedCount\":\"0\",\"InstalledPendingReboot\":\"0\",\"OperationStartTime\":\"2018-09-27T23:37:31Z\",\"OperationEndTime\":\"2018-09-27T23:39:31Z\",\"RebootOption\":\"RebootIfNeeded\",\"Operation\":\"Install\"},\"Process\":{\"Name\":\"syslogd\",\"Path\":\"/usr/sbin/syslogd\",\"Pid\":12345,\"ParentPid\":56789,\"LaunchedAt\":\"2018-09-27T22:37:31Z\",\"TerminatedAt\":\"2018-09-27T23:37:31Z\"},\"ProductArn\":\"arn:aws:securityhub:us-east-1:111111111111:product/111111111111/default\",\"ProductFields\":{\"generico/secure-pro/Count\":\"6\",\"Service_Name\":\"cloudtrail.amazonaws.com\",\"aws/inspector/AssessmentTemplateName\":\"My daily CVE assessment\",\"aws/inspector/AssessmentTargetName\":\"My prod env\",\"aws/inspector/RulesPackageName\":\"Common Vulnerabilities and Exposures\"},\"ProductName\":\"Security Hub\",\"RecordState\":\"ACTIVE\",\"Region\":\"us-east-1\",\"RelatedFindings\":[{\"ProductArn\":\"arn:aws:securityhub:us-west-2::product/aws/guardduty\",\"Id\":\"123e4567-e89b-12d3-a456-426655440000\"},{\"ProductArn\":\"arn:aws:securityhub:us-west-2::product/aws/guardduty\",\"Id\":\"AcmeNerfHerder-111111111111-x189dx7824\"}],\"Remediation\":{\"Recommendation\":{\"Text\":\"Run sudo yum update and cross your fingers and toes.\",\"Url\":\"http://myfp.com/recommendations/dangerous_things_and_how_to_fix_them.html\"}},\"Resources\":[{\"Type\":\"AwsEc2Instance\",\"Id\":\"i-cafebabe\",\"Partition\":\"aws\",\"Region\":\"us-west-2\",\"Tags\":{\"billingCode\":\"Lotus-1-2-3\",\"needsPatching\":\"true\"},\"Details\":{\"IamInstanceProfileArn\":\"arn:aws:iam::123456789012:role/IamInstanceProfileArn\",\"ImageId\":\"ami-79fd7eee\",\"IpV4Addresses\":[\"175.16.199.1\"],\"IpV6Addresses\":[\"2a02:cf40::\"],\"KeyName\":\"testkey\",\"LaunchedAt\":\"2018-09-29T01:25:54Z\",\"MetadataOptions\":{\"HttpEndpoint\":\"enabled\",\"HttpProtocolIpv6\":\"enabled\",\"HttpPutResponseHopLimit\":1,\"HttpTokens\":\"optional\",\"InstanceMetadataTags\":\"disabled\"},\"NetworkInterfaces\":[{\"NetworkInterfaceId\":\"eni-e5aa89a3\"}],\"SubnetId\":\"PublicSubnet\",\"Type\":\"i3.xlarge\",\"VirtualizationType\":\"hvm\",\"VpcId\":\"TestVPCIpv6\"}}],\"Sample\":true,\"SchemaVersion\":\"2018-10-08\",\"Severity\":{\"Label\":\"CRITICAL\",\"Original\":\"8.3\"},\"SourceUrl\":\"http://threatintelweekly.org/backdoors/8888\",\"ThreatIntelIndicators\":[{\"Type\":\"HASH_MD5\",\"Value\":\"ae2b1fca515949e5d54fb22b8ed95575\",\"Category\":\"BACKDOOR\",\"LastObservedAt\":\"2018-09-27T23:37:31Z\",\"Source\":\"Threat Intel Weekly\",\"SourceUrl\":\"http://threatintelweekly.org/backdoors/8888\"}],\"Threats\":[{\"FilePaths\":[{\"FileName\":\"b.txt\",\"FilePath\":\"/tmp/b.txt\",\"Hash\":\"sha256\",\"ResourceId\":\"arn:aws:ec2:us-west-2:123456789012:volume/vol-032f3bdd89aee112f\"}],\"ItemCount\":3,\"Name\":\"Iot.linux.mirai.vwisi\",\"Severity\":\"HIGH\"}],\"Title\":\"EC2.20 Both VPN tunnels for an AWS Site-to-Site VPN connection should be up\",\"Types\":[\"Software and Configuration Checks/Vulnerabilities/CVE\"],\"UpdatedAt\":\"2018-08-31T00:15:09Z\",\"UserDefinedFields\":{\"reviewedByCio\":\"true\",\"comeBackToLater\":\"Check this again on Monday\"},\"VerificationState\":\"UNKNOWN\",\"Vulnerabilities\":[{\"Cvss\":[{\"BaseScore\":4.7,\"BaseVector\":\"AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N\",\"Version\":\"V3\"},{\"BaseScore\":4.7,\"BaseVector\":\"AV:L/AC:M/Au:N/C:C/I:N/A:N\",\"Version\":\"V2\"}],\"Id\":\"CVE-2020-12345\",\"ReferenceUrls\":[\"http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-12418\",\"http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-17563\"],\"RelatedVulnerabilities\":[\"CVE-2020-12345\"],\"Vendor\":{\"Name\":\"Alas\",\"Url\":\"https://alas.aws.amazon.com/ALAS-2020-1337.html\",\"VendorCreatedAt\":\"2020-01-16T00:01:43Z\",\"VendorSeverity\":\"Medium\",\"VendorUpdatedAt\":\"2020-01-16T00:01:43Z\"},\"VulnerablePackages\":[{\"Architecture\":\"x86_64\",\"Epoch\":\"1\",\"Name\":\"openssl\",\"Release\":\"16.amzn2.0.3\",\"Version\":\"1.0.2k\"}]}],\"Workflow\":{\"Status\":\"NEW\"},\"WorkflowState\":\"NEW\"}",
                 "outcome": "success",
                 "type": [
@@ -866,6 +873,9 @@
             "network": {
                 "direction": "inbound",
                 "protocol": "tcp"
+            },
+            "observer": {
+                "vendor": "AWS Security Hub"
             },
             "organization": {
                 "name": "AWS"
@@ -1063,6 +1073,7 @@
                     "id": "xxx",
                     "name": "xxx"
                 },
+                "provider": "aws",
                 "region": "us-east-1"
             },
             "ecs": {
@@ -1073,6 +1084,7 @@
                     "configuration"
                 ],
                 "id": "xxxx",
+                "kind": "state",
                 "original": "{\"ProductArn\":\"xxx\",\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards/AWS-Foundational-Security-Best-Practices\"],\"Description\":\"This control checks whether your Amazon Elastic Compute Cloud (Amazon EC2) instance metadata version is configured with Instance Metadata Service Version 2 (IMDSv2). The control passes if HttpTokens is set to required for IMDSv2. The control fails if HttpTokens is set to optional.\",\"Compliance\":{\"Status\":\"FAILED\"},\"ProductName\":\"Security Hub\",\"FirstObservedAt\":\"2022-06-02T16:14:34.949Z\",\"CreatedAt\":\"2022-06-02T16:14:34.949Z\",\"LastObservedAt\":\"2022-06-17T08:43:26.724Z\",\"CompanyName\":\"AWS\",\"FindingProviderFields\":{\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards/AWS-Foundational-Security-Best-Practices\"],\"Severity\":{\"Normalized\":70,\"Label\":\"HIGH\",\"Product\":70,\"Original\":\"HIGH\"}},\"ProductFields\":{\"StandardsArn\":\"xxx\",\"StandardsSubscriptionArn\":\"xxx\",\"ControlId\":\"EC2.8\",\"RecommendationUrl\":\"https://example.com/\",\"RelatedAWSResources:0/name\":\"xxx\",\"RelatedAWSResources:0/type\":\"xxx\",\"StandardsControlArn\":\"xxx\",\"aws/securityhub/ProductName\":\"Security Hub\",\"aws/securityhub/CompanyName\":\"AWS\",\"Resources:0/Id\":\"xxx\",\"aws/securityhub/FindingId\":\"xxx\"},\"Remediation\":{\"Recommendation\":{\"Text\":\"For directions on how to fix this issue, consult the AWS Security Hub Foundational Security Best Practices documentation.\",\"Url\":\"https://example.com/\"}},\"SchemaVersion\":\"2018-10-08\",\"GeneratorId\":\"xxx\",\"RecordState\":\"ARCHIVED\",\"Title\":\"EC2.8 EC2 instances should use Instance Metadata Service Version 2 (IMDSv2)\",\"Workflow\":{\"Status\":\"NEW\"},\"Severity\":{\"Normalized\":70,\"Label\":\"HIGH\",\"Product\":70,\"Original\":\"HIGH\"},\"UpdatedAt\":\"2022-06-17T08:43:26.731Z\",\"WorkflowState\":\"NEW\",\"AwsAccountId\":\"xxx\",\"Region\":\"us-east-1\",\"Id\":\"xxxx\",\"Resources\":[{\"Partition\":\"aws\",\"Type\":\"AwsEc2Instance\",\"Details\":{\"AwsEc2Instance\":{\"KeyName\":\"xxx\",\"VpcId\":\"xxx\",\"NetworkInterfaces\":[{\"NetworkInterfaceId\":\"xxx\"}],\"ImageId\":\"xxx\",\"SubnetId\":\"xxx\",\"LaunchedAt\":\"2022-06-02T16:11:39.000Z\",\"IamInstanceProfileArn\":\"xxx\"}},\"Region\":\"us-east-1\",\"Id\":\"xxx\"}]        }",
                 "outcome": "failure",
                 "severity": 70,
@@ -1082,6 +1094,9 @@
             },
             "host": {
                 "id": "xxx"
+            },
+            "observer": {
+                "vendor": "AWS Security Hub"
             },
             "organization": {
                 "name": "AWS"
@@ -1200,6 +1215,7 @@
                 "account": {
                     "id": "xxx"
                 },
+                "provider": "aws",
                 "region": "us-east-1"
             },
             "ecs": {
@@ -1210,12 +1226,16 @@
                     "configuration"
                 ],
                 "id": "xxx",
+                "kind": "state",
                 "original": "{\"ProductArn\":\"xxx\",\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards/AWS-Foundational-Security-Best-Practices\"],\"Description\":\"This AWS control checks whether the EBS volumes that are in an attached state are encrypted.\",\"Compliance\":{\"Status\":\"NOT_AVAILABLE\",\"StatusReasons\":[{\"Description\":\"This finding has a compliance status of NOT AVAILABLE because AWS Config sent Security Hub a finding with a compliance state of Not Applicable. The potential reasons for a Not Applicable finding from Config are that (1) a resource has been moved out of scope of the Config rule; (2) the Config rule has been deleted; (3) the resource has been deleted; or (4) the logic of the Config rule itself includes scenarios where Not Applicable is returned. The specific reason why Not Applicable is returned is not available in the Config rule evaluation.\",\"ReasonCode\":\"CONFIG_RETURNS_NOT_APPLICABLE\"}]},\"ProductName\":\"Security Hub\",\"FirstObservedAt\":\"2022-06-17T10:25:14.800Z\",\"CreatedAt\":\"2022-06-17T10:25:14.800Z\",\"LastObservedAt\":\"2022-06-17T10:25:18.568Z\",\"CompanyName\":\"AWS\",\"FindingProviderFields\":{\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards/AWS-Foundational-Security-Best-Practices\"],\"Severity\":{\"Normalized\":40,\"Label\":\"MEDIUM\",\"Product\":40,\"Original\":\"INFORMATIONAL\"}},\"ProductFields\":{\"StandardsArn\":\"xxx\",\"StandardsSubscriptionArn\":\"xxx\",\"ControlId\":\"EC2.3\",\"RecommendationUrl\":\"https://example.com/\",\"RelatedAWSResources:0/name\":\"xxx\",\"RelatedAWSResources:0/type\":\"AWS::Config::ConfigRule\",\"StandardsControlArn\":\"xxx\",\"aws/securityhub/ProductName\":\"Security Hub\",\"aws/securityhub/CompanyName\":\"AWS\",\"aws/securityhub/annotation\":\"This finding has a compliance status of NOT AVAILABLE because AWS Config sent Security Hub a finding with a compliance state of Not Applicable. The potential reasons for a Not Applicable finding from Config are that (1) a resource has been moved out of scope of the Config rule; (2) the Config rule has been deleted; (3) the resource has been deleted; or (4) the logic of the Config rule itself includes scenarios where Not Applicable is returned. The specific reason why Not Applicable is returned is not available in the Config rule evaluation.\",\"Resources:0/Id\":\"xxx\",\"aws/securityhub/FindingId\":\"xxx\"},\"Remediation\":{\"Recommendation\":{\"Text\":\"For directions on how to fix this issue, consult the AWS Security Hub Foundational Security Best Practices documentation.\",\"Url\":\"https://example.com/\"}},\"SchemaVersion\":\"2018-10-08\",\"GeneratorId\":\"xxx\",\"RecordState\":\"ARCHIVED\",\"Title\":\"EC2.3 Attached EBS volumes should be encrypted at-rest\",\"Workflow\":{\"Status\":\"NEW\"},\"Severity\":{\"Normalized\":40,\"Label\":\"MEDIUM\",\"Product\":40,\"Original\":\"INFORMATIONAL\"},\"UpdatedAt\":\"2022-06-17T10:25:14.800Z\",\"WorkflowState\":\"NEW\",\"AwsAccountId\":\"xxx\",\"Region\":\"us-east-1\",\"Id\":\"xxx\",\"Resources\":[{\"Partition\":\"aws\",\"Type\":\"AwsEc2Volume\",\"Region\":\"us-east-1\",\"Id\":\"xxx\"}]        }",
                 "outcome": "unknown",
                 "severity": 40,
                 "type": [
                     "info"
                 ]
+            },
+            "observer": {
+                "vendor": "AWS Security Hub"
             },
             "organization": {
                 "name": "AWS"
@@ -1365,6 +1385,7 @@
                     "id": "arn:aws:ec2:ap-south-1:111111111111:instance/i-0e2ede89308a594d7",
                     "name": "instance/i-0e2ede89308a594d7"
                 },
+                "provider": "aws",
                 "region": "ap-south-1",
                 "service": {
                     "name": "ec2"
@@ -1379,6 +1400,7 @@
                 ],
                 "created": "2024-09-11T08:00:03.516Z",
                 "id": "arn:aws:securityhub:ap-south-1:111111111111:security-control/EC2.8/finding/8825ae3b-1f70-4c74-8337-baee8fcad8fd",
+                "kind": "state",
                 "original": "{\"AwsAccountId\":\"111111111111\",\"CompanyName\":\"AWS\",\"Compliance\":{\"AssociatedStandards\":[{\"StandardsId\":\"standards/aws-foundational-security-best-practices/v/1.0.0\"},{\"StandardsId\":\"standards/cis-aws-foundations-benchmark/v/3.0.0\"},{\"StandardsId\":\"standards/nist-800-53/v/5.0.0\"}],\"RelatedRequirements\":[\"CIS AWS Foundations Benchmark v3.0.0/5.6\",\"NIST.800-53.r5 AC-3\",\"NIST.800-53.r5 AC-3(15)\",\"NIST.800-53.r5 AC-3(7)\",\"NIST.800-53.r5 AC-6\"],\"SecurityControlId\":\"EC2.8\",\"Status\":\"PASSED\"},\"CreatedAt\":\"2024-09-10T10:40:32.189Z\",\"Description\":\"This control checks whether your Amazon Elastic Compute Cloud (Amazon EC2) instance metadata version is configured with Instance Metadata Service Version 2 (IMDSv2). The control passes if HttpTokens is set to required for IMDSv2. The control fails if HttpTokens is set to optional.\",\"FindingProviderFields\":{\"Severity\":{\"Label\":\"INFORMATIONAL\",\"Normalized\":0,\"Original\":\"INFORMATIONAL\"},\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"]},\"FirstObservedAt\":\"2024-09-10T10:40:32.189Z\",\"GeneratorId\":\"security-control/EC2.8\",\"Id\":\"arn:aws:securityhub:ap-south-1:111111111111:security-control/EC2.8/finding/8825ae3b-1f70-4c74-8337-baee8fcad8fd\",\"LastObservedAt\":\"2024-09-11T08:00:01.828Z\",\"ProcessedAt\":\"2024-09-11T08:00:03.516Z\",\"ProductArn\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub\",\"ProductFields\":{\"RelatedAWSResources:0/name\":\"securityhub-ec2-imdsv2-check-29027890\",\"RelatedAWSResources:0/type\":\"AWS::Config::ConfigRule\",\"Resources:0/Id\":\"arn:aws:ec2:ap-south-1:111111111111:instance/i-0e2ede89308a594d7\",\"aws/securityhub/CompanyName\":\"AWS\",\"aws/securityhub/FindingId\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub/arn:aws:securityhub:ap-south-1:111111111111:security-control/EC2.8/finding/8825ae3b-1f70-4c74-8337-baee8fcad8fd\",\"aws/securityhub/ProductName\":\"Security Hub\"},\"ProductName\":\"Security Hub\",\"RecordState\":\"ACTIVE\",\"Region\":\"ap-south-1\",\"Remediation\":{\"Recommendation\":{\"Text\":\"For information on how to correct this issue, consult the AWS Security Hub controls documentation.\",\"Url\":\"https://docs.aws.amazon.com/console/securityhub/EC2.8/remediation\"}},\"Resources\":[{\"Details\":{\"AwsEc2Instance\":{\"IamInstanceProfileArn\":\"arn:aws:iam::111111111111:instance-profile/elastic-agent-instance-profile-e4f7caa0-6f61-11ef-bb07-02fe87118279\",\"ImageId\":\"ami-04dffe071c46cddd4\",\"LaunchedAt\":\"2024-09-10T10:39:35.000Z\",\"MetadataOptions\":{\"HttpEndpoint\":\"enabled\",\"HttpProtocolIpv6\":\"disabled\",\"HttpPutResponseHopLimit\":2,\"HttpTokens\":\"required\",\"InstanceMetadataTags\":\"disabled\"},\"Monitoring\":{\"State\":\"disabled\"},\"NetworkInterfaces\":[{\"NetworkInterfaceId\":\"eni-0de300eee88c5c7fd\"}],\"SubnetId\":\"subnet-5d15a111\",\"VirtualizationType\":\"hvm\",\"VpcId\":\"vpc-39017251\"}},\"Id\":\"arn:aws:ec2:ap-south-1:111111111111:instance/i-0e2ede89308a594d7\",\"Partition\":\"aws\",\"Region\":\"ap-south-1\",\"Tags\":{\"Name\":\"elastic-agent-instance-e5f7caa0-6f60-11ef-bb07-02fe87118279\",\"Task\":\"Cloud Security Posture Management Scanner\",\"aws:cloudformation:logical-id\":\"ElasticAgentEc2Instance\",\"aws:cloudformation:stack-id\":\"arn:aws:cloudformation:ap-south-1:111111111111:stack/Elastic-Cloud-Security-Posture-Management/e5f7caa0-6f60-11ef-bb07-02fe87118279\",\"aws:cloudformation:stack-name\":\"Elastic-Cloud-Security-Posture-Management\"},\"Type\":\"AwsEc2Instance\"}],\"SchemaVersion\":\"2018-10-08\",\"Severity\":{\"Label\":\"INFORMATIONAL\",\"Normalized\":0,\"Original\":\"INFORMATIONAL\"},\"Title\":\"EC2 instances should use Instance Metadata Service Version 2 (IMDSv2)\",\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"],\"UpdatedAt\":\"2024-09-11T07:59:56.087Z\",\"Workflow\":{\"Status\":\"RESOLVED\"},\"WorkflowState\":\"NEW\"}",
                 "outcome": "success",
                 "severity": 0,
@@ -1388,6 +1410,9 @@
             },
             "host": {
                 "id": "arn:aws:ec2:ap-south-1:111111111111:instance/i-0e2ede89308a594d7"
+            },
+            "observer": {
+                "vendor": "AWS Security Hub"
             },
             "organization": {
                 "name": "AWS"
@@ -1520,6 +1545,7 @@
                 "account": {
                     "id": "111111111111"
                 },
+                "provider": "aws",
                 "region": "ap-south-1",
                 "service": {
                     "name": "s3"
@@ -1534,12 +1560,16 @@
                 ],
                 "created": "2024-09-13T22:50:30.870Z",
                 "id": "arn:aws:securityhub:ap-south-1:111111111111:security-control/S3.17/finding/1d687c1f-ef1e-464f-985a-5000efa9d4a1",
+                "kind": "state",
                 "original": "{\"AwsAccountId\":\"111111111111\",\"CompanyName\":\"AWS\",\"Compliance\":{\"AssociatedStandards\":[{\"StandardsId\":\"standards/nist-800-53/v/5.0.0\"}],\"RelatedRequirements\":[\"NIST.800-53.r5 SC-12(2)\",\"NIST.800-53.r5 CM-3(6)\",\"NIST.800-53.r5 SC-13\",\"NIST.800-53.r5 SC-28\",\"NIST.800-53.r5 SC-28(1)\",\"NIST.800-53.r5 SC-7(10)\",\"NIST.800-53.r5 CA-9(1)\",\"NIST.800-53.r5 SI-7(6)\",\"NIST.800-53.r5 AU-9\"],\"SecurityControlId\":\"S3.17\",\"Status\":\"FAILED\"},\"CreatedAt\":\"2024-08-14T10:14:37.338Z\",\"Description\":\"This control checks whether an Amazon S3 general purpose bucket is encrypted with an AWS KMS key (SSE-KMS or DSSE-KMS). The control fails if the bucket is encrypted with default encryption (SSE-S3).\",\"FindingProviderFields\":{\"Severity\":{\"Label\":\"MEDIUM\",\"Normalized\":40,\"Original\":\"MEDIUM\"},\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"]},\"FirstObservedAt\":\"2024-08-14T10:14:37.338Z\",\"GeneratorId\":\"security-control/S3.17\",\"Id\":\"arn:aws:securityhub:ap-south-1:111111111111:security-control/S3.17/finding/1d687c1f-ef1e-464f-985a-5000efa9d4a1\",\"LastObservedAt\":\"2024-09-13T22:50:29.249Z\",\"ProcessedAt\":\"2024-09-13T22:50:30.870Z\",\"ProductArn\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub\",\"ProductFields\":{\"RelatedAWSResources:0/name\":\"securityhub-s3-default-encryption-kms-3a38fc59\",\"RelatedAWSResources:0/type\":\"AWS::Config::ConfigRule\",\"Resources:0/Id\":\"arn:aws:s3:::s3-test-public-bucket\",\"aws/securityhub/CompanyName\":\"AWS\",\"aws/securityhub/FindingId\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub/arn:aws:securityhub:ap-south-1:111111111111:security-control/S3.17/finding/1d687c1f-ef1e-464f-985a-5000efa9d4a1\",\"aws/securityhub/ProductName\":\"Security Hub\",\"aws/securityhub/annotation\":\"Amazon S3 bucket is not encrypted with AWS KMS key.\"},\"ProductName\":\"Security Hub\",\"RecordState\":\"ACTIVE\",\"Region\":\"ap-south-1\",\"Remediation\":{\"Recommendation\":{\"Text\":\"For information on how to correct this issue, consult the AWS Security Hub controls documentation.\",\"Url\":\"https://docs.aws.amazon.com/console/securityhub/S3.17/remediation\"}},\"Resources\":[{\"Details\":{\"AwsS3Bucket\":{\"CreatedAt\":\"2024-08-14T09:32:06.000Z\",\"Name\":\"s3-test-public-bucket\",\"OwnerId\":\"e106g9b5e13878d5133aadfac8a012130c4260091100b311ed476f9e77cdca46\"}},\"Id\":\"arn:aws:s3:::s3-test-public-bucket\",\"Partition\":\"aws\",\"Region\":\"ap-south-1\",\"Type\":\"AwsS3Bucket\"}],\"SchemaVersion\":\"2018-10-08\",\"Severity\":{\"Label\":\"MEDIUM\",\"Normalized\":40,\"Original\":\"MEDIUM\"},\"Title\":\"S3 general purpose buckets should be encrypted at rest with AWS KMS keys\",\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"],\"UpdatedAt\":\"2024-09-13T22:50:13.008Z\",\"Workflow\":{\"Status\":\"NEW\"},\"WorkflowState\":\"NEW\"}",
                 "outcome": "failure",
                 "severity": 40,
                 "type": [
                     "info"
                 ]
+            },
+            "observer": {
+                "vendor": "AWS Security Hub"
             },
             "organization": {
                 "name": "AWS"
@@ -1686,6 +1716,7 @@
                 "account": {
                     "id": "111111111111"
                 },
+                "provider": "aws",
                 "region": "ap-south-1",
                 "service": {
                     "name": "ec2"
@@ -1700,12 +1731,16 @@
                 ],
                 "created": "2024-09-11T08:00:08.685Z",
                 "id": "arn:aws:securityhub:ap-south-1:111111111111:security-control/EC2.53/finding/f21e28e2-1077-4062-ac39-624b2776eb23",
+                "kind": "state",
                 "original": "{\"AwsAccountId\":\"111111111111\",\"CompanyName\":\"AWS\",\"Compliance\":{\"AssociatedStandards\":[{\"StandardsId\":\"standards/cis-aws-foundations-benchmark/v/3.0.0\"}],\"RelatedRequirements\":[\"CIS AWS Foundations Benchmark v3.0.0/5.2\"],\"SecurityControlId\":\"EC2.53\",\"Status\":\"PASSED\"},\"CreatedAt\":\"2024-09-10T11:03:33.389Z\",\"Description\":\"This control checks whether an Amazon EC2 security group allows ingress from 0.0.0.0/0 to remote server administration ports (ports 22 and 3389). The control fails if the security group allows ingress from 0.0.0.0/0 to port 22 or 3389.\",\"FindingProviderFields\":{\"Severity\":{\"Label\":\"INFORMATIONAL\",\"Normalized\":0,\"Original\":\"INFORMATIONAL\"},\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"]},\"FirstObservedAt\":\"2024-09-10T11:03:33.389Z\",\"GeneratorId\":\"security-control/EC2.53\",\"Id\":\"arn:aws:securityhub:ap-south-1:111111111111:security-control/EC2.53/finding/f21e28e2-1077-4062-ac39-624b2776eb23\",\"LastObservedAt\":\"2024-09-11T08:00:06.960Z\",\"ProcessedAt\":\"2024-09-11T08:00:08.685Z\",\"ProductArn\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub\",\"ProductFields\":{\"RelatedAWSResources:0/name\":\"securityhub-vpc-sg-port-restriction-check-8bef9db4\",\"RelatedAWSResources:0/type\":\"AWS::Config::ConfigRule\",\"Resources:0/Id\":\"arn:aws:ec2:ap-south-1:111111111111:security-group/sg-0dbc8c6200a0a9c51\",\"aws/securityhub/CompanyName\":\"AWS\",\"aws/securityhub/FindingId\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub/arn:aws:securityhub:ap-south-1:111111111111:security-control/EC2.53/finding/f21e28e2-1077-4062-ac39-624b2776eb23\",\"aws/securityhub/ProductName\":\"Security Hub\"},\"ProductName\":\"Security Hub\",\"RecordState\":\"ACTIVE\",\"Region\":\"ap-south-1\",\"Remediation\":{\"Recommendation\":{\"Text\":\"For information on how to correct this issue, consult the AWS Security Hub controls documentation.\",\"Url\":\"https://docs.aws.amazon.com/console/securityhub/EC2.53/remediation\"}},\"Resources\":[{\"Details\":{\"AwsEc2SecurityGroup\":{\"GroupId\":\"sg-0dbc8c6200a0a9c51\",\"GroupName\":\"elastic-agent-security-group-e4f7caa0-5f61-11ef-bb07-02fe87118279\",\"IpPermissionsEgress\":[{\"IpProtocol\":\"-1\",\"IpRanges\":[{\"CidrIp\":\"0.0.0.0/0\"}]}],\"OwnerId\":\"111111111111\",\"VpcId\":\"vpc-39017251\"}},\"Id\":\"arn:aws:ec2:ap-south-1:111111111111:security-group/sg-0dbc9c6210a0a9c51\",\"Partition\":\"aws\",\"Region\":\"ap-south-1\",\"Tags\":{\"aws:cloudformation:logical-id\":\"ElasticAgentSecurityGroup\",\"aws:cloudformation:stack-id\":\"arn:aws:cloudformation:ap-south-1:111111111111:stack/Elastic-Cloud-Security-Posture-Management/e5f7caa0-6f60-11ef-bb07-02fe87118279\",\"aws:cloudformation:stack-name\":\"Elastic-Cloud-Security-Posture-Management\"},\"Type\":\"AwsEc2SecurityGroup\"}],\"SchemaVersion\":\"2018-10-08\",\"Severity\":{\"Label\":\"INFORMATIONAL\",\"Normalized\":0,\"Original\":\"INFORMATIONAL\"},\"Title\":\"EC2 security groups should not allow ingress from 0.0.0.0/0 to remote server administration ports\",\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"],\"UpdatedAt\":\"2024-09-11T07:59:56.364Z\",\"Workflow\":{\"Status\":\"RESOLVED\"},\"WorkflowState\":\"NEW\"}",
                 "outcome": "success",
                 "severity": 0,
                 "type": [
                     "info"
                 ]
+            },
+            "observer": {
+                "vendor": "AWS Security Hub"
             },
             "organization": {
                 "name": "AWS"
@@ -1841,6 +1876,7 @@
                 "account": {
                     "id": "111111111111"
                 },
+                "provider": "aws",
                 "region": "ap-south-1",
                 "service": {
                     "name": "ec2"
@@ -1855,12 +1891,16 @@
                 ],
                 "created": "2024-09-10T16:51:39.864Z",
                 "id": "arn:aws:securityhub:ap-south-1:111111111111:security-control/EC2.3/finding/972eddbf-43ae-4886-9416-ac9ddc2cecc0",
+                "kind": "state",
                 "original": "{\"AwsAccountId\":\"111111111111\",\"CompanyName\":\"AWS\",\"Compliance\":{\"AssociatedStandards\":[{\"StandardsId\":\"standards/aws-foundational-security-best-practices/v/1.0.0\"},{\"StandardsId\":\"standards/nist-800-53/v/5.0.0\"}],\"RelatedRequirements\":[\"NIST.800-53.r5 CA-9(1)\",\"NIST.800-53.r5 CM-3(6)\",\"NIST.800-53.r5 SC-13\",\"NIST.800-53.r5 SC-28\",\"NIST.800-53.r5 SC-28(1)\",\"NIST.800-53.r5 SC-7(10)\",\"NIST.800-53.r5 SI-7(6)\"],\"SecurityControlId\":\"EC2.3\",\"Status\":\"FAILED\"},\"CreatedAt\":\"2024-09-10T16:51:26.034Z\",\"Description\":\"This AWS control checks whether the EBS volumes that are in an attached state are encrypted.\",\"FindingProviderFields\":{\"Severity\":{\"Label\":\"MEDIUM\",\"Normalized\":40,\"Original\":\"MEDIUM\"},\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"]},\"FirstObservedAt\":\"2024-09-10T16:50:59.623Z\",\"GeneratorId\":\"security-control/EC2.3\",\"Id\":\"arn:aws:securityhub:ap-south-1:111111111111:security-control/EC2.3/finding/972eddbf-43ae-4886-9416-ac9ddc2cecc0\",\"LastObservedAt\":\"2024-09-10T16:50:59.623Z\",\"ProcessedAt\":\"2024-09-10T16:51:39.864Z\",\"ProductArn\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub\",\"ProductFields\":{\"RelatedAWSResources:0/name\":\"securityhub-encrypted-volumes-4e81c587\",\"RelatedAWSResources:0/type\":\"AWS::Config::ConfigRule\",\"Resources:0/Id\":\"arn:aws:ec2:ap-south-1:111111111111:volume/vol-03822fa7de881616e\",\"aws/securityhub/CompanyName\":\"AWS\",\"aws/securityhub/FindingId\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub/arn:aws:securityhub:ap-south-1:111111111111:security-control/EC2.3/finding/972eddbf-43ae-4886-9416-ac9ddc2cecc0\",\"aws/securityhub/ProductName\":\"Security Hub\"},\"ProductName\":\"Security Hub\",\"RecordState\":\"ACTIVE\",\"Region\":\"ap-south-1\",\"Remediation\":{\"Recommendation\":{\"Text\":\"For information on how to correct this issue, consult the AWS Security Hub controls documentation.\",\"Url\":\"https://docs.aws.amazon.com/console/securityhub/EC2.3/remediation\"}},\"Resources\":[{\"Details\":{\"AwsEc2Volume\":{\"Attachments\":[{\"AttachTime\":\"2024-09-10T10:39:36.000Z\",\"DeleteOnTermination\":true,\"InstanceId\":\"i-0f1ede89308a584d8\",\"Status\":\"attached\"}],\"CreateTime\":\"2024-09-10T10:39:36.313Z\",\"Encrypted\":false,\"Size\":32,\"SnapshotId\":\"snap-07cb2350b59fa5cce\",\"Status\":\"in-use\"}},\"Id\":\"arn:aws:ec2:ap-south-1:111111111111:volume/vol-03821fa7de881617e\",\"Partition\":\"aws\",\"Region\":\"ap-south-1\",\"Type\":\"AwsEc2Volume\"}],\"SchemaVersion\":\"2018-10-08\",\"Severity\":{\"Label\":\"MEDIUM\",\"Normalized\":40,\"Original\":\"MEDIUM\"},\"Title\":\"Attached EBS volumes should be encrypted at-rest\",\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"],\"UpdatedAt\":\"2024-09-10T16:51:26.034Z\",\"Workflow\":{\"Status\":\"NEW\"},\"WorkflowState\":\"NEW\"}",
                 "outcome": "failure",
                 "severity": 40,
                 "type": [
                     "info"
                 ]
+            },
+            "observer": {
+                "vendor": "AWS Security Hub"
             },
             "organization": {
                 "name": "AWS"
@@ -1996,6 +2036,7 @@
                 "account": {
                     "id": "111111111111"
                 },
+                "provider": "aws",
                 "region": "ap-south-1",
                 "service": {
                     "name": "iam"
@@ -2010,12 +2051,16 @@
                 ],
                 "created": "2024-09-15T16:48:59.493Z",
                 "id": "arn:aws:iam::111111111111:user/developers/devuser@dev.dev",
+                "kind": "state",
                 "original": "{\"AwsAccountId\":\"111111111111\",\"CompanyName\":\"AWS\",\"Compliance\":{\"AssociatedStandards\":[{\"StandardsId\":\"standards/aws-foundational-security-best-practices/v/1.0.0\"},{\"StandardsId\":\"standards/nist-800-53/v/5.0.0\"},{\"StandardsId\":\"standards/pci-dss/v/3.2.1\"}],\"RelatedRequirements\":[\"CIS AWS Foundations Benchmark v1.2.0/1.16\"],\"SecurityControlId\":\"IAM.2\",\"Status\":\"FAILED\"},\"CreatedAt\":\"2024-09-10T12:40:36.785Z\",\"Description\":\"This AWS control checks that none of your IAM users have policies attached. Instead, IAM users must inherit permissions from IAM groups or roles.\",\"FindingProviderFields\":{\"Severity\":{\"Label\":\"LOW\",\"Normalized\":1,\"Original\":\"LOW\"},\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"]},\"FirstObservedAt\":\"2024-09-10T12:40:36.785Z\",\"GeneratorId\":\"security-control/SSM.1\",\"Id\":\"arn:aws:iam::111111111111:user/developers/devuser@dev.dev\",\"LastObservedAt\":\"2024-09-15T16:48:57.829Z\",\"ProcessedAt\":\"2024-09-15T16:48:59.493Z\",\"ProductArn\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub\",\"ProductFields\":{\"RelatedAWSResources:0/name\":\"securityhub-iam-user-no-policies-check-832bb806\",\"RelatedAWSResources:0/type\":\"AWS::Config::ConfigRule\",\"Resources:0/Id\":\"arn:aws:iam::111111111111:user/developers/devuser@dev.dev\",\"aws/securityhub/CompanyName\":\"AWS\",\"aws/securityhub/FindingId\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub/arn:aws:securityhub:ap-south-1:111111111111:security-control/SSM.1/finding/12b0c84a-bba5-4fb4-bb36-3b0e62b1945c\",\"aws/securityhub/ProductName\":\"Security Hub\"},\"ProductName\":\"Security Hub\",\"RecordState\":\"ACTIVE\",\"Region\":\"ap-south-1\",\"Remediation\":{\"Recommendation\":{\"Text\":\"For information on how to correct this issue, consult the AWS Security Hub controls documentation.\",\"Url\":\"https://docs.aws.amazon.com/console/securityhub/IAM.2/remediation\"}},\"Resources\":[{\"Partition\":\"aws\",\"Type\":\"AwsIamUser\",\"Details\":{\"AwsIamUser\":{\"Path\":\"/developers/\",\"AttachedManagedPolicies\":[{\"PolicyArn\":\"arn:aws:iam::aws:policy/AWSSecurityHubFullAccess\",\"PolicyName\":\"AWSSecurityHubFullAccess\"}],\"UserName\":\"Dev UserName\",\"GroupList\":[\"DevUsers\"],\"UserId\":\"DevUserId\",\"CreateDate\":\"2023-01-10T01:07:37.000Z\"}},\"Region\":\"ap-south-1\",\"Id\":\"arn:aws:iam::111111111111:user/developers/devuser@dev.dev\"}],\"SchemaVersion\":\"2018-10-08\",\"Severity\":{\"Label\":\"LOW\",\"Normalized\":1,\"Original\":\"LOW\"},\"Title\":\"IAM users should not have IAM policies attached\",\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"],\"UpdatedAt\":\"2024-09-15T16:48:45.279Z\",\"Workflow\":{\"Status\":\"NEW\"},\"WorkflowState\":\"NEW\"}",
                 "outcome": "failure",
                 "severity": 1,
                 "type": [
                     "info"
                 ]
+            },
+            "observer": {
+                "vendor": "AWS Security Hub"
             },
             "organization": {
                 "name": "AWS"
@@ -2154,6 +2199,7 @@
                 "account": {
                     "id": "111111111111"
                 },
+                "provider": "aws",
                 "region": "ap-south-1",
                 "service": {
                     "name": "eks"
@@ -2168,12 +2214,16 @@
                 ],
                 "created": "2024-09-15T16:48:59.493Z",
                 "id": "arn:aws:eks:ap-south-1:111111111111:cluster/democluster",
+                "kind": "state",
                 "original": "{\"AwsAccountId\":\"111111111111\",\"CompanyName\":\"AWS\",\"Compliance\":{\"SecurityControlId\":\"EKS.1\",\"Status\":\"FAILED\"},\"CreatedAt\":\"2024-09-11T12:40:36.785Z\",\"Description\":\"This control checks whether an Amazon EKS cluster endpoint is publicly accessible. The control fails if an EKS cluster has an endpoint that is publicly accessible.\",\"FindingProviderFields\":{\"Severity\":{\"Label\":\"HIGH\",\"Normalized\":70,\"Original\":\"HIGH\"},\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"]},\"FirstObservedAt\":\"2024-09-11T12:40:36.785Z\",\"GeneratorId\":\"security-control/EKS.1\",\"Id\":\"arn:aws:eks:ap-south-1:111111111111:cluster/democluster\",\"LastObservedAt\":\"2024-09-15T16:48:57.829Z\",\"ProcessedAt\":\"2024-09-15T16:48:59.493Z\",\"ProductArn\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub\",\"ProductFields\":{\"RelatedAWSResources:0/name\":\"securityhub-eks-endpoint-no-public-access-2dc35c63\",\"RelatedAWSResources:0/type\":\"AWS::Config::ConfigRule\",\"Resources:0/Id\":\"arn:aws:eks:ap-south-1:111111111111:cluster/democluster\",\"aws/securityhub/CompanyName\":\"AWS\",\"aws/securityhub/FindingId\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub/arn:aws:securityhub:ap-south-1:111111111111:security-control/SSM.1/finding/12b0c84a-bba5-4fb4-bb36-3b0e62b1945c\",\"aws/securityhub/ProductName\":\"Security Hub\",\"aws/securityhub/annotation\":\"Cluster Endpoint of democluster is Publicly accessible\"},\"ProductName\":\"Security Hub\",\"RecordState\":\"ACTIVE\",\"Region\":\"ap-south-1\",\"Remediation\":{\"Recommendation\":{\"Text\":\"For information on how to correct this issue, consult the AWS Security Hub controls documentation.\",\"Url\":\"https://docs.aws.amazon.com/console/securityhub/EKS.1/remediation\"}},\"Resources\":[{\"Partition\":\"aws\",\"Type\":\"AwsEksCluster\",\"Details\":{\"AwsEksCluster\":{\"Version\":\"1.27\",\"Arn\":\"arn:aws:eks:ap-south-1:111111111111:cluster/democluster\",\"ResourcesVpcConfig\":{\"EndpointPublicAccess\":true,\"SecurityGroupIds\":[\"sg-111\"],\"SubnetIds\":[\"subnet-aaa\",\"subnet-bbb\"]},\"RoleArn\":\"arn:aws:iam::111111111111:role/EKSClusterRole\",\"Name\":\"democluster\"}},\"Region\":\"ap-south-1\",\"Id\":\"arn:aws:eks:ap-south-1:111111111111:cluster/democluster\",\"Tags\":{\"environment\":\"dev\",\"managed_by\":\"terraform\",\"project\":\"demo\",\"team\":\"dev\"}}],\"SchemaVersion\":\"2018-10-08\",\"Severity\":{\"Label\":\"HIGH\",\"Normalized\":70,\"Original\":\"HIGH\"},\"Title\":\"EKS cluster endpoints should not be publicly accessible\",\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"],\"UpdatedAt\":\"2024-09-15T16:48:45.279Z\",\"Workflow\":{\"Status\":\"NEW\"},\"WorkflowState\":\"NEW\"}",
                 "outcome": "failure",
                 "severity": 70,
                 "type": [
                     "info"
                 ]
+            },
+            "observer": {
+                "vendor": "AWS Security Hub"
             },
             "orchestrator": {
                 "cluster": {
@@ -2303,6 +2353,7 @@
                 "account": {
                     "id": "111111111111"
                 },
+                "provider": "aws",
                 "region": "ap-south-1"
             },
             "ecs": {
@@ -2314,12 +2365,16 @@
                 ],
                 "created": "2024-09-11T07:53:27.460Z",
                 "id": "arn:aws:securityhub:ap-south-1:111111111111:security-control/IAM.27/finding/9ec777ec-6a92-416f-a27c-fa22b5827b6f",
+                "kind": "state",
                 "original": "{\"AwsAccountId\":\"111111111111\",\"CompanyName\":\"AWS\",\"Compliance\":{\"AssociatedStandards\":[{\"StandardsId\":\"standards/cis-aws-foundations-benchmark/v/3.0.0\"}],\"RelatedRequirements\":[\"CIS AWS Foundations Benchmark v3.0.0/1.22\"],\"SecurityControlId\":\"IAM.27\",\"Status\":\"PASSED\",\"StatusReasons\":[{\"Description\":\"AWS Config evaluated your resources against the rule. The rule did not apply to the AWS resources in its scope, the specified resources were deleted, or the evaluation results were deleted.\",\"ReasonCode\":\"CONFIG_EVALUATIONS_EMPTY\"}]},\"CreatedAt\":\"2024-08-14T12:11:57.803Z\",\"Description\":\"This control checks whether an IAM identity (user, role, or group) has the AWS managed policy AWSCloudShellFullAccess attached. The control fails if an IAM identity has the AWSCloudShellFullAccess policy attached.\",\"FindingProviderFields\":{\"Severity\":{\"Label\":\"INFORMATIONAL\",\"Normalized\":0,\"Original\":\"INFORMATIONAL\"},\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"]},\"FirstObservedAt\":\"2024-08-14T12:11:57.803Z\",\"GeneratorId\":\"security-control/IAM.27\",\"Id\":\"arn:aws:securityhub:ap-south-1:111111111111:security-control/IAM.27/finding/9ec777ec-6a92-416f-a27c-fa22b5827b6f\",\"LastObservedAt\":\"2024-09-11T07:53:19.500Z\",\"ProcessedAt\":\"2024-09-11T07:53:27.460Z\",\"ProductArn\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub\",\"ProductFields\":{\"RelatedAWSResources:0/name\":\"securityhub-iam-policy-blacklisted-check-0ab52b49\",\"RelatedAWSResources:0/type\":\"AWS::Config::ConfigRule\",\"Resources:0/Id\":\"arn:aws:iam::111111111111:root\",\"aws/securityhub/CompanyName\":\"AWS\",\"aws/securityhub/FindingId\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub/arn:aws:securityhub:ap-south-1:111111111111:security-control/IAM.27/finding/9ec777ec-6a92-416f-a27c-fa22b5827b6f\",\"aws/securityhub/ProductName\":\"Security Hub\",\"aws/securityhub/annotation\":\"AWS Config evaluated your resources against the rule. The rule did not apply to the AWS resources in its scope, the specified resources were deleted, or the evaluation results were deleted.\"},\"ProductName\":\"Security Hub\",\"RecordState\":\"ACTIVE\",\"Region\":\"ap-south-1\",\"Remediation\":{\"Recommendation\":{\"Text\":\"For information on how to correct this issue, consult the AWS Security Hub controls documentation.\",\"Url\":\"https://docs.aws.amazon.com/console/securityhub/IAM.27/remediation\"}},\"Resources\":[{\"Id\":\"AWS::::Account:111111111111\",\"Partition\":\"aws\",\"Region\":\"ap-south-1\",\"Type\":\"AwsAccount\"}],\"SchemaVersion\":\"2018-10-08\",\"Severity\":{\"Label\":\"INFORMATIONAL\",\"Normalized\":0,\"Original\":\"INFORMATIONAL\"},\"Title\":\"IAM identities should not have the AWSCloudShellFullAccess policy attached\",\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"],\"UpdatedAt\":\"2024-09-11T07:53:19.500Z\",\"Workflow\":{\"Status\":\"RESOLVED\"},\"WorkflowState\":\"NEW\"}",
                 "outcome": "success",
                 "severity": 0,
                 "type": [
                     "info"
                 ]
+            },
+            "observer": {
+                "vendor": "AWS Security Hub"
             },
             "organization": {
                 "name": "AWS"
@@ -2447,6 +2502,7 @@
                     "id": "111111111111"
                 },
                 "availability_zone": "ap-south-1c",
+                "provider": "aws",
                 "region": "ap-south-1",
                 "service": {
                     "name": "ec2"
@@ -2461,12 +2517,16 @@
                 ],
                 "created": "2024-09-13T22:50:27.295Z",
                 "id": "arn:aws:securityhub:ap-south-1:111111111111:security-control/EC2.44/finding/0397ae8e-d2b2-4a75-964f-fde027670405",
+                "kind": "state",
                 "original": "{\"AwsAccountId\":\"111111111111\",\"CompanyName\":\"AWS\",\"Compliance\":{\"AssociatedStandards\":[{\"StandardsId\":\"standards/aws-resource-tagging-standard/v/1.0.0\"}],\"SecurityControlId\":\"EC2.44\",\"SecurityControlParameters\":[{\"Name\":\"requiredTagKeys\",\"Value\":[]}],\"Status\":\"FAILED\"},\"CreatedAt\":\"2024-08-14T10:14:50.020Z\",\"Description\":\"This control checks whether an Amazon EC2 subnet has tags with the specific keys defined in the parameter requiredTagKeys. The control fails if the subnet doesn’t have any tag keys or if it doesn’t have all the keys specified in the parameter requiredTagKeys. If the parameter requiredTagKeys isn't provided, the control only checks for the existence of a tag key and fails if the subnet isn't tagged with any key. System tags, which are automatically applied and begin with aws:, are ignored.\",\"FindingProviderFields\":{\"Severity\":{\"Label\":\"LOW\",\"Normalized\":1,\"Original\":\"LOW\"},\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"]},\"FirstObservedAt\":\"2024-08-14T10:14:50.020Z\",\"GeneratorId\":\"security-control/EC2.44\",\"Id\":\"arn:aws:securityhub:ap-south-1:111111111111:security-control/EC2.44/finding/0397ae8e-d2b2-4a75-964f-fde027670405\",\"LastObservedAt\":\"2024-09-13T22:50:24.617Z\",\"ProcessedAt\":\"2024-09-13T22:50:27.295Z\",\"ProductArn\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub\",\"ProductFields\":{\"RelatedAWSResources:0/name\":\"securityhub-tagged-ec2-subnet-4c30afd3\",\"RelatedAWSResources:0/type\":\"AWS::Config::ConfigRule\",\"Resources:0/Id\":\"arn:aws:ec2:ap-south-1:111111111111:subnet/subnet-c28c74b9\",\"aws/securityhub/CompanyName\":\"AWS\",\"aws/securityhub/FindingId\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub/arn:aws:securityhub:ap-south-1:111111111111:security-control/EC2.44/finding/0397ae8e-d2b2-4a75-964f-fde027670405\",\"aws/securityhub/ProductName\":\"Security Hub\",\"aws/securityhub/annotation\":\"No tags are present.\"},\"ProductName\":\"Security Hub\",\"RecordState\":\"ACTIVE\",\"Region\":\"ap-south-1\",\"Remediation\":{\"Recommendation\":{\"Text\":\"For information on how to correct this issue, consult the AWS Security Hub controls documentation.\",\"Url\":\"https://docs.aws.amazon.com/console/securityhub/EC2.44/remediation\"}},\"Resources\":[{\"Details\":{\"AwsEc2Subnet\":{\"AssignIpv6AddressOnCreation\":false,\"AvailabilityZone\":\"ap-south-1c\",\"AvailabilityZoneId\":\"aps1-az2\",\"AvailableIpAddressCount\":4091,\"CidrBlock\":\"171.32.32.0/20\",\"DefaultForAz\":true,\"MapPublicIpOnLaunch\":true,\"OwnerId\":\"111111111111\",\"State\":\"available\",\"SubnetArn\":\"arn:aws:ec2:ap-south-1:111111111111:subnet/subnet-c19c74b9\",\"SubnetId\":\"subnet-c19c74b9\",\"VpcId\":\"vpc-39017152\"}},\"Id\":\"arn:aws:ec2:ap-south-1:111111111111:subnet/subnet-c28c74b9\",\"Partition\":\"aws\",\"Region\":\"ap-south-1\",\"Type\":\"AwsEc2Subnet\"}],\"SchemaVersion\":\"2018-10-08\",\"Severity\":{\"Label\":\"LOW\",\"Normalized\":1,\"Original\":\"LOW\"},\"Title\":\"EC2 subnets should be tagged\",\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"],\"UpdatedAt\":\"2024-09-13T22:50:15.737Z\",\"Workflow\":{\"Status\":\"NEW\"},\"WorkflowState\":\"NEW\"}",
                 "outcome": "failure",
                 "severity": 1,
                 "type": [
                     "info"
                 ]
+            },
+            "observer": {
+                "vendor": "AWS Security Hub"
             },
             "organization": {
                 "name": "AWS"
@@ -2603,6 +2663,7 @@
                     "id": "111111111111"
                 },
                 "availability_zone": "ap-south-1a",
+                "provider": "aws",
                 "region": "ap-south-1",
                 "service": {
                     "name": "elasticloadbalancing"
@@ -2617,12 +2678,16 @@
                 ],
                 "created": "2024-09-13T22:50:27.295Z",
                 "id": "arn:aws:elasticloadbalancing:ap-south-1:111111111111:loadbalancer/net/a799f20cd3754462297d4874c25e67ae/894921ab8833ff1e",
+                "kind": "state",
                 "original": "{\"AwsAccountId\":\"111111111111\",\"CompanyName\":\"AWS\",\"Compliance\":{\"SecurityControlId\":\"ELB.6\",\"Status\":\"FAILED\"},\"CreatedAt\":\"2024-08-14T10:14:50.020Z\",\"Description\":\"This control checks whether Application, Gateway, and Network Load Balancers have deletion protection enabled. The control fails if deletion protection is disabled.\",\"FindingProviderFields\":{\"Severity\":{\"Label\":\"MEDIUM\",\"Normalized\":40,\"Original\":\"MEDIUM\"},\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"]},\"FirstObservedAt\":\"2024-08-14T10:14:50.020Z\",\"GeneratorId\":\"security-control/EC2.44\",\"Id\":\"arn:aws:elasticloadbalancing:ap-south-1:111111111111:loadbalancer/net/a799f20cd3754462297d4874c25e67ae/894921ab8833ff1e\",\"LastObservedAt\":\"2024-09-13T22:50:24.617Z\",\"ProcessedAt\":\"2024-09-13T22:50:27.295Z\",\"ProductArn\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub\",\"ProductFields\":{\"RelatedAWSResources:0/name\":\"securityhub-tagged-ec2-subnet-4c30afd3\",\"RelatedAWSResources:0/type\":\"AWS::Config::ConfigRule\",\"Resources:0/Id\":\"arn:aws:elasticloadbalancing:ap-south-1:111111111111:loadbalancer/net/a799f20cd3754462297d4874c25e67ae/894921ab8833ff1e\",\"aws/securityhub/CompanyName\":\"AWS\",\"aws/securityhub/FindingId\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub/arn:aws:securityhub:ap-south-1:111111111111:security-control/ELB.6/finding/9e7771db-5b77-48df-a103-1370cf6d401a\",\"aws/securityhub/ProductName\":\"Security Hub\",\"aws/securityhub/annotation\":\"No tags are present.\"},\"ProductName\":\"Security Hub\",\"RecordState\":\"ACTIVE\",\"Region\":\"ap-south-1\",\"Remediation\":{\"Recommendation\":{\"Text\":\"For information on how to correct this issue, consult the AWS Security Hub controls documentation.\",\"Url\":\"https://docs.aws.amazon.com/console/securityhub/ELB.6/remediation\"}},\"Resources\":[{\"Partition\":\"aws\",\"Type\":\"AwsElbv2LoadBalancer\",\"Details\":{\"AwsElbv2LoadBalancer\":{\"IpAddressType\":\"ipv4\",\"Type\":\"network\",\"CreatedTime\":\"2024-04-17T21:35:20.303Z\",\"Scheme\":\"internet-facing\",\"VpcId\":\"vpc-132ddf1f407252a0a\",\"CanonicalHostedZoneId\":\"ZLPOA36VPKAMP\",\"AvailabilityZones\":[{\"ZoneName\":\"ap-south-1b\",\"SubnetId\":\"subnet-aaa\"},{\"ZoneName\":\"ap-south-1a\",\"SubnetId\":\"subnet-bbb\"}],\"State\":{\"Code\":\"active\"},\"DNSName\":\"a799f20cd3754462297d4874c25e67ae-894921ab8833ff1e.elb.ap-south-1.amazonaws.com\"}},\"Region\":\"ap-south-1\",\"Id\":\"arn:aws:elasticloadbalancing:ap-south-1:111111111111:loadbalancer/net/a799f20cd3754462297d4874c25e67ae/894921ab8833ff1e\",\"Tags\":{\"kubernetes.io/service-name\":\"default/traefik\",\"kubernetes.io/cluster/demo\":\"owned\"}}],\"SchemaVersion\":\"2018-10-08\",\"Severity\":{\"Label\":\"LOW\",\"Normalized\":1,\"Original\":\"LOW\"},\"Title\":\"EC2 subnets should be tagged\",\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"],\"UpdatedAt\":\"2024-09-13T22:50:15.737Z\",\"Workflow\":{\"Status\":\"NEW\"},\"WorkflowState\":\"NEW\"}",
                 "outcome": "failure",
                 "severity": 1,
                 "type": [
                     "info"
                 ]
+            },
+            "observer": {
+                "vendor": "AWS Security Hub"
             },
             "organization": {
                 "name": "AWS"
@@ -2797,6 +2862,7 @@
                     "ap-south-1b",
                     "ap-south-1a"
                 ],
+                "provider": "aws",
                 "region": "ap-south-1",
                 "service": {
                     "name": [
@@ -2814,12 +2880,16 @@
                 ],
                 "created": "2024-09-13T22:50:27.295Z",
                 "id": "arn:aws:elasticloadbalancing:ap-south-1:111111111111:loadbalancer/net/a799f20cd3754462297d4874c25e67ae/894921ab8833ff1e",
+                "kind": "state",
                 "original": "{\"AwsAccountId\":\"111111111111\",\"CompanyName\":\"AWS\",\"Compliance\":{\"SecurityControlId\":\"ELB.6\",\"Status\":\"FAILED\"},\"CreatedAt\":\"2024-08-14T10:14:50.020Z\",\"Description\":\"This control checks whether Application, Gateway, and Network Load Balancers have deletion protection enabled. The control fails if deletion protection is disabled.\",\"FindingProviderFields\":{\"Severity\":{\"Label\":\"MEDIUM\",\"Normalized\":40,\"Original\":\"MEDIUM\"},\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"]},\"FirstObservedAt\":\"2024-08-14T10:14:50.020Z\",\"GeneratorId\":\"security-control/EC2.44\",\"Id\":\"arn:aws:elasticloadbalancing:ap-south-1:111111111111:loadbalancer/net/a799f20cd3754462297d4874c25e67ae/894921ab8833ff1e\",\"LastObservedAt\":\"2024-09-13T22:50:24.617Z\",\"ProcessedAt\":\"2024-09-13T22:50:27.295Z\",\"ProductArn\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub\",\"ProductFields\":{\"RelatedAWSResources:0/name\":\"securityhub-tagged-ec2-subnet-4c30afd3\",\"RelatedAWSResources:0/type\":\"AWS::Config::ConfigRule\",\"Resources:0/Id\":\"arn:aws:elasticloadbalancing:ap-south-1:111111111111:loadbalancer/net/a799f20cd3754462297d4874c25e67ae/894921ab8833ff1e\",\"aws/securityhub/CompanyName\":\"AWS\",\"aws/securityhub/FindingId\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub/arn:aws:securityhub:ap-south-1:111111111111:security-control/ELB.6/finding/9e7771db-5b77-48df-a103-1370cf6d401a\",\"aws/securityhub/ProductName\":\"Security Hub\",\"aws/securityhub/annotation\":\"No tags are present.\"},\"ProductName\":\"Security Hub\",\"RecordState\":\"ACTIVE\",\"Region\":\"ap-south-1\",\"Remediation\":{\"Recommendation\":{\"Text\":\"For information on how to correct this issue, consult the AWS Security Hub controls documentation.\",\"Url\":\"https://docs.aws.amazon.com/console/securityhub/ELB.6/remediation\"}},\"Resources\":[{\"Partition\":\"aws\",\"Type\":\"AwsElbv2LoadBalancer\",\"Details\":{\"AwsElbv2LoadBalancer\":{\"IpAddressType\":\"ipv4\",\"Type\":\"network\",\"CreatedTime\":\"2024-04-17T21:35:20.303Z\",\"Scheme\":\"internet-facing\",\"VpcId\":\"vpc-132ddf1f407252a0a\",\"CanonicalHostedZoneId\":\"ZLPOA36VPKAMP\",\"AvailabilityZones\":[{\"ZoneName\":\"ap-south-1b\",\"SubnetId\":\"subnet-aaa\"},{\"ZoneName\":\"ap-south-1a\",\"SubnetId\":\"subnet-bbb\"}],\"State\":{\"Code\":\"active\"},\"DNSName\":\"a799f20cd3754462297d4874c25e67ae-894921ab8833ff1e.elb.ap-south-1.amazonaws.com\"}},\"Region\":\"ap-south-1\",\"Id\":\"arn:aws:elasticloadbalancing:ap-south-1:111111111111:loadbalancer/net/a799f20cd3754462297d4874c25e67ae/894921ab8833ff1e\",\"Tags\":{\"kubernetes.io/service-name\":\"default/traefik\",\"kubernetes.io/cluster/demo\":\"owned\"}},{\"Partition\":\"aws\",\"Type\":\"AwsElbv2LoadBalancer\",\"Details\":{\"AwsElbv2LoadBalancer\":{\"IpAddressType\":\"ipv4\",\"Type\":\"network\",\"CreatedTime\":\"2024-04-18T21:35:20.303Z\",\"Scheme\":\"internet-facing\",\"VpcId\":\"vpc-132ddf1f407252a0a\",\"CanonicalHostedZoneId\":\"ZLPOA36VPKAMP\",\"AvailabilityZones\":[{\"ZoneName\":\"ap-south-1b\",\"SubnetId\":\"subnet-aaa\"},{\"ZoneName\":\"ap-south-1a\",\"SubnetId\":\"subnet-bbb\"}],\"State\":{\"Code\":\"active\"},\"DNSName\":\"a888f20cd3754462297d4874c25e67ae-994921ab8833ff1e.elb.ap-south-1.amazonaws.com\"}},\"Region\":\"ap-south-1\",\"Id\":\"arn:aws:elasticloadbalancing:ap-south-1:111111111111:loadbalancer/net/a888f20cd3754462297d4874c25e67ae/994921ab8833ff1e\",\"Tags\":{\"kubernetes.io/cluster/demo\":\"owned\"}}],\"SchemaVersion\":\"2018-10-08\",\"Severity\":{\"Label\":\"LOW\",\"Normalized\":1,\"Original\":\"LOW\"},\"Title\":\"EC2 subnets should be tagged\",\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"],\"UpdatedAt\":\"2024-09-13T22:50:15.737Z\",\"Workflow\":{\"Status\":\"NEW\"},\"WorkflowState\":\"NEW\"}",
                 "outcome": "failure",
                 "severity": 1,
                 "type": [
                     "info"
                 ]
+            },
+            "observer": {
+                "vendor": "AWS Security Hub"
             },
             "organization": {
                 "name": "AWS"
@@ -2985,6 +3055,7 @@
                     "id": "arn:aws:ec2:ap-south-1:111111111111:instance/i-0f2ede89308a594d8",
                     "name": "instance/i-0f2ede89308a594d8"
                 },
+                "provider": "aws",
                 "region": "ap-south-1",
                 "service": {
                     "name": "ec2"
@@ -2999,6 +3070,7 @@
                 ],
                 "created": "2024-09-21T08:00:03.516Z",
                 "id": "arn:aws:securityhub:ap-south-1:111111111111:security-control/EC2.8/finding/8925ae3b-1f70-4c74-8337-baee8fcad8fe",
+                "kind": "state",
                 "original": "{\"AwsAccountId\":\"111111111111\",\"CompanyName\":\"AWS\",\"Compliance\":{\"AssociatedStandards\":[{\"StandardsId\":\"standards/aws-foundational-security-best-practices/v/1.0.0\"},{\"StandardsId\":\"standards/cis-aws-foundations-benchmark/v/3.0.0\"},{\"StandardsId\":\"standards/nist-800-53/v/5.0.0\"}],\"RelatedRequirements\":[\"CIS AWS Foundations Benchmark v3.0.0/5.6\",\"NIST.800-53.r5 AC-3\",\"NIST.800-53.r5 AC-3(15)\",\"NIST.800-53.r5 AC-3(7)\",\"NIST.800-53.r5 AC-6\"],\"SecurityControlId\":\"EC2.8\",\"Status\":\"PASSED\"},\"CreatedAt\":\"2024-09-20T10:40:32.189Z\",\"Description\":\"This control checks whether your Amazon Elastic Compute Cloud (Amazon EC2) instance metadata version is configured with Instance Metadata Service Version 2 (IMDSv2). The control passes if HttpTokens is set to required for IMDSv2. The control fails if HttpTokens is set to optional.\",\"FindingProviderFields\":{\"Severity\":{\"Label\":\"INFORMATIONAL\",\"Normalized\":0,\"Original\":\"INFORMATIONAL\"},\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"]},\"FirstObservedAt\":\"2024-09-20T10:40:32.189Z\",\"GeneratorId\":\"security-control/EC2.8\",\"Id\":\"arn:aws:securityhub:ap-south-1:111111111111:security-control/EC2.8/finding/8925ae3b-1f70-4c74-8337-baee8fcad8fe\",\"LastObservedAt\":\"2024-09-21T08:00:01.828Z\",\"ProcessedAt\":\"2024-09-21T08:00:03.516Z\",\"ProductArn\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub\",\"ProductFields\":{\"RelatedAWSResources:0/name\":\"securityhub-ec2-imdsv2-check-29027890\",\"RelatedAWSResources:0/type\":\"AWS::Config::ConfigRule\",\"Resources:0/Id\":\"arn:aws:ec2:ap-south-1:111111111111:instance/i-0f2ede89308a594d8\",\"aws/securityhub/CompanyName\":\"AWS\",\"aws/securityhub/FindingId\":\"arn:aws:securityhub:ap-south-1::product/aws/securityhub/arn:aws:securityhub:ap-south-1:111111111111:security-control/EC2.8/finding/8925ae3b-1f70-4c74-8337-baee8fcad8fe\",\"aws/securityhub/ProductName\":\"Security Hub\"},\"ProductName\":\"Security Hub\",\"RecordState\":\"ACTIVE\",\"Region\":\"ap-south-1\",\"Remediation\":{\"Recommendation\":{\"Text\":\"For information on how to correct this issue, consult the AWS Security Hub controls documentation.\",\"Url\":\"https://docs.aws.amazon.com/console/securityhub/EC2.8/remediation\"}},\"Resources\":[{\"Details\":{\"AwsEc2Instance\":{\"IamInstanceProfileArn\":\"arn:aws:iam::111111111111:instance-profile/elastic-agent-instance-profile-e4f7caa0-6f61-11ef-bb07-02fe87118279\",\"ImageId\":\"ami-04dffe071c46cddd4\",\"IpV4Addresses\":[\"89.160.20.156\",\"89.160.20.157\"],\"IpV6Addresses\":[\"2a02:cf40::\"],\"LaunchedAt\":\"2024-09-20T10:39:35.000Z\",\"MetadataOptions\":{\"HttpEndpoint\":\"enabled\",\"HttpProtocolIpv6\":\"disabled\",\"HttpPutResponseHopLimit\":2,\"HttpTokens\":\"required\",\"InstanceMetadataTags\":\"disabled\"},\"Monitoring\":{\"State\":\"disabled\"},\"NetworkInterfaces\":[{\"NetworkInterfaceId\":\"eni-0de300eee88c5c7fd\"}],\"SubnetId\":\"subnet-5d15a111\",\"VirtualizationType\":\"hvm\",\"VpcId\":\"vpc-39017251\"}},\"Id\":\"arn:aws:ec2:ap-south-1:111111111111:instance/i-0f2ede89308a594d8\",\"Partition\":\"aws\",\"Region\":\"ap-south-1\",\"Tags\":{\"Name\":\"elastic-agent-instance-e5f7caa0-6f60-11ef-bb07-02fe87118279\",\"Task\":\"Cloud Security Posture Management Scanner\",\"aws:cloudformation:logical-id\":\"ElasticAgentEc2Instance\",\"aws:cloudformation:stack-id\":\"arn:aws:cloudformation:ap-south-1:111111111111:stack/Elastic-Cloud-Security-Posture-Management/e5f7caa0-6f60-11ef-bb07-02fe87118279\",\"aws:cloudformation:stack-name\":\"Elastic-Cloud-Security-Posture-Management\"},\"Type\":\"AwsEc2Instance\"}],\"SchemaVersion\":\"2018-10-08\",\"Severity\":{\"Label\":\"INFORMATIONAL\",\"Normalized\":0,\"Original\":\"INFORMATIONAL\"},\"Title\":\"EC2 instances should use Instance Metadata Service Version 2 (IMDSv2)\",\"Types\":[\"Software and Configuration Checks/Industry and Regulatory Standards\"],\"UpdatedAt\":\"2024-09-21T07:59:56.087Z\",\"Workflow\":{\"Status\":\"RESOLVED\"},\"WorkflowState\":\"NEW\"}",
                 "outcome": "success",
                 "severity": 0,
@@ -3013,6 +3085,9 @@
                     "89.160.20.157",
                     "2a02:cf40::"
                 ]
+            },
+            "observer": {
+                "vendor": "AWS Security Hub"
             },
             "organization": {
                 "name": "AWS"

--- a/packages/aws/data_stream/securityhub_findings/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/securityhub_findings/elasticsearch/ingest_pipeline/default.yml
@@ -4,6 +4,9 @@ processors:
   - set:
       field: ecs.version
       value: '8.11.0'
+  - set:
+      field: event.kind
+      value: state
   - append:
       field: event.type
       value: info
@@ -30,13 +33,14 @@ processors:
         - json.CreatedAt
       target_field: _id
       ignore_missing: true
-  - remove: 
-      field: 
-        - cloud.provider
-        - event.kind
-        - observer.vendor
-      ignore_missing: true
-      description: Fields defined as constant_keyword are removed from _source for storage efficiency.
+  - set:
+      field: observer.vendor
+      value: AWS Security Hub
+      tag: set_observer_vendor
+  - set:
+      field: cloud.provider
+      value: aws
+      tag: set_cloud_provider
   - rename:
       field: json.Action.ActionType
       target_field: aws.securityhub_findings.action.type

--- a/packages/aws/data_stream/securityhub_findings/fields/ecs.yml
+++ b/packages/aws/data_stream/securityhub_findings/fields/ecs.yml
@@ -1,10 +1,7 @@
 # Define ECS constant fields as constant_keyword
 - name: cloud.provider
   type: constant_keyword
-  value: aws
 - name: event.kind
   type: constant_keyword
-  value: state
 - name: observer.vendor
   type: constant_keyword
-  value: AWS Security Hub

--- a/packages/aws/elasticsearch/transform/latest_cdr_misconfigurations/fields/ecs.yml
+++ b/packages/aws/elasticsearch/transform/latest_cdr_misconfigurations/fields/ecs.yml
@@ -1,13 +1,10 @@
 # Define ECS constant fields as constant_keyword
 - name: cloud.provider
   type: constant_keyword
-  value: aws
 - name: event.kind
   type: constant_keyword
-  value: state
 - name: observer.vendor
   type: constant_keyword
-  value: AWS Security Hub
 # Define ECS fields for transform
 - name: cloud.account.id
   external: ecs

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: aws
 title: AWS
-version: 2.31.0
+version: 2.31.1
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:

--- a/packages/ti_crowdstrike/_dev/build/docs/README.md
+++ b/packages/ti_crowdstrike/_dev/build/docs/README.md
@@ -36,7 +36,7 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
 ### Permissions
-This integration includes assets such as latest transform which requires users installing thre integration to have `kibana_system` role.
+This integration includes assets such as latest transform which requires users installing the integration to have `kibana_system` role.
 
 This module has been tested against the **CrowdStrike Falcon Intelligence API Version v1**.
 

--- a/packages/ti_crowdstrike/_dev/build/docs/README.md
+++ b/packages/ti_crowdstrike/_dev/build/docs/README.md
@@ -35,6 +35,9 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
+### Permissions
+This integration includes assets such as latest transform which requires users installing thre integration to have `kibana_system` role.
+
 This module has been tested against the **CrowdStrike Falcon Intelligence API Version v1**.
 
 ## Setup
@@ -70,7 +73,10 @@ User should either have `admin` role or `Detection Exception Manager` role to ac
 The ingested IOCs expire after a certain duration. A separate [Elastic Transform](https://www.elastic.co/guide/en/elasticsearch/reference/current/transforms.html) is created for Intel and IOC datasets to facilitate only active Indicators and IOCs, respectively, being available to the end users. Since we want to retain only valuable information and avoid duplicated data, the CrowdStrike Falcon Intelligence Elastic integration forces the intel indicators to rotate into a custom index called: `logs-ti_crowdstrike_latest.dest_intel` and forces the IOC logs to rotate into a custom index called: `logs-ti_crowdstrike_latest.dest_ioc`.
 **Please, refer to this index in order to set alerts and so on.**
 
-#### Handling Orphaned IOCs
+### Transform Permissions
+The latest transforms for both Intel and IOC datasets require users to have `kibana_system` role as noted in [permissions](https://www.elastic.co/docs/current/integrations/ti_crowdstrike#permissions).
+
+### Handling Orphaned IOCs
 
 IOC expiration is set default to false in CrowdStrike console but user can set the expiration duration in using the admin console. Some CrowdStrike IOCs may never expire and will continue to stay in the latest destination index. To avoid any false positives from such orphaned IOCs, users are allowed to configure `IOC Expiration Duration` parameter for both the dataset Intel and IOC, respectively, while setting up the integration. This parameter deletes all data inside the destination index `logs-ti_crowdstrike_latest.intel` and `logs-ti_crowdstrike_latest.ioc` after this specified duration is reached. Users must pull entire feed instead of incremental feed when this expiration happens so that the IOCs get reset.
 

--- a/packages/ti_crowdstrike/changelog.yml
+++ b/packages/ti_crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Set transform unattended to true for infinite retries.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1111
 - version: "1.1.7"
   changes:
     - description: Fix labels.is_ioc_transform_source values

--- a/packages/ti_crowdstrike/changelog.yml
+++ b/packages/ti_crowdstrike/changelog.yml
@@ -1,9 +1,12 @@
 # newer versions go on top
 - version: "1.2.0"
   changes:
-    - description: Set transform unattended to true for infinite retries.
-      type: bugfix
-      link: https://github.com/elastic/integrations/pull/1111
+    - description: Set transform unattended to true for indefinite retries.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/11605
+    - description: Update documentation with required permissions for running transforms.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/11605
 - version: "1.1.7"
   changes:
     - description: Fix labels.is_ioc_transform_source values

--- a/packages/ti_crowdstrike/docs/README.md
+++ b/packages/ti_crowdstrike/docs/README.md
@@ -36,7 +36,7 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
 ### Permissions
-This integration includes assets such as latest transform which requires users installing thre integration to have `kibana_system` role.
+This integration includes assets such as latest transform which requires users installing the integration to have `kibana_system` role.
 
 This module has been tested against the **CrowdStrike Falcon Intelligence API Version v1**.
 

--- a/packages/ti_crowdstrike/docs/README.md
+++ b/packages/ti_crowdstrike/docs/README.md
@@ -35,6 +35,9 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
+### Permissions
+This integration includes assets such as latest transform which requires users installing thre integration to have `kibana_system` role.
+
 This module has been tested against the **CrowdStrike Falcon Intelligence API Version v1**.
 
 ## Setup
@@ -70,7 +73,10 @@ User should either have `admin` role or `Detection Exception Manager` role to ac
 The ingested IOCs expire after a certain duration. A separate [Elastic Transform](https://www.elastic.co/guide/en/elasticsearch/reference/current/transforms.html) is created for Intel and IOC datasets to facilitate only active Indicators and IOCs, respectively, being available to the end users. Since we want to retain only valuable information and avoid duplicated data, the CrowdStrike Falcon Intelligence Elastic integration forces the intel indicators to rotate into a custom index called: `logs-ti_crowdstrike_latest.dest_intel` and forces the IOC logs to rotate into a custom index called: `logs-ti_crowdstrike_latest.dest_ioc`.
 **Please, refer to this index in order to set alerts and so on.**
 
-#### Handling Orphaned IOCs
+### Transform Permissions
+The latest transforms for both Intel and IOC datasets require users to have `kibana_system` role as noted in [permissions](https://www.elastic.co/docs/current/integrations/ti_crowdstrike#permissions).
+
+### Handling Orphaned IOCs
 
 IOC expiration is set default to false in CrowdStrike console but user can set the expiration duration in using the admin console. Some CrowdStrike IOCs may never expire and will continue to stay in the latest destination index. To avoid any false positives from such orphaned IOCs, users are allowed to configure `IOC Expiration Duration` parameter for both the dataset Intel and IOC, respectively, while setting up the integration. This parameter deletes all data inside the destination index `logs-ti_crowdstrike_latest.intel` and `logs-ti_crowdstrike_latest.ioc` after this specified duration is reached. Users must pull entire feed instead of incremental feed when this expiration happens so that the IOCs get reset.
 

--- a/packages/ti_crowdstrike/elasticsearch/transform/latest_intel/transform.yml
+++ b/packages/ti_crowdstrike/elasticsearch/transform/latest_intel/transform.yml
@@ -9,7 +9,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_crowdstrike_latest.dest_intel-3"
+  index: "logs-ti_crowdstrike_latest.dest_intel-4"
   aliases:
     - alias: "logs-ti_crowdstrike_latest.intel"
       move_on_creation: true
@@ -21,6 +21,8 @@ latest:
   sort: '@timestamp'
 description: Latest Intel Indicator data retrieved from CrowdStrike Intel API.
 frequency: 30s
+settings:
+  unattended: true
 sync:
   time:
     field: event.ingested
@@ -33,4 +35,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.3.0
+  fleet_transform_version: 0.4.0

--- a/packages/ti_crowdstrike/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_crowdstrike/elasticsearch/transform/latest_ioc/transform.yml
@@ -9,7 +9,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_crowdstrike_latest.dest_ioc-3"
+  index: "logs-ti_crowdstrike_latest.dest_ioc-4"
   aliases:
     - alias: "logs-ti_crowdstrike_latest.ioc"
       move_on_creation: true
@@ -21,6 +21,8 @@ latest:
   sort: '@timestamp'
 description: Latest IOC Indicator data retrieved from CrowdStrike IOC API.
 frequency: 30s
+settings:
+  unattended: true
 sync:
   time:
     field: event.ingested
@@ -33,4 +35,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.3.0
+  fleet_transform_version: 0.4.0

--- a/packages/ti_crowdstrike/manifest.yml
+++ b/packages/ti_crowdstrike/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_crowdstrike
 title: CrowdStrike Falcon Intelligence
-version: "1.1.7"
+version: "1.2.0"
 description: Collect logs from CrowdStrike Falcon Intelligence with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
Add `cloud.provider`, `event.kind`, and `observer.vendor` fields to 
`_source` as needed by CDR workflows.

The commit [here](https://github.com/elastic/integrations/commit/0e4409161a73e99763b266042288416edace0599#diff-c17e1251c36fc92221e2d3db57cc560bd80a4cf5d345fd18c6b646af6a458866L39) removed the fields from `_source`. But the fields are required to be 
present in `_source` for Cloud Detection and Response (CDR) workflows. This PR reverts 
the changes made in that commit and re-adds the fields into the ingest pipeline.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/security-team/issues/11020

Sample documents after the change:
1. Source index: [_source-updated-document-destination-index.json](https://github.com/user-attachments/files/17590629/_source-updated-document-destination-index.json)
2. Destination index: [_source-updated-document-source-index.json](https://github.com/user-attachments/files/17590630/_source-updated-document-source-index.json)
 
