### PR TITLE
Add log format option to all input configs

### DIFF
--- a/packages/proxysg/changelog.yml
+++ b/packages/proxysg/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add format config to all inputs
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/9999999
+      link: https://github.com/elastic/integrations/pull/11718
 - version: 0.3.0
   changes:
     - description: Do not do syslog parsing by default in TCP and UCP inputs

--- a/packages/proxysg/changelog.yml
+++ b/packages/proxysg/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.3.1
+  changes:
+    - description: Add format config to all inputs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999999
 - version: 0.3.0
   changes:
     - description: Do not do syslog parsing by default in TCP and UCP inputs

--- a/packages/proxysg/changelog.yml
+++ b/packages/proxysg/changelog.yml
@@ -2,7 +2,7 @@
 - version: 0.3.1
   changes:
     - description: Add format config to all inputs
-      type: enhancement
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/11718
 - version: 0.3.0
   changes:

--- a/packages/proxysg/data_stream/log/manifest.yml
+++ b/packages/proxysg/data_stream/log/manifest.yml
@@ -44,7 +44,9 @@ streams:
           - text: ssl
             value: ssl
         default: main
-        description: Log configuration type for input.
+        description: >
+          Log configuration type for input. For a description of the log formats see [here](https://techdocs.broadcom.com/us/en/symantec-security-software/web-and-network-security/edge-swg/7-3/getting-started/page-help-administration/page-help-logging/log-formats/default-formats.html).
+
         required: true
         show_user: true
       - name: processors
@@ -126,7 +128,9 @@ streams:
           - text: ssl
             value: ssl
         default: main
-        description: Log configuration type for input.
+        description: >
+          Log configuration type for input. For a description of the log formats see [here](https://techdocs.broadcom.com/us/en/symantec-security-software/web-and-network-security/edge-swg/7-3/getting-started/page-help-administration/page-help-logging/log-formats/default-formats.html).
+
         required: true
         show_user: true
   - input: tcp
@@ -207,8 +211,8 @@ streams:
           - text: ssl
             value: ssl
         default: main
-        required: true
         description: >
           Log configuration type for input. For a description of the log formats see [here](https://techdocs.broadcom.com/us/en/symantec-security-software/web-and-network-security/edge-swg/7-3/getting-started/page-help-administration/page-help-logging/log-formats/default-formats.html).
 
+        required: true
         show_user: true

--- a/packages/proxysg/data_stream/log/manifest.yml
+++ b/packages/proxysg/data_stream/log/manifest.yml
@@ -119,6 +119,12 @@ streams:
         options:
           - text: main
             value: main
+          - text: bcreportermain_v1
+            value: bcreportermain_v1
+          - text: bcreporterssl_v1
+            value: bcreporterssl_v1
+          - text: ssl
+            value: ssl
         default: main
         description: Log configuration type for input.
         required: true
@@ -194,6 +200,12 @@ streams:
         options:
           - text: main
             value: main
+          - text: bcreportermain_v1
+            value: bcreportermain_v1
+          - text: bcreporterssl_v1
+            value: bcreporterssl_v1
+          - text: ssl
+            value: ssl
         default: main
         required: true
         description: >

--- a/packages/proxysg/manifest.yml
+++ b/packages/proxysg/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.1
 name: proxysg
 title: "Broadcom ProxySG"
-version: 0.3.0
+version: 0.3.1
 source:
   license: "Elastic-2.0"
 description: "Collect access logs from Broadcom ProxySG with Elastic Agent."


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

In ProxySG integration, add new log format config options to all inputs. Previously, the new formats were added to only one input.  These config values need to exist on all inputs, so all can be configured to all supported log formats.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

