### PR TITLE
Support the first 30-40 event types for the Aruba integration

### DIFF
--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -377,6 +377,7 @@ Note: Descriptions have not been filled out
 |------------|------------------|
 | <ip>       | server.ip        |
 | <mac>      | server.mac       |
+| <mac>      | destination.mac  |
 | <port>     | aruba.port       |
 | <vni>      | network.vlan.id  |
 

--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -346,31 +346,31 @@ Note: Descriptions have not been filled out
 | <after>         | aruba.firmware.after         |
 
 #### [Hardware Health Monitor events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/HW-HEALTH-MONITOR.htm)
-| Doc Fields   | Schema Mapping          |
-|--------------|-------------------------|
-| <addr>       | aruba.hardware.addr     |
-| <bus>        | aruba.hardware.bus      |
-| <cap>        | aruba.hardware.cap      |
-| <cecount>    | aruba.hardware.cecount  |
-| <channel>    | aruba.hardware.channel  |
-| <cpus>       | aruba.hardware.cpus     |
-| <device>     | aruba.hardware.device   |
-| <error_code> | error.code              |
-| <function>   | aruba.hardware.function |
-| <level>      | aruba.hardware.level    |
-| <location>   | aruba.hardware.location |
-| <mcgstatus>  | aruba.hardware.mcgstatus|
-| <misc>       | aruba.hardware.misc     |
-| <offlined>   | aruba.hardware.offlined |
-| <origin>     | aruba.hardware.origin   |
-| <page>       | aruba.hardware.page     |
-| <seg>        | aruba.hardware.seg      |
-| <slot>       | aruba.slot              |
-| <socket>     | aruba.hardware.socket   |
-| <status>     | aruba.status            |
-| <test_name>  | aruba.hardware.test_name|
-| <threshold>  | aruba.limit             |
-| <type>       | aruba.hardware.type     |
+| Doc Fields   | Schema Mapping           |
+|--------------|--------------------------|
+| <addr>       | aruba.hardware.addr      |
+| <bus>        | aruba.hardware.bus       |
+| <cap>        | aruba.hardware.cap       |
+| <cecount>    | aruba.hardware.cecount   |
+| <channel>    | aruba.hardware.channel   |
+| <cpus>       | aruba.hardware.cpus      |
+| <device>     | aruba.hardware.device    |
+| <error_code> | error.code               |
+| <function>   | aruba.hardware.function  |
+| <level>      | aruba.hardware.level     |
+| <location>   | aruba.hardware.location  |
+| <mcgstatus>  | aruba.hardware.mcgstatus |
+| <misc>       | aruba.hardware.misc      |
+| <offlined>   | aruba.hardware.offlined  |
+| <origin>     | aruba.hardware.origin    |
+| <page>       | aruba.hardware.page      |
+| <seg>        | aruba.hardware.seg       |
+| <slot>       | aruba.slot               |
+| <socket>     | aruba.hardware.socket    |
+| <status>     | aruba.status             |
+| <test_name>  | aruba.hardware.test_name |
+| <threshold>  | aruba.limit              |
+| <type>       | aruba.hardware.type      |
 
 #### [Hardware Switch controller sync events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/HSC-SYNCD.htm)
 | Doc Fields | Schema Mapping   |
@@ -381,40 +381,42 @@ Note: Descriptions have not been filled out
 | <vni>      | network.vlan.id  |
 
 #### [HTTPS Server events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/HTTPS_SERVER.htm)
-| Field | Description | Type | Common |
-|-------|-------------|------|--------|
-| aruba.server.sessions | | | |
-| aruba.server.status  | | | aruba.status |
-| aruba.server.timeout | | | |
-| aruba.server.user    | | | server.user.name |
-| aruba.server.vrf     | | | aruba.vrf.id |
+| Doc Fields | Schema Mapping        |
+|------------|-----------------------|
+| <mode>     | aruba.server.mode     |
+| <sessions> | aruba.server.sessions |
+| <status>   | aruba.status          |
+| <timeout>  | aruba.timeout         |
+| <user>     | server.user.name      |
+| <vrf>      | aruba.vrf.id          |
 
 #### [In-System Programming events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ISP.htm)
-| Field                  | Description | Type | Common                       |
-|------------------------|-------------|------|------------------------------|
-| aruba.system.devicespec|             |      | |
-| aruba.system.file      |             |      | file.name                    |
-| aruba.system.fromver   |             |      | service.version              |
-| aruba.system.line      |             |      | log.syslog.severity.name     |
-| aruba.system.modspec   |             |      | |
-| aruba.system.numdevs   |             |      | |
-| aruba.system.pass      |             |      | event.action                 |
-| aruba.system.time      |             |      | |
-| aruba.system.tover     |             |      | service.target.version       |
+| Doc Fields   | Schema Mapping           |
+|--------------|--------------------------|
+| <devicespec> | aruba.system.devicespec  |
+| <file>       | file.name                |
+| <fromver>    | service.version          |
+| <line>       | aruba.system.line        |
+| <modspec>    | aruba.system.modspec     |
+| <numdevs>    | aruba.system.numdevs     |
+| <pass>       | event.action             |
+| <time>       | aruba.system.time        |
+| <tover>      | service.target.version   |
 
 #### [Interface events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/INTERFACE.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.interface.interface |             |      | observer.ingress.interface.name |
-| aruba.interface.state     |             |      | aruba.status                 |
+| Doc Fields   | Schema Mapping             |
+|--------------|----------------------------|
+| <interface>  | aruba.interface.id         |
+| <port_speed> | aruba.interface.port_speed |
+| <state>      | aruba.status               |
 
 #### [Internal storage events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/INTERNAL-STORAGE.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.storage.error       |             |      | error.message                |
-| aruba.storage.module_num  |             |      | aruba.slot                   |
-| aruba.storage.name        |             |      |                              |
-| aruba.storage.usage       |             |      |                              |
+| Doc Fields    | Schema Mapping        |
+|---------------|-----------------------|
+| <error>       | event.reason          |
+| <module_num>  | aruba.slot            |
+| <name>        | aruba.storage.name    |
+| <usage>       | aruba.storage.usage   |
 
 #### [IP source lockdown events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IP_SOURCE_LOCKDOWN.htm)
 | Field                              | Description | Type | Common                       |
@@ -423,32 +425,32 @@ Note: Descriptions have not been filled out
 | aruba.lockdown.max_supported_limit |             |      | aruba.limit                  |
 
 #### [IP tunnels events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IP_TUNNEL.htm)
-| Field               | Description | Type | Common                       |
-|---------------------|-------------|------|------------------------------|
-| aruba.tunnel.dest_ip|             |      | destination.ip               |
-| aruba.tunnel.ip_mtu |             |      | aruba.mtu                    |
-| aruba.tunnel.name   |             |      | observer.ingress.interface.name |
-| aruba.tunnel.src_ip |             |      | source.ip                    |
-| aruba.tunnel.ttl    |             |      |                              |
-| aruba.tunnel.type   |             |      |                              |
-| aruba.tunnel.vrf    |             |      | aruba.vrf.id                 |
+| Doc Fields   | Schema Mapping            |
+|--------------|---------------------------|
+| <dst_ip>     | destination.ip            |
+| <ip_mtu>     | aruba.mtu                 |
+| <tunnel_name>| aruba.tunnel.name         |
+| <src_ip>     | source.ip                 |
+| <ttl>        | aruba.tunnel.ttl          |
+| <type>       | aruba.tunnel.type         |
+| <vrf>        | aruba.vrf.id              |
 
 #### [IP-SLA events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IPSLA.htm)
-| Field                  | Description | Type | Common                       |
-|------------------------|-------------|------|------------------------------|
-| aruba.ip_sla.interface |             |      | observer.ingress.interface.name |
-| aruba.ip_sla.name      |             |      |                              |
-| aruba.ip_sla.operation |             |      | event.action                 |
-| aruba.ip_sla.reason    |             |      | event.reason                 |
-| aruba.ip_sla.state     |             |      | aruba.status                 |
+| Doc Fields | Schema Mapping         |
+|------------|------------------------|
+| <interface> | aruba.interface.name  |
+| <name>      | aruba.ip_sla.name     |
+| <operation> | event.action          |
+| <reason>    | event.reason          |
+| <state>     | aruba.status          |
 
 #### [IPv6 Router Advertisement events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IPV6-RA.htm)
-| Field                       | Description | Type | Common                       |
-|-----------------------------|-------------|------|------------------------------|
-| aruba.ipv6_router.intf      |             |      | observer.ingress.interface.name |
-| aruba.ipv6_router.ipv6_addr |             |      | server.ip                    |
-| aruba.ipv6_router.prefix    |             |      | aruba.prefix                 |
-| aruba.ipv6_router.prefixlen |             |      | aruba.len                    |
+| Doc Fields  | Schema Mapping       |
+|-------------|----------------------|
+| <intf>      | aruba.interface.id   |
+| <ipv6_addr> | server.ip            |
+| <prefix>    | aruba.prefix         |
+| <prefixlen> | aruba.len            |
 
 #### [IRDP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IRDP.htm)
 | Field                       | Description | Type | Common                       |

--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -409,7 +409,7 @@ Note: Descriptions have not been filled out
 |--------------|----------------------------|
 | <interface>  | aruba.interface.id         |
 | <port_speed> | aruba.interface.port_speed |
-| <state>      | aruba.status               |
+| <state>      | aruba.interface.state      |
 
 #### [Internal storage events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/INTERNAL-STORAGE.htm)
 | Doc Fields    | Schema Mapping        |
@@ -439,7 +439,7 @@ Note: Descriptions have not been filled out
 #### [IP-SLA events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IPSLA.htm)
 | Doc Fields | Schema Mapping         |
 |------------|------------------------|
-| <interface> | aruba.interface.name  |
+| <interface> | aruba.interface.id    |
 | <name>      | aruba.ip_sla.name     |
 | <operation> | event.action          |
 | <reason>    | event.reason          |

--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -370,12 +370,12 @@ Note: Descriptions have not been filled out
 | <type>       | aruba.hardware.type     |
 
 #### [Hardware Switch controller sync events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/HSC-SYNCD.htm)
-| Field               | Description | Type | Common                       |
-|---------------------|-------------|------|------------------------------|
-| aruba.hardware.ip   |             |      | server.ip                    |
-| aruba.hardware.mac  |             |      | server.mac                   |
-| aruba.hardware.port |             |      | server.port                  |
-| aruba.hardware.vni  |             |      | network.vlan.id              |
+| Doc Fields | Schema Mapping   |
+|------------|------------------|
+| <ip>       | server.ip        |
+| <mac>      | server.mac       |
+| <port>     | aruba.port       |
+| <vni>      | network.vlan.id  |
 
 #### [HTTPS Server events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/HTTPS_SERVER.htm)
 | Field | Description | Type | Common |

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
@@ -189,10 +189,10 @@
                     "device": "6000RCSE4802"
                 },
                 "interface": {
-                    "id": "1/1/38"
+                    "id": "1/1/38",
+                    "state": "down"
                 },
-                "sequence": "1/1",
-                "status": "down"
+                "sequence": "1/1"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -691,10 +691,10 @@
                     "device": "6300-DIST-RDL"
                 },
                 "interface": {
-                    "id": "1/1/11"
+                    "id": "1/1/11",
+                    "state": "down"
                 },
-                "sequence": "1",
-                "status": "down"
+                "sequence": "1"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -1570,10 +1570,10 @@
                     "device": "8360-Primaire"
                 },
                 "interface": {
-                    "id": "1/1/15"
+                    "id": "1/1/15",
+                    "state": "down"
                 },
-                "sequence": "1/1",
-                "status": "down"
+                "sequence": "1/1"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -1609,10 +1609,10 @@
                     "device": "8360-Primaire"
                 },
                 "interface": {
-                    "id": "1/1/29"
+                    "id": "1/1/29",
+                    "state": "down - Administratively down"
                 },
-                "sequence": "1/1",
-                "status": "down - Administratively down"
+                "sequence": "1/1"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -1648,10 +1648,10 @@
                     "device": "8360-Primaire"
                 },
                 "interface": {
-                    "id": "1/1/37"
+                    "id": "1/1/37",
+                    "state": "down - Disabled by STP"
                 },
