### PR TITLE
Fix broken link in Custom API using Common Expression Language

### DIFF
--- a/packages/httpjson/_dev/build/docs/README.md
+++ b/packages/httpjson/_dev/build/docs/README.md
@@ -4,7 +4,7 @@ The custom API input integration is used to ingest data from custom RESTful API'
 
 The input itself supports sending both GET and POST requests, transform requests and responses during runtime, paginate and keep a running state on information from the last collected events.
 
-If you are starting development of a new custom HTTP API input, we recommend that you use the [Common Expression Language input](../cel/overview) which provides greater flexibility and an improved developer experience.
+If you are starting development of a new custom HTTP API input, we recommend that you use the [Common Expression Language input](https://www.elastic.co/docs/current/integrations/cel) which provides greater flexibility and an improved developer experience.
 
 ## Configuration
 

--- a/packages/httpjson/changelog.yml
+++ b/packages/httpjson/changelog.yml
@@ -1,7 +1,7 @@
 - version: "1.21.1"
   changes:
     - description: Fix broken link in Custom API using Common Expression Language.
-      type: bug
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/11803
 - version: "1.21.0"
   changes:

--- a/packages/httpjson/changelog.yml
+++ b/packages/httpjson/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.21.1"
+  changes:
+    - description: Fix broken link in Custom API using Common Expression Language.
+      type: bug
+      link: https://github.com/elastic/integrations/pull/11803
 - version: "1.21.0"
   changes:
     - description: Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/httpjson/docs/README.md
+++ b/packages/httpjson/docs/README.md
@@ -4,7 +4,7 @@ The custom API input integration is used to ingest data from custom RESTful API'
 
 The input itself supports sending both GET and POST requests, transform requests and responses during runtime, paginate and keep a running state on information from the last collected events.
 
-If you are starting development of a new custom HTTP API input, we recommend that you use the [Common Expression Language input](../cel/overview) which provides greater flexibility and an improved developer experience.
+If you are starting development of a new custom HTTP API input, we recommend that you use the [Common Expression Language input](https://www.elastic.co/docs/current/integrations/cel) which provides greater flexibility and an improved developer experience.
 
 ## Configuration
 

--- a/packages/httpjson/manifest.yml
+++ b/packages/httpjson/manifest.yml
@@ -3,7 +3,7 @@ name: httpjson
 title: Custom API
 description: Collect custom events from an API endpoint with Elastic agent
 type: integration
-version: "1.21.0"
+version: "1.21.1"
 conditions:
   kibana:
     version: "^8.13.0"


### PR DESCRIPTION
This PR fixes a broken link on the [Custom API](https://www.elastic.co/docs/current/integrations/httpjson) doc page pointing to [Common Expression Language input](https://www.elastic.co/docs/current/cel/overview).

Relates to https://github.com/elastic/integration-docs/pull/579

