### PR TITLE
[cisco_ise] Revert mapping change for cisco_av_pair that was introduced with 1.24.1

### DIFF
--- a/packages/cisco_ise/changelog.yml
+++ b/packages/cisco_ise/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Revert mapping change for cisco_av_pair that was introduced with 1.24.1.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/666666
+      link: https://github.com/elastic/integrations/pull/11800
 - version: "1.24.1"
   changes:
     - description: Fix multiple pipeline processing issues.

--- a/packages/cisco_ise/changelog.yml
+++ b/packages/cisco_ise/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.24.2"
+  changes:
+    - description: Revert mapping change for cisco_av_pair that was introduced with 1.24.1.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/666666
 - version: "1.24.1"
   changes:
     - description: Fix multiple pipeline processing issues.

--- a/packages/cisco_ise/data_stream/log/_dev/test/pipeline/test-pipeline-passed-authentications.log-expected.json
+++ b/packages/cisco_ise/data_stream/log/_dev/test/pipeline/test-pipeline-passed-authentications.log-expected.json
@@ -1189,16 +1189,7 @@
                         "name": "CISE_Passed_Authentications"
                     },
                     "cisco_av_pair": {
-                        "audit-session-id": "CB7D4E0A00000FE896B0CB97",
-                        "client-iif-id": "483760223",
-                        "cts-pac-opaque": "****",
-                        "dc-certainty-metric": "0",
-                        "dc-device-class-tag": "Un-Classified Device",
-                        "dc-device-name": "Unknown Device",
-                        "dc-profile-name": "Un-Classified Device",
-                        "dc-protocol-map": "1",
-                        "method": "dot1x",
-                        "service-type": "Framed"
+                        "cts-pac-opaque": "****"
                     },
                     "client": {
                         "latency": 243

--- a/packages/cisco_ise/data_stream/log/elasticsearch/ingest_pipeline/pipeline_passed_authentications.yml
+++ b/packages/cisco_ise/data_stream/log/elasticsearch/ingest_pipeline/pipeline_passed_authentications.yml
@@ -143,16 +143,24 @@ processors:
   - script:
       tag: foreach_av_pair
       if: ctx.cisco_ise?.log?.log_details != null && ctx.cisco_ise.log.log_details['cisco-av-pair'] instanceof List
+      params:
+        'coa-push': true
+        'cts-device-capability': true
+        'cts-environment-data': true
+        'cts-environment-version': true
+        'cts-pac-opaque': true
       source: |-
         def m = new HashMap();
         for (val in ctx.cisco_ise.log.log_details['cisco-av-pair']) {
           int pos = val.indexOf("=");
           if (pos == -1) {
-            m[val] = null;
+            if(params.containsKey(val)) m[val] = null;
           } else {
-            m[val.substring(0,pos)] = val.substring(pos+1);
+            def key = val.substring(0,pos);
+            if(params.containsKey(key)) m[key] = val.substring(pos+1);
           }
         }
+        
         ctx.cisco_ise.log["cisco_av_pair"] = m;
   - kv:
       tag: kv_av_pair

--- a/packages/cisco_ise/data_stream/log/fields/fields.yml
+++ b/packages/cisco_ise/data_stream/log/fields/fields.yml
@@ -225,8 +225,18 @@
         - name: name
           type: keyword
     - name: cisco_av_pair
-      type: object
-      enabled: false
+      type: group
+      fields:
+        - name: coa-push
+          type: boolean
+        - name: cts-device-capability
+          type: keyword
+        - name: cts-environment-data
+          type: keyword
+        - name: cts-environment-version
+          type: keyword
+        - name: cts-pac-opaque
+          type: keyword
     - name: class
       type: keyword
     - name: client

--- a/packages/cisco_ise/docs/README.md
+++ b/packages/cisco_ise/docs/README.md
@@ -288,7 +288,11 @@ An example event for `log` looks as following:
 | cisco_ise.log.calling_station_id |  | keyword |
 | cisco_ise.log.category.name |  | keyword |
 | cisco_ise.log.cause |  | keyword |
-| cisco_ise.log.cisco_av_pair |  | object |
+| cisco_ise.log.cisco_av_pair.coa-push |  | boolean |
+| cisco_ise.log.cisco_av_pair.cts-device-capability |  | keyword |
+| cisco_ise.log.cisco_av_pair.cts-environment-data |  | keyword |
+| cisco_ise.log.cisco_av_pair.cts-environment-version |  | keyword |
+| cisco_ise.log.cisco_av_pair.cts-pac-opaque |  | keyword |
 | cisco_ise.log.class |  | keyword |
 | cisco_ise.log.client.latency |  | long |
 | cisco_ise.log.cmdset |  | keyword |

--- a/packages/cisco_ise/manifest.yml
+++ b/packages/cisco_ise/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ise
 title: Cisco ISE
-version: "1.24.1"
+version: "1.24.2"
 description: Collect logs from Cisco ISE with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

[cisco_ise] Revert mapping change for cisco_av_pair that was introduced with 1.24.1
https://github.com/elastic/integrations/pull/11619/files#diff-ce8c42e24fb4e94c7fb135eed466345a68c36cb91a247069fb9ea88312f97bbbL228

The mapping change in 1.24.1 causes the error, when the user tries to use to update to this version of integration
```
mapper_exception Root causes: mapper_exception the (enabled) parameter can't be upgraded for the object mapping [cisco_ise.log.cisco_av_pair].
```

Similar issue with Okta integration that happened earlier was mentioned here 
https://support.elastic.dev/knowledge/view/1a2f83e7
and the kibana ticket
https://github.com/elastic/kibana/issues/193044

The discussed and accepted solution is:
1. Revert the mapping change with this PR (next patch release)
2. Follow up with PR with the breaking mapping change with the next minor release of the package with constraint on 8.17 if the fix on Kibana side is added with 8.17. 

In addition, added a filtering code that ensures that only known mapped fields for `cisco_av_pair` namely:
```
coa-push
cts-device-capability
cts-environment-data
cts-environment-version
cts-pac-opaque
```
are indexed. All the other fields are discarded. The tests were failing otherwise for the new logs with the new key/values.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