-                "sequence": "1/1",
-                "status": "down - Disabled by STP"
+                "sequence": "1/1"
             },
             "ecs": {
                 "version": "8.11.0"

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
@@ -150,6 +150,9 @@
                 "hardware": {
                     "device": "6000RCSE4802"
                 },
+                "interface": {
+                    "id": "1/1/38"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -185,7 +188,11 @@
                 "hardware": {
                     "device": "6000RCSE4802"
                 },
-                "sequence": "1/1"
+                "interface": {
+                    "id": "1/1/38"
+                },
+                "sequence": "1/1",
+                "status": "down"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -646,6 +653,9 @@
                 "hardware": {
                     "device": "6300-DIST-RDL"
                 },
+                "interface": {
+                    "id": "1/1/11"
+                },
                 "sequence": "1"
             },
             "ecs": {
@@ -680,7 +690,11 @@
                 "hardware": {
                     "device": "6300-DIST-RDL"
                 },
-                "sequence": "1"
+                "interface": {
+                    "id": "1/1/11"
+                },
+                "sequence": "1",
+                "status": "down"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -1517,6 +1531,9 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "interface": {
+                    "id": "1/1/15"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -1552,7 +1569,11 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "sequence": "1/1"
+                "interface": {
+                    "id": "1/1/15"
+                },
+                "sequence": "1/1",
+                "status": "down"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -1587,7 +1608,11 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "sequence": "1/1"
+                "interface": {
+                    "id": "1/1/29"
+                },
+                "sequence": "1/1",
+                "status": "down - Administratively down"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -1622,7 +1647,11 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "sequence": "1/1"
+                "interface": {
+                    "id": "1/1/37"
+                },
+                "sequence": "1/1",
+                "status": "down - Disabled by STP"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -3722,6 +3751,9 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "interface": {
+                    "id": "vlan1234"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -3756,6 +3788,9 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "vlan1234"
                 },
                 "sequence": "1/1"
             },

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
@@ -125,6 +125,18 @@
 2024-06-19T13:54:24.900661-05:00 8360-Primaire hpe-restd[1956]: Event|8512|LOG_INFO|ERPS|-|some_port_name is already configured as RPL port for instance some_instance_id
 2024-06-19T13:54:24.900661-05:00 8360-Primaire hpe-restd[1956]: Event|8513|LOG_INFO|ERPS|-|RPL configuration is not allowed on ISL port some_interface_name
 2024-06-19T13:54:24.900661-05:00 8360-Primaire hpe-restd[1956]: Event|8515|LOG_INFO|ERPS|-|Operational state of the ring some_ring_id, instance some_instance_id changed to Initializing with reason some_reason
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8801|LOG_INFO|AMM|-|Hardware VTEP DB setup is completed
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8802|LOG_INFO|AMM|-|Physical Port eth0 is created in Hardware VTEP DB
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8803|LOG_INFO|AMM|-|Physical Port eth0 is deleted from Hardware VTEP DB
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8804|LOG_INFO|AMM|-|HSC configuration is completed on the switch and pushed to Hardware VTEP DB
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8805|LOG_INFO|AMM|-|HSC configuration is deleted from the switch and Hardware VTEP DB
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8806|LOG_INFO|AMM|-|Local MAC 00:1A:2B:3C:4D:5E learnt on VLAN 10 is updated in the Hardware VTEP DB
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8807|LOG_INFO|AMM|-|Local MAC 00:1A:2B:3C:4D:5E learnt on VLAN 10 is removed from the Hardware VTEP DB
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8808|LOG_INFO|AMM|-|VXLAN IP 192.168.1.1 is updated in the Hardware VTEP DB
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8809|LOG_INFO|AMM|-|VXLAN IP 192.168.1.1 is removed from Switch and Hardware VTEP DB
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8810|LOG_INFO|AMM|-|Unicast Remote MAC 00:1A:2B:3C:4D:5E learnt on VNI 100 is added to the switch
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8811|LOG_INFO|AMM|-|Unicast Remote MAC 00:1A:2B:3C:4D:5E learnt on VNI 100 is removed from the switch
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8812|LOG_INFO|AMM|-|Tunnel 192.168.1.1 is removed from Hardware VTEP DB
 2024-06-19T13:54:24.900661-05:00 8360-Primaire hpe-restd[1956]: Event|9201|LOG_INFO|DCBx|-|DCBX Enabled
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-restd[1956]: Event|9202|LOG_INFO|DCBx|-|DCBX Disabled
 2024-06-19T13:54:24.900661-05:00 8360-Primaire hpe-restd[1956]: Event|9203|LOG_INFO|DCBx|-|DCBX is enabled on interface eth0

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
@@ -19,6 +19,11 @@
 2024-06-18T13:05:38.182641-05:00 8360-Primaire fand[1094]: Event|223|LOG_WARN|AMM|1/1|Fan tray 1 FRU EPPROM is incorrectly programmed.
 2024-06-18T13:06:38.182641-05:00 8360-Primaire fand[1094]: Event|224|LOG_WARN|AMM|1/1|Front-to-Back airflow fan tray 2 disabled; this system requires Back-to-Front airflow.
 2024-06-18T13:07:38.182641-05:00 8360-Primaire fand[1094]: Event|225|LOG_WARN|AMM|1/1|Fan tray 1 misconfigured; this fan tray has been disabled.
+2024-07-31T15:40:10.904876-05:00 8360-Primaire intfd[808]: Event|401|LOG_INFO|INTF|1/1|Interface port_admin set to up for 1/1/15 interface
+2024-07-31T15:40:10.904876-05:00 8360-Primaire intfd[808]: Event|402|LOG_INFO|INTF|1/1|Interface port_admin set to down for 1/1/29 interface
+2024-07-31T15:40:10.904876-05:00 8360-Primaire intfd[808]: Event|406|LOG_INFO|INTF|1/1|Interface 1/1/29 encountered a hardware error that caused a link reset
+2024-07-31T15:40:10.904876-05:00 8360-Primaire intfd[808]: Event|407|LOG_INFO|INTF|1/1|Interface 1/1/29 downshifted to speed 1000 Mbps because link attempt failed at higher speed.
+2024-07-31T15:40:10.904876-05:00 8360-Primaire intfd[808]: Event|408|LOG_WARN|INTF|1/1|Interface 1/1/29 is down because MACsec and PFC features are mutually exclusive.
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|1501|LOG_ERR|COPP|-|CoPP initialization failed
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|1502|LOG_INFO|COPP|-|COPP initialization successful
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|1503|LOG_ERR|COPP|-|Ingress FP Group create failed
@@ -88,6 +93,25 @@
 2024-06-19T14:22:07.025548-05:00 8360-Primaire acctd[358]: Event|3013|LOG_WARN|AMM|1/1|Page mock_page correctable memory error count 2 exceeded threshold 1 and 3
 2024-06-21T18:32:07.025548-05:00 8360-Primaire dhcpd[999]: Event|3401|LOG_INFO|DHCPD|-|DHCP Relay Enabled
 2024-06-21T18:32:07.025548-05:00 8360-Primaire dhcpd[999]: Event|3402|LOG_INFO|DHCPD|-|DHCP Relay Disabled
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3901|LOG_INFO|IPV6ROUTER|-|ipv6 ra enabled on interface: eth0
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3902|LOG_INFO|IPV6ROUTER|-|ipv6 ra disabled on interface: eth0
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3903|LOG_INFO|IPV6ROUTER|-|Disabled sending MTU in Router-Advertisement messages on eth0
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3904|LOG_INFO|IPV6ROUTER|-|Enabled sending MTU in Router-Advertisement messages on eth0
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3905|LOG_INFO|IPV6ROUTER|-|Disabled sending RDNSS in Router-Advertisement messages on eth0
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3906|LOG_INFO|IPV6ROUTER|-|Enabled sending RDNSS in Router-Advertisement messages on eth0
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3907|LOG_INFO|IPV6ROUTER|-|Disabled sending DNSSL in Router-Advertisement messages on eth0
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3908|LOG_INFO|IPV6ROUTER|-|Enabled sending DNSSL in Router-Advertisement messages on eth0
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3909|LOG_INFO|IPV6ROUTER|-|Interface: eth0 is added to router discovery
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3910|LOG_INFO|IPV6ROUTER|-|Interface: eth0 is deleted from router discovery
+2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3911|LOG_INFO|IPV6ROUTER|-|Added ipv6 prefix: FE80::C000:1DFF:FEE0:C01/64 on interface: eth0
+2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3912|LOG_INFO|IPV6ROUTER|-|Deleted ipv6 prefix: FE80::C000:1DFF:FEE0:C01/64 from interface: eth0
+2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3913|LOG_INFO|IPV6ROUTER|-|Added RA Prefix: FE80::C000:1DFF:FEE0:C01/64 on interface: eth0 to prefix list
+2024-06-18T12:58:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3914|LOG_INFO|IPV6ROUTER|-|Deleted RA Prefix: FE80::C000:1DFF:FEE0:C01/64 on interface: eth0 from prefix list
+2024-06-18T12:59:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3915|LOG_INFO|IPV6ROUTER|-|default prefix is configured on interface eth0
+2024-06-18T13:00:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3916|LOG_INFO|IPV6ROUTER|-|RDNSS is added on interface: eth0
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3917|LOG_INFO|IPV6ROUTER|-|RDNSS is deleted on interface: eth0
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3918|LOG_INFO|IPV6ROUTER|-|DNSSL is added on interface: eth0
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3919|LOG_INFO|IPV6ROUTER|-|DNSSL is deleted on interface: eth0
 2024-06-20T14:00:38.324517-05:00 8360-Primaire hpe-firmware[1989034]: Event|4401|LOG_INFO|AMM|-|User admin: primary image updated via TFTP from 192.168.1.1. Firmware version, Before Update: 1.0.0 After Update: 1.1.0
 2024-06-20T14:01:38.324517-05:00 8360-Primaire hpe-firmware[1989034]: Event|4402|LOG_INFO|AMM|-|User admin: secondary image updated via USB. Firmware version, Before Update: 1.0.0 After Update: 1.1.0
 2024-06-20T14:02:38.324517-05:00 8360-Primaire hpe-firmware[1989034]: Event|4403|LOG_ERR|AMM|-|User admin: primary image update failed via TFTP from 192.168.1.1
@@ -95,6 +119,11 @@
 2024-06-20T14:04:38.324517-05:00 8360-Primaire hpe-firmware[1989034]: Event|4405|LOG_ERR|AMM|-|Firmware image signature not valid
 2024-06-20T14:05:38.324517-05:00 8360-Primaire hpe-firmware[1989034]: Event|4406|LOG_ERR|AMM|-|Firmware image is not compatible with hardware
 2024-06-20T14:06:38.324517-05:00 8360-Primaire hpe-firmware[1989034]: Event|4407|LOG_ERR|AMM|-|Firmware image is invalid
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5601|LOG_INFO|HTTPSSERVER|-|User admin has enabled read-only for REST mode
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5602|LOG_INFO|HTTPSSERVER|-|User admin has enabled HTTPS Server on VRF default
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5603|LOG_INFO|HTTPSSERVER|-|User admin closed all HTTPS sessions
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5604|LOG_INFO|HTTPSSERVER|-|User admin changed the HTTPS Server max user sessions amount to 10
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5605|LOG_INFO|HTTPSSERVER|-|User admin changed the HTTPS Server idle timeout to 300
 2024-06-20T15:52:07.025548-05:00 8360-Primaire credmgrd[456]: Event|6501|LOG_WARN|CREDMGR|-|An internal error occurred while reading the export password and default export password was used instead.
 2024-06-20T15:52:07.025548-05:00 8360-Primaire credmgrd[456]: Event|6502|LOG_WARN|CREDMGR|-|A critical system file has been corrupted. Please configure your export password to the one used by your most recent configuration export and import your most recent configuration.
 2024-06-20T15:52:07.025548-05:00 8360-Primaire credmgrd[456]: Event|6504|LOG_INFO|CREDMGR|-|Self-signed certificate successfully created for the https-server.
@@ -106,6 +135,17 @@
 2024-08-15T15:41:15.858927+03:00 Switchname hpe-restd[2226]: Event|6803|LOG_INFO|AMM|-|config_management_event_type:config_management_event_value
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|6804|LOG_ERR|AMM|-|Error while copying configs. Error: error_message
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|6805|LOG_INFO|AMM|-|Information while copying configs. Info: info_message
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7200|LOG_ERR|INSYSTEM|-|Internal fatal error at main.c:42
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7210|LOG_ERR|INSYSTEM|-|Non-failsafe update needed for device123. Please run the allow-unsafe-updates command
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7211|LOG_ERR|INSYSTEM|-|Do not interrupt non-failsafe update for device123
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7212|LOG_INFO|INSYSTEM|-|Starting update for device123 from version 1.0.0 to version 2.0.0
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7213|LOG_INFO|INSYSTEM|-|Update successful for device123 from version 1.0.0 to version 2.0.0
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7214|LOG_ERR|INSYSTEM|-|Update failed for device123
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7215|LOG_INFO|INSYSTEM|-|Deferred update for device123 will be performed after an automatic module reset
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7216|LOG_INFO|INSYSTEM|-|Approximately 5 minute(s) remaining to update 3 device(s) on moduleA
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7217|LOG_ERR|INSYSTEM|-|Insufficient redundant power is available to update device123
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7218|LOG_INFO|INSYSTEM|-|Programmable device updates are pending that require a power cycle. Wait for all fabric and line modules to be ready, then power the system off and back on again
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7219|LOG_CRIT|INSYSTEM|-|Failed to write-protect device123 (pass mock_pass)
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7305|LOG_INFO|AMM|-|BFD echo was enabled on interface 1/1/25
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7306|LOG_INFO|AMM|-|BFD echo was disabled on interface 1/1/25
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7307|LOG_INFO|AMM|-|BFD session is up. session_id=ZWxhc3RpYy5jby9kb2Nz, vrf=vpn-Internet, op_mode=mock_op_mode, src_port=1/1/18, dest_ip=127.0.0.1, local_state=mock_local_state, local_diag=mock_local_diag, remote_state=mock_remote_state, remote_diag=mock_remote_diag
@@ -120,6 +160,14 @@
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7319|LOG_WARN|AMM|-|BFD single-hop is not supported on interface 1/1/25
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7320|LOG_WARN|AMM|-|BFD session interval override not supported for protocol mock_from
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7321|LOG_WARN|AMM|-|BFD session routed-in interval override of 1234 ms is out of bounds for protocol mock_from, using 1234 ms instead
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-ipsla[1234]: Event|7401|LOG_ERR|IP-SLA|-|IP-SLA session:session1 state changed to failed down due to reason timeout
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-ipsla[1234]: Event|7402|LOG_INFO|IP-SLA|-|IP-SLA session:session1 state changed to up due to reason user_request
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-ipsla[1234]: Event|7403|LOG_INFO|IP-SLA|-|IP-SLA session1: added
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-ipsla[1234]: Event|7404|LOG_ERR|IP-SLA|-|IP-SLA session:session1 is incomplete to schedule
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-ipsla[1234]: Event|7405|LOG_ERR|IP-SLA|-|IP-SLA session:session1 interface eth0 is not ready and SLA is disabled
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-ipsla[1234]: Event|7406|LOG_ERR|IP-SLA|-|IP-SLA session:session1 interface eth0 is ready and SLA is enabled
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-ipsla[1234]: Event|7407|LOG_ERR|IP-SLA|-|IP-SLA session:session1 failed to bind source, reason: invalid_source
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-ipsla[1234]: Event|7408|LOG_ERR|IP-SLA|-|IP-SLA session:session1 failed to initialize socket, reason: socket_error
 2024-06-19T13:56:24.900661-05:00 8360-Primaire hpe-cpud[1980]: Event|7501|LOG_ERR|CPU_RX|-|Kernel filter "someAction" failed on unit myUnit for myFilter
 2024-06-19T13:56:24.900661-05:00 8360-Primaire hpe-cpud[1980]: Event|7502|LOG_ERR|CPU_RX|-|Cannot create kernel filter on unit myUnit for myFilter. All filters are in use. Configuring fewer per-port features can help with this issue.
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7701|LOG_INFO|AMM|-|TA Profile devices-v2.arubanetworks.com created
@@ -176,6 +224,10 @@
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8810|LOG_INFO|AMM|-|Unicast Remote MAC 00:1A:2B:3C:4D:5E learnt on VNI 100 is added to the switch
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8811|LOG_INFO|AMM|-|Unicast Remote MAC 00:1A:2B:3C:4D:5E learnt on VNI 100 is removed from the switch
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8812|LOG_INFO|AMM|-|Tunnel 192.168.1.1 is removed from Hardware VTEP DB
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-storage[1234]: Event|9101|LOG_ERR|AMM|-|Failed to report storage Storage1 details for module 5. Error: Disk failure
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-storage[1234]: Event|9102|LOG_INFO|AMM|-|Storage Storage1 health alert. Endurance utilization at 85% in module 5
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-storage[1234]: Event|9103|LOG_INFO|AMM|-|Storage Storage1 endurance utilization at 85% in module 5
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-storage[1234]: Event|9104|LOG_ERR|AMM|-|Storage Storage1 health alert. Endurance utilization at 95% in module 5. Failure is imminent. Please backup data
 2024-06-19T13:54:24.900661-05:00 8360-Primaire hpe-restd[1956]: Event|9201|LOG_INFO|DCBx|-|DCBX Enabled
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-restd[1956]: Event|9202|LOG_INFO|DCBx|-|DCBX Disabled
 2024-06-19T13:54:24.900661-05:00 8360-Primaire hpe-restd[1956]: Event|9203|LOG_INFO|DCBx|-|DCBX is enabled on interface eth0
@@ -203,6 +255,29 @@
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-evpn[1234]: Event|9516|LOG_INFO|EVPN|-|EVPN RT: rt created for VRF: vrf
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-evpn[1234]: Event|9517|LOG_INFO|EVPN|-|EVPN RT: rt deleted for VRF: vrf
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-evpn[1234]: Event|9518|LOG_INFO|EVPN|-|EVPN RT: rt updated for VRF: vrf
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9601|LOG_ERR|IPTUNNEL|-|Tunnel Creation Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9602|LOG_INFO|IPTUNNEL|-|Tunnel Created - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9603|LOG_ERR|IPTUNNEL|-|Tunnel Deletion Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9604|LOG_INFO|IPTUNNEL|-|Tunnel Deleted - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9605|LOG_ERR|IPTUNNEL|-|Tunnel Modification Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1) TTL (64)
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9606|LOG_INFO|IPTUNNEL|-|Tunnel Source IP Modified - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.2) Remote IP (192.168.2.1)
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9607|LOG_INFO|IPTUNNEL|-|Tunnel Destination IP Modified - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.2)
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9608|LOG_INFO|IPTUNNEL|-|Tunnel TTL Modified - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1) TTL (128)
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9609|LOG_ERR|IPTUNNEL|-|Tunnel MTU Modification Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1) MTU (1500)
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9610|LOG_INFO|IPTUNNEL|-|Tunnel MTU Modified - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1) MTU (1500)
+2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9611|LOG_ERR|IPTUNNEL|-|Tunnel Nexthop Add Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)
+2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9612|LOG_INFO|IPTUNNEL|-|Tunnel Nexthop Added - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)
+2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9613|LOG_ERR|IPTUNNEL|-|Tunnel Nexthop Modify Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)
+2024-06-18T12:58:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9614|LOG_INFO|IPTUNNEL|-|Tunnel Nexthop Modified - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)
+2024-06-18T12:59:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9615|LOG_ERR|IPTUNNEL|-|Tunnel Nexthop Delete Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)
+2024-06-18T13:00:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9616|LOG_INFO|IPTUNNEL|-|Tunnel Nexthop Deleted - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|9801|LOG_WARN|IP|-|IP_SOURCE_LOCKDOWN resource utilization has reached 80 percent of the supported limit of 1000 on the system
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|9802|LOG_ERR|IP|-|IP_SOURCE_LOCKDOWN resource utilization has exceeded maximum supported limit of 1000 on the system. IP source-lockdown functionality will not work for new entries
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|9803|LOG_INFO|IP|-|IP_SOURCE_LOCKDOWN resource utilization has reduced below 80 percent of the supported limit of 1000 on the system
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|9804|LOG_INFO|IP|-|IPV4_SOURCE_LOCKDOWN is enabled on interface eth0
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|9805|LOG_INFO|IP|-|IPV4_SOURCE_LOCKDOWN is disabled on interface eth0
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|9806|LOG_INFO|IP|-|IPV6_SOURCE_LOCKDOWN is enabled on interface eth1
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|9807|LOG_INFO|IP|-|IPV6_SOURCE_LOCKDOWN is disabled on interface eth1
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|10002|LOG_INFO|AMM|-|mock_acl_name on 1/1/25 (route-in): 10 mock ace string
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|10003|LOG_ERR|AMM|-|ACL mock_acl_type mock_acl_name failed to apply on mock_application
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|10401|LOG_INFO|AMM|-|ARP inspection mock_status on vlan vpn-Internet.

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -841,6 +841,197 @@
             ]
         },
         {
+            "@timestamp": "2024-07-31T15:40:10.904876-05:00",
+            "aruba": {
+                "component": {
+                    "category": "INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "1/1/15"
+                },
+                "sequence": "1/1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "401",
+                "original": "2024-07-31T15:40:10.904876-05:00 8360-Primaire intfd[808]: Event|401|LOG_INFO|INTF|1/1|Interface port_admin set to up for 1/1/15 interface",
+                "sequence": 1
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "intfd",
+                    "procid": "808"
+                }
+            },
+            "message": "Interface port_admin set to up for 1/1/15 interface",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-07-31T15:40:10.904876-05:00",
+            "aruba": {
+                "component": {
+                    "category": "INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "1/1/29"
+                },
+                "sequence": "1/1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "402",
+                "original": "2024-07-31T15:40:10.904876-05:00 8360-Primaire intfd[808]: Event|402|LOG_INFO|INTF|1/1|Interface port_admin set to down for 1/1/29 interface",
+                "sequence": 1
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "intfd",
+                    "procid": "808"
+                }
+            },
+            "message": "Interface port_admin set to down for 1/1/29 interface",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-07-31T15:40:10.904876-05:00",
+            "aruba": {
+                "component": {
+                    "category": "INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "1/1/29"
+                },
+                "sequence": "1/1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "406",
+                "original": "2024-07-31T15:40:10.904876-05:00 8360-Primaire intfd[808]: Event|406|LOG_INFO|INTF|1/1|Interface 1/1/29 encountered a hardware error that caused a link reset",
+                "sequence": 1
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "intfd",
+                    "procid": "808"
+                }
+            },
+            "message": "Interface 1/1/29 encountered a hardware error that caused a link reset",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-07-31T15:40:10.904876-05:00",
+            "aruba": {
+                "component": {
+                    "category": "INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "1/1/29",
+                    "port_speed": 1000
+                },
+                "sequence": "1/1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "407",
+                "original": "2024-07-31T15:40:10.904876-05:00 8360-Primaire intfd[808]: Event|407|LOG_INFO|INTF|1/1|Interface 1/1/29 downshifted to speed 1000 Mbps because link attempt failed at higher speed.",
+                "sequence": 1
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "intfd",
+                    "procid": "808"
+                }
+            },
+            "message": "Interface 1/1/29 downshifted to speed 1000 Mbps because link attempt failed at higher speed.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-07-31T15:40:10.904876-05:00",
+            "aruba": {
+                "component": {
+                    "category": "INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "1/1/29"
+                },
+                "sequence": "1/1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "408",
+                "original": "2024-07-31T15:40:10.904876-05:00 8360-Primaire intfd[808]: Event|408|LOG_WARN|INTF|1/1|Interface 1/1/29 is down because MACsec and PFC features are mutually exclusive.",
+                "sequence": 1
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "intfd",
+                    "procid": "808"
+                }
+            },
+            "message": "Interface 1/1/29 is down because MACsec and PFC features are mutually exclusive.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",
             "aruba": {
                 "component": {
@@ -3597,6 +3788,719 @@
             ]
         },
         {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPV6ROUTER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3901",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3901|LOG_INFO|IPV6ROUTER|-|ipv6 ra enabled on interface: eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ipv6ra",
+                    "procid": "1234"
+                }
+            },
+            "message": "ipv6 ra enabled on interface: eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPV6ROUTER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3902",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3902|LOG_INFO|IPV6ROUTER|-|ipv6 ra disabled on interface: eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ipv6ra",
+                    "procid": "1234"
+                }
+            },
+            "message": "ipv6 ra disabled on interface: eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPV6ROUTER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3903",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3903|LOG_INFO|IPV6ROUTER|-|Disabled sending MTU in Router-Advertisement messages on eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ipv6ra",
+                    "procid": "1234"
+                }
+            },
+            "message": "Disabled sending MTU in Router-Advertisement messages on eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPV6ROUTER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3904",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3904|LOG_INFO|IPV6ROUTER|-|Enabled sending MTU in Router-Advertisement messages on eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ipv6ra",
+                    "procid": "1234"
+                }
+            },
+            "message": "Enabled sending MTU in Router-Advertisement messages on eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPV6ROUTER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3905",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3905|LOG_INFO|IPV6ROUTER|-|Disabled sending RDNSS in Router-Advertisement messages on eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ipv6ra",
+                    "procid": "1234"
+                }
+            },
+            "message": "Disabled sending RDNSS in Router-Advertisement messages on eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPV6ROUTER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3906",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3906|LOG_INFO|IPV6ROUTER|-|Enabled sending RDNSS in Router-Advertisement messages on eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ipv6ra",
+                    "procid": "1234"
+                }
+            },
+            "message": "Enabled sending RDNSS in Router-Advertisement messages on eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPV6ROUTER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3907",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3907|LOG_INFO|IPV6ROUTER|-|Disabled sending DNSSL in Router-Advertisement messages on eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ipv6ra",
+                    "procid": "1234"
+                }
+            },
+            "message": "Disabled sending DNSSL in Router-Advertisement messages on eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPV6ROUTER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3908",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3908|LOG_INFO|IPV6ROUTER|-|Enabled sending DNSSL in Router-Advertisement messages on eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ipv6ra",
+                    "procid": "1234"
+                }
+            },
+            "message": "Enabled sending DNSSL in Router-Advertisement messages on eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPV6ROUTER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3909",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3909|LOG_INFO|IPV6ROUTER|-|Interface: eth0 is added to router discovery"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ipv6ra",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface: eth0 is added to router discovery",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPV6ROUTER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3910",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3910|LOG_INFO|IPV6ROUTER|-|Interface: eth0 is deleted from router discovery"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ipv6ra",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface: eth0 is deleted from router discovery",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPV6ROUTER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "len": 64,
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3911",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3911|LOG_INFO|IPV6ROUTER|-|Added ipv6 prefix: FE80::C000:1DFF:FEE0:C01/64 on interface: eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ipv6ra",
+                    "procid": "1234"
+                }
+            },
+            "message": "Added ipv6 prefix: FE80::C000:1DFF:FEE0:C01/64 on interface: eth0",
+            "server": {
+                "ip": "FE80::C000:1DFF:FEE0:C01"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:56:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPV6ROUTER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "len": 64,
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3912",
+                "original": "2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3912|LOG_INFO|IPV6ROUTER|-|Deleted ipv6 prefix: FE80::C000:1DFF:FEE0:C01/64 from interface: eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ipv6ra",
+                    "procid": "1234"
+                }
+            },
+            "message": "Deleted ipv6 prefix: FE80::C000:1DFF:FEE0:C01/64 from interface: eth0",
+            "server": {
+                "ip": "FE80::C000:1DFF:FEE0:C01"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:57:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPV6ROUTER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "prefix": "FE80::C000:1DFF:FEE0:C01/64",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3913",
+                "original": "2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3913|LOG_INFO|IPV6ROUTER|-|Added RA Prefix: FE80::C000:1DFF:FEE0:C01/64 on interface: eth0 to prefix list"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ipv6ra",
+                    "procid": "1234"
+                }
+            },
+            "message": "Added RA Prefix: FE80::C000:1DFF:FEE0:C01/64 on interface: eth0 to prefix list",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:58:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPV6ROUTER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "prefix": "FE80::C000:1DFF:FEE0:C01/64",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3914",
+                "original": "2024-06-18T12:58:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3914|LOG_INFO|IPV6ROUTER|-|Deleted RA Prefix: FE80::C000:1DFF:FEE0:C01/64 on interface: eth0 from prefix list"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ipv6ra",
+                    "procid": "1234"
+                }
+            },
+            "message": "Deleted RA Prefix: FE80::C000:1DFF:FEE0:C01/64 on interface: eth0 from prefix list",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:59:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPV6ROUTER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3915",
+                "original": "2024-06-18T12:59:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3915|LOG_INFO|IPV6ROUTER|-|default prefix is configured on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ipv6ra",
+                    "procid": "1234"
+                }
+            },
+            "message": "default prefix is configured on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:00:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPV6ROUTER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3916",
+                "original": "2024-06-18T13:00:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3916|LOG_INFO|IPV6ROUTER|-|RDNSS is added on interface: eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ipv6ra",
+                    "procid": "1234"
+                }
+            },
+            "message": "RDNSS is added on interface: eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPV6ROUTER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3917",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3917|LOG_INFO|IPV6ROUTER|-|RDNSS is deleted on interface: eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ipv6ra",
+                    "procid": "1234"
+                }
+            },
+            "message": "RDNSS is deleted on interface: eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPV6ROUTER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3918",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3918|LOG_INFO|IPV6ROUTER|-|DNSSL is added on interface: eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ipv6ra",
+                    "procid": "1234"
+                }
+            },
+            "message": "DNSSL is added on interface: eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPV6ROUTER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3919",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3919|LOG_INFO|IPV6ROUTER|-|DNSSL is deleted on interface: eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ipv6ra",
+                    "procid": "1234"
+                }
+            },
+            "message": "DNSSL is deleted on interface: eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-06-20T14:00:38.324517-05:00",
             "aruba": {
                 "component": {
@@ -3868,6 +4772,212 @@
                 }
             },
             "message": "Firmware image is invalid",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "HTTPSSERVER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "server": {
