### PR TITLE
Add "Security Solution" tags to security-related CDR integrations

### DIFF
--- a/packages/prisma_cloud/changelog.yml
+++ b/packages/prisma_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/11716
 - version: "1.3.1"
   changes:
     - description: Fix null checks in the host_profile CEL program, simplify the host CEL expression.

--- a/packages/prisma_cloud/kibana/tags.yml
+++ b/packages/prisma_cloud/kibana/tags.yml
@@ -1,0 +1,4 @@
+- text: Security Solution
+  asset_types:
+    - dashboard
+    - search

--- a/packages/prisma_cloud/manifest.yml
+++ b/packages/prisma_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: prisma_cloud
 title: "Palo Alto Prisma Cloud"
-version: "1.3.1"
+version: "1.4.0"
 description: "Collect logs from Prisma Cloud with Elastic Agent."
 type: integration
 categories:

--- a/packages/wiz/changelog.yml
+++ b/packages/wiz/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.0"
+  changes:
+    - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/11716
 - version: "2.2.0"
   changes:
     - description: Default to vulnerable asset `id` when `provider_unique_id` is missing for resource.id field in the vulnerability data stream.

--- a/packages/wiz/kibana/tags.yml
+++ b/packages/wiz/kibana/tags.yml
@@ -1,0 +1,4 @@
+- text: Security Solution
+  asset_types:
+    - dashboard
+    - search

--- a/packages/wiz/manifest.yml
+++ b/packages/wiz/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: wiz
 title: Wiz
-version: "2.2.0"
+version: "2.3.0"
 description: Collect logs from Wiz with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Description

Adds tags.yml to all security integrations so that dashboards and saved searches are tagged with "Security Solution", and will be shown in the Security Solution UI.

Related integrations with "Security solution" tag:
- Added
  - [x] Wiz
  - [x] Prisma Cloud
- Pre-existent
  - [x] Google Security Command Center
  - [x] Microsoft Defender
  - [x] Qualys VMDR
  - [x] Tenable IO and SC
  - [x] Rapid7
  - [x] Snyk
  - [x] Amazon Security Lake
  - [x] VMware Carbon Black Cloud
  - [x] AWS Inspector & AWS Security Hub belong to `packages/aws` and they use `asset_ids`

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Testing

Follow these [guidelines](https://docs.elastic.dev/security-solution/cloud-security/qa/test-integration-package#build-and-test-with-the-local-elasticsearch-and-kibana) to install `elastic-package`, build the new packages and integrates them with your local ES & Kibana

## Related issues

- Closes https://github.com/elastic/kibana/issues/195968
- Relates to https://github.com/elastic/integrations/pull/7789 (here we're basically mimicking that change-set)

## Screenshots

I've got no Wiz-related data locally, but I do have it for Prisma Cloud and their tags config is the same:

<details><summary>Prisma Cloud</summary>
<img width="624" alt="Screenshot 2024-11-14 at 13 45 34" src="https://github.com/user-attachments/assets/7feb33ab-8415-4a37-8610-8d2692d23e78">
<img width="711" alt="Screenshot 2024-11-14 at 13 46 01" src="https://github.com/user-attachments/assets/2c472d99-4407-4f43-93fb-9dacabf58b9d">
</details> 

## Warnings

Running `elastic-package lint` returned these pre-existent warnings for the modified packages. Is this something we should worry about? The packages were eventually build successfully though:

**wiz**

> 2024/11/14 13:19:39  INFO Skipped errors: found 2 validation errors:
>    1. file "/Users/alberto/git/integrations/packages/wiz/kibana/dashboard/wiz-be3fd3f0-6358-11ee-9db4-21f79f2e6273.json" is invalid: expected filter in dashboard: no filter found and at least one panel does not have a filter (SVR00002)
>    2. file "/Users/alberto/git/integrations/packages/wiz/kibana/dashboard/wiz-d8f91a20-6363-11ee-a265-c3569aa0cebf.json" is invalid: expected filter in dashboard: no filter found and at least one panel does not have a filter (SVR00002)

**prisma_cloud**

> 2024/11/14 13:20:04  INFO Skipped errors: found 1 validation error:
>    1. references found in dashboard kibana/dashboard/prisma_cloud-19913580-7495-11ee-9d52-2d0fa627877e.json: prisma_cloud-d140b5e0-771d-11ee-b6b7-396983b7218f (search) (SVR00004)