### PR TITLE
aws_inspector: add note about AWS Permissions and Role ARN support

### DIFF
--- a/packages/aws/_dev/build/docs/README.md
+++ b/packages/aws/_dev/build/docs/README.md
@@ -168,6 +168,7 @@ make sure these permissions are given:
 * `ec2:DescribeInstances`
 * `ec2:DescribeRegions`
 * `iam:ListAccountAliases`
+* `inspector2:ListFindings`
 * `logs:DescribeLogGroups`
 * `logs:FilterLogEvents`
 * `organizations:ListAccounts`

--- a/packages/aws/_dev/build/docs/inspector.md
+++ b/packages/aws/_dev/build/docs/inspector.md
@@ -21,6 +21,8 @@ The [AWS Inspector](https://docs.aws.amazon.com/inspector/) integration collects
 ## Note
 
   - For the current integration package, it is compulsory to add Secret Access Key and Access Key ID.
+  - This data stream doesn't support setting a Role ARN.
+  - Ensure your IAM has the `inspector2:ListFindings` permission granted. Without this permission, API requests will be denied.
 
 ## Logs
 

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.31.4"
+  changes:
+    - description: Update documentation with required permissions for AWS Inspector.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11794
 - version: "2.31.3"
   changes:
     - description: Removed the `reducedTimeRange` filter from the AWS Billing Total Estimated Charges lens to ensure value is displayed.

--- a/packages/aws/docs/README.md
+++ b/packages/aws/docs/README.md
@@ -168,6 +168,7 @@ make sure these permissions are given:
 * `ec2:DescribeInstances`
 * `ec2:DescribeRegions`
 * `iam:ListAccountAliases`
+* `inspector2:ListFindings`
 * `logs:DescribeLogGroups`
 * `logs:FilterLogEvents`
 * `organizations:ListAccounts`

--- a/packages/aws/docs/inspector.md
+++ b/packages/aws/docs/inspector.md
@@ -21,6 +21,8 @@ The [AWS Inspector](https://docs.aws.amazon.com/inspector/) integration collects
 ## Note
 
   - For the current integration package, it is compulsory to add Secret Access Key and Access Key ID.
+  - This data stream doesn't support setting a Role ARN.
+  - Ensure your IAM has the `inspector2:ListFindings` permission granted. Without this permission, API requests will be denied.
 
 ## Logs
 
@@ -355,3 +357,4 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | host.os.codename | OS codename, if any. | keyword |
 | input.type | Input type | keyword |
 | log.offset | Log offset | long |
+

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: aws
 title: AWS
-version: 2.31.3
+version: 2.31.4
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

`inspector2:ListFindings` is a required AWS permission for IAM users in order to avoid this error when enabling the Inspector data stream:
```
{\"message\":\"User: arn:aws:iam::123456789:user/service/elastic is not authorized to perform: inspector2:ListFindings on resource: arn:aws:inspector2:eu-west-1: 123456789:/findings/list\"}"
```
See https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoninspector2.html.

It also clarifies that `Role ARN`, which is a global setting for the AWS integration, is not supported for the Inspector data stream as it make requests to the Inspector API through HTTPJSON, while `Role ARN` is a setting for AWS-based inputs.
 
## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