+                    "mode": "read-only"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5601",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5601|LOG_INFO|HTTPSSERVER|-|User admin has enabled read-only for REST mode"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "User admin has enabled read-only for REST mode",
+            "server": {
+                "user": {
+                    "name": "admin"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "HTTPSSERVER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "status": "enabled",
+                "vrf": {
+                    "id": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5602",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5602|LOG_INFO|HTTPSSERVER|-|User admin has enabled HTTPS Server on VRF default"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "User admin has enabled HTTPS Server on VRF default",
+            "server": {
+                "user": {
+                    "name": "admin"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "HTTPSSERVER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5603",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5603|LOG_INFO|HTTPSSERVER|-|User admin closed all HTTPS sessions"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "User admin closed all HTTPS sessions",
+            "server": {
+                "user": {
+                    "name": "admin"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "HTTPSSERVER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "server": {
+                    "sessions": 10
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5604",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5604|LOG_INFO|HTTPSSERVER|-|User admin changed the HTTPS Server max user sessions amount to 10"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "User admin changed the HTTPS Server max user sessions amount to 10",
+            "server": {
+                "user": {
+                    "name": "admin"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "HTTPSSERVER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "timeout": 300
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5605",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5605|LOG_INFO|HTTPSSERVER|-|User admin changed the HTTPS Server idle timeout to 300"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "User admin changed the HTTPS Server idle timeout to 300",
+            "server": {
+                "user": {
+                    "name": "admin"
+                }
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -4261,6 +5371,428 @@
                 }
             },
             "message": "Information while copying configs. Info: info_message",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "INSYSTEM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "system": {
+                    "line": 42
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7200",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7200|LOG_ERR|INSYSTEM|-|Internal fatal error at main.c:42"
+            },
+            "file": {
+                "name": "main.c"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-faultmon",
+                    "procid": "1234"
+                }
+            },
+            "message": "Internal fatal error at main.c:42",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "INSYSTEM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "system": {
+                    "devicespec": "device123"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7210",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7210|LOG_ERR|INSYSTEM|-|Non-failsafe update needed for device123. Please run the allow-unsafe-updates command"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-faultmon",
+                    "procid": "1234"
+                }
+            },
+            "message": "Non-failsafe update needed for device123. Please run the allow-unsafe-updates command",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "INSYSTEM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "system": {
+                    "devicespec": "device123"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7211",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7211|LOG_ERR|INSYSTEM|-|Do not interrupt non-failsafe update for device123"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-faultmon",
+                    "procid": "1234"
+                }
+            },
+            "message": "Do not interrupt non-failsafe update for device123",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "INSYSTEM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "system": {
+                    "devicespec": "device123"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7212",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7212|LOG_INFO|INSYSTEM|-|Starting update for device123 from version 1.0.0 to version 2.0.0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-faultmon",
+                    "procid": "1234"
+                }
+            },
+            "message": "Starting update for device123 from version 1.0.0 to version 2.0.0",
+            "service": {
+                "target": {
+                    "version": "2.0.0"
+                },
+                "version": "1.0.0"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "INSYSTEM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "system": {
+                    "devicespec": "device123"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7213",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7213|LOG_INFO|INSYSTEM|-|Update successful for device123 from version 1.0.0 to version 2.0.0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-faultmon",
+                    "procid": "1234"
+                }
+            },
+            "message": "Update successful for device123 from version 1.0.0 to version 2.0.0",
+            "service": {
+                "target": {
+                    "version": "2.0.0"
+                },
+                "version": "1.0.0"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "INSYSTEM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "system": {
+                    "devicespec": "device123"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7214",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7214|LOG_ERR|INSYSTEM|-|Update failed for device123"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-faultmon",
+                    "procid": "1234"
+                }
+            },
+            "message": "Update failed for device123",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "INSYSTEM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "system": {
+                    "devicespec": "device123"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7215",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7215|LOG_INFO|INSYSTEM|-|Deferred update for device123 will be performed after an automatic module reset"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-faultmon",
+                    "procid": "1234"
+                }
+            },
+            "message": "Deferred update for device123 will be performed after an automatic module reset",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "INSYSTEM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "system": {
+                    "modspec": "moduleA",
+                    "numdevs": 3,
+                    "time": 5
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7216",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7216|LOG_INFO|INSYSTEM|-|Approximately 5 minute(s) remaining to update 3 device(s) on moduleA"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-faultmon",
+                    "procid": "1234"
+                }
+            },
+            "message": "Approximately 5 minute(s) remaining to update 3 device(s) on moduleA",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "INSYSTEM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "system": {
+                    "devicespec": "device123"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7217",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7217|LOG_ERR|INSYSTEM|-|Insufficient redundant power is available to update device123"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-faultmon",
+                    "procid": "1234"
+                }
+            },
+            "message": "Insufficient redundant power is available to update device123",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "INSYSTEM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7218",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7218|LOG_INFO|INSYSTEM|-|Programmable device updates are pending that require a power cycle. Wait for all fabric and line modules to be ready, then power the system off and back on again"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-faultmon",
+                    "procid": "1234"
+                }
+            },
+            "message": "Programmable device updates are pending that require a power cycle. Wait for all fabric and line modules to be ready, then power the system off and back on again",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "INSYSTEM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "system": {
+                    "devicespec": "device123",
+                    "pass": "mock_pass"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7219",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7219|LOG_CRIT|INSYSTEM|-|Failed to write-protect device123 (pass mock_pass)"
+            },
+            "log": {
+                "level": "LOG_CRIT",
+                "syslog": {
+                    "appname": "hpe-faultmon",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to write-protect device123 (pass mock_pass)",
             "tags": [
                 "preserve_original_event"
             ]
@@ -4851,6 +6383,315 @@
                 }
             },
             "message": "BFD session routed-in interval override of 1234 ms is out of bounds for protocol mock_from, using 1234 ms instead",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IP-SLA"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "ip_sla": {
