### PR TITLE
[aws_logs] Move default_region configuration from the advanced options

### DIFF
--- a/packages/aws_logs/changelog.yml
+++ b/packages/aws_logs/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.4.1"
+  changes:
+    - description: Move default_region configuration from the advanced options
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10789
 - version: "1.4.0"
   changes:
     - description: Update file_selectors field to be able to receive multiline configuration 

--- a/packages/aws_logs/manifest.yml
+++ b/packages/aws_logs/manifest.yml
@@ -3,7 +3,7 @@ name: aws_logs
 title: Custom AWS Logs
 description: Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.
 type: integration
-version: "1.4.0"
+version: "1.4.1"
 categories:
   - observability
   - custom
@@ -81,7 +81,7 @@ vars:
     title: Default AWS Region
     multi: false
     required: false
-    show_user: false
+    show_user: true
     default: ""
     description: Default region to use prior to connecting to region specific services/endpoints if no AWS region is set from environment variable, credentials or instance profile. If none of the above are set and no default region is set as well, `us-east-1` is used. A region, either from environment variable, credentials or instance profile or from this default region setting, needs to be set when using regions in non-regular AWS environments such as AWS China or US Government Isolated.
   - name: proxy_url


### PR DESCRIPTION
## Proposed commit message

Please explain:

- WHAT: Move default_region configuration to the main configuration section from the advanced options
- WHY:  the download of objects (S3 polling) is silently failing without default_region set

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<img width="793" alt="Screenshot 2024-11-08 at 17 36 44" src="https://github.com/user-attachments/assets/ca49d486-43c6-4d17-b057-c4cfb9843874">

