### PR TITLE
[Custom AWS logs] Remove ingest pipeline option

### DIFF
--- a/packages/aws_logs/changelog.yml
+++ b/packages/aws_logs/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Remove ingest pipeline input option.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/10480
+      link: https://github.com/elastic/integrations/pull/11681
 - version: "1.4.0"
   changes:
     - description: Update file_selectors field to be able to receive multiline configuration 

--- a/packages/aws_logs/changelog.yml
+++ b/packages/aws_logs/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.4.1"
+  changes:
+    - description: Remove ingest pipeline input option.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10480
 - version: "1.4.0"
   changes:
     - description: Update file_selectors field to be able to receive multiline configuration 

--- a/packages/aws_logs/data_stream/generic/agent/stream/aws-cloudwatch.yml.hbs
+++ b/packages/aws_logs/data_stream/generic/agent/stream/aws-cloudwatch.yml.hbs
@@ -1,8 +1,5 @@
 data_stream:
   dataset: {{data_stream.dataset}}
-{{#if pipeline}}
-pipeline: {{pipeline}}
-{{/if}}
 
 {{#unless log_group_name}}
 {{#unless log_group_name_prefix}}

--- a/packages/aws_logs/data_stream/generic/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws_logs/data_stream/generic/agent/stream/aws-s3.yml.hbs
@@ -1,8 +1,5 @@
 data_stream:
   dataset: {{data_stream.dataset}}
-{{#if pipeline}}
-pipeline: {{pipeline}}
-{{/if}}
 
 {{! The aws-s3 input can be configured to read from an SQS queue or an S3 bucket. }}
 

--- a/packages/aws_logs/data_stream/generic/manifest.yml
+++ b/packages/aws_logs/data_stream/generic/manifest.yml
@@ -129,13 +129,6 @@ streams:
         description: >
           Set the name for your dataset. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
 
-      - name: pipeline
-        type: text
-        title: Ingest Pipeline
-        description: |
-          The Ingest Node pipeline ID to be used by the integration.
-        required: false
-        show_user: true
       - name: custom
         title: Custom configurations
         description: >
@@ -380,13 +373,6 @@ streams:
         description: >
           Set the name for your dataset. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
 
-      - name: pipeline
-        type: text
-        title: Ingest Pipeline
-        description: |
-          The Ingest Node pipeline ID to be used by the integration.
-        required: false
-        show_user: true
       - name: custom
         title: Custom configurations
         description: >

--- a/packages/aws_logs/manifest.yml
+++ b/packages/aws_logs/manifest.yml
@@ -3,7 +3,7 @@ name: aws_logs
 title: Custom AWS Logs
 description: Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.
 type: integration
-version: "1.4.0"
+version: "1.4.1"
 categories:
   - observability
   - custom


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Remove ingest pipeline option in config for custom aws logs integration. This option does not work, whatever is put in as the value for this config parameter, was being ignored. The way to change ingest pipeline is to choose `Add custom pipeline`:

<img width="546" alt="Screenshot 2024-11-08 at 2 33 53 PM" src="https://github.com/user-attachments/assets/613eb946-cc14-402f-b833-2393af0f38c2">

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Closes https://github.com/elastic/integrations/issues/10729