+                    "name": "session1"
+                },
+                "sequence": "-",
+                "status": "down"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7401",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-ipsla[1234]: Event|7401|LOG_ERR|IP-SLA|-|IP-SLA session:session1 state changed to failed down due to reason timeout",
+                "reason": "timeout"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-ipsla",
+                    "procid": "1234"
+                }
+            },
+            "message": "IP-SLA session:session1 state changed to failed down due to reason timeout",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IP-SLA"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "ip_sla": {
+                    "name": "session1"
+                },
+                "sequence": "-",
+                "status": "up"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7402",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-ipsla[1234]: Event|7402|LOG_INFO|IP-SLA|-|IP-SLA session:session1 state changed to up due to reason user_request",
+                "reason": "user_request"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ipsla",
+                    "procid": "1234"
+                }
+            },
+            "message": "IP-SLA session:session1 state changed to up due to reason user_request",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IP-SLA"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "ip_sla": {
+                    "name": "session1"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "added",
+                "category": [
+                    "network"
+                ],
+                "code": "7403",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-ipsla[1234]: Event|7403|LOG_INFO|IP-SLA|-|IP-SLA session1: added"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ipsla",
+                    "procid": "1234"
+                }
+            },
+            "message": "IP-SLA session1: added",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IP-SLA"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "ip_sla": {
+                    "name": "session1"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7404",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-ipsla[1234]: Event|7404|LOG_ERR|IP-SLA|-|IP-SLA session:session1 is incomplete to schedule"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-ipsla",
+                    "procid": "1234"
+                }
+            },
+            "message": "IP-SLA session:session1 is incomplete to schedule",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IP-SLA"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                },
+                "ip_sla": {
+                    "name": "session1"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7405",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-ipsla[1234]: Event|7405|LOG_ERR|IP-SLA|-|IP-SLA session:session1 interface eth0 is not ready and SLA is disabled"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-ipsla",
+                    "procid": "1234"
+                }
+            },
+            "message": "IP-SLA session:session1 interface eth0 is not ready and SLA is disabled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IP-SLA"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                },
+                "ip_sla": {
+                    "name": "session1"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7406",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-ipsla[1234]: Event|7406|LOG_ERR|IP-SLA|-|IP-SLA session:session1 interface eth0 is ready and SLA is enabled"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-ipsla",
+                    "procid": "1234"
+                }
+            },
+            "message": "IP-SLA session:session1 interface eth0 is ready and SLA is enabled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IP-SLA"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "ip_sla": {
+                    "name": "session1"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7407",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-ipsla[1234]: Event|7407|LOG_ERR|IP-SLA|-|IP-SLA session:session1 failed to bind source, reason: invalid_source",
+                "reason": " invalid_source"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-ipsla",
+                    "procid": "1234"
+                }
+            },
+            "message": "IP-SLA session:session1 failed to bind source, reason: invalid_source",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IP-SLA"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "ip_sla": {
+                    "name": "session1"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7408",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-ipsla[1234]: Event|7408|LOG_ERR|IP-SLA|-|IP-SLA session:session1 failed to initialize socket, reason: socket_error",
+                "reason": " socket_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-ipsla",
+                    "procid": "1234"
+                }
+            },
+            "message": "IP-SLA session:session1 failed to initialize socket, reason: socket_error",
             "tags": [
                 "preserve_original_event"
             ]
