### PR TITLE
cisco_duo: fix the parsing of last_published timestamp

### DIFF
--- a/packages/cisco_duo/changelog.yml
+++ b/packages/cisco_duo/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.5"
+  changes:
+    - description: Fix the parsing of last_published timestamp in Activity and Telephony data streams.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11772
 - version: "2.2.4"
   changes:
     - description: Fix the handling of details fields for Activity logs.

--- a/packages/cisco_duo/data_stream/activity/agent/stream/cel.yml.hbs
+++ b/packages/cisco_duo/data_stream/activity/agent/stream/cel.yml.hbs
@@ -28,10 +28,13 @@ program: |
             state
         :
             state.with({
-                "mintime": has(state.?cursor.last_published) ?
-                    string(int(state.cursor.last_published.parse_time(time_layout.RFC3339Nano)) * 1000)
-                :
-                    string(int(now - duration(state.initial_interval)) * 1000)
+                "mintime": string(1000 * int(
+                    state.?cursor.last_published.optMap(t,
+                        t.parse_time(time_layout.RFC3339Nano)
+                    ).orValue(
+                        now - duration(state.initial_interval)
+                    )
+                )),
             })
     ).as(state, state.with({
         // the duration between maxtime and mintime should be less than 180d to avoid error_code 400 from API.

--- a/packages/cisco_duo/data_stream/activity/agent/stream/cel.yml.hbs
+++ b/packages/cisco_duo/data_stream/activity/agent/stream/cel.yml.hbs
@@ -28,7 +28,10 @@ program: |
             state
         :
             state.with({
-                "mintime": string(int(state.?cursor.last_published.orValue(int(now - duration(state.initial_interval)) * 1000))),
+                "mintime": has(state.?cursor.last_published) ?
+                    string(int(state.cursor.last_published.parse_time(time_layout.RFC3339Nano)) * 1000)
+                :
+                    string(int(now - duration(state.initial_interval)) * 1000)
             })
     ).as(state, state.with({
         // the duration between maxtime and mintime should be less than 180d to avoid error_code 400 from API.

--- a/packages/cisco_duo/data_stream/telephony_v2/agent/stream/cel.yml.hbs
+++ b/packages/cisco_duo/data_stream/telephony_v2/agent/stream/cel.yml.hbs
@@ -28,7 +28,10 @@ program: |
             state
         :
             state.with({
-                "mintime": string(int(state.?cursor.last_published.orValue(int(now - duration(state.initial_interval)) * 1000))),
+                "mintime": has(state.?cursor.last_published) ?
+                    string(int(state.cursor.last_published.parse_time(time_layout.RFC3339Nano)) * 1000)
+                :
+                    string(int(now - duration(state.initial_interval)) * 1000)
             })
     ).as(state, state.with({
         // calculate maxtime to be the current time minus a buffer (2 minutes) to avoid potential synchronization issues.

--- a/packages/cisco_duo/data_stream/telephony_v2/agent/stream/cel.yml.hbs
+++ b/packages/cisco_duo/data_stream/telephony_v2/agent/stream/cel.yml.hbs
@@ -28,10 +28,13 @@ program: |
             state
         :
             state.with({
-                "mintime": has(state.?cursor.last_published) ?
-                    string(int(state.cursor.last_published.parse_time(time_layout.RFC3339Nano)) * 1000)
-                :
-                    string(int(now - duration(state.initial_interval)) * 1000)
+                "mintime": string(1000 * int(
+                    state.?cursor.last_published.optMap(t,
+                        t.parse_time(time_layout.RFC3339Nano)
+                    ).orValue(
+                        now - duration(state.initial_interval)
+                    )
+                )),
             })
     ).as(state, state.with({
         // calculate maxtime to be the current time minus a buffer (2 minutes) to avoid potential synchronization issues.

--- a/packages/cisco_duo/manifest.yml
+++ b/packages/cisco_duo/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cisco_duo
 title: Cisco Duo
-version: "2.2.4"
+version: "2.2.5"
 description: Collect logs from Cisco Duo with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

For Activity and Telephony data streams, the timestamp of the last event published is stored in the cursor state as a string with the format `2024-05-23T03:06:24.755940+00:00`, leading to the following error when populating `mintime`:
```
{"log.level":"debug","@timestamp":"2024-11-18T17:02:20.338Z","message":"response state","component":{"binary":"filebeat","dataset":"elastic_agent.filebeat","id":"cel-default","type":"cel"},"log":{"source":"cel-default"},"log.logger":"input.cel","log.origin":{"file.line":254,"file.name":"cel/input.go","function":"github.com/elastic/beats/v7/x-pack/filebeat/input/cel.input.run.func1"},"input_url":"https://api-<>.duosecurity.com","service.name":"filebeat","id":"cel-cisco_duo.activity-<>","input_source":"https://api-<>.duosecurity.com","cel":{"ecs.version":"1.6.0","state":"{\"cursor\":{\"last_published\":\"2024-05-23T03:06:24.755940+00:00\"},\"events\":{\"error\":{\"message\":\"failed eval: ERROR: \\u003cinput\\u003e:2:21: type conversion error from 'string' to 'int'\\n |     state.want_more ?\\n | ....................^\"}},\"initial_interval\":\"2160h\",\"integration_key\":\"*\",\"limit\":1000,\"secret_key\":\"*\",\"url\":\"https://api-<>.duosecurity.com\",\"want_more\":false}"},"ecs.version":"1.6.0"}
```

`last_published` needs to be parsed to a valid timestamp before the `int()` conversion.

This doesn't affect the rest of data streams where the last timestamp can be directly collected as an UNIX timestamp.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
