### PR TITLE
ti_misp: update the use of fingerprint processors

### DIFF
--- a/packages/ti_misp/changelog.yml
+++ b/packages/ti_misp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.35.8"
+  changes:
+    - description: Fix the handling of duplicated events with fingerprint processors.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11824
 - version: "1.35.7"
   changes:
     - description: Set request rate limits.

--- a/packages/ti_misp/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_misp/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
@@ -38,6 +38,8 @@ processors:
       if: ctx.json?.response != null && ctx.json.response.isEmpty()
   - fingerprint:
       fields:
+        - json.Event.timestamp
+        - json.Event.Attribute.first_seen
         - json.Event.Attribute.uuid
         - json.Event.Object.Attribute.uuid
       target_field: "_id"

--- a/packages/ti_misp/data_stream/threat_attributes/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_misp/data_stream/threat_attributes/elasticsearch/ingest_pipeline/default.yml
@@ -34,6 +34,14 @@ processors:
   - json:
       field: event.original
       target_field: misp.attribute
+  - fingerprint:
+      fields:
+        - misp.attribute.first_seen
+        - misp.attribute.timestamp
+        - misp.attribute.uuid
+        - misp.attribute.Event.uuid
+      target_field: "_id"
+      ignore_missing: true
   - set:
       field: threat.indicator.provider
       value: misp

--- a/packages/ti_misp/manifest.yml
+++ b/packages/ti_misp/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_misp
 title: MISP
-version: "1.35.7"
+version: "1.35.8"
 description: Ingest threat intelligence indicators from MISP platform with Elastic Agent.
 type: integration
 format_version: "3.0.2"


### PR DESCRIPTION
## Proposed commit message

Adding a fingerprint processor for the `threat_attributes` data stream to avoid ingesting the same indicators every time a request to the API is made.

Updated the fingerprint for the `threat` data stream, by including created/updated timestamps, so subsequent updates of the indicators are also ingested.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

