### PR TITLE
Universal Profiling Agent: add project_id

### DIFF
--- a/packages/universal_profiling_agent/agent/input/input.yml.hbs
+++ b/packages/universal_profiling_agent/agent/input/input.yml.hbs
@@ -5,3 +5,4 @@ pf-host-agent:
     probabilistic_threshold: {{profiler.probabilistic_threshold}}
     probabilistic_interval: {{profiler.probabilistic_interval}}
     disable_tls: {{profiler.disable_tls}}
+    project_id: {{profiler.project_id}}

--- a/packages/universal_profiling_agent/changelog.yml
+++ b/packages/universal_profiling_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 8.17.0
+  changes:
+    - description: Add project_id
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/11707
 - version: 8.14.0
   changes:
     - description: Update requirement text

--- a/packages/universal_profiling_agent/manifest.yml
+++ b/packages/universal_profiling_agent/manifest.yml
@@ -1,11 +1,11 @@
 name: profiler_agent
 title: Universal Profiling Agent
-version: 8.14.0
+version: 8.17.0
 categories: ["elastic_stack", "monitoring"]
 description: Fleet-wide, whole-system, continuous profiling with zero instrumentation.
 conditions:
   kibana:
-    version: ^8.13.2
+    version: ^8.17.0
   elastic:
     subscription: basic
 format_version: 3.0.2
@@ -62,6 +62,12 @@ policy_templates:
             show_user: true
             type: bool
             default: false
+          - name: profiler.project_id
+            title: Project ID
+            description: Splits profiling data into logical groups that you control.
+            show_user: true
+            type: integer
+            default: 1
     multiple: false
 agent:
   privileges:


### PR DESCRIPTION
## Proposed commit message

Add project ID as optional configuration option.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

