### PR TITLE
Set proper value for constant keyword in transform

### DIFF
--- a/packages/ti_anomali/elasticsearch/ingest_pipeline/latest_ioc.yml
+++ b/packages/ti_anomali/elasticsearch/ingest_pipeline/latest_ioc.yml
@@ -3,4 +3,4 @@ description: Prepare documents before ingestion for latest IoC.
 processors:
   - set:
       field: "labels.is_ioc_transform_source"
-      value: false
+      value: "false"

--- a/packages/ti_anomali/elasticsearch/ingest_pipeline/latest_ioc.yml
+++ b/packages/ti_anomali/elasticsearch/ingest_pipeline/latest_ioc.yml
@@ -1,0 +1,6 @@
+---
+description: Prepare documents before ingestion for latest IoC.
+processors:
+  - set:
+      field: "labels.is_ioc_transform_source"
+      value: false

--- a/packages/ti_anomali/elasticsearch/transform/latest_intelligence/transform.yml
+++ b/packages/ti_anomali/elasticsearch/transform/latest_intelligence/transform.yml
@@ -13,6 +13,7 @@ dest:
   aliases:
     - alias: "logs-ti_anomali_latest.intelligence"
       move_on_creation: true
+  pipeline: "1.23.0-latest_ioc" # Should be something like '{{ IngestPipeline "latest_ioc" }}'
 latest:
   unique_key:
     - event.dataset

--- a/packages/ti_anomali/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_anomali/elasticsearch/transform/latest_ioc/transform.yml
@@ -13,6 +13,7 @@ dest:
   aliases:
     - alias: "logs-ti_anomali_latest.threatstream"
       move_on_creation: true
+  pipeline: "1.23.0-latest_ioc" # Should be something like '{{ IngestPipeline "latest_ioc" }}'
 latest:
   unique_key:
     - event.dataset


### PR DESCRIPTION
Fix value of `labels.is_ioc_transform_source`, a constant keyword that has a different value in the source index.

See https://github.com/elastic/elastic-package/issues/2218#issuecomment-2477128353