### PR TITLE
[O11y][MySQL] Update README to clarify the supported setup information for `replica_status` data stream

### DIFF
--- a/packages/mysql/_dev/build/docs/README.md
+++ b/packages/mysql/_dev/build/docs/README.md
@@ -40,7 +40,7 @@ Data streams:
          
 ## Note:
 - MySQL and Percona from version `8.0.22` onwards and MariaDB from version `10.5.1` onwards support the `SHOW REPLICA STATUS;` query. Versions prior to these use the `SHOW SLAVE STATUS;` query.
-- `replica_status` data stream is currently supporting master-slave or master-replica replication configurations as specified in the [MySQL Replication Configuration](https://dev.mysql.com/doc/refman/8.4/en/replication-configuration.html) documentation.
+- The `replica_status` data stream supports master-slave or master-replica replication configurations as specified in the [MySQL Replication Configuration](https://dev.mysql.com/doc/refman/8.4/en/replication-configuration.html) documentation.
 
 ## Prerequisites
 

--- a/packages/mysql/_dev/build/docs/README.md
+++ b/packages/mysql/_dev/build/docs/README.md
@@ -40,6 +40,7 @@ Data streams:
          
 ## Note:
 - MySQL and Percona from version `8.0.22` onwards and MariaDB from version `10.5.1` onwards support the `SHOW REPLICA STATUS;` query. Versions prior to these use the `SHOW SLAVE STATUS;` query.
+- `replica_status` data stream is currently supporting master-slave or master-replica replication configurations as specified in the [MySQL Replication Configuration](https://dev.mysql.com/doc/refman/8.4/en/replication-configuration.html) documentation.
 
 ## Prerequisites
 

--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.25.1
+  changes:
+    - description: Update README to clarify the setup information for replica_status data stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1 #FIX ME
 - version: 1.25.0
   changes:
     - description: Add `schemaname` field in the performance data stream.

--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: 1.25.1
   changes:
-    - description: Update README to clarify the setup information for replica_status data stream.
+    - description: Update README to clarify the setup information for `replica_status` data stream.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/11861
 - version: 1.25.0

--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update README to clarify the setup information for replica_status data stream.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1 #FIX ME
+      link: https://github.com/elastic/integrations/pull/11861
 - version: 1.25.0
   changes:
     - description: Add `schemaname` field in the performance data stream.

--- a/packages/mysql/docs/README.md
+++ b/packages/mysql/docs/README.md
@@ -40,7 +40,7 @@ Data streams:
          
 ## Note:
 - MySQL and Percona from version `8.0.22` onwards and MariaDB from version `10.5.1` onwards support the `SHOW REPLICA STATUS;` query. Versions prior to these use the `SHOW SLAVE STATUS;` query.
-- `replica_status` data stream is currently supporting master-slave or master-replica replication configurations as specified in the [MySQL Replication Configuration](https://dev.mysql.com/doc/refman/8.4/en/replication-configuration.html) documentation.
+- The `replica_status` data stream supports master-slave or master-replica replication configurations as specified in the [MySQL Replication Configuration](https://dev.mysql.com/doc/refman/8.4/en/replication-configuration.html) documentation.
 
 ## Prerequisites
 

--- a/packages/mysql/docs/README.md
+++ b/packages/mysql/docs/README.md
@@ -40,6 +40,7 @@ Data streams:
          
 ## Note:
 - MySQL and Percona from version `8.0.22` onwards and MariaDB from version `10.5.1` onwards support the `SHOW REPLICA STATUS;` query. Versions prior to these use the `SHOW SLAVE STATUS;` query.
+- `replica_status` data stream is currently supporting master-slave or master-replica replication configurations as specified in the [MySQL Replication Configuration](https://dev.mysql.com/doc/refman/8.4/en/replication-configuration.html) documentation.
 
 ## Prerequisites
 

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: mysql
 title: MySQL
-version: "1.25.0"
+version: "1.25.1"
 description: Collect logs and metrics from MySQL servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Update README to clarify the supported setup information for `replica_status` data stream.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #11826