### PR TITLE
[docker] use ecs definition of the 'event.dataset' field for container_logs

### DIFF
--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 2.12.0
+  changes:
+    - description: Use ecs definition of the 'event.dataset' field for container_logs.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/11196
 - version: 2.11.0
   changes:
     - description: Bump package-spec version to 3.2.2 to run on Serverless and stack version 9.0.

--- a/packages/docker/data_stream/container_logs/agent/stream/stream.yml.hbs
+++ b/packages/docker/data_stream/container_logs/agent/stream/stream.yml.hbs
@@ -16,3 +16,5 @@ parsers:
 processors:
 {{processors}}
 {{/if}}
+data_stream:
+  dataset: {{data_stream.dataset}}

--- a/packages/docker/data_stream/container_logs/fields/base-fields.yml
+++ b/packages/docker/data_stream/container_logs/fields/base-fields.yml
@@ -14,10 +14,6 @@
   type: constant_keyword
   description: Event module
   value: docker
-- name: event.dataset
-  type: constant_keyword
-  description: Event dataset
-  value: docker.container_logs
 - name: log.offset
   type: long
   description: Offset of the entry in the log file.

--- a/packages/docker/data_stream/container_logs/fields/ecs.yml
+++ b/packages/docker/data_stream/container_logs/fields/ecs.yml
@@ -36,3 +36,5 @@
   name: host.os.version
 - external: ecs
   name: host.type
+- external: ecs
+  name: event.dataset

--- a/packages/docker/data_stream/container_logs/manifest.yml
+++ b/packages/docker/data_stream/container_logs/manifest.yml
@@ -39,6 +39,14 @@ streams:
           #     pattern: '^\['
           #     negate: true
           #     match: after
+      - name: data_stream.dataset
+        type: text
+        title: 'Datasream Dataset name'
+        description: Name of Datastream dataset
+        multi: false
+        default: docker.container_logs
+        required: true
+        show_user: false
       - name: processors
         type: yaml
         title: Processors

--- a/packages/docker/docs/README.md
+++ b/packages/docker/docs/README.md
@@ -1132,7 +1132,7 @@ The Docker `container_logs` data stream collects container logs.
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
-| event.dataset | Event dataset | constant_keyword |
+| event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | keyword |
 | event.module | Event module | constant_keyword |
 | host | A host is defined as a general computing instance. ECS host.\* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes. | group |
 | host.architecture | Operating system architecture. | keyword |

--- a/packages/docker/manifest.yml
+++ b/packages/docker/manifest.yml
@@ -1,6 +1,6 @@
 name: docker
 title: Docker
-version: 2.11.0
+version: 2.12.0
 description: Collect metrics and logs from Docker instances with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

- WHAT: use ecs definition of the 'event.dataset' field for container_logs
- WHY:  There is no need to set event.dataset explicitly - this should be done on the elastic-agent side https://github.com/elastic/beats/pull/20076. This PR is similar to https://github.com/elastic/integrations/pull/7667

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
