### PR TITLE
[claroty_ctd] Fixed batch size issue in data collection for asset and baseline data-streams.

### DIFF
--- a/packages/claroty_ctd/changelog.yml
+++ b/packages/claroty_ctd/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: 0.2.1
+- version: 0.1.2
   changes:
     - description: Fixed batch size issue in data collection for asset and baseline data-streams.
       type: bugfix

--- a/packages/claroty_ctd/changelog.yml
+++ b/packages/claroty_ctd/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fixed batch size issue in data collection for asset and baseline data-streams.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/11647
 - version: 0.1.1
   changes:
     - description: Ensure empty replacement is included in configuration.

--- a/packages/claroty_ctd/changelog.yml
+++ b/packages/claroty_ctd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.2.1
+  changes:
+    - description: Fixed batch size issue in data collection for asset and baseline data-streams.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: 0.1.1
   changes:
     - description: Ensure empty replacement is included in configuration.

--- a/packages/claroty_ctd/data_stream/asset/agent/stream/cel.yml.hbs
+++ b/packages/claroty_ctd/data_stream/asset/agent/stream/cel.yml.hbs
@@ -90,7 +90,7 @@ program: |
         : state.want_more && (int(state.counter) + int(body.?count_in_page.orValue(0))) < int(body.?count_total.orValue(-1)) ?
           optional.of(state.first_updated)
         :
-          optional.of(state.?cursor.last_updated),
+          state.?cursor.last_updated,
         "username" : state.username,
         "password" : state.password,
         "batch_size" : state.batch_size,

--- a/packages/claroty_ctd/data_stream/asset/agent/stream/cel.yml.hbs
+++ b/packages/claroty_ctd/data_stream/asset/agent/stream/cel.yml.hbs
@@ -90,7 +90,7 @@ program: |
         : state.want_more && (int(state.counter) + int(body.?count_in_page.orValue(0))) < int(body.?count_total.orValue(-1)) ?
           optional.of(state.first_updated)
         :
-          optional.of(state.cursor.last_updated),
+          optional.of(state.?cursor.last_updated),
         "username" : state.username,
         "password" : state.password,
         "batch_size" : state.batch_size,

--- a/packages/claroty_ctd/data_stream/baseline/agent/stream/cel.yml.hbs
+++ b/packages/claroty_ctd/data_stream/baseline/agent/stream/cel.yml.hbs
@@ -90,7 +90,7 @@ program: |
         : state.want_more && (int(state.counter) + int(body.?count_in_page.orValue(0))) < int(body.?count_total.orValue(-1)) ?
           optional.of(state.first_updated)
         :
-          optional.of(state.?cursor.last_updated),
+          state.?cursor.last_updated,
         "username" : state.username,
         "password" : state.password,
         "batch_size" : state.batch_size,

--- a/packages/claroty_ctd/data_stream/baseline/agent/stream/cel.yml.hbs
+++ b/packages/claroty_ctd/data_stream/baseline/agent/stream/cel.yml.hbs
@@ -90,7 +90,7 @@ program: |
         : state.want_more && (int(state.counter) + int(body.?count_in_page.orValue(0))) < int(body.?count_total.orValue(-1)) ?
           optional.of(state.first_updated)
         :
-          optional.of(state.cursor.last_updated),
+          optional.of(state.?cursor.last_updated),
         "username" : state.username,
         "password" : state.password,
         "batch_size" : state.batch_size,

--- a/packages/claroty_ctd/manifest.yml
+++ b/packages/claroty_ctd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.4
 name: claroty_ctd
 title: Claroty CTD
-version: 0.2.1
+version: 0.1.2
 description: Collect logs from Claroty CTD using Elastic Agent.
 type: integration
 categories:

--- a/packages/claroty_ctd/manifest.yml
+++ b/packages/claroty_ctd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.4
 name: claroty_ctd
 title: Claroty CTD
-version: 0.1.1
+version: 0.2.1
 description: Collect logs from Claroty CTD using Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Type of change
- Bugfix

## Proposed commit message

