### PR TITLE
Replace Metricbeat with Elastic Agent

### DIFF
--- a/packages/prometheus/_dev/build/docs/README.md
+++ b/packages/prometheus/_dev/build/docs/README.md
@@ -21,7 +21,7 @@ to retrieve the metrics from (`/metrics` by default) can be configured with Metr
 `Use Types` parameter (default: true) enables a different layout for metrics storage, leveraging Elasticsearch
 types, including {{ url "elasticsearch-histograms" "histograms" }}.
 
-`Rate Counters` parameter (default: true) enables calculating a rate out of Prometheus counters. When enabled, Metricbeat stores
+`Rate Counters` parameter (default: true) enables calculating a rate out of Prometheus counters. When enabled, Elastic Agent stores
 the counter increment since the last collection. This metric should make some aggregations easier and with better
 performance. This parameter can only be enabled in combination with `Use Types`.
 
@@ -181,14 +181,14 @@ remote_write:
 > TIP: In order to assure the health of the whole queue, the following configuration
  [parameters](https://prometheus.io/docs/practices/remote_write/#parameters) should be considered:
 
-- `max_shards`: Sets the maximum number of parallelism with which Prometheus will try to send samples to Metricbeat.
-It is recommended that this setting should be equal to the number of cores of the machine where Metricbeat runs.
-Metricbeat can handle connections in parallel and hence setting `max_shards` to the number of parallelism that
-Metricbeat can actually achieve is the optimal queue configuration.
+- `max_shards`: Sets the maximum number of parallelism with which Prometheus will try to send samples to Elastic Agent.
+It is recommended that this setting should be equal to the number of cores of the machine where Elastic Agent runs.
+Elastic Agent can handle connections in parallel and hence setting `max_shards` to the number of parallelism that
+Elastic Agent can actually achieve is the optimal queue configuration.
 - `max_samples_per_send`: Sets the number of samples to batch together for each send. Recommended values are
 between 100 (default) and 1000. Having a bigger batch can lead to improved throughput and in more efficient
-storage since Metricbeat groups metrics with the same labels into same event documents.
-However this will increase the memory usage of Metricbeat.
+storage since Elastic Agent groups metrics with the same labels into same event documents.
+However this will increase the memory usage of Elastic Agent.
 - `capacity`: It is recommended to set capacity to 3-5 times `max_samples_per_send`.
 Capacity sets the number of samples that are queued in memory per shard, and hence capacity should be high enough so as to
 be able to cover `max_samples_per_send`.
@@ -249,7 +249,7 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 `use_types` parameter (default: true) enables a different layout for metrics storage, leveraging Elasticsearch
 types, including {{ url "elasticsearch-histograms" "histograms" }}.
 
-`rate_counters` parameter (default: true) enables calculating a rate out of Prometheus counters. When enabled, Metricbeat stores
+`rate_counters` parameter (default: true) enables calculating a rate out of Prometheus counters. When enabled, Elastic Agent stores
 the counter increment since the last collection. This metric should make some aggregations easier and with better
 performance. This parameter can only be enabled in combination with `use_types`.
 

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.20.1"
   changes:
-    - description: Replace Metricbeat with Elastic Agent.
+    - description: Improve documentation to replace references to Metricbeat with Elastic Agent.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/11876
 - version: "1.20.0"

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.20.1"
+  changes:
+    - description: Replace Metricbeat with Elastic Agent.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/11876
 - version: "1.20.0"
   changes:
     - description: Add support for `metrics_count` to count number of metrics per Elasticsearch document.

--- a/packages/prometheus/docs/README.md
+++ b/packages/prometheus/docs/README.md
@@ -21,7 +21,7 @@ to retrieve the metrics from (`/metrics` by default) can be configured with Metr
 `Use Types` parameter (default: true) enables a different layout for metrics storage, leveraging Elasticsearch
 types, including [histograms](https://www.elastic.co/guide/en/elasticsearch/reference/current/histogram.html).
 
-`Rate Counters` parameter (default: true) enables calculating a rate out of Prometheus counters. When enabled, Metricbeat stores
+`Rate Counters` parameter (default: true) enables calculating a rate out of Prometheus counters. When enabled, Elastic Agent stores
 the counter increment since the last collection. This metric should make some aggregations easier and with better
 performance. This parameter can only be enabled in combination with `Use Types`.
 
@@ -296,14 +296,14 @@ remote_write:
 > TIP: In order to assure the health of the whole queue, the following configuration
  [parameters](https://prometheus.io/docs/practices/remote_write/#parameters) should be considered:
 
-- `max_shards`: Sets the maximum number of parallelism with which Prometheus will try to send samples to Metricbeat.
-It is recommended that this setting should be equal to the number of cores of the machine where Metricbeat runs.
-Metricbeat can handle connections in parallel and hence setting `max_shards` to the number of parallelism that
-Metricbeat can actually achieve is the optimal queue configuration.
+- `max_shards`: Sets the maximum number of parallelism with which Prometheus will try to send samples to Elastic Agent.
+It is recommended that this setting should be equal to the number of cores of the machine where Elastic Agent runs.
+Elastic Agent can handle connections in parallel and hence setting `max_shards` to the number of parallelism that
+Elastic Agent can actually achieve is the optimal queue configuration.
 - `max_samples_per_send`: Sets the number of samples to batch together for each send. Recommended values are
 between 100 (default) and 1000. Having a bigger batch can lead to improved throughput and in more efficient
-storage since Metricbeat groups metrics with the same labels into same event documents.
-However this will increase the memory usage of Metricbeat.
+storage since Elastic Agent groups metrics with the same labels into same event documents.
+However this will increase the memory usage of Elastic Agent.
 - `capacity`: It is recommended to set capacity to 3-5 times `max_samples_per_send`.
 Capacity sets the number of samples that are queued in memory per shard, and hence capacity should be high enough so as to
 be able to cover `max_samples_per_send`.
@@ -458,7 +458,7 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 `use_types` parameter (default: true) enables a different layout for metrics storage, leveraging Elasticsearch
 types, including [histograms](https://www.elastic.co/guide/en/elasticsearch/reference/current/histogram.html).
 
-`rate_counters` parameter (default: true) enables calculating a rate out of Prometheus counters. When enabled, Metricbeat stores
+`rate_counters` parameter (default: true) enables calculating a rate out of Prometheus counters. When enabled, Elastic Agent stores
 the counter increment since the last collection. This metric should make some aggregations easier and with better
 performance. This parameter can only be enabled in combination with `use_types`.
 

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.10.0
 name: prometheus
 title: Prometheus
-version: 1.20.0
+version: 1.20.1
 description: Collect metrics from Prometheus servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Replaces occurrences of `Metricbeat` with `Elastic Agent` on the [Prometheus](https://www.elastic.co/docs/current/integrations/prometheus) integration page. 

Closes  https://github.com/elastic/integrations/issues/11490