### PR TITLE
[servicenow] Add product version and remove `logs` from configuration page description.

### DIFF
--- a/packages/servicenow/_dev/build/docs/README.md
+++ b/packages/servicenow/_dev/build/docs/README.md
@@ -4,12 +4,12 @@
 
 [ServiceNow](https://www.servicenow.com/?state=seamless) is a cloud-based platform that helps organizations improve their workflows and business processes, mainly in IT service management. It offers features like workflow automation, a self-service portal for users, integration with other systems, and helpful reporting tools.
 
-ServiceNow uses tables to store data, making it easy to manage and retrieve information. A key part of the platform is the [Configuration Management Database](https://www.servicenow.com/products/servicenow-platform/configuration-management-database.html) (CMDB), which keeps track of IT assets and how they are connected. This helps organizations monitor changes, manage configurations, and ensure reliable services. Overall, ServiceNow boosts efficiency, visibility, and user satisfaction, making it a popular choice for various industries.
+ServiceNow uses tables to store data, making it easy to manage and retrieve information. A key part of the platform is the [Configuration Management Database](https://www.servicenow.com/products/servicenow-platform/configuration-management-database.html) (CMDB), which keeps track of IT assets and how they are connected.
 
 The ServiceNow integration can be used in three different modes to collect logs:
-- AWS S3 polling mode: ServiceNow writes data to S3, and Elastic Agent polls the S3 bucket by listing its contents and reading new files. Refer to the [ServiceNow documentation](https://www.servicenow.com/community/now-platform-forum/aws-s3-integration-with-servicenow/td-p/1121852) for how to integrate AWS S3 with ServiceNow for retrieving logs into an S3 bucket.
-- AWS S3 SQS mode: ServiceNow writes data to S3; S3 sends a notification of a new object to SQS; the Elastic Agent receives the notification from SQS and then reads the S3 object. Multiple agents can be used in this mode.
-- REST API mode: ServiceNow offers table APIs to retrieve data from its tables; the Elastic Agent polls these APIs to list their contents and read any new data. Visit this [page](https://developer.servicenow.com/dev.do#!/reference/api/washingtondc/rest/c_TableAPI#table-GET) for additional information about REST APIs.
+- **AWS S3 polling mode**: ServiceNow writes data to S3, and Elastic Agent polls the S3 bucket by listing its contents and reading new files. Refer to the [ServiceNow documentation](https://www.servicenow.com/community/now-platform-forum/aws-s3-integration-with-servicenow/td-p/1121852) for how to integrate AWS S3 with ServiceNow for retrieving logs into an S3 bucket.
+- **AWS S3 SQS mode**: ServiceNow writes data to S3; S3 sends a notification of a new object to SQS; the Elastic Agent receives the notification from SQS and then reads the S3 object. Multiple agents can be used in this mode.
+- **REST API mode**: ServiceNow offers table APIs to retrieve data from its tables; the Elastic Agent polls these APIs to list their contents and read any new data. Visit this [page](https://developer.servicenow.com/dev.do#!/reference/api/washingtondc/rest/c_TableAPI#table-GET) for additional information about REST APIs.
 
 ## Compatibility
 
@@ -55,7 +55,7 @@ Below is a list of the default ones.
 **Note**:
 
 1. This integration currently supports ECS mapping for default ServiceNow tables listed above. For custom tables created by users, ECS mapping is not automatically provided. If you want to add mappings for custom tables, please refer to this [tutorial guide](https://www.elastic.co/guide/en/fleet/current/data-streams-pipeline-tutorial.html).
-2. For each table, a tag will be added based on the name of the table from which data is fetched.
+2. A tag will be added to each table based on its name. For example, if logs are ingested from the `alm_hardware` table, users can view them in Discover by using the query `tags: "alm_hardware"`.
 
 ## Requirements
 
@@ -114,27 +114,34 @@ There are some minimum requirements for running Elastic Agent. For more informat
 3. Click on the "ServiceNow" integration from the search results.
 4. Click on the "Add ServiceNow" button to add the integration.
 5. While adding the integration, if you want to collect logs via REST API, then you have to put the following details:
+   - collect logs via REST API toggled on
    - API URL
    - username
    - password
    - table name
+   - timestamp field
    - timezone
-   - collect logs via REST API toggled on
 
    or if you want to collect logs via AWS S3, then you have to put the following details:
+   - collect logs via S3 Bucket toggled on
    - access key id
    - secret access key
    - bucket arn
+   - table name
+   - timestamp field
    - timezone
-   - collect logs via S3 Bucket toggled on
 
    or if you want to collect logs via AWS SQS, then you have to put the following details:
+   - collect logs via S3 Bucket toggled off
    - access key id
    - secret access key
    - queue url
+   - table name
+   - timestamp field
    - timezone
-   - collect logs via S3 Bucket toggled off
 6. Click on "Save and Continue" to save the integration.
+
+**Note**: To fetch parquet file data, enable the toggle, `Parquet Codec`
 
 ## Logs Reference
 

--- a/packages/servicenow/_dev/build/docs/README.md
+++ b/packages/servicenow/_dev/build/docs/README.md
@@ -13,7 +13,7 @@ The ServiceNow integration can be used in three different modes to collect logs:
 
 ## Compatibility
 
-This module has been tested against the latest (updated Aug 1, 2024) ServiceNow API.
+This module has been tested with the latest(updated as of August 1, 2024) version of Xanadu on ServiceNow.
 
 ## Data streams
 

--- a/packages/servicenow/changelog.yml
+++ b/packages/servicenow/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Add product version and remove logs from decsription.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.1.0"
   changes:
     - description: Initial draft of the package.

--- a/packages/servicenow/changelog.yml
+++ b/packages/servicenow/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.1.1"
+- version: "0.2.0"
   changes:
     - description: Implement support for timestamp field input by the user and the ingestion of Parquet files through AWS S3 or SQS input types.
       type: enhancement

--- a/packages/servicenow/changelog.yml
+++ b/packages/servicenow/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "0.1.1"
   changes:
-    - description: Add product version and remove logs from decsription.
+    - description: Implement support for timestamp field input by the user and the ingestion of Parquet files through AWS S3 or SQS input types.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/11639
 - version: "0.1.0"

--- a/packages/servicenow/changelog.yml
+++ b/packages/servicenow/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add product version and remove logs from decsription.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/11639
 - version: "0.1.0"
   changes:
     - description: Initial draft of the package.

--- a/packages/servicenow/data_stream/event/_dev/test/pipeline/test-common-config.yml
+++ b/packages/servicenow/data_stream/event/_dev/test/pipeline/test-common-config.yml
@@ -5,3 +5,4 @@ fields:
     - hide_sensitive
   _conf:
     timezone: America/Los_Angeles
+    timestamp_field: sys_updated_on

--- a/packages/servicenow/data_stream/event/agent/stream/aws-s3.yml.hbs
+++ b/packages/servicenow/data_stream/event/agent/stream/aws-s3.yml.hbs
@@ -30,17 +30,29 @@ api_timeout: {{api_timeout}}
 {{#if max_number_of_messages}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
+{{#if file_selectors}}
 file_selectors:
-{{#if bucket_list_prefix}}
-- regex: {{bucket_list_prefix}}
-  expand_event_list_from_field: result
-  content_type: application/json
+{{file_selectors}}
 {{/if}}
 
 {{/if}}
+
+{{#if decode_parquet_enabled}}
+decoding.codec.parquet.enabled: {{decode_parquet_enabled}}
+{{#if decoding_batch_size}}
+decoding.codec.parquet.batch_size: {{decoding_batch_size}}
+{{/if}}
+{{#if decoding_process_parallel}}
+decoding.codec.parquet.process_parallel: {{decoding_process_parallel}}
+{{/if}}
+
+{{else}}
 
 expand_event_list_from_field: result
 content_type: application/json
+
+{{/if}}
+
 {{#if access_key_id}}
 access_key_id: {{access_key_id}}
 {{/if}}
@@ -97,6 +109,7 @@ fields_under_root: true
 fields:
   _conf:
     timezone: {{timezone}}
+    timestamp_field: {{timestamp_field}}
     table_name: {{table_name}}
 {{#if processors}}
 processors:

--- a/packages/servicenow/data_stream/event/agent/stream/aws-s3.yml.hbs
+++ b/packages/servicenow/data_stream/event/agent/stream/aws-s3.yml.hbs
@@ -39,11 +39,11 @@ file_selectors:
 
 {{#if decode_parquet_enabled}}
 decoding.codec.parquet.enabled: {{decode_parquet_enabled}}
-{{#if decoding_batch_size}}
-decoding.codec.parquet.batch_size: {{decoding_batch_size}}
+{{#if decoding_parquet_batch_size}}
+decoding.codec.parquet.batch_size: {{decoding_parquet_batch_size}}
 {{/if}}
-{{#if decoding_process_parallel}}
-decoding.codec.parquet.process_parallel: {{decoding_process_parallel}}
+{{#if decoding_parquet_process_parallel}}
+decoding.codec.parquet.process_parallel: {{decoding_parquet_process_parallel}}
 {{/if}}
 
 {{else}}

--- a/packages/servicenow/data_stream/event/agent/stream/cel.yml.hbs
+++ b/packages/servicenow/data_stream/event/agent/stream/cel.yml.hbs
@@ -20,8 +20,10 @@ state:
   table_name: {{table_name}}
   batch_size: {{batch_size}}
   initial_interval: {{initial_interval}}
+  timestamp_field: {{timestamp_field}}
 regexp:
   next_link: '<([^,]*)>;rel="next"'
+  content: 'text/html'
 redact:
   fields: ~
 program: |
@@ -32,10 +34,10 @@ program: |
           "sysparm_display_value": ["all"],
           "sysparm_exclude_reference_link": ["true"],
           "sysparm_limit": [string(state.batch_size)],
-          "sysparm_query": ["ORDERBYsys_updated_on^sys_updated_on>"+start],
+          "sysparm_query": ["ORDERBY"+state.timestamp_field+"^"+state.timestamp_field+">"+start],
         }.format_query()
       )
-    )).as(resp, resp.StatusCode == 200 ?
+    )).as(resp, resp.StatusCode == 200 && (resp.Header["Content-Type"][0].re_find_submatch("content") == []) ?
       (
         (has(resp.?Header.Link) && size(resp.Header.Link) != 0) ?
           resp.Header.Link[0].re_find_submatch("next_link")[?1]
@@ -49,20 +51,14 @@ program: |
             "message": modEvt.encode_json()
           })),
           "cursor": {
-            "last_event": (
-              has(body.result) && size(body.result) > 0 ?
-                (
-                  has(state.?cursor.last_event) ?
-                    max([body.result.map(e, e.sys_updated_on.value).max(), state.cursor.last_event])
-                  :
-                    body.result.map(e, e.sys_updated_on.value).max()
-                )
-              :
-                state.?cursor.last_event.orValue(now)
-            ),
+            "last_event": (body.?result.orValue([]).map(r,
+              state.timestamp_field in r && has(r[state.timestamp_field].value),
+              r[state.timestamp_field].value
+            )+[state.?cursor.last_event.orValue(now)]).max(),
             ?"next_page": next_page,
           },
           "want_more": next_page.hasValue() && body.?result.orValue([]).size() != 0,
+          "timestamp_field": state.timestamp_field,
         })
       )
     :
@@ -80,6 +76,7 @@ program: |
           },
         },
         "want_more": false,
+        "timestamp_field": state.timestamp_field,
       }
     )
   )
@@ -105,6 +102,7 @@ publisher_pipeline.disable_host: true
 fields_under_root: true
 fields:
   _conf:
+    timestamp_field: {{timestamp_field}}
     timezone: {{timezone}}
 {{#if processors}}
 processors:

--- a/packages/servicenow/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/servicenow/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -32,6 +32,21 @@ processors:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
+      field: _conf.timestamp_field
+      tag: rename_timestamp_field
+      target_field: temp
+      ignore_missing: true
+  - script:
+      lang: painless
+      tag: script_to_search_timestamp_field
+      description: Script to search timestamp field
+      if: ctx.servicenow?.event != null
+      source: >-
+        def obj = ctx.servicenow.event;
+        if (obj.containsKey(ctx.temp)) {
+            ctx.servicenow.event.timestamp_field = obj.get(ctx.temp);
+        }
+  - rename:
       field: _conf.table_name
       tag: rename_table_name
       target_field: servicenow.event.table_name
@@ -40,7 +55,7 @@ processors:
   - fingerprint:
       fields:
         - servicenow.event.sys_id.value
-        - servicenow.event.sys_updated_on.value
+        - servicenow.event.timestamp_field.value
         - servicenow.event.table_name
       target_field: _id
       ignore_missing: true
@@ -2866,8 +2881,8 @@ processors:
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_event_sys_updated_on_value
-      copy_from: servicenow.event.sys_updated_on.value
+      tag: set_@timestamp_from_event_timestamp_field_value
+      copy_from: servicenow.event.timestamp_field.value
       ignore_empty_value: true
   - convert:
       field: servicenow.event.port.value
@@ -3217,10 +3232,6 @@ processors:
       if: ctx.servicenow?.event?.table_name == 'task_ci'
   - remove:
       field:
-        - _conf.table_name
-      ignore_missing: true
-  - remove:
-      field:
         - servicenow.event.asset.display_value
         - servicenow.event.city.display_value
         - servicenow.event.company.display_value
@@ -3244,7 +3255,6 @@ processors:
         - servicenow.event.sys_created_on.value
         - servicenow.event.sys_id.display_value
         - servicenow.event.sys_tags.display_value
-        - servicenow.event.sys_updated_on.value
         - servicenow.event.time_zone.display_value
         - servicenow.event.dept_head.display_value
         - servicenow.event.severity.value
@@ -3256,8 +3266,11 @@ processors:
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
-      field: servicenow.event.table_name
-      tag: remove_event_table_name
+      field:
+        - servicenow.event.table_name
+        - temp
+        - servicenow.event.timestamp_field
+      tag: remove_non_required_fields
       ignore_missing: true
   - script:
       tag: script_to_drop_null_values

--- a/packages/servicenow/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/servicenow/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -31,11 +31,6 @@ processors:
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - rename:
-      field: _conf.timestamp_field
-      tag: rename_timestamp_field
-      target_field: temp
-      ignore_missing: true
   - script:
       lang: painless
       tag: script_to_search_timestamp_field
@@ -43,8 +38,8 @@ processors:
       if: ctx.servicenow?.event != null
       source: >-
         def obj = ctx.servicenow.event;
-        if (obj.containsKey(ctx.temp)) {
-            ctx.servicenow.event.timestamp_field = obj.get(ctx.temp);
+        if (obj.containsKey(ctx._conf.timestamp_field)) {
+            ctx.servicenow.event.timestamp_field = obj.get(ctx._conf.timestamp_field);
         }
   - rename:
       field: _conf.table_name
@@ -3268,7 +3263,7 @@ processors:
   - remove:
       field:
         - servicenow.event.table_name
-        - temp
+        - _conf.timestamp_field
         - servicenow.event.timestamp_field
       tag: remove_non_required_fields
       ignore_missing: true

--- a/packages/servicenow/data_stream/event/manifest.yml
+++ b/packages/servicenow/data_stream/event/manifest.yml
@@ -65,7 +65,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        description: Timestamp to store inside cursor to retrieve tables after intervals.
+        description: Name of the timestamp field from the table to store inside cursor to retrieve tables after intervals.
         default: sys_updated_on
       - name: hide_sensitive
         type: bool
@@ -332,22 +332,22 @@ streams:
         show_user: true
         default: false
         description: The parquet codec is used to decode parquet compressed data streams.
-      - name: decoding_batch_size
+      - name: decoding_parquet_batch_size
         type: integer
         title: Batch Size of Parquet Decoding
         multi: false
         required: false
         show_user: false
         default: 1
-        description: The batch_size attribute can be used to specify the number of records to read from the parquet stream at a time.
-      - name: decoding_process_parallel
+        description: Number of records to read from the parquet stream at a time.
+      - name: decoding_parquet_process_parallel
         required: false
         show_user: false
         title: Process Parellel of Parquet Decoding
         type: bool
         multi: false
         default: false
-        description: If the process_parallel attribute is set to true then functions which read multiple columns will read those columns in parallel from the parquet stream with a number of readers equal to the number of columns.
+        description: If set to true, functions which read multiple columns will read those columns in parallel from the parquet stream with a number of readers equal to the number of columns. See [Parquet Codec](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#attrib-decoding-parquet) for details.
       - name: table_name
         type: text
         title: Table Name
@@ -361,7 +361,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        description: Timestamp to store inside cursor to retrieve tables after intervals.
+        description: Name of the timestamp field from the table to store inside cursor to retrieve tables after intervals.
         default: sys_updated_on
       - name: hide_sensitive
         type: bool

--- a/packages/servicenow/data_stream/event/manifest.yml
+++ b/packages/servicenow/data_stream/event/manifest.yml
@@ -3,7 +3,7 @@ type: logs
 streams:
   - input: cel
     title: ServiceNow tables
-    description: Collect tables from ServiceNow instance via API.
+    description: Collect tables from ServiceNow.
     template_path: cel.yml.hbs
     enabled: false
     vars:
@@ -59,6 +59,14 @@ streams:
         multi: false
         required: true
         show_user: true
+      - name: timestamp_field
+        type: text
+        title: Timestamp Field
+        multi: false
+        required: true
+        show_user: true
+        description: Timestamp to store inside cursor to retrieve tables after intervals.
+        default: sys_updated_on
       - name: hide_sensitive
         type: bool
         title: Hide Sensitive Details
@@ -214,7 +222,7 @@ streams:
   - input: aws-s3
     template_path: aws-s3.yml.hbs
     title: ServiceNow tables
-    description: Collect tables from ServiceNow instance via AWS S3 or SQS.
+    description: Collect tables from ServiceNow.
     enabled: false
     vars:
       - name: collect_s3_logs
@@ -225,20 +233,6 @@ streams:
         type: bool
         multi: false
         default: false
-      - name: bucket_arn
-        type: text
-        title: '[S3] Bucket ARN'
-        multi: false
-        required: false
-        show_user: true
-        description: It is a required parameter for collecting logs via the AWS S3 Bucket.
-      - name: queue_url
-        type: text
-        title: '[SQS] Queue URL'
-        multi: false
-        required: false
-        show_user: true
-        description: URL of the AWS SQS queue that messages will be received from. It is a required parameter for collecting logs via the AWS SQS.
       - name: access_key_id
         type: password
         title: Access Key ID
@@ -263,20 +257,27 @@ streams:
         show_user: true
         description: Required when using temporary security credentials.
         secret: true
+      - name: bucket_arn
+        type: text
+        title: '[S3] Bucket ARN'
+        multi: false
+        required: false
+        show_user: true
+        description: It is a required parameter for collecting logs via the AWS S3 Bucket.
       - name: bucket_list_prefix
         type: text
         title: "Bucket Prefix"
         multi: false
-        required: true
+        required: false
         show_user: true
-        description: Prefix to fetch data from AWS S3 bucket or AWS SQS queue.
-      - name: table_name
+        description: Prefix to apply for the list request to the S3 bucket.
+      - name: queue_url
         type: text
-        title: Table Name
-        description: Name of the table from which to retrieve the records.
+        title: '[SQS] Queue URL'
         multi: false
-        required: true
+        required: false
         show_user: true
+        description: URL of the AWS SQS queue that messages will be received from. It is a required parameter for collecting logs via the AWS SQS.
       - name: interval
         type: text
         title: '[S3] Interval'
@@ -285,6 +286,83 @@ streams:
         show_user: true
         default: 1m
         description: 'Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.'
+      - name: number_of_workers
+        type: integer
+        title: '[S3] Number of Workers'
+        multi: false
+        required: false
+        show_user: true
+        default: 5
+        description: Number of workers that will process the S3 objects listed.
+      - name: visibility_timeout
+        type: text
+        title: '[SQS] Visibility Timeout'
+        multi: false
+        required: false
+        show_user: true
+        default: 300s
+        description: 'The duration that the received messages are hidden from subsequent retrieve requests after being retrieved by a ReceiveMessage request. The maximum is 12 hours. NOTE: Supported units for this parameter are h/m/s.'
+      - name: api_timeout
+        type: text
+        title: '[SQS] API Timeout'
+        multi: false
+        required: false
+        show_user: true
+        default: 120s
+        description: 'The maximum duration of AWS API can take. The maximum is half of the visibility timeout value. Supported units for this parameter are h/m/s.'
+      - name: region
+        type: text
+        title: "[SQS] Region"
+        multi: false
+        required: false
+        show_user: true
+        description: The name of the AWS region of the end point. If this option is given it takes precedence over the region name obtained from the queue_url value. It is a required parameter for collecting logs via the AWS SQS.
+      - name: max_number_of_messages
+        type: integer
+        title: '[SQS] Maximum Concurrent SQS Messages'
+        required: false
+        show_user: true
+        default: 5
+        description: The maximum number of SQS messages that can be inflight at any time.
+      - name: decode_parquet_enabled
+        type: bool
+        title: Parquet Codec
+        multi: false
+        required: false
+        show_user: true
+        default: false
+        description: The parquet codec is used to decode parquet compressed data streams.
+      - name: decoding_batch_size
+        type: integer
+        title: Batch Size of Parquet Decoding
+        multi: false
+        required: false
+        show_user: false
+        default: 1
+        description: The batch_size attribute can be used to specify the number of records to read from the parquet stream at a time.
+      - name: decoding_process_parallel
+        required: false
+        show_user: false
+        title: Process Parellel of Parquet Decoding
+        type: bool
+        multi: false
+        default: false
+        description: If the process_parallel attribute is set to true then functions which read multiple columns will read those columns in parallel from the parquet stream with a number of readers equal to the number of columns.
+      - name: table_name
+        type: text
+        title: Table Name
+        description: Name of the table from which to retrieve the records.
+        multi: false
+        required: true
+        show_user: true
+      - name: timestamp_field
+        type: text
+        title: Timestamp Field
+        multi: false
+        required: true
+        show_user: true
+        description: Timestamp to store inside cursor to retrieve tables after intervals.
+        default: sys_updated_on
       - name: hide_sensitive
         type: bool
         title: Hide Sensitive Details
@@ -353,14 +431,6 @@ streams:
             text: US/Mountain
           - value: US/Pacific
             text: US/Pacific
-      - name: number_of_workers
-        type: integer
-        title: '[S3] Number of Workers'
-        multi: false
-        required: false
-        show_user: true
-        default: 5
-        description: Number of workers that will process the S3 objects listed.
       - name: shared_credential_file
         type: text
         title: Shared Credential File
@@ -404,36 +474,13 @@ streams:
         required: false
         show_user: false
         description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>. Please ensure your username and password are in URL encoded format.
-      - name: visibility_timeout
-        type: text
-        title: '[SQS] Visibility Timeout'
+      - name: file_selectors
+        type: yaml
+        title: "[SQS] File Selectors"
         multi: false
         required: false
-        show_user: true
-        default: 300s
-        description: 'The duration that the received messages are hidden from subsequent retrieve requests after being retrieved by a ReceiveMessage request. The maximum is 12 hours. NOTE: Supported units for this parameter are h/m/s.'
-      - name: api_timeout
-        type: text
-        title: '[SQS] API Timeout'
-        multi: false
-        required: false
-        show_user: true
-        default: 120s
-        description: 'The maximum duration of AWS API can take. The maximum is half of the visibility timeout value. Supported units for this parameter are h/m/s.'
-      - name: region
-        type: text
-        title: "[SQS] Region"
-        multi: false
-        required: false
-        show_user: true
-        description: The name of the AWS region of the end point. If this option is given it takes precedence over the region name obtained from the queue_url value. It is a required parameter for collecting logs via the AWS SQS.
-      - name: max_number_of_messages
-        type: integer
-        title: '[SQS] Maximum Concurrent SQS Messages'
-        required: false
-        show_user: true
-        default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        show_user: false
+        description: If the SQS queue will have events that correspond to files that this integration shouldn't process, file_selectors can be used to limit the files that are downloaded. This is a list of selectors which are made up of regex and expand_event_list_from_field options. The regex should match the S3 object key in the SQS message, and the optional expand_event_list_from_field is the same as the global setting. If file_selectors is given, then any global expand_event_list_from_field value is ignored in favor of the ones specified in the file_selectors. Regexes use [RE2 syntax](https://pkg.go.dev/regexp/syntax). Files that don’t match one of the regexes will not be processed.
       - name: tags
         type: text
         title: Tags

--- a/packages/servicenow/data_stream/event/manifest.yml
+++ b/packages/servicenow/data_stream/event/manifest.yml
@@ -3,7 +3,7 @@ type: logs
 streams:
   - input: cel
     title: ServiceNow tables
-    description: Collect table logs from ServiceNow instance via API.
+    description: Collect tables from ServiceNow instance via API.
     template_path: cel.yml.hbs
     enabled: false
     vars:
@@ -214,7 +214,7 @@ streams:
   - input: aws-s3
     template_path: aws-s3.yml.hbs
     title: ServiceNow tables
-    description: Collect table logs from ServiceNow instance via AWS S3 or SQS.
+    description: Collect tables from ServiceNow instance via AWS S3 or SQS.
     enabled: false
     vars:
       - name: collect_s3_logs

--- a/packages/servicenow/data_stream/event/sample_event.json
+++ b/packages/servicenow/data_stream/event/sample_event.json
@@ -1,22 +1,22 @@
 {
     "@timestamp": "2024-09-24T05:39:40.000Z",
     "agent": {
-        "ephemeral_id": "aba7282e-8755-44b7-bf51-aab726b3bb4d",
-        "id": "243ebe11-4a3c-4c33-8b0b-2df4c8097581",
+        "ephemeral_id": "46c20579-a05b-4d10-9050-910b0357621f",
+        "id": "7415adc4-fbf0-4c7e-9a6c-1d225d2f823b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.14.0"
     },
     "data_stream": {
         "dataset": "servicenow.event",
-        "namespace": "38350",
+        "namespace": "14470",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "243ebe11-4a3c-4c33-8b0b-2df4c8097581",
+        "id": "7415adc4-fbf0-4c7e-9a6c-1d225d2f823b",
         "snapshot": false,
         "version": "8.14.0"
     },
@@ -29,7 +29,7 @@
         "created": "2016-12-12T15:19:57.000Z",
         "dataset": "servicenow.event",
         "id": "1c741bd70b2322007518478d83673af3",
-        "ingested": "2024-11-01T08:19:10Z",
+        "ingested": "2024-11-13T11:04:01Z",
         "kind": "event",
         "severity": 3,
         "timezone": "America/Los_Angeles",
@@ -103,7 +103,8 @@
                 "value": "admin"
             },
             "sys_updated_on": {
-                "display_value": "2024-09-23T22:39:40.000-07:00"
+                "display_value": "2024-09-23T22:39:40.000-07:00",
+                "value": "2024-09-24T05:39:40.000Z"
             }
         }
     },

--- a/packages/servicenow/docs/README.md
+++ b/packages/servicenow/docs/README.md
@@ -4,12 +4,12 @@
 
 [ServiceNow](https://www.servicenow.com/?state=seamless) is a cloud-based platform that helps organizations improve their workflows and business processes, mainly in IT service management. It offers features like workflow automation, a self-service portal for users, integration with other systems, and helpful reporting tools.
 
-ServiceNow uses tables to store data, making it easy to manage and retrieve information. A key part of the platform is the [Configuration Management Database](https://www.servicenow.com/products/servicenow-platform/configuration-management-database.html) (CMDB), which keeps track of IT assets and how they are connected. This helps organizations monitor changes, manage configurations, and ensure reliable services. Overall, ServiceNow boosts efficiency, visibility, and user satisfaction, making it a popular choice for various industries.
+ServiceNow uses tables to store data, making it easy to manage and retrieve information. A key part of the platform is the [Configuration Management Database](https://www.servicenow.com/products/servicenow-platform/configuration-management-database.html) (CMDB), which keeps track of IT assets and how they are connected.
 
 The ServiceNow integration can be used in three different modes to collect logs:
-- AWS S3 polling mode: ServiceNow writes data to S3, and Elastic Agent polls the S3 bucket by listing its contents and reading new files. Refer to the [ServiceNow documentation](https://www.servicenow.com/community/now-platform-forum/aws-s3-integration-with-servicenow/td-p/1121852) for how to integrate AWS S3 with ServiceNow for retrieving logs into an S3 bucket.
-- AWS S3 SQS mode: ServiceNow writes data to S3; S3 sends a notification of a new object to SQS; the Elastic Agent receives the notification from SQS and then reads the S3 object. Multiple agents can be used in this mode.
-- REST API mode: ServiceNow offers table APIs to retrieve data from its tables; the Elastic Agent polls these APIs to list their contents and read any new data. Visit this [page](https://developer.servicenow.com/dev.do#!/reference/api/washingtondc/rest/c_TableAPI#table-GET) for additional information about REST APIs.
+- **AWS S3 polling mode**: ServiceNow writes data to S3, and Elastic Agent polls the S3 bucket by listing its contents and reading new files. Refer to the [ServiceNow documentation](https://www.servicenow.com/community/now-platform-forum/aws-s3-integration-with-servicenow/td-p/1121852) for how to integrate AWS S3 with ServiceNow for retrieving logs into an S3 bucket.
+- **AWS S3 SQS mode**: ServiceNow writes data to S3; S3 sends a notification of a new object to SQS; the Elastic Agent receives the notification from SQS and then reads the S3 object. Multiple agents can be used in this mode.
+- **REST API mode**: ServiceNow offers table APIs to retrieve data from its tables; the Elastic Agent polls these APIs to list their contents and read any new data. Visit this [page](https://developer.servicenow.com/dev.do#!/reference/api/washingtondc/rest/c_TableAPI#table-GET) for additional information about REST APIs.
 
 ## Compatibility
 
@@ -55,7 +55,7 @@ Below is a list of the default ones.
 **Note**:
 
 1. This integration currently supports ECS mapping for default ServiceNow tables listed above. For custom tables created by users, ECS mapping is not automatically provided. If you want to add mappings for custom tables, please refer to this [tutorial guide](https://www.elastic.co/guide/en/fleet/current/data-streams-pipeline-tutorial.html).
-2. For each table, a tag will be added based on the name of the table from which data is fetched.
+2. A tag will be added to each table based on its name. For example, if logs are ingested from the `alm_hardware` table, users can view them in Discover by using the query `tags: "alm_hardware"`.
 
 ## Requirements
 
@@ -114,27 +114,34 @@ There are some minimum requirements for running Elastic Agent. For more informat
 3. Click on the "ServiceNow" integration from the search results.
 4. Click on the "Add ServiceNow" button to add the integration.
 5. While adding the integration, if you want to collect logs via REST API, then you have to put the following details:
+   - collect logs via REST API toggled on
    - API URL
    - username
    - password
    - table name
+   - timestamp field
    - timezone
-   - collect logs via REST API toggled on
 
    or if you want to collect logs via AWS S3, then you have to put the following details:
+   - collect logs via S3 Bucket toggled on
    - access key id
    - secret access key
    - bucket arn
+   - table name
+   - timestamp field
    - timezone
-   - collect logs via S3 Bucket toggled on
 
    or if you want to collect logs via AWS SQS, then you have to put the following details:
+   - collect logs via S3 Bucket toggled off
    - access key id
    - secret access key
    - queue url
+   - table name
+   - timestamp field
    - timezone
-   - collect logs via S3 Bucket toggled off
 6. Click on "Save and Continue" to save the integration.
+
+**Note**: To fetch parquet file data, enable the toggle, `Parquet Codec`
 
 ## Logs Reference
 
@@ -150,22 +157,22 @@ An example event for `event` looks as following:
 {
     "@timestamp": "2024-09-24T05:39:40.000Z",
     "agent": {
-        "ephemeral_id": "aba7282e-8755-44b7-bf51-aab726b3bb4d",
-        "id": "243ebe11-4a3c-4c33-8b0b-2df4c8097581",
+        "ephemeral_id": "46c20579-a05b-4d10-9050-910b0357621f",
+        "id": "7415adc4-fbf0-4c7e-9a6c-1d225d2f823b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.14.0"
     },
     "data_stream": {
         "dataset": "servicenow.event",
-        "namespace": "38350",
+        "namespace": "14470",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "243ebe11-4a3c-4c33-8b0b-2df4c8097581",
+        "id": "7415adc4-fbf0-4c7e-9a6c-1d225d2f823b",
         "snapshot": false,
         "version": "8.14.0"
     },
@@ -178,7 +185,7 @@ An example event for `event` looks as following:
         "created": "2016-12-12T15:19:57.000Z",
         "dataset": "servicenow.event",
         "id": "1c741bd70b2322007518478d83673af3",
-        "ingested": "2024-11-01T08:19:10Z",
+        "ingested": "2024-11-13T11:04:01Z",
         "kind": "event",
         "severity": 3,
         "timezone": "America/Los_Angeles",
@@ -252,7 +259,8 @@ An example event for `event` looks as following:
                 "value": "admin"
             },
             "sys_updated_on": {
-                "display_value": "2024-09-23T22:39:40.000-07:00"
+                "display_value": "2024-09-23T22:39:40.000-07:00",
+                "value": "2024-09-24T05:39:40.000Z"
             }
         }
     },

--- a/packages/servicenow/docs/README.md
+++ b/packages/servicenow/docs/README.md
@@ -13,7 +13,7 @@ The ServiceNow integration can be used in three different modes to collect logs:
 
 ## Compatibility
 
-This module has been tested against the latest (updated Aug 1, 2024) ServiceNow API.
+This module has been tested with the latest(updated as of August 1, 2024) version of Xanadu on ServiceNow.
 
 ## Data streams
 

--- a/packages/servicenow/kibana/dashboard/servicenow-e6093b0d-38a6-4b05-8354-4bbaef28b667.json
+++ b/packages/servicenow/kibana/dashboard/servicenow-e6093b0d-38a6-4b05-8354-4bbaef28b667.json
@@ -43,7 +43,7 @@
             },
             "showApplySelections": false
         },
-        "description": "This dashboard shows Knowledge Table logs collected by the ServiceNow integration.",
+        "description": "This dashboard shows Knowledge Table collected by the ServiceNow integration.",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [

--- a/packages/servicenow/manifest.yml
+++ b/packages/servicenow/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: servicenow
 title: "ServiceNow"
-version: 0.1.0
+version: 0.1.1
 description: "Collect logs from ServiceNow with Elastic Agent."
 type: integration
 categories:

--- a/packages/servicenow/manifest.yml
+++ b/packages/servicenow/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: servicenow
 title: "ServiceNow"
-version: 0.1.1
+version: 0.2.0
 description: "Collect logs from ServiceNow with Elastic Agent."
 type: integration
 categories:

--- a/packages/servicenow/manifest.yml
+++ b/packages/servicenow/manifest.yml
@@ -71,11 +71,11 @@ policy_templates:
     description: Collect ServiceNow logs.
     inputs:
       - type: cel
-        title: Collect ServiceNow table logs via API
-        description: Collect table logs from ServiceNow instance via API.
+        title: Collect ServiceNow tables via API
+        description: Collect tables from ServiceNow instance via API.
       - type: aws-s3
-        title: Collect ServiceNow table logs via AWS S3 or AWS SQS
-        description: Collect table logs from ServiceNow instance via AWS S3 or AWS SQS.
+        title: Collect ServiceNow tables via AWS S3 or AWS SQS
+        description: Collect tables from ServiceNow instance via AWS S3 or AWS SQS.
 owner:
   github: elastic/security-service-integrations
   type: elastic


### PR DESCRIPTION
Type of change
- Enhancement

## Proposed commit message

- Add support for the timestamp_field input from the user to store inside cursor for data retrieval after intervals and also map with the `@timestamp` field.
- Provide support for ingesting Parquet files through AWS S3 or SQS.
- Add product version in the Readme.
- Remove `logs` keyword from the description on configuration page.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install the elastic package locally.
- Start the elastic stack using the elastic package.
- Move to integrations/packages/servicenow directory.
- Run the following command to run tests.

> elastic-package test
```
elastic-package test
2024/11/20 15:23:50  INFO New version is available - v0.107.1. Download from: https://github.com/elastic/elastic-package/releases/tag/v0.107.1
Run asset tests for the package
2024/11/20 15:23:50  INFO License text found in "/root/github/integrations/LICENSE.txt" will be included in package
--- Test results for package: servicenow - START ---
╭────────────┬─────────────┬───────────┬─────────────────────────────────────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE    │ DATA STREAM │ TEST TYPE │ TEST NAME                                                           │ RESULT │ TIME ELAPSED │
├────────────┼─────────────┼───────────┼─────────────────────────────────────────────────────────────────────┼────────┼──────────────┤
│ servicenow │             │ asset     │ dashboard servicenow-014c13b4-59bc-4bfa-bcb2-fdc1828020bf is loaded │ PASS   │       1.22µs │
│ servicenow │             │ asset     │ dashboard servicenow-0305f883-12a8-4021-af73-fbe05e797c3f is loaded │ PASS   │        232ns │
│ servicenow │             │ asset     │ dashboard servicenow-22d413b7-ffb5-450f-b5f8-7dcd54fab22f is loaded │ PASS   │        227ns │
│ servicenow │             │ asset     │ dashboard servicenow-297414cc-3b65-40b1-b15b-e33cf676b3bf is loaded │ PASS   │        222ns │
│ servicenow │             │ asset     │ dashboard servicenow-488772bc-4ce5-48c6-9e8a-d948439dbf39 is loaded │ PASS   │        237ns │
│ servicenow │             │ asset     │ dashboard servicenow-648308f9-ebdf-46fe-b6ce-b90dfcf2d1dd is loaded │ PASS   │        260ns │
│ servicenow │             │ asset     │ dashboard servicenow-b182c6a6-3b4e-413f-899d-dd255b1a3623 is loaded │ PASS   │        297ns │
│ servicenow │             │ asset     │ dashboard servicenow-b4795d3e-8c8b-48b2-900e-edc89db4d336 is loaded │ PASS   │        301ns │
│ servicenow │             │ asset     │ dashboard servicenow-d2eb3f0c-4ddb-4683-afab-2820d2616ca2 is loaded │ PASS   │        312ns │
│ servicenow │             │ asset     │ dashboard servicenow-d8977587-d9b4-4487-b321-a8402da07d48 is loaded │ PASS   │        328ns │
│ servicenow │             │ asset     │ dashboard servicenow-d929c3a1-7af8-428e-8357-8b2e8d3e3050 is loaded │ PASS   │        347ns │
│ servicenow │             │ asset     │ dashboard servicenow-e6093b0d-38a6-4b05-8354-4bbaef28b667 is loaded │ PASS   │        363ns │
│ servicenow │             │ asset     │ search servicenow-00004bce-eac2-46d4-bb4e-ce6849c50a36 is loaded    │ PASS   │        249ns │
│ servicenow │             │ asset     │ search servicenow-01396f16-041b-4ec5-b104-d29fe68f09ad is loaded    │ PASS   │        276ns │
│ servicenow │             │ asset     │ search servicenow-046f04ce-7f31-4929-81fa-34561fb369f0 is loaded    │ PASS   │        274ns │
│ servicenow │             │ asset     │ search servicenow-1c323098-190c-4592-aca5-dd9e64de540b is loaded    │ PASS   │        306ns │
│ servicenow │             │ asset     │ search servicenow-26f2b1af-7d7d-4578-b325-322ac4c783fa is loaded    │ PASS   │        324ns │
│ servicenow │             │ asset     │ search servicenow-44db573d-f3e6-4f59-b1a4-328040220991 is loaded    │ PASS   │        311ns │
│ servicenow │             │ asset     │ search servicenow-722e7751-818d-41e2-b7ac-fcc90bb8241b is loaded    │ PASS   │        305ns │
│ servicenow │             │ asset     │ search servicenow-a5b0060e-4ace-4c9f-96e1-2d815bc9dd28 is loaded    │ PASS   │        334ns │
│ servicenow │             │ asset     │ search servicenow-afa470f8-4e19-4fee-8b17-5649a7b0ae51 is loaded    │ PASS   │        343ns │
│ servicenow │             │ asset     │ search servicenow-b9cc24b4-0cfe-458c-8645-23838623ca09 is loaded    │ PASS   │        356ns │
│ servicenow │             │ asset     │ search servicenow-e28e5e66-d00d-4e2c-af2e-a09d0d261b05 is loaded    │ PASS   │        422ns │
│ servicenow │ event       │ asset     │ index_template logs-servicenow.event is loaded                      │ PASS   │        356ns │
│ servicenow │ event       │ asset     │ ingest_pipeline logs-servicenow.event-0.1.1 is loaded               │ PASS   │        182ns │
╰────────────┴─────────────┴───────────┴─────────────────────────────────────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: servicenow - END   ---
Done
Run pipeline tests for the package
--- Test results for package: servicenow - START ---
╭────────────┬─────────────┬───────────┬───────────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE    │ DATA STREAM │ TEST TYPE │ TEST NAME                                 │ RESULT │ TIME ELAPSED │
├────────────┼─────────────┼───────────┼───────────────────────────────────────────┼────────┼──────────────┤
│ servicenow │ event       │ pipeline  │ (ingest pipeline warnings test-event.log) │ PASS   │ 524.113373ms │
│ servicenow │ event       │ pipeline  │ test-event.log                            │ PASS   │ 2.781682512s │
╰────────────┴─────────────┴───────────┴───────────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: servicenow - END   ---
Done
Run policy tests for the package
--- Test results for package: servicenow - START ---
No test results
--- Test results for package: servicenow - END   ---
Done
Run static tests for the package
--- Test results for package: servicenow - START ---
╭────────────┬─────────────┬───────────┬──────────────────────────┬────────┬──────────────╮
│ PACKAGE    │ DATA STREAM │ TEST TYPE │ TEST NAME                │ RESULT │ TIME ELAPSED │
├────────────┼─────────────┼───────────┼──────────────────────────┼────────┼──────────────┤
│ servicenow │ event       │ static    │ Verify sample_event.json │ PASS   │  270.99497ms │
╰────────────┴─────────────┴───────────┴──────────────────────────┴────────┴──────────────╯
--- Test results for package: servicenow - END   ---
Done
Run system tests for the package
2024/11/20 15:24:17  INFO License text found in "/root/github/integrations/LICENSE.txt" will be included in package
2024/11/20 15:25:24  INFO Write container logs to file: /root/github/integrations/build/container-logs/servicenow-1732096524308361349.log
--- Test results for package: servicenow - START ---
╭────────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE    │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├────────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ servicenow │ event       │ system    │ default   │ PASS   │ 47.325079073s │
╰────────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: servicenow - END   ---
Done
``` 