- Fixed batch size issue in data collection for asset and baseline data-streams.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install the elastic package locally.
- Start the elastic stack using the elastic package.
- Move to integrations/packages/claroty_ctd directory.
- Run the following command to run tests.

> elastic-package test
```
elastic-package test
2024/11/11 10:27:21  INFO New version is available - v0.106.0. Download from: https://github.com/elastic/elastic-package/releases/tag/v0.106.0
Run asset tests for the package
2024/11/11 10:27:21  INFO License text found in "/root/github/integrations/LICENSE.txt" will be included in package
--- Test results for package: claroty_ctd - START ---
╭─────────────┬─────────────┬───────────┬──────────────────────────────────────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE     │ DATA STREAM │ TEST TYPE │ TEST NAME                                                            │ RESULT │ TIME ELAPSED │
├─────────────┼─────────────┼───────────┼──────────────────────────────────────────────────────────────────────┼────────┼──────────────┤
│ claroty_ctd │             │ asset     │ dashboard claroty_ctd-0f0d9db1-dbf3-4d2f-b87c-c5d75e6ea62d is loaded │ PASS   │       1.28µs │
│ claroty_ctd │             │ asset     │ dashboard claroty_ctd-1051aba6-db32-473c-a24d-3b9200f22f17 is loaded │ PASS   │        250ns │
│ claroty_ctd │             │ asset     │ dashboard claroty_ctd-3ff35f11-fb3c-40b1-bb47-a0d5345fc0c7 is loaded │ PASS   │        215ns │
│ claroty_ctd │             │ asset     │ dashboard claroty_ctd-66d8c2cc-eeb7-420e-8c83-9c0cae66a7fe is loaded │ PASS   │        245ns │
│ claroty_ctd │             │ asset     │ dashboard claroty_ctd-a91b7c98-8dd4-479e-bc35-71641c85db97 is loaded │ PASS   │        225ns │
│ claroty_ctd │             │ asset     │ dashboard claroty_ctd-b7e0ad66-86c3-4b72-ae19-0576ed9fb1d6 is loaded │ PASS   │        271ns │
│ claroty_ctd │             │ asset     │ dashboard claroty_ctd-ce5edf6b-6671-4d1e-adc0-834a76ff9169 is loaded │ PASS   │        280ns │
│ claroty_ctd │             │ asset     │ dashboard claroty_ctd-e2106b06-3d16-4014-9343-f63ebb90a114 is loaded │ PASS   │        279ns │
│ claroty_ctd │             │ asset     │ search claroty_ctd-0cab445c-f2f9-4549-8224-2c66b114e973 is loaded    │ PASS   │        206ns │
│ claroty_ctd │             │ asset     │ search claroty_ctd-4c469790-a269-4d9f-8616-816379cbc3ad is loaded    │ PASS   │        225ns │
│ claroty_ctd │             │ asset     │ search claroty_ctd-9334e7c2-86b7-4aa4-8b0e-26b52c58bfd0 is loaded    │ PASS   │        258ns │
│ claroty_ctd │             │ asset     │ search claroty_ctd-afa635ef-ec61-44f6-8eb3-c61332a6f987 is loaded    │ PASS   │        234ns │
│ claroty_ctd │             │ asset     │ search claroty_ctd-d7b4f221-71ef-4c93-b875-d03cd10a6743 is loaded    │ PASS   │        249ns │
│ claroty_ctd │ asset       │ asset     │ index_template logs-claroty_ctd.asset is loaded                      │ PASS   │        130ns │
│ claroty_ctd │ asset       │ asset     │ ingest_pipeline logs-claroty_ctd.asset-0.1.2 is loaded               │ PASS   │        150ns │
│ claroty_ctd │ baseline    │ asset     │ index_template logs-claroty_ctd.baseline is loaded                   │ PASS   │        177ns │
│ claroty_ctd │ baseline    │ asset     │ ingest_pipeline logs-claroty_ctd.baseline-0.1.2 is loaded            │ PASS   │        123ns │
│ claroty_ctd │ event       │ asset     │ index_template logs-claroty_ctd.event is loaded                      │ PASS   │        227ns │
│ claroty_ctd │ event       │ asset     │ ingest_pipeline logs-claroty_ctd.event-0.1.2 is loaded               │ PASS   │        176ns │
╰─────────────┴─────────────┴───────────┴──────────────────────────────────────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: claroty_ctd - END   ---
Done
Run pipeline tests for the package
--- Test results for package: claroty_ctd - START ---
╭─────────────┬─────────────┬───────────┬──────────────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE     │ DATA STREAM │ TEST TYPE │ TEST NAME                                    │ RESULT │ TIME ELAPSED │
├─────────────┼─────────────┼───────────┼──────────────────────────────────────────────┼────────┼──────────────┤
│ claroty_ctd │ asset       │ pipeline  │ (ingest pipeline warnings test-asset.log)    │ PASS   │ 557.248316ms │
│ claroty_ctd │ asset       │ pipeline  │ test-asset.log                               │ PASS   │ 696.321011ms │
│ claroty_ctd │ baseline    │ pipeline  │ (ingest pipeline warnings test-baseline.log) │ PASS   │ 549.295864ms │
│ claroty_ctd │ baseline    │ pipeline  │ test-baseline.log                            │ PASS   │ 239.629156ms │
│ claroty_ctd │ event       │ pipeline  │ (ingest pipeline warnings test-event.json)   │ PASS   │ 521.381232ms │
│ claroty_ctd │ event       │ pipeline  │ test-event.json                              │ PASS   │ 380.909249ms │
╰─────────────┴─────────────┴───────────┴──────────────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: claroty_ctd - END   ---
Done
Run policy tests for the package
--- Test results for package: claroty_ctd - START ---
No test results
--- Test results for package: claroty_ctd - END   ---
Done
Run static tests for the package
--- Test results for package: claroty_ctd - START ---
╭─────────────┬─────────────┬───────────┬──────────────────────────┬────────┬──────────────╮
│ PACKAGE     │ DATA STREAM │ TEST TYPE │ TEST NAME                │ RESULT │ TIME ELAPSED │
├─────────────┼─────────────┼───────────┼──────────────────────────┼────────┼──────────────┤
│ claroty_ctd │ asset       │ static    │ Verify sample_event.json │ PASS   │ 155.397065ms │
│ claroty_ctd │ baseline    │ static    │ Verify sample_event.json │ PASS   │ 134.821166ms │
│ claroty_ctd │ event       │ static    │ Verify sample_event.json │ PASS   │ 183.772126ms │
╰─────────────┴─────────────┴───────────┴──────────────────────────┴────────┴──────────────╯
--- Test results for package: claroty_ctd - END   ---
Done
Run system tests for the package
2024/11/11 10:27:33  INFO License text found in "/root/github/integrations/LICENSE.txt" will be included in package
2024/11/11 10:28:25  INFO Write container logs to file: /root/github/integrations/build/container-logs/claroty-ctd-cel-1731301105235010769.log
2024/11/11 10:29:55  INFO Write container logs to file: /root/github/integrations/build/container-logs/claroty-ctd-cel-1731301195191156844.log
2024/11/11 10:31:22  INFO Write container logs to file: /root/github/integrations/build/container-logs/claroty-ctd-udp-1731301282807667755.log
2024/11/11 10:32:39  INFO Write container logs to file: /root/github/integrations/build/container-logs/claroty-ctd-tcp-1731301359103744950.log
--- Test results for package: claroty_ctd - START ---
╭─────────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE     │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├─────────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ claroty_ctd │ asset       │ system    │ asset     │ PASS   │   40.9970514s │
│ claroty_ctd │ baseline    │ system    │ baseline  │ PASS   │ 38.677870717s │
│ claroty_ctd │ event       │ system    │ tcp       │ PASS   │ 44.099375093s │
│ claroty_ctd │ event       │ system    │ udp       │ PASS   │ 46.730024481s │
╰─────────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: claroty_ctd - END   ---
Done
``` 
