### PR TITLE
remove hostname from zookeeper mntr data stream

### DIFF
--- a/packages/zookeeper/changelog.yml
+++ b/packages/zookeeper/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove `hostname` field from mntr data stream.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/11832
+      link: https://github.com/elastic/integrations/pull/11875
 - version: "1.13.0"
   changes:
     - description: Add processor support for connection, mntr and server data streams.

--- a/packages/zookeeper/changelog.yml
+++ b/packages/zookeeper/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.1"
+  changes:
+    - description: Remove `hostname` field from mntr data stream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11832
 - version: "1.13.0"
   changes:
     - description: Add processor support for connection, mntr and server data streams.

--- a/packages/zookeeper/data_stream/mntr/fields/fields.yml
+++ b/packages/zookeeper/data_stream/mntr/fields/fields.yml
@@ -1,10 +1,6 @@
 - name: zookeeper.mntr
   type: group
   fields:
-    - name: hostname
-      type: keyword
-      description: |
-        ZooKeeper hostname.
     - name: approximate_data_size
       type: long
       metric_type: gauge

--- a/packages/zookeeper/docs/README.md
+++ b/packages/zookeeper/docs/README.md
@@ -184,7 +184,6 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | zookeeper.mntr.approximate_data_size | Approximate size of ZooKeeper data. | long | gauge |
 | zookeeper.mntr.ephemerals_count | Number of ephemeral znodes. | long | gauge |
 | zookeeper.mntr.followers | Number of followers seen by the current host. | long | gauge |
-| zookeeper.mntr.hostname | ZooKeeper hostname. | keyword |  |
 | zookeeper.mntr.latency.avg | Average latency between ensemble hosts in milliseconds. | long | gauge |
 | zookeeper.mntr.latency.max | Maximum latency in milliseconds. | long | gauge |
 | zookeeper.mntr.latency.min | Minimum latency in milliseconds. | long | gauge |

--- a/packages/zookeeper/manifest.yml
+++ b/packages/zookeeper/manifest.yml
@@ -1,6 +1,6 @@
 name: zookeeper
 title: ZooKeeper Metrics
-version: "1.13.0"
+version: "1.13.1"
 description: Collect metrics from ZooKeeper service with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally
Run zookeeper locally
```
docker run -it -d -p 2181:2181 -p 2888:2888 -p 3888:3888 -e ZOO_4LW_COMMANDS_WHITELIST=srvr,mntr,cons,conf zookeeper
```

Add Zookeeper integration in local Kibana
Follow instructions of adding an agent
(to make it work locally I added following lines into my `/etc/hosts` file
```
127.0.0.1       fleet-server
127.0.0.1       elasticsearch
```

For generating some extra metrics I created a new key in zookeeper
```
docker exec -it <ZOOKEEPER_CONTAINER_ID> bash
./bin/zkCli.sh
create /test test-data
get /test
quit
exit
```
Check Kibana Discover page to make sure `zookeeper.mntr.hostname` field is not showing up
<img width="441" alt="Screenshot 2024-11-22 at 2 28 40 PM" src="https://github.com/user-attachments/assets/851702d2-cc79-4a42-81bd-e74fb69164c1">


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #11600

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->