### PR TITLE
Fix broken links for Barracuda and Websocket integrations

### DIFF
--- a/packages/barracuda/_dev/build/docs/README.md
+++ b/packages/barracuda/_dev/build/docs/README.md
@@ -9,7 +9,7 @@ Use the Barracuda WAF data stream to ingest log data. Then visualize that data i
 
 ## Upgrade
 
-The Technical preview `spamfirewall` data stream has been deprecated and removed, as of v1.0 of this integration. As we work on a replacement for the Spam Firewall integration, you can continue to use the [Spam Firewall filebeat module](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-barracuda.html).
+The Technical preview `spamfirewall` data stream has been deprecated and removed, as of v1.0 of this integration. As we work on a replacement for the Spam Firewall integration, you can continue to use the [Spam Firewall filebeat module](https://www.elastic.co/guide/en/beats/filebeat/8.15/filebeat-module-barracuda.html).
 
 ## WAF
 

--- a/packages/barracuda/changelog.yml
+++ b/packages/barracuda/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.1"
+  changes:
+    - description: Fix broken links for Barracuda integrations.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11896
 - version: "1.16.0"
   changes:
     - description: Improve access logs parsing.

--- a/packages/barracuda/docs/README.md
+++ b/packages/barracuda/docs/README.md
@@ -9,7 +9,7 @@ Use the Barracuda WAF data stream to ingest log data. Then visualize that data i
 
 ## Upgrade
 
-The Technical preview `spamfirewall` data stream has been deprecated and removed, as of v1.0 of this integration. As we work on a replacement for the Spam Firewall integration, you can continue to use the [Spam Firewall filebeat module](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-barracuda.html).
+The Technical preview `spamfirewall` data stream has been deprecated and removed, as of v1.0 of this integration. As we work on a replacement for the Spam Firewall integration, you can continue to use the [Spam Firewall filebeat module](https://www.elastic.co/guide/en/beats/filebeat/8.15/filebeat-module-barracuda.html).
 
 ## WAF
 

--- a/packages/barracuda/manifest.yml
+++ b/packages/barracuda/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: barracuda
 title: "Barracuda Web Application Firewall"
-version: "1.16.0"
+version: "1.16.1"
 description: "Collect logs from Barracuda Web Application Firewall with Elastic Agent."
 type: integration
 source:

--- a/packages/websocket/_dev/build/docs/README.md
+++ b/packages/websocket/_dev/build/docs/README.md
@@ -6,7 +6,7 @@ This input type connects to a WebSocket URL, listens for messages sent by the se
 
 ## Configuration
 
-The full documentation for configuring the WebSocket input can be found [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-websocket.html).
+The full documentation for configuring the WebSocket input can be found [here](https://www.elastic.co/guide/en/beats/filebeat/8.15/filebeat-input-websocket.html).
 
 To configure the WebSocket input, specify the connection URL and other optional parameters such as headers for authentication or protocol versions. Advanced options for connection handling, such as timeouts and subprotocols, can be configured in the "Advanced options" section.
 

--- a/packages/websocket/changelog.yml
+++ b/packages/websocket/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Fix broken links for Websocket integration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11896
 - version: "0.1.0"
   changes:
     - description: Initial Implementation.

--- a/packages/websocket/docs/README.md
+++ b/packages/websocket/docs/README.md
@@ -6,7 +6,7 @@ This input type connects to a WebSocket URL, listens for messages sent by the se
 
 ## Configuration
 
-The full documentation for configuring the WebSocket input can be found [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-websocket.html).
+The full documentation for configuring the WebSocket input can be found [here](https://www.elastic.co/guide/en/beats/filebeat/8.15/filebeat-input-websocket.html).
 
 To configure the WebSocket input, specify the connection URL and other optional parameters such as headers for authentication or protocol versions. Advanced options for connection handling, such as timeouts and subprotocols, can be configured in the "Advanced options" section.
 

--- a/packages/websocket/manifest.yml
+++ b/packages/websocket/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: websocket
 title: Custom Websocket logs
-version: 0.1.0
+version: 0.1.1
 description: Collect custom events from a socket server with Elastic agent.
 type: input
 categories:


### PR DESCRIPTION

As Filebeat is frozen at 8.15, this PR fixes the following broken links by replacing `current` with `8.15`:

- https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-websocket.html
- https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-barracuda.html

Relates https://github.com/elastic/integration-docs/issues/586
