### PR TITLE
Add entities.metadata and use keywords builder

### DIFF
--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -1,6 +1,11 @@
 # newer versions go on top
 # version map:
 # 0.1.x - 8.15.x
+- version: "0.6.0"
+  changes:
+    - description: Add entities.metadata field and use entity-builder
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/11865
 - version: "0.5.0"
   changes:
     - description: Add organization support for AWS and Azure

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,11 @@
+---
+description: Pipeline for processing Asset Invetory logs.
+processors:
+  - pipeline:
+      name: 'entity-keyword-builder@platform'
+      tag: entities-keyword-builder
+      ignore_missing_pipeline: true
+      on_failure:
+        - set:  
+            field: "error.message"
+            value: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message {{ _ingest.on_failure_message }}"

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/fields/entities.yml
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/fields/entities.yml
@@ -2,4 +2,8 @@
   type: group  
   fields:
   - name: metadata
+    description: Asset metadata used for the Inventory
     type: flattened
+  - name: keyword
+    description: Middle step in the metadata extraction used by the Inventory
+    type: keyword

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/fields/entities.yml
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/fields/entities.yml
@@ -1,0 +1,5 @@
+- name: entities
+  type: group  
+  fields:
+  - name: metadata
+    type: flattened

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.2
 name: cloud_asset_inventory
 title: "Cloud Asset Inventory"
-version: "0.5.0"
+version: "0.6.0"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Inventory"


### PR DESCRIPTION
### Summary of your changes

As part of implementing the first iteration of the [Cloud Entities in Entity Store](https://github.com/elastic/security-team/issues/10827), we need to populate the field `entities.metadata` with the relevant information and use the new `entities.keyword` builder to feed the entity store.


### Screenshot/Data
![image](https://github.com/user-attachments/assets/d26c9533-ae59-414c-bdf9-0d74903cbdbc)


### Related Issues
- Related https://github.com/elastic/security-team/issues/11094
- Related https://github.com/elastic/security-team/issues/10961