@@ -6566,6 +8407,613 @@
             ]
         },
         {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8801",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8801|LOG_INFO|AMM|-|Hardware VTEP DB setup is completed"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "Hardware VTEP DB setup is completed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8802",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8802|LOG_INFO|AMM|-|Physical Port eth0 is created in Hardware VTEP DB"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "Physical Port eth0 is created in Hardware VTEP DB",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8803",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8803|LOG_INFO|AMM|-|Physical Port eth0 is deleted from Hardware VTEP DB"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "Physical Port eth0 is deleted from Hardware VTEP DB",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8804",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8804|LOG_INFO|AMM|-|HSC configuration is completed on the switch and pushed to Hardware VTEP DB"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "HSC configuration is completed on the switch and pushed to Hardware VTEP DB",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8805",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8805|LOG_INFO|AMM|-|HSC configuration is deleted from the switch and Hardware VTEP DB"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "HSC configuration is deleted from the switch and Hardware VTEP DB",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8806",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8806|LOG_INFO|AMM|-|Local MAC 00:1A:2B:3C:4D:5E learnt on VLAN 10 is updated in the Hardware VTEP DB"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "Local MAC 00:1A:2B:3C:4D:5E learnt on VLAN 10 is updated in the Hardware VTEP DB",
+            "network": {
+                "vlan": {
+                    "id": "10"
+                }
+            },
+            "source": {
+                "mac": "00-1A-2B-3C-4D-5E"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8807",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8807|LOG_INFO|AMM|-|Local MAC 00:1A:2B:3C:4D:5E learnt on VLAN 10 is removed from the Hardware VTEP DB"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "Local MAC 00:1A:2B:3C:4D:5E learnt on VLAN 10 is removed from the Hardware VTEP DB",
+            "network": {
+                "vlan": {
+                    "id": "10"
+                }
+            },
+            "source": {
+                "mac": "00-1A-2B-3C-4D-5E"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8808",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8808|LOG_INFO|AMM|-|VXLAN IP 192.168.1.1 is updated in the Hardware VTEP DB"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "VXLAN IP 192.168.1.1 is updated in the Hardware VTEP DB",
+            "server": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8809",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8809|LOG_INFO|AMM|-|VXLAN IP 192.168.1.1 is removed from Switch and Hardware VTEP DB"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "VXLAN IP 192.168.1.1 is removed from Switch and Hardware VTEP DB",
+            "server": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8810",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8810|LOG_INFO|AMM|-|Unicast Remote MAC 00:1A:2B:3C:4D:5E learnt on VNI 100 is added to the switch"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "Unicast Remote MAC 00:1A:2B:3C:4D:5E learnt on VNI 100 is added to the switch",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "source": {
+                "mac": "00-1A-2B-3C-4D-5E"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8811",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8811|LOG_INFO|AMM|-|Unicast Remote MAC 00:1A:2B:3C:4D:5E learnt on VNI 100 is removed from the switch"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "Unicast Remote MAC 00:1A:2B:3C:4D:5E learnt on VNI 100 is removed from the switch",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "source": {
+                "mac": "00-1A-2B-3C-4D-5E"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8812",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8812|LOG_INFO|AMM|-|Tunnel 192.168.1.1 is removed from Hardware VTEP DB"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "Tunnel 192.168.1.1 is removed from Hardware VTEP DB",
+            "server": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "slot": 5,
+                "storage": {
+                    "name": "Storage1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9101",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-storage[1234]: Event|9101|LOG_ERR|AMM|-|Failed to report storage Storage1 details for module 5. Error: Disk failure",
+                "reason": "Disk failure"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-storage",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to report storage Storage1 details for module 5. Error: Disk failure",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "slot": 5,
+                "storage": {
+                    "name": "Storage1",
+                    "usage": 85
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9102",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-storage[1234]: Event|9102|LOG_INFO|AMM|-|Storage Storage1 health alert. Endurance utilization at 85% in module 5"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-storage",
+                    "procid": "1234"
+                }
+            },
+            "message": "Storage Storage1 health alert. Endurance utilization at 85% in module 5",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "slot": 5,
+                "storage": {
+                    "name": "Storage1",
+                    "usage": 85
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9103",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-storage[1234]: Event|9103|LOG_INFO|AMM|-|Storage Storage1 endurance utilization at 85% in module 5"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-storage",
+                    "procid": "1234"
+                }
+            },
+            "message": "Storage Storage1 endurance utilization at 85% in module 5",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "slot": 5,
+                "storage": {
+                    "name": "Storage1",
+                    "usage": 95
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9104",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-storage[1234]: Event|9104|LOG_ERR|AMM|-|Storage Storage1 health alert. Endurance utilization at 95% in module 5. Failure is imminent. Please backup data"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-storage",
+                    "procid": "1234"
+                }
+            },
+            "message": "Storage Storage1 health alert. Endurance utilization at 95% in module 5. Failure is imminent. Please backup data",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-06-19T13:54:24.900661-05:00",
             "aruba": {
                 "component": {
@@ -7601,6 +10049,1015 @@
                 }
             },
             "message": "EVPN RT: rt updated for VRF: vrf",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPTUNNEL"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "tunnel": {
+                    "name": "Tunnel1",
+                    "type": "GRE"
+                },
+                "vrf": {
+                    "id": "VRF1"
+                }
+            },
+            "destination": {
+                "ip": "192.168.2.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9601",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9601|LOG_ERR|IPTUNNEL|-|Tunnel Creation Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-tunnel",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel Creation Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)",
+            "source": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPTUNNEL"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "tunnel": {
+                    "name": "Tunnel1",
+                    "type": "GRE"
+                },
+                "vrf": {
+                    "id": "VRF1"
+                }
+            },
+            "destination": {
+                "ip": "192.168.2.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9602",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9602|LOG_INFO|IPTUNNEL|-|Tunnel Created - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-tunnel",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel Created - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)",
+            "source": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPTUNNEL"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "tunnel": {
+                    "name": "Tunnel1",
+                    "type": "GRE"
+                },
+                "vrf": {
+                    "id": "VRF1"
+                }
+            },
+            "destination": {
+                "ip": "192.168.2.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9603",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9603|LOG_ERR|IPTUNNEL|-|Tunnel Deletion Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-tunnel",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel Deletion Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)",
+            "source": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPTUNNEL"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "tunnel": {
+                    "name": "Tunnel1",
+                    "type": "GRE"
+                },
+                "vrf": {
+                    "id": "VRF1"
+                }
+            },
+            "destination": {
+                "ip": "192.168.2.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9604",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9604|LOG_INFO|IPTUNNEL|-|Tunnel Deleted - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-tunnel",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel Deleted - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)",
+            "source": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPTUNNEL"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "tunnel": {
+                    "name": "Tunnel1",
+                    "ttl": "64",
+                    "type": "GRE"
+                },
+                "vrf": {
+                    "id": "VRF1"
+                }
+            },
+            "destination": {
+                "ip": "192.168.2.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9605",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9605|LOG_ERR|IPTUNNEL|-|Tunnel Modification Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1) TTL (64)"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-tunnel",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel Modification Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1) TTL (64)",
+            "source": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPTUNNEL"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "tunnel": {
+                    "name": "Tunnel1",
+                    "type": "GRE"
+                },
+                "vrf": {
+                    "id": "VRF1"
+                }
+            },
+            "destination": {
+                "ip": "192.168.2.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9606",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9606|LOG_INFO|IPTUNNEL|-|Tunnel Source IP Modified - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.2) Remote IP (192.168.2.1)"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-tunnel",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel Source IP Modified - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.2) Remote IP (192.168.2.1)",
+            "source": {
+                "ip": "192.168.1.2"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPTUNNEL"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "tunnel": {
+                    "name": "Tunnel1",
+                    "type": "GRE"
+                },
+                "vrf": {
+                    "id": "VRF1"
+                }
+            },
+            "destination": {
+                "ip": "192.168.2.2"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9607",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9607|LOG_INFO|IPTUNNEL|-|Tunnel Destination IP Modified - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.2)"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-tunnel",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel Destination IP Modified - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.2)",
+            "source": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPTUNNEL"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "tunnel": {
+                    "name": "Tunnel1",
+                    "ttl": "128",
+                    "type": "GRE"
+                },
+                "vrf": {
+                    "id": "VRF1"
+                }
+            },
+            "destination": {
+                "ip": "192.168.2.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9608",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9608|LOG_INFO|IPTUNNEL|-|Tunnel TTL Modified - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1) TTL (128)"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-tunnel",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel TTL Modified - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1) TTL (128)",
+            "source": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPTUNNEL"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mtu": "1500",
+                "sequence": "-",
+                "tunnel": {
+                    "name": "Tunnel1",
+                    "type": "GRE"
+                },
+                "vrf": {
+                    "id": "VRF1"
+                }
+            },
+            "destination": {
+                "ip": "192.168.2.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9609",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9609|LOG_ERR|IPTUNNEL|-|Tunnel MTU Modification Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1) MTU (1500)"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-tunnel",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel MTU Modification Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1) MTU (1500)",
+            "source": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPTUNNEL"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mtu": "1500",
+                "sequence": "-",
+                "tunnel": {
+                    "name": "Tunnel1",
+                    "type": "GRE"
+                },
+                "vrf": {
+                    "id": "VRF1"
+                }
+            },
+            "destination": {
+                "ip": "192.168.2.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9610",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9610|LOG_INFO|IPTUNNEL|-|Tunnel MTU Modified - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1) MTU (1500)"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-tunnel",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel MTU Modified - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1) MTU (1500)",
+            "source": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPTUNNEL"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "tunnel": {
+                    "name": "Tunnel1",
+                    "type": "GRE"
+                },
+                "vrf": {
+                    "id": "VRF1"
+                }
+            },
+            "destination": {
+                "ip": "192.168.2.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9611",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9611|LOG_ERR|IPTUNNEL|-|Tunnel Nexthop Add Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-tunnel",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel Nexthop Add Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)",
+            "source": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:56:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPTUNNEL"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "tunnel": {
+                    "name": "Tunnel1",
+                    "type": "GRE"
+                },
+                "vrf": {
+                    "id": "VRF1"
+                }
+            },
+            "destination": {
+                "ip": "192.168.2.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9612",
+                "original": "2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9612|LOG_INFO|IPTUNNEL|-|Tunnel Nexthop Added - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-tunnel",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel Nexthop Added - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)",
+            "source": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:57:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPTUNNEL"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "tunnel": {
+                    "name": "Tunnel1",
+                    "type": "GRE"
+                },
+                "vrf": {
+                    "id": "VRF1"
+                }
+            },
+            "destination": {
+                "ip": "192.168.2.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9613",
+                "original": "2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9613|LOG_ERR|IPTUNNEL|-|Tunnel Nexthop Modify Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-tunnel",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel Nexthop Modify Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)",
+            "source": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:58:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPTUNNEL"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "tunnel": {
+                    "name": "Tunnel1",
+                    "type": "GRE"
+                },
+                "vrf": {
+                    "id": "VRF1"
+                }
+            },
+            "destination": {
+                "ip": "192.168.2.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9614",
+                "original": "2024-06-18T12:58:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9614|LOG_INFO|IPTUNNEL|-|Tunnel Nexthop Modified - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-tunnel",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel Nexthop Modified - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)",
+            "source": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:59:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPTUNNEL"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "tunnel": {
+                    "name": "Tunnel1",
+                    "type": "GRE"
+                },
+                "vrf": {
+                    "id": "VRF1"
+                }
+            },
+            "destination": {
+                "ip": "192.168.2.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9615",
+                "original": "2024-06-18T12:59:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9615|LOG_ERR|IPTUNNEL|-|Tunnel Nexthop Delete Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-tunnel",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel Nexthop Delete Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)",
+            "source": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:00:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPTUNNEL"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "tunnel": {
+                    "name": "Tunnel1",
+                    "type": "GRE"
+                },
+                "vrf": {
+                    "id": "VRF1"
+                }
+            },
+            "destination": {
+                "ip": "192.168.2.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9616",
+                "original": "2024-06-18T13:00:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9616|LOG_INFO|IPTUNNEL|-|Tunnel Nexthop Deleted - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-tunnel",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel Nexthop Deleted - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)",
+            "source": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "limit": 1000,
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9801",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|9801|LOG_WARN|IP|-|IP_SOURCE_LOCKDOWN resource utilization has reached 80 percent of the supported limit of 1000 on the system"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "IP_SOURCE_LOCKDOWN resource utilization has reached 80 percent of the supported limit of 1000 on the system",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "limit": 1000,
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9802",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|9802|LOG_ERR|IP|-|IP_SOURCE_LOCKDOWN resource utilization has exceeded maximum supported limit of 1000 on the system. IP source-lockdown functionality will not work for new entries"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "IP_SOURCE_LOCKDOWN resource utilization has exceeded maximum supported limit of 1000 on the system. IP source-lockdown functionality will not work for new entries",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "limit": 1000,
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9803",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|9803|LOG_INFO|IP|-|IP_SOURCE_LOCKDOWN resource utilization has reduced below 80 percent of the supported limit of 1000 on the system"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "IP_SOURCE_LOCKDOWN resource utilization has reduced below 80 percent of the supported limit of 1000 on the system",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9804",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|9804|LOG_INFO|IP|-|IPV4_SOURCE_LOCKDOWN is enabled on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "IPV4_SOURCE_LOCKDOWN is enabled on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9805",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|9805|LOG_INFO|IP|-|IPV4_SOURCE_LOCKDOWN is disabled on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "IPV4_SOURCE_LOCKDOWN is disabled on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth1"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9806",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|9806|LOG_INFO|IP|-|IPV6_SOURCE_LOCKDOWN is enabled on interface eth1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "IPV6_SOURCE_LOCKDOWN is enabled on interface eth1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth1"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9807",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|9807|LOG_INFO|IP|-|IPV6_SOURCE_LOCKDOWN is disabled on interface eth1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-copp",
+                    "procid": "1233"
+                }
+            },
+            "message": "IPV6_SOURCE_LOCKDOWN is disabled on interface eth1",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -6551,7 +6551,7 @@
                     "device": "8360-Primaire"
                 },
                 "interface": {
-                    "name": "eth0"
+                    "id": "eth0"
                 },
                 "ip_sla": {
                     "name": "session1"
@@ -6591,7 +6591,7 @@
                     "device": "8360-Primaire"
                 },
                 "interface": {
-                    "name": "eth0"
+                    "id": "eth0"
                 },
                 "ip_sla": {
                     "name": "session1"

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -8613,7 +8613,7 @@
                     "id": "10"
                 }
             },
-            "source": {
+            "server": {
                 "mac": "00-1A-2B-3C-4D-5E"
             },
             "tags": [
@@ -8655,7 +8655,7 @@
                     "id": "10"
                 }
             },
-            "source": {
+            "server": {
                 "mac": "00-1A-2B-3C-4D-5E"
             },
             "tags": [
@@ -8748,6 +8748,9 @@
                 },
                 "sequence": "-"
             },
+            "destination": {
+                "mac": "00-1A-2B-3C-4D-5E"
+            },
             "ecs": {
                 "version": "8.11.0"
             },
@@ -8771,9 +8774,6 @@
                     "id": "100"
                 }
             },
-            "source": {
-                "mac": "00-1A-2B-3C-4D-5E"
-            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -8789,6 +8789,9 @@
                     "device": "8360-Primaire"
                 },
                 "sequence": "-"
+            },
+            "destination": {
+                "mac": "00-1A-2B-3C-4D-5E"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -8812,9 +8815,6 @@
                 "vlan": {
                     "id": "100"
                 }
-            },
-            "source": {
-                "mac": "00-1A-2B-3C-4D-5E"
             },
             "tags": [
                 "preserve_original_event"

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -227,7 +227,7 @@ processors:
       description: "Log when interface link status is [up|down]"
       if: "['403', '404'].contains(ctx.event?.code)"
       patterns:
-        - "^Link status for interface %{DATA:aruba.interface.id} is (up|%{GREEDYDATA:aruba.status})"
+        - "^Link status for interface %{DATA:aruba.interface.id} is (up|%{GREEDYDATA:aruba.interface.state})"
   - grok:
       field: message
       tag: copp_event_406_407_408
@@ -802,7 +802,7 @@ processors:
         - "^%{IP_SLA_SESSION_NAME} failed to (bind source|initialize socket), reason:%{GREEDYDATA:event.reason}"
         - "^%{IP_SLA_SESSION_NAME}: %{GREEDYDATA:event.action}"
         - "^%{IP_SLA_SESSION_NAME} is incomplete to schedule"
-        - "^%{IP_SLA_SESSION_NAME} interface %{DATA:aruba.interface.name} is( not)? ready and SLA is (disabled|enabled)"
+        - "^%{IP_SLA_SESSION_NAME} interface %{DATA:aruba.interface.id} is( not)? ready and SLA is (disabled|enabled)"
       pattern_definitions:
         IP_SLA_SESSION_NAME: "IP-SLA (session:)?%{DATA:aruba.ip_sla.name}"
 

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -212,6 +212,32 @@ processors:
       pattern_definitions:
         FAN_STATUS: "[-_0-9a-zA-Z]+"
 
+    # Interface events (40x)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/INTERFACE.htm
+  - grok:
+      field: message
+      tag: copp_event_401_402
+      description: "Log when interface port_admin set to [up|down]"
+      if: "['401', '402'].contains(ctx.event?.code)"
+      patterns:
+        - "^Interface port_admin set to (up|down) for %{DATA:aruba.interface.id} interface"
+  - grok:
+      field: message
+      tag: copp_event_403_404
+      description: "Log when interface link status is [up|down]"
+      if: "['403', '404'].contains(ctx.event?.code)"
+      patterns:
+        - "^Link status for interface %{DATA:aruba.interface.id} is (up|%{GREEDYDATA:aruba.status})"
+  - grok:
+      field: message
+      tag: copp_event_406_407_408
+      description: "Log when interface encountered an error that requires user intervention | a downshift | is down due to incompatible MACsec and PFC configutration"
+      if: "['406', '407', '408'].contains(ctx.event?.code)"
+      patterns:
+        - "^Interface %{DATA:aruba.interface.id} %{407_PATTERN}?"
+      pattern_definitions:
+        407_PATTERN: "downshifted to speed %{NUMBER:aruba.interface.port_speed:long} Mbps because link attempt failed at higher speed"
+
     # CoPP Events (15xx)
     # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/COPP.htm
 
@@ -542,6 +568,22 @@ processors:
         3011_3012_3013_COMMON: "correctable memory error count %{NUMBER:aruba.hardware.cecount:long} exceeded threshold %{NUMBER:aruba.limit:long}(?:%{3011_3012_3013_OPTIONAL})?"
         3011_3012_3013_OPTIONAL: " and %{NUMBER:aruba.hardware.offlined:long}"
 
+  # IPv6 Router Advertisement events (39xx)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IPV6-RA.htm
+  - grok:
+      if: "['3901', '3902', '3903', '3904', '3905', '3906', '3907', '3908', '3909', '3910', '3911', '3912', '3913', '3914', '3915', '3916', '3917', '3918', '3919'].contains(ctx.event?.code)"
+      tag: ipv6_router_event
+      field: "message"
+      description: "Event raised when ipv6 router changes occurs"
+      patterns:
+        - "^ipv6 ra (dis|en)abled on interface: %{GREEDYDATA:aruba.interface.id}"
+        - "^(Dis|En)abled sending (MTU|RDNSS|DNSSL) in Router-Advertisement messages on %{GREEDYDATA:aruba.interface.id}"
+        - "^Interface: %{DATA:aruba.interface.id} is (added to|deleted from) router discovery"
+        - "^(Added|Deleted) ipv6 prefix: %{IP:server.ip}/%{NUMBER:aruba.len:long} (on|from) interface: %{GREEDYDATA:aruba.interface.id}"
+        - "^(Added|Deleted) RA Prefix: %{DATA:aruba.prefix} on interface: %{DATA:aruba.interface.id} (to|from) prefix list"
+        - "^default prefix is configured on interface %{GREEDYDATA:aruba.interface.id}"
+        - "^(RDNSS|DNSSL) is (added|deleted) on interface: %{GREEDYDATA:aruba.interface.id}"
+
   # Firmware Update events (44xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/FIRMWARE_UPDATE.htm
   # Following events do not need further processing
@@ -562,6 +604,22 @@ processors:
       description: "Indicates that a switch firmware update failed from a remote or local source"
       patterns:
         - "^User %{DATA:user.name}: %{DATA:aruba.firmware.image_profile} image update failed via %{DATA:aruba.firmware.dnld_type}( from %{HOSTNAME:source.address})?$"
+
+  # HTTPS Server events (560x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/HTTPS_SERVER.htm
+  - grok:
+      if: "['5601', '5602', '5603', '5604', '5605'].contains(ctx.event?.code)"
+      tag: server_event_5601_5602_5603_5604_5605
+      field: "message"
+      description: "Logs a message when a user changes REST mode | enable/disable VFR config | closes HTTPS session | changes max user sessions | changes idle timeout"
+      patterns:
+        - "^User %{DATA:server.user.name} (%{5601_PATTERN}|%{5602_PATTERN}|%{5603_PATTERN}|%{5604_PATTERN}|%{5605_PATTERN})$"
+      pattern_definitions:
+        5601_PATTERN: "has enabled %{DATA:aruba.server.mode} for REST mode"
+        5602_PATTERN: "has %{DATA:aruba.status} HTTPS Server on VRF %{DATA:aruba.vrf.id}"
+        5603_PATTERN: "closed all HTTPS sessions"
+        5604_PATTERN: "changed the HTTPS Server max user sessions amount to %{NUMBER:aruba.server.sessions:long}"
+        5605_PATTERN: "changed the HTTPS Server idle timeout to %{NUMBER:aruba.timeout:long}"
 
   # Credential Manager events (65xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CREDMGR.htm
@@ -622,6 +680,53 @@ processors:
       field: "message"
       description: "Logs a message when copying config has some information"
       pattern: "Information while copying configs. Info: %{event.reason}"
+
+  # In-System Programming events (72xx)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ISP.htm
+  - grok:
+      if: "ctx.event?.code == '7200'"
+      tag: system_event_7200
+      field: "message"
+      description: "ISP internal fatal error"
+      patterns: 
+        - "^Internal fatal error at %{DATA:file.name}\\s?:\\s?%{NUMBER:aruba.system.line:long}"
+  - grok:
+      if: "['7210', '7211'].contains(ctx.event?.code)"
+      tag: system_event_7210_7211
+      field: "message"
+      description: "A non-failsafe device update is needed, but the allow-unsafe-updates command has not yet been run | about to start, so do not interrupt it"
+      patterns:
+        - "^Non-failsafe update needed for %{DATA:aruba.system.devicespec}. Please run the allow-unsafe-updates command"
+        - "^Do not interrupt non-failsafe update for %{GREEDYDATA:aruba.system.devicespec}"
+  - grok:
+      if: "['7212', '7213'].contains(ctx.event?.code)"
+      tag: system_event_7210_7211
+      field: "message"
+      description: "A device update is about to start | was successful or in some cases was successfully arranged to be performed later"
+      patterns:
+        - "^(Starting update|Update successful) for %{DATA:aruba.system.devicespec} from version %{DATA:service.version} to version %{GREEDYDATA:service.target.version}"
+  - grok:
+      if: "['7214', '7215', '7217'].contains(ctx.event?.code)"
+      tag: system_event_7214_7215_7217
+      field: "message"
+      description: "A device update failed | was postponed until after an automatic reset of its module | Unable to update non-redundant power supply"
+      patterns:
+        - "^Update failed for %{GREEDYDATA:aruba.system.devicespec}"
+        - "^Deferred update for %{DATA:aruba.system.devicespec} will be performed after an automatic module reset"
+        - "^Insufficient redundant power is available to update %{GREEDYDATA:aruba.system.devicespec}"
+  - grok:
+      if: "ctx.event?.code == '7216'"
+      tag: system_event_7216
+      field: "message"
+      description: "Indicates the approximate remaining update time for a module"
+      patterns: 
+        - "^Approximately %{NUMBER:aruba.system.time:long} minute\\(s\\) remaining to update %{NUMBER:aruba.system.numdevs:long} device\\(s\\) on %{GREEDYDATA:aruba.system.modspec}"
+  - dissect:
+      if: "ctx.event.code == '7219'"
+      tag: system_event_7219
+      field: "message"
+      description: "Failed to write-protect a module or device"
+      pattern: "Failed to write-protect %{aruba.system.devicespec} (pass %{aruba.system.pass})"
 
   # BFD events (73xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/BFD.htm
@@ -684,6 +789,22 @@ processors:
       description: "Event raised when a BFD session specifies an interval outside the specified bounds"
       patterns:
         - "^BFD session %{DATA:aruba.bfd.direction} interval override of %{NUMBER:aruba.bfd.requested_interval:long} ms is out of bounds for protocol %{DATA:aruba.bfd.from}, using %{NUMBER:aruba.bfd.applied_interval:long} ms instead"
+
+  # IP-SLA events (740x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IPSLA.htm
+  - grok:
+      if: "['7401', '7402', '7403', '7404', '7405', '7406', '7407', '7408'].contains(ctx.event?.code)"
+      tag: storage_event_7401_7402_7403_7404_7405_7406_7407_7408
+      field: "message"
+      description: "Event raised for IP-SLA events"
+      patterns:
+        - "^%{IP_SLA_SESSION_NAME} state changed to( failed)? %{DATA:aruba.status} due to reason %{GREEDYDATA:event.reason}"
+        - "^%{IP_SLA_SESSION_NAME} failed to (bind source|initialize socket), reason:%{GREEDYDATA:event.reason}"
+        - "^%{IP_SLA_SESSION_NAME}: %{GREEDYDATA:event.action}"
+        - "^%{IP_SLA_SESSION_NAME} is incomplete to schedule"
+        - "^%{IP_SLA_SESSION_NAME} interface %{DATA:aruba.interface.name} is( not)? ready and SLA is (disabled|enabled)"
+      pattern_definitions:
+        IP_SLA_SESSION_NAME: "IP-SLA (session:)?%{DATA:aruba.ip_sla.name}"
 
   # CPU_RX Events (75xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CPU_RX.htm
@@ -900,26 +1021,40 @@ processors:
   # Hardware switch controller sync events (88xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/HSC-SYNCD.htm
   - grok:
-    if: "['8802', '8803'].contains(ctx.event?.code)"
-    tag: hardware_event_8802_8803
-    field: "message"
-    description: "Log when physical port is [created|deleted] in hardware VTEP DB"
-    patterns:
-      - "^Physical Port %{DATA:aruba.port} is (created|deleted) in Hardware VTEP DB"
+      if: "['8802', '8803'].contains(ctx.event?.code)"
+      tag: hardware_event_8802_8803
+      field: message
+      description: "Log when physical port is [created|deleted] in hardware VTEP DB"
+      patterns:
+        - "^Physical Port %{DATA:aruba.port} is (created|deleted) (in|from) Hardware VTEP DB"
   - grok:
-    if: "['8806', '8807'].contains(ctx.event?.code)"
-    tag: hardware_event_8806_8807
-    field: "message"
-    description: "Logs when local MAC learn on VLAN is [updated|removed] in the Hardwar VTEP DB"
-    patterns:
-      - "^Local MAC %{MAC:source.mac} learnt on VLAN %{network.vlan.id} is (updated in|removed from) the Hardware VTEP DB"
+      if: "['8806', '8807'].contains(ctx.event?.code)"
+      tag: hardware_event_8806_8807
+      field: "message"
+      description: "Logs when local MAC learn on VLAN is [updated|removed] in the Hardwar VTEP DB"
+      patterns:
+        - "^Local MAC %{MAC:source.mac} learnt on VLAN %{DATA:network.vlan.id} is (updated in|removed from) the Hardware VTEP DB"
   - grok:
-    if: "['8808', '8809'].contains(ctx.event?.code)"
-    tag: hardware_event_8808_8809
-    field: "message"
-    description: "Logs when VXLAN IP is [updated|removed] in the Hardware VTEP DB"
-    patterns:
-      - "^VXLAN IP %{IP:server.ip} is (updated in the|removed from Switch and) Hardware VTEP DB"
+      if: "['8808', '8809'].contains(ctx.event?.code)"
+      tag: hardware_event_8808_8809
+      field: "message"
+      description: "Logs when VXLAN IP is [updated|removed] in the Hardware VTEP DB"
+      patterns:
+        - "^VXLAN IP %{IP:server.ip} is (updated in the|removed from Switch and) Hardware VTEP DB"
+  - grok:
+      if: "['8810', '8811'].contains(ctx.event?.code)"
+      tag: hardware_event_8810_8811
+      field: "message"
+      description: "Logs when unicast remote MAC learnt on VNI is [added|removed] to the switch"
+      patterns:
+        - "^Unicast Remote MAC %{MAC:source.mac} learnt on VNI %{DATA:network.vlan.id} is (added to|removed from) the switch"
+  - grok:
+      if: "ctx.event?.code == '8812'"
+      tag: hardware_event_8812
+      field: "message"
+      description: "Logs when tunnel is removed from Hardware VTEP DB"
+      patterns:
+        - "^Tunnel %{IP:server.ip} is removed from Hardware VTEP DB"
 
   # CDP events (89xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CDP.htm
@@ -930,6 +1065,17 @@ processors:
       description: "Log to indicate CDP neighbor addition/modification/deletion"
       patterns:
         - "^CDP neighbor %{MAC:source.mac} is (added|updated|deleted) on %{GREEDYDATA:aruba.interface.name}"
+
+  # Internal storage events (910x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/INTERNAL-STORAGE.htm
+  - grok:
+      if: "['9101', '9102', '9103', '9104'].contains(ctx.event?.code)"
+      tag: storage_event_9101_9102_9103_9104
+      field: "message"
+      description: "Event raised when there is a storage reporting failure | health deteriorates | change in storage endurance | failure is imminent"
+      patterns:
+        - "^Failed to report storage %{DATA:aruba.storage.name} details for module %{NUMBER:aruba.slot:long}. Error: %{GREEDYDATA:event.reason}"
+        - "^Storage %{DATA:aruba.storage.name} (health alert. E|e)ndurance utilization at %{NUMBER:aruba.storage.usage:long}\\% in module %{NUMBER:aruba.slot:long}(. Failure is imminent. Please backup data)?"
 
   # DCBX Events (92xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DCBX.htm
@@ -1034,6 +1180,38 @@ processors:
       if: "['9516', '9517', '9518'].contains(ctx.event?.code)"
       patterns:
           - "^EVPN RT: %{DATA:aruba.evpn.rt} (created|deleted|updated) for VRF: %{DATA:aruba.vrf.id}$"
+
+  # IP tunnels events (96xx)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IP_TUNNEL.htm
+  - grok:
+      if: "['9601', '9602', '9603', '9604', '9605', '9606', '9607', '9608', '9609', '9610', '9611', '9612', '9613', '9614', '9615', '9616'].contains(ctx.event?.code)"
+      tag: storage_event_9601_9602_9603_9604_9605_9606_9607_9608_9609_9610_9611_9612_9613_9614_9615_9616
+      field: "message"
+      description: "Event raised when tunnel events"
+      patterns:
+        - "^Tunnel (Creation Failed|Created|Deletion Failed|Deleted) - %{TUNNEL_NAME} %{TUNNEL_TYPE} %{TUNNEL_VFR} %{TUNNEL_LOCAL_IP} %{TUNNEL_REMOTE_IP}"
+        - "^Tunnel (Source|Destination) IP Modified - %{TUNNEL_NAME} %{TUNNEL_TYPE} %{TUNNEL_VFR} %{TUNNEL_LOCAL_IP} %{TUNNEL_REMOTE_IP}"
+        - "^Tunnel (TTL Modified|Modification Failed) - %{TUNNEL_NAME} %{TUNNEL_TYPE} %{TUNNEL_VFR} %{TUNNEL_LOCAL_IP} %{TUNNEL_REMOTE_IP} TTL \\(%{DATA:aruba.tunnel.ttl}\\)"
+        - "^Tunnel MTU (Modified|Modification Failed) - %{TUNNEL_NAME} %{TUNNEL_TYPE} %{TUNNEL_VFR} %{TUNNEL_LOCAL_IP} %{TUNNEL_REMOTE_IP} MTU \\(%{DATA:aruba.mtu}\\)"
+        - "^Tunnel Nexthop (Add Failed|Added|Modify Failed|Modified|Delete Failed|Deleted) - %{TUNNEL_NAME} %{TUNNEL_TYPE} %{TUNNEL_VFR} %{TUNNEL_LOCAL_IP} %{TUNNEL_REMOTE_IP}" 
+      pattern_definitions:
+        TUNNEL_NAME: "Name \\(%{DATA:aruba.tunnel.name}\\)"
+        TUNNEL_TYPE: "Type \\(%{DATA:aruba.tunnel.type}\\)"
+        TUNNEL_VFR: "VRF \\(%{DATA:aruba.vrf.id}\\)"
+        TUNNEL_LOCAL_IP: "Local IP \\(%{IP:source.ip}\\)"
+        TUNNEL_REMOTE_IP: "Remote IP \\(%{IP:destination.ip}\\)"
+
+  # IP source lockdown events (980x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IP_SOURCE_LOCKDOWN.htm
+  - grok:
+      if: "['9801', '9802', '9803', '9804', '9805', '9806', '9807'].contains(ctx.event?.code)"
+      tag: storage_event_9801_9802_9803_9804_9805_9806_9807
+      field: "message"
+      description: "This log event informs the user that IP_SOURCE_LOCKDOWN resource utilization has reached 80 percent of the supported limits"
+      patterns:
+        - "^IP_SOURCE_LOCKDOWN resource utilization has (reached|reduced)( below)? 80 percent of the supported limit of %{NUMBER:aruba.limit:long} on the system"
+        - "^IP_SOURCE_LOCKDOWN resource utilization has exceeded maximum supported limit of %{NUMBER:aruba.limit:long} on the system. IP source-lockdown functionality will not work for new entries"
+        - "^(IPV4_SOURCE_LOCKDOWN|IPV6_SOURCE_LOCKDOWN) is (enabled|disabled) on interface %{GREEDYDATA:aruba.interface.id}"
 
   # ACLs events (100xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ACL.htm

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1033,7 +1033,7 @@ processors:
       field: "message"
       description: "Logs when local MAC learn on VLAN is [updated|removed] in the Hardwar VTEP DB"
       patterns:
-        - "^Local MAC %{MAC:source.mac} learnt on VLAN %{DATA:network.vlan.id} is (updated in|removed from) the Hardware VTEP DB"
+        - "^Local MAC %{MAC:server.mac} learnt on VLAN %{DATA:network.vlan.id} is (updated in|removed from) the Hardware VTEP DB"
   - grok:
       if: "['8808', '8809'].contains(ctx.event?.code)"
       tag: hardware_event_8808_8809
@@ -1047,7 +1047,7 @@ processors:
       field: "message"
       description: "Logs when unicast remote MAC learnt on VNI is [added|removed] to the switch"
       patterns:
-        - "^Unicast Remote MAC %{MAC:source.mac} learnt on VNI %{DATA:network.vlan.id} is (added to|removed from) the switch"
+        - "^Unicast Remote MAC %{MAC:destination.mac} learnt on VNI %{DATA:network.vlan.id} is (added to|removed from) the switch"
   - grok:
       if: "ctx.event?.code == '8812'"
       tag: hardware_event_8812
@@ -1369,6 +1369,22 @@ processors:
       ignore_missing: true
   - gsub:
       field: host.mac
+      pattern: "[:.]"
+      replacement: "-"
+      ignore_missing: true
+  - uppercase:
+      field: server.mac
+      ignore_missing: true
+  - gsub:
+      field: server.mac
+      pattern: "[:.]"
+      replacement: "-"
+      ignore_missing: true
+  - uppercase:
+      field: destination.mac
+      ignore_missing: true
+  - gsub:
+      field: destination.mac
       pattern: "[:.]"
       replacement: "-"
       ignore_missing: true

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -677,6 +677,31 @@ processors:
       if: "ctx.event?.code == '8515'"
       pattern: "Operational state of the ring %{aruba.erps.ring_id}, instance %{aruba.instance.id} changed to Initializing with reason %{event.reason}"
 
+
+  # Hardware switch controller sync events (88xx)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/HSC-SYNCD.htm
+  - grok:
+    if: "['8802', '8803'].contains(ctx.event?.code)"
+    tag: hardware_event_8802_8803
+    field: "message"
+    description: "Log when physical port is [created|deleted] in hardware VTEP DB"
+    patterns:
+      - "^Physical Port %{DATA:aruba.port} is (created|deleted) in Hardware VTEP DB"
+  - grok:
+    if: "['8806', '8807'].contains(ctx.event?.code)"
+    tag: hardware_event_8806_8807
+    field: "message"
+    description: "Logs when local MAC learn on VLAN is [updated|removed] in the Hardwar VTEP DB"
+    patterns:
+      - "^Local MAC %{MAC:source.mac} learnt on VLAN %{network.vlan.id} is (updated in|removed from) the Hardware VTEP DB"
+  - grok:
+    if: "['8808', '8809'].contains(ctx.event?.code)"
+    tag: hardware_event_8808_8809
+    field: "message"
+    description: "Logs when VXLAN IP is [updated|removed] in the Hardware VTEP DB"
+    patterns:
+      - "^VXLAN IP %{IP:server.ip} is (updated in the|removed from Switch and) Hardware VTEP DB"
+
   # CDP events (89xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CDP.htm
   - grok:

--- a/packages/hpe_aruba_cx/data_stream/log/fields/ecs.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/ecs.yml
@@ -15,6 +15,8 @@
 - external: ecs
   name: destination.ip
 - external: ecs
+  name: destination.mac
+- external: ecs
   name: ecs.version
 - external: ecs
   name: error.code

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -440,6 +440,9 @@
         - name: port_speed
           type: long
           description: ""
+        - name: state
+          type: keyword
+          description: ""
     - name: ip_sla
       type: group
       fields:

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -437,6 +437,9 @@
         - name: name
           type: keyword
           description: ""
+        - name: port_speed
+          type: long
+          description: ""
     - name: ip_sla
       type: group
       fields:
@@ -708,10 +711,10 @@
       type: group
       fields:
         - name: sessions
-          type: keyword
-          description: ""
-        - name: timeout
           type: long
+          description: ""
+        - name: mode
+          type: keyword
           description: ""
     - name: session
       type: group
@@ -735,7 +738,7 @@
           type: keyword
           description: ""
         - name: usage
-          type: keyword
+          type: long
           description: ""
     - name: subsystem
       type: keyword
@@ -746,14 +749,20 @@
         - name: devicespec
           type: keyword
           description: ""
+        - name: line
+          type: long
+          description: ""
         - name: modspec
           type: keyword
           description: ""
         - name: numdevs
           type: long
           description: ""
+        - name: pass
+          type: keyword
+          description: ""
         - name: time
-          type: date
+          type: long
           description: ""
     - name: time
       type: group
@@ -761,6 +770,9 @@
         - name: seconds
           type: long
           description: ""
+    - name: timeout
+      type: long
+      description: ""
     - name: tunnel
       type: group
       fields:
@@ -768,6 +780,9 @@
           type: keyword
           description: ""
         - name: type
+          type: keyword
+          description: ""
+        - name: name
           type: keyword
           description: ""
     - name: vrf

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -346,75 +346,77 @@ Note: Descriptions have not been filled out
 | <after>         | aruba.firmware.after         |
 
 #### [Hardware Health Monitor events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/HW-HEALTH-MONITOR.htm)
-| Doc Fields   | Schema Mapping          |
-|--------------|-------------------------|
-| <addr>       | aruba.hardware.addr     |
-| <bus>        | aruba.hardware.bus      |
-| <cap>        | aruba.hardware.cap      |
-| <cecount>    | aruba.hardware.cecount  |
-| <channel>    | aruba.hardware.channel  |
-| <cpus>       | aruba.hardware.cpus     |
-| <device>     | aruba.hardware.device   |
-| <error_code> | error.code              |
-| <function>   | aruba.hardware.function |
-| <level>      | aruba.hardware.level    |
-| <location>   | aruba.hardware.location |
-| <mcgstatus>  | aruba.hardware.mcgstatus|
-| <misc>       | aruba.hardware.misc     |
-| <offlined>   | aruba.hardware.offlined |
-| <origin>     | aruba.hardware.origin   |
-| <page>       | aruba.hardware.page     |
-| <seg>        | aruba.hardware.seg      |
-| <slot>       | aruba.slot              |
-| <socket>     | aruba.hardware.socket   |
-| <status>     | aruba.status            |
-| <test_name>  | aruba.hardware.test_name|
-| <threshold>  | aruba.limit             |
-| <type>       | aruba.hardware.type     |
+| Doc Fields   | Schema Mapping           |
+|--------------|--------------------------|
+| <addr>       | aruba.hardware.addr      |
+| <bus>        | aruba.hardware.bus       |
+| <cap>        | aruba.hardware.cap       |
+| <cecount>    | aruba.hardware.cecount   |
+| <channel>    | aruba.hardware.channel   |
+| <cpus>       | aruba.hardware.cpus      |
+| <device>     | aruba.hardware.device    |
+| <error_code> | error.code               |
+| <function>   | aruba.hardware.function  |
+| <level>      | aruba.hardware.level     |
+| <location>   | aruba.hardware.location  |
+| <mcgstatus>  | aruba.hardware.mcgstatus |
+| <misc>       | aruba.hardware.misc      |
+| <offlined>   | aruba.hardware.offlined  |
+| <origin>     | aruba.hardware.origin    |
+| <page>       | aruba.hardware.page      |
+| <seg>        | aruba.hardware.seg       |
+| <slot>       | aruba.slot               |
+| <socket>     | aruba.hardware.socket    |
+| <status>     | aruba.status             |
+| <test_name>  | aruba.hardware.test_name |
+| <threshold>  | aruba.limit              |
+| <type>       | aruba.hardware.type      |
 
 #### [Hardware Switch controller sync events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/HSC-SYNCD.htm)
-| Field               | Description | Type | Common                       |
-|---------------------|-------------|------|------------------------------|
-| aruba.hardware.ip   |             |      | server.ip                    |
-| aruba.hardware.mac  |             |      | server.mac                   |
-| aruba.hardware.port |             |      | server.port                  |
-| aruba.hardware.vni  |             |      | network.vlan.id              |
+| Doc Fields | Schema Mapping   |
+|------------|------------------|
+| <ip>       | server.ip        |
+| <mac>      | server.mac       |
+| <port>     | aruba.port       |
+| <vni>      | network.vlan.id  |
 
 #### [HTTPS Server events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/HTTPS_SERVER.htm)
-| Field | Description | Type | Common |
-|-------|-------------|------|--------|
-| aruba.server.sessions | | | |
-| aruba.server.status  | | | aruba.status |
-| aruba.server.timeout | | | |
-| aruba.server.user    | | | server.user.name |
-| aruba.server.vrf     | | | aruba.vrf.id |
+| Doc Fields | Schema Mapping        |
+|------------|-----------------------|
+| <mode>     | aruba.server.mode     |
+| <sessions> | aruba.server.sessions |
+| <status>   | aruba.status          |
+| <timeout>  | aruba.timeout         |
+| <user>     | server.user.name      |
+| <vrf>      | aruba.vrf.id          |
 
 #### [In-System Programming events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ISP.htm)
-| Field                  | Description | Type | Common                       |
-|------------------------|-------------|------|------------------------------|
-| aruba.system.devicespec|             |      | |
-| aruba.system.file      |             |      | file.name                    |
-| aruba.system.fromver   |             |      | service.version              |
-| aruba.system.line      |             |      | log.syslog.severity.name     |
-| aruba.system.modspec   |             |      | |
-| aruba.system.numdevs   |             |      | |
-| aruba.system.pass      |             |      | event.action                 |
-| aruba.system.time      |             |      | |
-| aruba.system.tover     |             |      | service.target.version       |
+| Doc Fields   | Schema Mapping           |
+|--------------|--------------------------|
+| <devicespec> | aruba.system.devicespec  |
+| <file>       | file.name                |
+| <fromver>    | service.version          |
+| <line>       | aruba.system.line        |
+| <modspec>    | aruba.system.modspec     |
+| <numdevs>    | aruba.system.numdevs     |
+| <pass>       | event.action             |
+| <time>       | aruba.system.time        |
+| <tover>      | service.target.version   |
 
 #### [Interface events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/INTERFACE.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.interface.interface |             |      | observer.ingress.interface.name |
-| aruba.interface.state     |             |      | aruba.status                 |
+| Doc Fields   | Schema Mapping             |
+|--------------|----------------------------|
+| <interface>  | aruba.interface.id         |
+| <port_speed> | aruba.interface.port_speed |
+| <state>      | aruba.status               |
 
 #### [Internal storage events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/INTERNAL-STORAGE.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.storage.error       |             |      | error.message                |
-| aruba.storage.module_num  |             |      | aruba.slot                   |
-| aruba.storage.name        |             |      |                              |
-| aruba.storage.usage       |             |      |                              |
+| Doc Fields    | Schema Mapping        |
+|---------------|-----------------------|
+| <error>       | event.reason          |
+| <module_num>  | aruba.slot            |
+| <name>        | aruba.storage.name    |
+| <usage>       | aruba.storage.usage   |
 
 #### [IP source lockdown events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IP_SOURCE_LOCKDOWN.htm)
 | Field                              | Description | Type | Common                       |
@@ -423,32 +425,32 @@ Note: Descriptions have not been filled out
 | aruba.lockdown.max_supported_limit |             |      | aruba.limit                  |
 
 #### [IP tunnels events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IP_TUNNEL.htm)
-| Field               | Description | Type | Common                       |
-|---------------------|-------------|------|------------------------------|
-| aruba.tunnel.dest_ip|             |      | destination.ip               |
-| aruba.tunnel.ip_mtu |             |      | aruba.mtu                    |
-| aruba.tunnel.name   |             |      | observer.ingress.interface.name |
-| aruba.tunnel.src_ip |             |      | source.ip                    |
-| aruba.tunnel.ttl    |             |      |                              |
-| aruba.tunnel.type   |             |      |                              |
-| aruba.tunnel.vrf    |             |      | aruba.vrf.id                 |
+| Doc Fields   | Schema Mapping            |
+|--------------|---------------------------|
+| <dst_ip>     | destination.ip            |
+| <ip_mtu>     | aruba.mtu                 |
+| <tunnel_name>| aruba.tunnel.name         |
+| <src_ip>     | source.ip                 |
+| <ttl>        | aruba.tunnel.ttl          |
+| <type>       | aruba.tunnel.type         |
+| <vrf>        | aruba.vrf.id              |
 
 #### [IP-SLA events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IPSLA.htm)
-| Field                  | Description | Type | Common                       |
-|------------------------|-------------|------|------------------------------|
-| aruba.ip_sla.interface |             |      | observer.ingress.interface.name |
-| aruba.ip_sla.name      |             |      |                              |
-| aruba.ip_sla.operation |             |      | event.action                 |
-| aruba.ip_sla.reason    |             |      | event.reason                 |
-| aruba.ip_sla.state     |             |      | aruba.status                 |
+| Doc Fields | Schema Mapping         |
+|------------|------------------------|
+| <interface> | aruba.interface.name  |
+| <name>      | aruba.ip_sla.name     |
+| <operation> | event.action          |
+| <reason>    | event.reason          |
+| <state>     | aruba.status          |
 
 #### [IPv6 Router Advertisement events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IPV6-RA.htm)
-| Field                       | Description | Type | Common                       |
-|-----------------------------|-------------|------|------------------------------|
-| aruba.ipv6_router.intf      |             |      | observer.ingress.interface.name |
-| aruba.ipv6_router.ipv6_addr |             |      | server.ip                    |
-| aruba.ipv6_router.prefix    |             |      | aruba.prefix                 |
-| aruba.ipv6_router.prefixlen |             |      | aruba.len                    |
+| Doc Fields  | Schema Mapping       |
+|-------------|----------------------|
+| <intf>      | aruba.interface.id   |
+| <ipv6_addr> | server.ip            |
+| <prefix>    | aruba.prefix         |
+| <prefixlen> | aruba.len            |
 
 #### [IRDP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IRDP.htm)
 | Field                       | Description | Type | Common                       |
@@ -1398,6 +1400,7 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.instance.id |  | keyword |
 | aruba.interface.id |  | keyword |
 | aruba.interface.name |  | keyword |
+| aruba.interface.port_speed |  | long |
 | aruba.ip_sla.name |  | keyword |
 | aruba.l3.encaps_allocated |  | keyword |
 | aruba.l3.encaps_free |  | keyword |
@@ -1473,20 +1476,24 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.port |  | keyword |
 | aruba.prefix |  | keyword |
 | aruba.sequence |  | keyword |
-| aruba.server.sessions |  | keyword |
-| aruba.server.timeout |  | long |
+| aruba.server.mode |  | keyword |
+| aruba.server.sessions |  | long |
 | aruba.session.id |  | keyword |
 | aruba.session.name |  | keyword |
 | aruba.slot |  | long |
 | aruba.status |  | keyword |
 | aruba.storage.name |  | keyword |
-| aruba.storage.usage |  | keyword |
+| aruba.storage.usage |  | long |
 | aruba.subsystem |  | keyword |
 | aruba.system.devicespec |  | keyword |
+| aruba.system.line |  | long |
 | aruba.system.modspec |  | keyword |
 | aruba.system.numdevs |  | long |
-| aruba.system.time |  | date |
+| aruba.system.pass |  | keyword |
+| aruba.system.time |  | long |
 | aruba.time.seconds |  | long |
+| aruba.timeout |  | long |
+| aruba.tunnel.name |  | keyword |
 | aruba.tunnel.ttl |  | keyword |
 | aruba.tunnel.type |  | keyword |
 | aruba.vrf.id |  | keyword |

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -377,6 +377,7 @@ Note: Descriptions have not been filled out
 |------------|------------------|
 | <ip>       | server.ip        |
 | <mac>      | server.mac       |
+| <mac>      | destination.mac  |
 | <port>     | aruba.port       |
 | <vni>      | network.vlan.id  |
 
@@ -1511,6 +1512,7 @@ The `log` dataset collects the HPE Aruba CX logs.
 | destination.address | Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | destination.ip | IP address of the destination (IPv4 or IPv6). | ip |
+| destination.mac | MAC address of the destination. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | error.code | Error code describing the error. | keyword |
 | error.type | The type of the error, for example the class name of the exception. | keyword |

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -409,7 +409,7 @@ Note: Descriptions have not been filled out
 |--------------|----------------------------|
 | <interface>  | aruba.interface.id         |
 | <port_speed> | aruba.interface.port_speed |
-| <state>      | aruba.status               |
+| <state>      | aruba.interface.state      |
 
 #### [Internal storage events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/INTERNAL-STORAGE.htm)
 | Doc Fields    | Schema Mapping        |
@@ -439,7 +439,7 @@ Note: Descriptions have not been filled out
 #### [IP-SLA events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IPSLA.htm)
 | Doc Fields | Schema Mapping         |
 |------------|------------------------|
-| <interface> | aruba.interface.name  |
+| <interface> | aruba.interface.id    |
 | <name>      | aruba.ip_sla.name     |
 | <operation> | event.action          |
 | <reason>    | event.reason          |
@@ -1402,6 +1402,7 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.interface.id |  | keyword |
 | aruba.interface.name |  | keyword |
 | aruba.interface.port_speed |  | long |
+| aruba.interface.state |  | keyword |
 | aruba.ip_sla.name |  | keyword |
 | aruba.l3.encaps_allocated |  | keyword |
 | aruba.l3.encaps_free |  | keyword |


### PR DESCRIPTION
**Change Log:**

- Added logs, documentation and parsing for
- Hardware Health Monitor events
- Hardware Switch controller sync events
- HTTPS Server events
- IP source lockdown events
- IP tunnel events
- IP-SLA events
- IPv6 Router Advertisement events
