### PR TITLE
Support the first 40-60 event types for the Aruba integration

### DIFF
--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -562,91 +562,96 @@ Note: Descriptions have not been filled out
 
 
 #### [MAC Address mode configuration events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3_MAC_ADDRESS_CONFIGURATION.htm)
-| Field               | Description | Type | Common                       |
-|---------------------|-------------|------|------------------------------|
-| aruba.mac.mac       |             |      | server.mac                   |
-| aruba.mac.new_mode  |             |      |                              |
-| aruba.mac.old_mode  |             |      |                              |
-| aruba.mac.vlan      |             |      | network.vlan.id              |
+| Docs Field | Schema Mapping       |
+|------------|----------------------|
+| <mac>      | server.mac           |
+| <new_mode> | aruba.mac.new_mode   |
+| <old_mode> | aruba.mac.old_mode   |
+| <vlan>     | network.vlan.id      |
 
 #### [MAC Learning events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MAC-LEARN.htm)
-| Field               | Description | Type | Common                       |
-|---------------------|-------------|------|------------------------------|
-| aruba.mac.from-intf |             |      | observer.ingress.interface.name |
-| aruba.mac.mac       |             |      | server.mac                   |
-| aruba.mac.to-intf   |             |      | observer.egress.interface.name |
-| aruba.mac.vlan      |             |      | network.vlan.id              |
+| Docs Field  | Schema Mapping               |
+|-------------|------------------------------|
+| <from-intf> | aruba.interface.prev_id      |
+| <intf>      | aruba.interface.id           |
+| <mac>       | server.mac                   |
+| <to-intf>   | aruba.mac.interface.id       |
+| <vlan>      | network.vlan.id              |
 
 #### [MACsec events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MACSEC.htm)
-| Field               | Description | Type | Common                       |
-|---------------------|-------------|------|------------------------------|
-| aruba.mac.ckn       |             |      |                              |
-| aruba.mac.ifname    |             |      | observer.ingress.interface.name |
-| aruba.mac.latest_an |             |      |                              |
-| aruba.mac.latest_kn |             |      |                              |
-| aruba.mac.old_an    |             |      |                              |
-| aruba.mac.old_kn    |             |      |                              |
-| aruba.mac.sci       |             |      |                              |
+| Docs Field   | Schema Mapping               |
+|--------------|------------------------------|
+| <ckn>        | aruba.mac.ckn                |
+| <ifname>     | aruba.interface.name         |
+| <latest_an>  | aruba.mac.latest_an          |
+| <latest_kn>  | aruba.mac.latest_kn          |
+| <old_an>     | aruba.mac.old_an             |
+| <old_kn>     | aruba.mac.old_kn             |
+| <sci>        | aruba.mac.sci                |
 
 #### [Management events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MGMT.htm)
-| Field                                      | Description | Type | Common                       |
-|--------------------------------------------|-------------|------|------------------------------|
-| aruba.management.mgmt_intf_config_crit     |             |      | log.syslog.severity.name     |
-| aruba.management.mgmt_intf_config_err      |             |      | error.message                |
-| aruba.management.config_param              |             |      |                              |
+| Docs Field                  | Schema Mapping           |
+|-----------------------------|--------------------------|
+| <mgmt_intf_config_crit>     | aruba.mgmt.config_crit   |
+| <mgmt_intf_config_err>      | aruba.mgmt.config_err    |
+| <mgmt_intf_config_param>    | aruba.mgmt.config_param  |
 
 #### [MDNS events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MDNS.htm)
-| Field                                      | Description | Type | Common                       |
-|--------------------------------------------|-------------|------|------------------------------|
+| Docs Field                  | Schema Mapping           |
+|-----------------------------|--------------------------|
 
 
 #### [MGMD events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MGMD.htm)
-| Field                  | Description | Type | Common                       |
-|------------------------|-------------|------|------------------------------|
-| aruba.mgmd.if_name     |             |      | observer.ingress.interface.name |
-| aruba.mgmd.ip_address  |             |      | client.ip                    |
-| aruba.mgmd.l3Port      |             |      |                              |
-| aruba.mgmd.pkt_type    |             |      |                              |
-| aruba.mgmd.port        |             |      | server.port                  |
-| aruba.mgmd.ring_id     |             |      | aruba.instance.id            |
-| aruba.mgmd.size_value  |             |      | aruba.len                    |
-| aruba.mgmd.state       |             |      | aruba.status                 |
-| aruba.mgmd.status      |             |      | aruba.status                 |
-| aruba.mgmd.sub_system  |             |      | aruba.subsystem              |
-| aruba.mgmd.vlan        |             |      | network.vlan.id              |
+| Docs Field  | Schema Mapping              |
+|-------------|-----------------------------|
+| <if_name>   | aruba.interface.name        |
+| <ip_address>| client.ip                   |
+| <l3Port>    | aruba.mgmd.l3_port          |
+| <mgmd_type> | aruba.mgmd.mgmd_type        |
+| <pkt_type>  | aruba.mgmd.pkt_type         |
+| <port>      | aruba.port                  |
+| <port0>     | aruba.port                  |
+| <port1>     | aruba.mgmd.port1            |
+| <ring_id>   | aruba.mgmd.ring_id          |
+| <size_value>| aruba.len                   |
+| <state>     | aruba.status                |
+| <status>    | aruba.status                |
+| <sub_system>| aruba.subsystem             |
+| <type>      | aruba.mgmd.type             |
+| <vlan>      | network.vlan.id             |
 
 #### [Mirroring events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MIRRORING.htm)
-| Field                  | Description | Type | Common                       |
-|------------------------|-------------|------|------------------------------|
-| aruba.mirroring.session|             |      | aruba.session.id             |
+| Docs Field | Schema Mapping       |
+|------------|----------------------|
+| <number>   | aruba.session.id     |
 
 #### [Module events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MODULE.htm)
-| Field                  | Description | Type | Common                       |
-|------------------------|-------------|------|------------------------------|
-| aruba.module.name      |             |      | observer.ingress.interface.name |
-| aruba.module.part_number |           |      | aruba.unit                   |
-| aruba.module.priority  |             |      | aruba.priority               |
-| aruba.module.reason    |             |      | event.reason                 |
-| aruba.module.type      |             |      |                              |
+| Docs Field    | Schema Mapping         |
+|---------------|------------------------|
+| <name>        | aruba.module.name      |
+| <part_number> | aruba.unit             |
+| <priority>    | aruba.priority         |
+| <reason>      | event.reason           |
+| <type>        | aruba.module.type      |
 
 #### [MSDP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MSDP.htm)
-| Field                  | Description | Type | Common                       |
-|------------------------|-------------|------|------------------------------|
-| aruba.msdp.grp_ip      |             |      |                              |
-| aruba.msdp.if_name     |             |      | observer.ingress.interface.name |
-| aruba.msdp.peer_ip     |             |      | client.ip                    |
-| aruba.msdp.port        |             |      | server.port                  |
-| aruba.msdp.rp_ip       |             |      |                              |
-| aruba.msdp.src_ip      |             |      | source.ip                    |
-| aruba.msdp.state       |             |      | aruba.status                 |
-| aruba.msdp.status      |             |      | aruba.status                 |
-| aruba.msdp.tcp_entity  |             |      |                              |
-| aruba.msdp.vrf_name    |             |      | aruba.vrf.name               |
+| Docs Field  | Schema Mapping               |
+|-------------|------------------------------|
+| <grp_ip>    | aruba.msdp.grp_ip            |
+| <if_name>   | aruba.interface.name         |
+| <peer_ip>   | client.ip                    |
+| <port>      | aruba.port                   |
+| <rp_ip>     | aruba.msdp.rp_ip             |
+| <src_ip>    | source.ip                    |
+| <state>     | aruba.status                 |
+| <status>    | aruba.status                 |
+| <tcp_entity>| aruba.msdp.tcp_entity        |
+| <vrf_name>  | aruba.vrf.name               |
 
 #### [Multicast Traffic Manager events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MTM.htm)
-| Field                  | Description | Type | Common                       |
-|------------------------|-------------|------|------------------------------|
-| aruba.multicast.limit  |             |      | aruba.limit                  |
+| Docs Field | Schema Mapping |
+|------------|----------------|
+| <limit>    | aruba.limit    |
 
 #### [Multiple spanning tree protocol events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MSTP.htm)
 | Field                       | Description | Type | Common                       |

--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -555,10 +555,10 @@ Note: Descriptions have not been filled out
 | <vlan>       | network.vlan.id        |
 
 #### [Loopback events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LOOPBACK.htm)
-| Docs Field | Schema Mapping       |
-|------------|----------------------|
-| <interface> | aruba.interface.id   |
-| <state>     | aruba.status         |
+| Docs Field  | Schema Mapping        |
+|-------------|-----------------------|
+| <interface> | aruba.interface.id    |
+| <state>     | aruba.interface.state |
 
 
 #### [MAC Address mode configuration events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3_MAC_ADDRESS_CONFIGURATION.htm)

--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -451,56 +451,57 @@ Note: Descriptions have not been filled out
 | aruba.ipv6_router.prefixlen |             |      | aruba.len                    |
 
 #### [IRDP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IRDP.htm)
-| Field                       | Description | Type | Common                       |
-|-----------------------------|-------------|------|------------------------------|
-| aruba.irdp.interface        |             |      | observer.ingress.interface.name |
+| Docs Field | Schema Mapping       |
+|------------|----------------------|
+| <interface> | aruba.interface.id   |
 
 #### [L3 Encap capacity events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3_ENCAP.htm)
-| Field                       | Description | Type | Common                       |
-|-----------------------------|-------------|------|------------------------------|
-| aruba.l3.encaps_allocated   |             |      |                              |
-| aruba.l3.encaps_free        |             |      |                              |
+| Docs Field          | Schema Mapping               |
+|---------------------|------------------------------|
+| <encaps_allocated>  | aruba.l3.encaps_allocated    |
+| <encaps_free>       | aruba.l3.encaps_free         |
 
 #### [L3 Resource Manager events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3_RESMGR.htm)
-| Field                       | Description | Type | Common                       |
-|-----------------------------|-------------|------|------------------------------|
-| aruba.l3.prefix             |             |      | aruba.prefix                 |
+| Docs Field | Schema Mapping  |
+|------------|-----------------|
+| <prefix>   | aruba.prefix    |
 
 #### [LACP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LACP.htm)
-| Field                       | Description | Type | Common                       |
-|-----------------------------|-------------|------|------------------------------|
-| aruba.lacp.actor_state      |             |      |                              |
-| aruba.lacp.fallback         |             |      |                              |
-| aruba.lacp.fsm_state        |             |      |                              |
-| aruba.lacp.intf_id          |             |      | observer.ingress.interface.id|
-| aruba.lacp.lacp_fallback_mode |           |      |                              |
-| aruba.lacp.lacp_fallback_timeout |        |      | aruba.timeout                |
-| aruba.lacp.lacp_mode        |             |      |                              |
-| aruba.lacp.lacp_rate        |             |      |                              |
-| aruba.lacp.lag_id           |             |      | aruba.instance.id            |
-| aruba.lacp.lag_number       |             |      |                              |
-| aruba.lacp.lag_speed        |             |      |                              |
-| aruba.lacp.mode             |             |      |                              |
-| aruba.lacp.partner_state    |             |      |                              |
-| aruba.lacp.partner_sys_id   |             |      |                              |
-| aruba.lacp.port_speed       |             |      |                              |
-| aruba.lacp.system_id        |             |      |                              |
-| aruba.lacp.system_priority  |             |      |                              |
+| Docs Field              | Schema Mapping            |
+|-------------------------|---------------------------|
+| <actor_state>           | aruba.lacp.actor_state    |
+| <fallback>              | aruba.lacp.fallback       |
+| <fsm_state>             | aruba.lacp.fsm_state      |
+| <intf_id>               | aruba.interface.id        |
+| <intf_id>               | aruba.interface.prev_id   |
+| <lacp_fallback_mode>    | aruba.lacp.fallback_mode  |
+| <lacp_fallback_timeout> | aruba.timeout             |
+| <mode>                  | aruba.lacp.mode           |
+| <lacp_rate>             | aruba.lacp.rate           |
+| <lag_id>                | aruba.instance.id         |
+| <lag_number>            | aruba.lacp.lag_number     |
+| <lag_speed>             | aruba.lacp.lag_speed      |
+| <lacp_mode>             | aruba.lacp.lacp_mode      |
+| <partner_state>         | aruba.lacp.partner_state  |
+| <partner_sys_id>        | aruba.lacp.partner_sys_id |
+| <port_speed>            | aruba.lacp.port_speed     |
+| <system_id>             | aruba.lacp.system_id      |
+| <system_priority>       | aruba.lacp.system_priority|
 
 #### [LAG events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LAG.htm)
-| Field               | Description | Type | Common                       |
-|---------------------|-------------|------|------------------------------|
-| aruba.lag.error     |             |      | error.message                |
-| aruba.lag.hw_port   |             |      | server.port                  |
-| aruba.lag.interface |             |      | observer.ingress.interface.name |
-| aruba.lag.lag_id    |             |      | aruba.instance.id            |
-| aruba.lag.mode      |             |      | event.type                   |
-| aruba.lag.port      |             |      | server.port                  |
-| aruba.lag.psc       |             |      |                              |
-| aruba.lag.rc        |             |      | error.code                   |
-| aruba.lag.tid       |             |      | process.thread.id            |
-| aruba.lag.unit      |             |      | aruba.unit                   |
-| aruba.lag.vlan      |             |      | network.vlan.id              |
+| Docs Field | Schema Mapping               |
+|------------|------------------------------|
+| <error>    | event.reason                 |
+| <hw_port>  | aruba.port                   |
+| <interface>| aruba.interface.id           |
+| <lag_id>   | aruba.instance.id            |
+| <mode>     | aruba.lag.mode               |
+| <port>     | aruba.port                   |
+| <psc>      | aruba.lag.psc                |
+| <rc>       | error.code                   |
+| <tid>      | process.thread.id            |
+| <unit>     | aruba.unit                   |
+| <vlan>     | network.vlan.id              |
 
 #### [Layer 3 Interface events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3INTERFACE.htm)
 | Field               | Description | Type | Common                       |
@@ -519,40 +520,39 @@ Note: Descriptions have not been filled out
 | aruba.l3.vlanid     |             |      | network.vlan.id              |
 
 #### [LED events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LED.htm)
-| Field               | Description | Type | Common                       |
-|---------------------|-------------|------|------------------------------|
-| aruba.led.count     |             |      | aruba.count                  |
-| aruba.led.subsystem |             |      | aruba.subsystem              |
+| Docs Field  | Schema Mapping         |
+|-------------|------------------------|
+| <count>     | aruba.count            |
+| <subsystem> | aruba.subsystem        |
 
 #### [LLDP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LLDP.htm)
-| Field                  | Description | Type | Common                       |
-|------------------------|-------------|------|------------------------------|
-| aruba.lldp.chassisid   |             |      | aruba.instance.id            |
-| aruba.lldp.interface   |             |      | observer.ingress.interface.name |
-| aruba.lldp.ip          |             |      | source.ip                    |
-| aruba.lldp.ninterface  |             |      |                              |
-| aruba.lldp.npvid       |             |      |                              |
-| aruba.lldp.port        |             |      | server.port                  |
-| aruba.lldp.pvid        |             |      | network.vlan.id              |
-| aruba.lldp.reinit_delay|             |      |                              |
-| aruba.lldp.tx_delay    |             |      |                              |
-| aruba.lldp.tx_hold     |             |      |                              |
-| aruba.lldp.tx_timer    |             |      |                              |
+| Docs Field   | Schema Mapping               |
+|--------------|------------------------------|
+| <chassisid>  | aruba.instance.id            |
+| <interface>  | aruba.interface.id           |
+| <ninterface> | aruba.lldp.ninterface        |
+| <npvid>      | aruba.lldp.npvid             |
+| <pvid>       | aruba.lldp.pvid              |
+| <hold>       | aruba.lldp.tx_hold           |
+| <value>      | aruba.lldp.tx_delay          |
+| <value>      | aruba.lldp.reinit_delay      |
+| <value>      | aruba.lldp.tx_timer          |
+| <value>      | server.ip                    |
 
 
 #### [Loop Protect events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LOOP-PROTECT.htm)
-| Field                  | Description | Type | Common                       |
-|------------------------|-------------|------|------------------------------|
-| aruba.loop.portName    |             |      | source.port                  |
-| aruba.loop.rx_port     |             |      |                              |
-| aruba.loop.tx_port     |             |      |                              |
-| aruba.loop.vlan        |             |      | network.vlan.id              |
+| Docs Field   | Schema Mapping         |
+|--------------|------------------------|
+| <portName>   | aruba.port             |
+| <rxportName> | aruba.loop.rx_port     |
+| <txportName> | aruba.loop.tx_port     |
+| <vlan>       | network.vlan.id        |
 
 #### [Loopback events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LOOPBACK.htm)
-| Field                  | Description | Type | Common                       |
-|------------------------|-------------|------|------------------------------|
-| aruba.loopback.interface |           |      | observer.ingress.interface.name |
-| aruba.loopback.status  |             |      | aruba.status                 |
+| Docs Field | Schema Mapping       |
+|------------|----------------------|
+| <interface> | aruba.interface.id   |
+| <state>     | aruba.status         |
 
 
 #### [MAC Address mode configuration events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3_MAC_ADDRESS_CONFIGURATION.htm)

--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -454,8 +454,8 @@ Note: Descriptions have not been filled out
 | <prefixlen> | aruba.len            |
 
 #### [IRDP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IRDP.htm)
-| Docs Field | Schema Mapping       |
-|------------|----------------------|
+| Docs Field  | Schema Mapping       |
+|-------------|----------------------|
 | <interface> | aruba.interface.id   |
 
 #### [L3 Encap capacity events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3_ENCAP.htm)
@@ -470,26 +470,27 @@ Note: Descriptions have not been filled out
 | <prefix>   | aruba.prefix    |
 
 #### [LACP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LACP.htm)
-| Docs Field              | Schema Mapping            |
-|-------------------------|---------------------------|
-| <actor_state>           | aruba.lacp.actor_state    |
-| <fallback>              | aruba.lacp.fallback       |
-| <fsm_state>             | aruba.lacp.fsm_state      |
-| <intf_id>               | aruba.interface.id        |
-| <intf_id>               | aruba.interface.prev_id   |
-| <lacp_fallback_mode>    | aruba.lacp.fallback_mode  |
-| <lacp_fallback_timeout> | aruba.timeout             |
-| <mode>                  | aruba.lacp.mode           |
-| <lacp_rate>             | aruba.lacp.rate           |
-| <lag_id>                | aruba.instance.id         |
-| <lag_number>            | aruba.lacp.lag_number     |
-| <lag_speed>             | aruba.lacp.lag_speed      |
-| <lacp_mode>             | aruba.lacp.lacp_mode      |
-| <partner_state>         | aruba.lacp.partner_state  |
-| <partner_sys_id>        | aruba.lacp.partner_sys_id |
-| <port_speed>            | aruba.lacp.port_speed     |
-| <system_id>             | aruba.lacp.system_id      |
-| <system_priority>       | aruba.lacp.system_priority|
+| Docs Field              | Schema Mapping             |
+|-------------------------|----------------------------|
+| <actor_state>           | aruba.lacp.actor_state     |
+| <fallback>              | aruba.lacp.fallback        |
+| <fsm_state>             | aruba.lacp.fsm_state       |
+| <intf_id>               | aruba.interface.id         |
+| <intf_id>               | aruba.interface.prev_id    |
+| <intf_name>             | aruba.interface.name       |
+| <lacp_fallback_mode>    | aruba.lacp.fallback_mode   |
+| <lacp_fallback_timeout> | aruba.timeout              |
+| <mode>                  | aruba.lacp.mode            |
+| <lacp_rate>             | aruba.lacp.rate            |
+| <lag_id>                | aruba.instance.id          |
+| <lag_number>            | aruba.lacp.lag_number      |
+| <lag_speed>             | aruba.lacp.lag_speed       |
+| <lacp_mode>             | aruba.lacp.lacp_mode       |
+| <partner_state>         | aruba.lacp.partner_state   |
+| <partner_sys_id>        | aruba.lacp.partner_sys_id  |
+| <port_speed>            | aruba.lacp.port_speed      |
+| <system_id>             | aruba.lacp.system_id       |
+| <system_priority>       | aruba.lacp.system_priority |
 
 #### [LAG events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LAG.htm)
 | Docs Field | Schema Mapping               |
@@ -507,20 +508,22 @@ Note: Descriptions have not been filled out
 | <vlan>     | network.vlan.id              |
 
 #### [Layer 3 Interface events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3INTERFACE.htm)
-| Field               | Description | Type | Common                       |
-|---------------------|-------------|------|------------------------------|
-| aruba.l3.addr       |             |      | destination.address          |
-| aruba.l3.addr_status|             |      | aruba.status                 |
-| aruba.l3.egress_id  |             |      | observer.egress.interface.id |
-| aruba.l3.err        |             |      | error.message                |
-| aruba.l3.interface  |             |      | observer.ingress.interface.name |
-| aruba.l3.ipaddr     |             |      | destination.ip               |
-| aruba.l3.mtu        |             |      | aruba.mtu                    |
-| aruba.l3.nexthop    |             |      | destination.address          |
-| aruba.l3.port       |             |      | server.port                  |
-| aruba.l3.prefix     |             |      | aruba.prefix                 |
-| aruba.l3.state      |             |      | aruba.status                 |
-| aruba.l3.vlanid     |             |      | network.vlan.id              |
+| Docs Field      | Schema Mapping               |
+|----------------|-------------------------------|
+| <addr>        | server.address                 |
+| <addr_status> | aruba.status                   |
+| <egress_id>   | observer.egress.interface.id   |
+| <err>         | event.reason                   |
+| <interface>   | aruba.interface.id             |
+| <intf>        | aruba.interface.id             |
+| <ipaddr>      | host.ip                        |
+| <mtu>         | aruba.mtu                      |
+| <nexthop>     | aruba.l3.nexthop               |
+| <port>        | aruba.port                     |
+| <prefix>      | aruba.prefix                   |
+| <state>       | aruba.status                   |
+| <value>       | server.ip                      |
+| <vlanid>      | network.vlan.id                |
 
 #### [LED events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LED.htm)
 | Docs Field  | Schema Mapping         |

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
@@ -10,6 +10,12 @@
                 "hardware": {
                     "device": "6000RCSE4802"
                 },
+                "instance": {
+                    "id": "ab:cd:ef:12:34:56"
+                },
+                "interface": {
+                    "id": "1/1/38"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -44,6 +50,12 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "6000RCSE4802"
+                },
+                "instance": {
+                    "id": "ab:cd:ef:12:34:56"
+                },
+                "interface": {
+                    "id": "1/1/38"
                 },
                 "sequence": "1/1"
             },
@@ -80,6 +92,12 @@
                 "hardware": {
                     "device": "6000RCSE4802"
                 },
+                "instance": {
+                    "id": "ab:cd:ef:12:34:56"
+                },
+                "interface": {
+                    "id": "1/1/38"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -114,6 +132,17 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "6000RCSE4802"
+                },
+                "instance": {
+                    "id": "ab:cd:ef:12:34:56"
+                },
+                "interface": {
+                    "id": "1/1/38"
+                },
+                "lldp": {
+                    "ninterface": "ab:cd:ef:12:34:56",
+                    "npvid": 0,
+                    "pvid": 394
                 },
                 "sequence": "1/1"
             },
@@ -578,6 +607,12 @@
                 "hardware": {
                     "device": "6300-DIST-RDL"
                 },
+                "instance": {
+                    "id": "ab:cd:ef:12:34:56"
+                },
+                "interface": {
+                    "id": "1/1/3"
+                },
                 "sequence": "1"
             },
             "ecs": {
@@ -611,6 +646,12 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "6300-DIST-RDL"
+                },
+                "instance": {
+                    "id": "ab:cd:ef:12:34:56"
+                },
+                "interface": {
+                    "id": "1/1/3"
                 },
                 "sequence": "1"
             },
@@ -1156,6 +1197,12 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "instance": {
+                    "id": "ab:cd:ef:12:34:56"
+                },
+                "interface": {
+                    "id": "1/1/15"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -1190,6 +1237,12 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "ab:cd:ef:12:34:56"
+                },
+                "interface": {
+                    "id": "mgmt"
                 },
                 "sequence": "1/1"
             },
@@ -1226,6 +1279,12 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "instance": {
+                    "id": "ab:cd:ef:12:34:56"
+                },
+                "interface": {
+                    "id": "1/1/17"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -1260,6 +1319,12 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "ab:cd:ef:12:34:56"
+                },
+                "interface": {
+                    "id": "1/1/15"
                 },
                 "sequence": "1/1"
             },
@@ -1296,6 +1361,9 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "lldp": {
+                    "tx_delay": 2
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -1330,6 +1398,17 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "ab:cd:ef:12:34:56"
+                },
+                "interface": {
+                    "id": "1/1/8"
+                },
+                "lldp": {
+                    "ninterface": "ab:cd:ef:12:34:56",
+                    "npvid": 0,
+                    "pvid": 1
                 },
                 "sequence": "1/1"
             },
@@ -1994,6 +2073,13 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "instance": {
+                    "id": "50"
+                },
+                "interface": {
+                    "id": "1/1/26",
+                    "prev_id": "1/1/26"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -2028,6 +2114,12 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "47"
+                },
+                "interface": {
+                    "id": "1/1/47"
                 },
                 "sequence": "1/1"
             },
@@ -2064,6 +2156,17 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "instance": {
+                    "id": "50"
+                },
+                "interface": {
+                    "id": "1/1/25"
+                },
+                "lacp": {
+                    "actor_state": "ALFOX",
+                    "partner_state": "ALFO",
+                    "partner_sys_id": "4096,ab:cd:ef:12:34:56"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -2098,6 +2201,16 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "sport: 2"
+                },
+                "interface": {
+                    "id": "1/1/25"
+                },
+                "lacp": {
+                    "actor_state": "ALFOX",
+                    "partner_state": "PSFO"
                 },
                 "sequence": "1/1"
             },
@@ -2134,6 +2247,9 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "instance": {
+                    "id": "50"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -2168,6 +2284,12 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "lag50"
+                },
+                "interface": {
+                    "id": "1/1/26"
                 },
                 "sequence": "1/1"
             },
@@ -2204,6 +2326,16 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "instance": {
+                    "id": "50"
+                },
+                "interface": {
+                    "id": "1/1/25"
+                },
+                "lacp": {
+                    "actor_state": "ALFNCD",
+                    "partner_state": "ALFNCD"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -2238,6 +2370,16 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "50"
+                },
+                "interface": {
+                    "id": "1/1/25"
+                },
+                "lacp": {
+                    "actor_state": "ALFNCD",
+                    "partner_state": "ALFNC"
                 },
                 "sequence": "1/1"
             },
@@ -2274,6 +2416,16 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "instance": {
+                    "id": "50"
+                },
+                "interface": {
+                    "id": "1/1/25"
+                },
+                "lacp": {
+                    "actor_state": "ALFNC",
+                    "partner_state": "ALFNC"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -2308,6 +2460,16 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "50"
+                },
+                "interface": {
+                    "id": "1/1/25"
+                },
+                "lacp": {
+                    "actor_state": "ALFNC",
+                    "partner_state": "ALFN"
                 },
                 "sequence": "1/1"
             },
@@ -2344,6 +2506,16 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "instance": {
+                    "id": "50"
+                },
+                "interface": {
+                    "id": "1/1/25"
+                },
+                "lacp": {
+                    "actor_state": "ALFN",
+                    "partner_state": "ALFN"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -2378,6 +2550,16 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "50"
+                },
+                "interface": {
+                    "id": "1/1/25"
+                },
+                "lacp": {
+                    "actor_state": "ALFN",
+                    "partner_state": "ALFO"
                 },
                 "sequence": "1/1"
             },
@@ -2414,6 +2596,16 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "instance": {
+                    "id": "50"
+                },
+                "interface": {
+                    "id": "1/1/25"
+                },
+                "lacp": {
+                    "actor_state": "ALFO",
+                    "partner_state": "ALFO"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -2448,6 +2640,16 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "50"
+                },
+                "interface": {
+                    "id": "1/1/25"
+                },
+                "lacp": {
+                    "actor_state": "ALFOX",
+                    "partner_state": "ALFO"
                 },
                 "sequence": "1/1"
             },
@@ -2484,6 +2686,16 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "instance": {
+                    "id": "50"
+                },
+                "interface": {
+                    "id": "1/1/25"
+                },
+                "lacp": {
+                    "actor_state": "ALFOX",
+                    "partner_state": "PSFO"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -2518,6 +2730,16 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "50"
+                },
+                "interface": {
+                    "id": "1/1/25"
+                },
+                "lacp": {
+                    "actor_state": "ALFOE",
+                    "partner_state": "PSFO"
                 },
                 "sequence": "1/1"
             },
@@ -2554,6 +2776,16 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "instance": {
+                    "id": "50"
+                },
+                "interface": {
+                    "id": "1/1/25"
+                },
+                "lacp": {
+                    "actor_state": "ALFOE",
+                    "partner_state": "PLFO"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -2588,6 +2820,16 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "50"
+                },
+                "interface": {
+                    "id": "1/1/25"
+                },
+                "lacp": {
+                    "actor_state": "ALFO",
+                    "partner_state": "PLFO"
                 },
                 "sequence": "1/1"
             },
@@ -2624,6 +2866,16 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "instance": {
+                    "id": "50"
+                },
+                "interface": {
+                    "id": "1/1/25"
+                },
+                "lacp": {
+                    "actor_state": "ALFO",
+                    "partner_state": "PLIO"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -2658,6 +2910,16 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "50"
+                },
+                "interface": {
+                    "id": "1/1/25"
+                },
+                "lacp": {
+                    "actor_state": "ALIO",
+                    "partner_state": "PLIO"
                 },
                 "sequence": "1/1"
             },
@@ -2694,6 +2956,16 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "instance": {
+                    "id": "50"
+                },
+                "interface": {
+                    "id": "1/1/25"
+                },
+                "lacp": {
+                    "actor_state": "ALFO",
+                    "partner_state": "ALIO"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -2728,6 +3000,16 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "50"
+                },
+                "interface": {
+                    "id": "1/1/25"
+                },
+                "lacp": {
+                    "actor_state": "ALFO",
+                    "partner_state": "ALFNCD"
                 },
                 "sequence": "1/1"
             },
@@ -2764,7 +3046,11 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "sequence": "1/1"
+                "interface": {
+                    "id": "vlan76"
+                },
+                "sequence": "1/1",
+                "status": "up"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -2799,7 +3085,11 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "sequence": "1/1"
+                "interface": {
+                    "id": "vlan76"
+                },
+                "sequence": "1/1",
+                "status": "down"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -2834,6 +3124,9 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "interface": {
+                    "id": "vlan1595"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -2855,6 +3148,9 @@
                 }
             },
             "message": "Interface vlan1595, configured with ipv4 address 10.137.221.2/24",
+            "server": {
+                "ip": "10.137.221.2"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -3476,6 +3772,9 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "vlan1595"
                 },
                 "sequence": "1/1"
             },

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
@@ -4118,6 +4118,7 @@
         },
         {
             "@timestamp": "2023-11-30T11:11:48.161462-05:00",
+            "_temp": {},
             "aruba": {
                 "component": {
                     "category": "AMM"
@@ -4125,6 +4126,15 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "mgmt": {
+                    "config_param": {
+                        "default_gateway": "127.0.0.1",
+                        "domain_name": "",
+                        "hostname": "8360-ServerName",
+                        "ip": "127.0.0.1",
+                        "link_state": "up"
+                    }
                 },
                 "sequence": "-"
             },
@@ -4152,6 +4162,7 @@
         },
         {
             "@timestamp": "2023-11-30T11:11:48.161346-05:00",
+            "_temp": {},
             "aruba": {
                 "component": {
                     "category": "AMM"
@@ -4159,6 +4170,15 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "mgmt": {
+                    "config_param": {
+                        "dns_server_1": "127.0.0.1",
+                        "dns_server_2": "127.0.0.1",
+                        "ipv6_linklocal": "FE80::C000:1DFF:FEE0:C01/64",
+                        "mac_address": "ab:cd:ef:12:34:56",
+                        "subnet_mask": "17"
+                    }
                 },
                 "sequence": "-"
             },
@@ -4186,6 +4206,7 @@
         },
         {
             "@timestamp": "2023-11-30T11:09:33.733026-05:00",
+            "_temp": {},
             "aruba": {
                 "component": {
                     "category": "AMM"
@@ -4193,6 +4214,14 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "mgmt": {
+                    "config_param": {
+                        "default_gateway": "127.0.0.1",
+                        "domain_name": "",
+                        "hostname": "8360-ServerName",
+                        "ip": "127.0.0.1"
+                    }
                 },
                 "sequence": "-"
             },
@@ -4228,6 +4257,9 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "mgmt": {
+                    "config_param": "Netlink event up with message type 16 for management interface."
+                },
                 "sequence": "-"
             },
             "ecs": {
@@ -4262,6 +4294,9 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "mgmt": {
+                    "config_param": "Netlink event down with message type 16 for management interface."
+                },
                 "sequence": "-"
             },
             "ecs": {
@@ -4295,6 +4330,9 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "mgmt": {
+                    "config_crit": "Link state is down."
                 },
                 "sequence": "-"
             },

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
@@ -1,3 +1,11 @@
+2024-06-18T12:45:38.182641-05:00 8360-Primaire lldpd[1234]: Event|101|LOG_INFO|AMM|-|LLDP Enabled
+2024-06-18T12:46:38.182641-05:00 8360-Primaire lldpd[1234]: Event|102|LOG_INFO|AMM|-|LLDP Disabled
+2024-06-18T12:47:38.182641-05:00 8360-Primaire lldpd[1234]: Event|103|LOG_INFO|AMM|-|Configured LLDP tx-timer to 30
+2024-06-18T12:51:38.182641-05:00 8360-Primaire lldpd[1234]: Event|107|LOG_INFO|AMM|-|Configured LLDP Management IP 192.168.1.1
+2024-06-18T12:52:38.182641-05:00 8360-Primaire lldpd[1234]: Event|108|LOG_INFO|AMM|-|Configured LLDP tx-hold to 4
+2024-06-18T12:54:38.182641-05:00 8360-Primaire lldpd[1234]: Event|110|LOG_INFO|AMM|-|Configured LLDP reinit-delay to 1
+2024-06-18T12:55:38.182641-05:00 8360-Primaire lldpd[1234]: Event|111|LOG_INFO|AMM|-|LLDP statistics cleared
+2024-06-18T12:56:38.182641-05:00 8360-Primaire lldpd[1234]: Event|112|LOG_INFO|AMM|-|LLDP neighbor info cleared
 2024-06-18T12:44:38.182641-05:00 8360-Primaire fand[1094]: Event|201|LOG_INFO|AMM|1/1|There are 4 total fans in subsystem A.
 2024-06-18T12:45:38.182641-05:00 8360-Primaire fand[1094]: Event|202|LOG_INFO|AMM|1/1|Subsystem A setting fan speed control register to 3: 1500.
 2024-06-18T12:46:38.182641-05:00 8360-Primaire fand[1094]: Event|203|LOG_INFO|AMM|1/1|Air flow direction: Front-to-Back.
@@ -19,6 +27,56 @@
 2024-06-18T13:05:38.182641-05:00 8360-Primaire fand[1094]: Event|223|LOG_WARN|AMM|1/1|Fan tray 1 FRU EPPROM is incorrectly programmed.
 2024-06-18T13:06:38.182641-05:00 8360-Primaire fand[1094]: Event|224|LOG_WARN|AMM|1/1|Front-to-Back airflow fan tray 2 disabled; this system requires Back-to-Front airflow.
 2024-06-18T13:07:38.182641-05:00 8360-Primaire fand[1094]: Event|225|LOG_WARN|AMM|1/1|Fan tray 1 misconfigured; this fan tray has been disabled.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-led[1234]: Event|501|LOG_INFO|LED|-|There are 5 LED types in subsystem A
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-led[1234]: Event|502|LOG_INFO|LED|-|There are 10 LED configs in subsystem B
+2024-06-18T12:45:38.182641-05:00 8360-Primaire loopback[1234]: Event|901|LOG_INFO|LOOPBACK|-|Loopback Interface eth0, created
+2024-06-18T12:46:38.182641-05:00 8360-Primaire loopback[1234]: Event|902|LOG_INFO|LOOPBACK|-|Loopback Interface eth0, deleted
+2024-06-18T12:47:38.182641-05:00 8360-Primaire loopback[1234]: Event|903|LOG_INFO|LOOPBACK|-|Loopback Interface eth0, configured administratively up
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1301|LOG_INFO|LACP|-|Dynamic LAG 1 created
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1302|LOG_INFO|LACP|-|Dynamic LAG 1 deleted
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1305|LOG_INFO|LACP|-|LACP system priority set to 100
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1306|LOG_INFO|LACP|-|LACP mode set to active for LAG 1
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1307|LOG_INFO|LACP|-|LACP system ID set to 00:11:22:33:44:55
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1308|LOG_INFO|LACP|-|LACP rate set to fast for LAG 1
+2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1311|LOG_WARN|LACP|-|Partner is lost (timed out) for interface eth1 LAG 1. State: down
+2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1312|LOG_ERR|LACP|-|Failed to create LAG 1
+2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1313|LOG_INFO|LACP|-|LAG 1 set as VSX
+2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1301|LOG_INFO|LACP|-|Dynamic LAG 1 created
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1302|LOG_INFO|LACP|-|Dynamic LAG 1 deleted
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1303|LOG_INFO|LACP|-|Interface eth1 added to LAG 1. Existing configuration on interface eth1 will be removed.
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1304|LOG_INFO|LACP|-|Interface eth1 removed from LAG 1. It will be set with default configuration with admin down state.
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1305|LOG_INFO|LACP|-|LACP system priority set to 100
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1306|LOG_INFO|LACP|-|LACP mode set to active for LAG 1
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1307|LOG_INFO|LACP|-|LACP system ID set to 00:11:22:33:44:55
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1308|LOG_INFO|LACP|-|LACP rate set to fast for LAG 1
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1310|LOG_WARN|LACP|-|Partner is out of sync for interface eth1 LAG 1. Actor state: up, partner state down
+2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1311|LOG_WARN|LACP|-|Partner is lost (timed out) for interface eth1 LAG 1. State: down
+2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1312|LOG_ERR|LACP|-|Failed to create LAG 1
+2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1313|LOG_INFO|LACP|-|LAG 1 set as VSX
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1314|LOG_INFO|LACP|-|LAG 1 not sending LACPDUs through interface eth0 because VSX information is not complete
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1315|LOG_ERR|LACP|-|LACP fallback mode set to active for lag 1
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1316|LOG_ERR|LACP|-|LACP fallback timeout set to 30 for lag 1
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1317|LOG_ERR|LACP|-|LACP fallback timeout 30 expired for lag 1
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1318|LOG_ERR|LACP|-|Interface eth0 enabled by fallback for lag 1
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1319|LOG_INFO|LACP|-|LAG global load balancing mode is set to src-dst-ip
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1320|LOG_INFO|LACP|-|LAG load balancing mode is set to src-dst-ip for lag 1
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1322|LOG_INFO|LACP|-|Interface eth0 cannot be part of Lag 1. Speed mismatched (Interface speed 1000Mbps Lag base speed 100Mbps). throttle_count: 100
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1323|LOG_INFO|LACP|-|Fallback is enabled for LAG 1
+2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1324|LOG_INFO|LACP|-|LACP Graceful Shut is initiated
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1401|LOG_INFO|LAG|-|Trunk set succeeds unit 1 lag_id 1001
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1402|LOG_ERR|LAG|-|Lag creation failed unit 1 lag_id 1001 rc 1 error some_error
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1403|LOG_ERR|LAG|-|Destroy lag failed on unit 1 lag_id 1001 rc 1 error some_error
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1404|LOG_INFO|LAG|-|Trunk member add port succeeds on unit 1 hw_port 2 tid 3
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1405|LOG_ERR|LAG|-|Trunk port attach error on hw_port 2 tid 3 rc 1 some_error
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1406|LOG_ERR|LAG|-|Failed to set egress enable on hw_port 2 tid 3 rc 1 error some_error
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1407|LOG_ERR|LAG|-|Failed to delete hw_port 2 from tid 3 rc 1 error some_error
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1408|LOG_ERR|LAG|-|Trunk psc set failed on unit 1 lag_id 1001 psc 2 rc 1 error some_error
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1409|LOG_INFO|LAG|-|LAG eth0, set to load balance mode to src-dst-ip
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1410|LOG_INFO|LAG|-|Add port eth1 to LAG eth0
+2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1411|LOG_INFO|LAG|-|Remove port eth1 from LAG eth0
+2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1412|LOG_INFO|LAG|-|Add port eth1 to vlan 10 for L3 LAG eth0
+2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1413|LOG_INFO|LAG|-|Remove port eth1 to vlan 10 for L3 LAG eth0
+2024-06-18T12:58:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1414|LOG_INFO|LAG|-|Destroy L3 LAG interface eth0
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|1501|LOG_ERR|COPP|-|CoPP initialization failed
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|1502|LOG_INFO|COPP|-|COPP initialization successful
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|1503|LOG_ERR|COPP|-|Ingress FP Group create failed
@@ -32,6 +90,36 @@
 2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|1511|LOG_ERR|COPP|-|CoPP deinitialization failed on slot 3
 2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|1512|LOG_ERR|COPP|-|Failed to configure hardware for CoPP on slot 3 class myClass
 2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|1513|LOG_ERR|COPP|-|Failed to retrieve CoPP statistics from slot 3 class myClass
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1701|LOG_INFO|LAYER3INTF|-|L3-Interface eth0, created
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1702|LOG_INFO|LAYER3INTF|-|L3-Interface eth0, deleted
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1704|LOG_ERR|LAYER3INTF|-|Failed to create 100 for layer 3 interface eth0
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1705|LOG_ERR|LAYER3INTF|-|Failed to destroy layer 3 interface eth0 vlan 100, error: some_error
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1706|LOG_ERR|LAYER3INTF|-|Failed to delete an l3 interface eth0, error: some_error
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1707|LOG_ERR|LAYER3INTF|-|Failed to add L3 host entry for ip 192.168.1.1, error: some_error' throttle_count: 1
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1708|LOG_INFO|LAYER3INTF|-|Added L3 host entry for ip 192.168.1.1
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1709|LOG_ERR|LAYER3INTF|-|Failed to delete L3 host entry for ip 192.168.1.1, error: some_error
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1710|LOG_INFO|LAYER3INTF|-|Deleted L3 host entry for ip 192.168.1.1
+2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1711|LOG_ERR|LAYER3INTF|-|Failed to get L3 host hit for ip 192.168.1.1
+2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1712|LOG_ERR|LAYER3INTF|-|L3 interface error: some_error
+2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1713|LOG_INFO|LAYER3INTF|-|Added Nexthop 192.168.1.2, egress_id 1001, for route 192.168.1.0/24
+2024-06-18T12:58:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1714|LOG_INFO|LAYER3INTF|-|Delete Nexthop 192.168.1.2 for route 192.168.1.0/24
+2024-06-18T12:59:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1715|LOG_INFO|LAYER3INTF|-|Added route 192.168.1.0/24
+2024-06-18T13:00:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1716|LOG_INFO|LAYER3INTF|-|Update: route state: up
+2024-06-18T13:01:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1717|LOG_INFO|LAYER3INTF|-|Delete route 192.168.1.0/24
+2024-06-18T13:02:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1718|LOG_ERR|LAYER3INTF|-|Delete route 192.168.1.0/24, error: some_error
+2024-06-18T13:03:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1719|LOG_ERR|LAYER3INTF|-|Add route 192.168.1.0/24, error: some_error' throttle_count: 1
+2024-06-18T13:04:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1720|LOG_ERR|LAYER3INTF|-|Error creating egress object for port eth1, error: some_error
+2024-06-18T13:05:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1721|LOG_INFO|LAYER3INTF|-|Created L3 egress ID 1001 for port eth1 intf eth0
+2024-06-18T13:06:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1722|LOG_ERR|LAYER3INTF|-|Error deleting egress object for port eth1, error: some_error
+2024-06-18T13:07:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1723|LOG_INFO|LAYER3INTF|-|Deleted L3 egress ID 1001 for port eth1
+2024-06-18T13:08:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1724|LOG_INFO|LAYER3INTF|-|Interface eth0, configured with ipv4 address 192.168.1.1
+2024-06-18T13:09:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1725|LOG_INFO|LAYER3INTF|-|Interface eth0, configured with ipv6 address FE80::C000:1DFF:FEE0:C01/64
+2024-06-18T13:10:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1726|LOG_INFO|LAYER3INTF|-|Interface eth0, ipv4 address deleted 192.168.1.1
+2024-06-18T13:11:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1727|LOG_INFO|LAYER3INTF|-|Interface eth0, ipv6 address deleted FE80::C000:1DFF:FEE0:C01/64
+2024-06-18T13:12:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1728|LOG_INFO|LAYER3INTF|-|IPv6 Address Status: Interface eth0, address 2001:db8:3333:4444:5555:6666:7777:8888, status active
+2024-06-18T13:13:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1729|LOG_INFO|LAYER3INTF|-|Interface eth0, configured with secondary ipv4 address 192.168.1.2
+2024-06-18T13:14:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1730|LOG_INFO|LAYER3INTF|-|Interface eth0, secondary ipv4 address deleted 192.168.1.2
+2024-06-18T13:15:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1731|LOG_ERR|LAYER3INTF|-|IP MTU 1500 not applied due to hardware resource limitation
 2024-06-19T13:54:24.900661-05:00 8360-Primaire hpe-ecmpd[1980]: Event|1801|LOG_ERR|ECMP|-|Failed to update ecmp object for route aruba_route, error: aruba_error
 2024-06-19T13:54:24.900661-05:00 8360-Primaire hpe-ecmpd[1980]: Event|1802|LOG_INFO|ECMP|-|Update ecmp object for route aruba_route
 2024-06-19T13:54:24.900661-05:00 8360-Primaire hpe-ecmpd[1980]: Event|1803|LOG_ERR|ECMP|-|Failed to delete ecmp egress object aruba_egress_id, error: aruba_error message
@@ -51,6 +139,14 @@
 2024-06-19T14:22:07.025544-05:00 8360-Primaire acctd[358]: Event|2303|LOG_INFO|AMM|1/1|RADIUS radius type radius_action: radius_event
 2024-06-19T14:22:07.025546-05:00 8360-Primaire acctd[358]: Event|2304|LOG_INFO|AMM|1/1|RADIUS Server with Address: 127.0.0.1, Authport:1/1/6, VRF_ID:vpn-Internet is "aruba_status"
 2024-06-19T14:22:07.025547-05:00 8360-Primaire acctd[358]: Event|2305|LOG_INFO|AMM|1/1|TACACS server host 127.0.0.1 port 1/1/6 vrf vpn-Internet aruba_status
+2024-06-18T12:45:38.182641-05:00 8360-Primaire loopprotect[1234]: Event|2801|LOG_WARN|LOOPPROTECT|-|Port eth0 is disabled by Loop-protection after loop detection on VLAN 10
+2024-06-18T12:46:38.182641-05:00 8360-Primaire loopprotect[1234]: Event|2802|LOG_WARN|LOOPPROTECT|-|Ports TX eth1 and RX eth2 are disabled by Loop-protect after loop detection on VLAN 20
+2024-06-18T12:47:38.182641-05:00 8360-Primaire loopprotect[1234]: Event|2803|LOG_WARN|LOOPPROTECT|-|Loop detected on port eth3 on VLAN 30
+2024-06-18T12:48:38.182641-05:00 8360-Primaire loopprotect[1234]: Event|2804|LOG_INFO|LOOPPROTECT|-|Port eth4 enabled after disable time expired
+2024-06-18T12:49:38.182641-05:00 8360-Primaire loopprotect[1234]: Event|2805|LOG_INFO|LOOPPROTECT|-|Port eth5 added for loop-protection
+2024-06-18T12:50:38.182641-05:00 8360-Primaire loopprotect[1234]: Event|2806|LOG_INFO|LOOPPROTECT|-|Port eth6 deleted from loop-protection
+2024-06-18T12:51:38.182641-05:00 8360-Primaire loopprotect[1234]: Event|2807|LOG_INFO|LOOPPROTECT|-|Loop-Protection stats cleared for port eth7
+2024-06-18T12:52:38.182641-05:00 8360-Primaire loopprotect[1234]: Event|2808|LOG_INFO|LOOPPROTECT|-|Ports TX eth8 and RX eth9 are involved during TX port disabling
 2024-06-19T14:22:07.025548-05:00 8360-Primaire acctd[358]: Event|2901|LOG_INFO|AMM|1/1|127.0.0.1: Peer up. vrf-name: vpn-Internet
 2024-06-19T14:22:07.025548-05:00 8360-Primaire acctd[358]: Event|2901|LOG_INFO|AMM|1/1|8360-ServerName: Peer up. vrf-name: vpn-Internet
 2024-06-19T14:22:07.025548-05:00 8360-Primaire acctd[358]: Event|2902|LOG_INFO|AMM|1/1|127.0.0.1: Peer down. error-code: error_code, error-sub-code: error_sub_code. vrf-name: vpn-Internet
@@ -88,6 +184,7 @@
 2024-06-19T14:22:07.025548-05:00 8360-Primaire acctd[358]: Event|3013|LOG_WARN|AMM|1/1|Page mock_page correctable memory error count 2 exceeded threshold 1 and 3
 2024-06-21T18:32:07.025548-05:00 8360-Primaire dhcpd[999]: Event|3401|LOG_INFO|DHCPD|-|DHCP Relay Enabled
 2024-06-21T18:32:07.025548-05:00 8360-Primaire dhcpd[999]: Event|3402|LOG_INFO|DHCPD|-|DHCP Relay Disabled
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-irdp[1234]: Event|3501|LOG_INFO|IRDP|-|IRDP enabled on interface eth0
 2024-06-20T14:00:38.324517-05:00 8360-Primaire hpe-firmware[1989034]: Event|4401|LOG_INFO|AMM|-|User admin: primary image updated via TFTP from 192.168.1.1. Firmware version, Before Update: 1.0.0 After Update: 1.1.0
 2024-06-20T14:01:38.324517-05:00 8360-Primaire hpe-firmware[1989034]: Event|4402|LOG_INFO|AMM|-|User admin: secondary image updated via USB. Firmware version, Before Update: 1.0.0 After Update: 1.1.0
 2024-06-20T14:02:38.324517-05:00 8360-Primaire hpe-firmware[1989034]: Event|4403|LOG_ERR|AMM|-|User admin: primary image update failed via TFTP from 192.168.1.1
@@ -195,6 +292,9 @@
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|10003|LOG_ERR|AMM|-|ACL mock_acl_type mock_acl_name failed to apply on mock_application
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|10401|LOG_INFO|AMM|-|ARP inspection mock_status on vlan vpn-Internet.
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|10402|LOG_ERR|AMM|-|ARP inspection mock_status on port 1/1/25.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-l3encap[1234]: Event|10601|LOG_WARN|L3ENCAP|-|L3 resources critical for neighbor and route forwarding are low. Used: 80, Available: 20
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-l3encap[1234]: Event|10602|LOG_INFO|L3ENCAP|-|L3 resources critical for neighbor and route forwarding are at safe levels. Used: 50, Available: 50
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-l3encap[1234]: Event|10603|LOG_ERR|L3ENCAP|-|Out of L3 resources critical for neighbor and route forwarding. Used: 100, Available: 0
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-dpsed[1234]: Event|10901|LOG_CRIT|DPSE|-|Line card module R0X39B triggered backplane sequence recovery
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-dpsed[1234]: Event|10904|LOG_CRIT|DPSE|-|Line card module R0X39B completed backplane sequence recovery
 2024-06-19T13:57:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|11101|LOG_WARN|AMM|-|Interface eth0: link fault detected
@@ -206,6 +306,7 @@
 2024-06-19T14:03:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|11107|LOG_INFO|AMM|-|MAC Lockout packet drop detected for AA:BB:CC:DD:EE:FF as source address: 5.
 2024-06-19T14:04:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|11108|LOG_INFO|AMM|-|MAC Lockout packet drop detected for AA:BB:CC:DD:EE:FF as destination address: 3.
 2024-06-19T14:05:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|11109|LOG_INFO|AMM|-|MAC Lockout packet drop detected for AA:BB:CC:DD:EE:FF as source: 5 and destination: 3 address.
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-l3resmgr[1234]: Event|11501|LOG_WARN|L3RSMGR|-|IPv6 route prefix FE80::C000:1DFF:FEE0:C01/64 is not supported on this platform.
 2024-06-20T13:54:38.182641-05:00 8360-Primaire hpe-cfmd[1204]: Event|11601|LOG_ERR|CFM|-|Connection lost for Maintenance Endpoint myEndpointId on eth0.
 2024-06-20T13:55:38.182641-05:00 8360-Primaire hpe-cfmd[1204]: Event|11602|LOG_INFO|CFM|-|Connection restored for Maintenance Endpoint myEndpointId on eth0.
 2024-06-21T13:56:38.182641-05:00 8360-Primaire hpe-container[1255]: Event|11801|LOG_INFO|CONTAINER|-|Container myContainerName is created

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
@@ -131,6 +131,28 @@
 2024-06-19T14:22:07.025544-05:00 8360-Primaire acctd[358]: Event|2303|LOG_INFO|AMM|1/1|RADIUS radius type radius_action: radius_event
 2024-06-19T14:22:07.025546-05:00 8360-Primaire acctd[358]: Event|2304|LOG_INFO|AMM|1/1|RADIUS Server with Address: 127.0.0.1, Authport:1/1/6, VRF_ID:vpn-Internet is "aruba_status"
 2024-06-19T14:22:07.025547-05:00 8360-Primaire acctd[358]: Event|2305|LOG_INFO|AMM|1/1|TACACS server host 127.0.0.1 port 1/1/6 vrf vpn-Internet aruba_status
+2024-06-18T12:45:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2601|LOG_ERR|MGMD|-|Failed to alloc a multicast pkt(interface vlan10)
+2024-06-18T12:46:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2602|LOG_INFO|MGMD|-|Received IGMPv1 query from 192.168.1.1 when the device is configured for IGMPv2.
+2024-06-18T12:47:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2603|LOG_ERR|MGMD|-|Unable to alloc a buf of size 1024 for subsystem1
+2024-06-18T12:48:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2604|LOG_INFO|MGMD|-|Interface eth0: Other Querier detected for IGMP
+2024-06-18T12:49:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2605|LOG_INFO|MGMD|-|IGMP Querier Election in progress for interface eth0 with IP address 192.168.1.1
+2024-06-18T12:50:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2606|LOG_INFO|MGMD|-|Interface eth0: End IGMP Querier role
+2024-06-18T12:51:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2607|LOG_INFO|MGMD|-|Interface eth0: Start IGMP Querier role addr: 192.168.1.1
+2024-06-18T12:52:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2608|LOG_WARN|MGMD|-|Received packet from 192.168.1.1, type 11, on invalid port 8080
+2024-06-18T12:53:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2609|LOG_INFO|MGMD|-|Received IGMPv1 query from 192.168.1.1 when the device is configured for IGMPv3.
+2024-06-18T12:54:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2610|LOG_INFO|MGMD|-|Received IGMPv2 query from 192.168.1.1 when the device is configured for IGMPv3.
+2024-06-18T12:55:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2611|LOG_INFO|MGMD|-|IGMP snooping is enabled on VLAN 10.
+2024-06-18T12:56:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2612|LOG_INFO|MGMD|-|IGMP is enabled on Interface eth0
+2024-06-18T12:57:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2613|LOG_INFO|MGMD|-|Port eth0 on vlan 10 is set to enabled mode for IGMP.
+2024-06-18T12:58:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2614|LOG_ERR|MGMD|-|IGMP is not operational on VLAN 10 due to resource unavailability
+2024-06-18T12:59:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2615|LOG_ERR|MGMD|-|IGMP is not operational on interface eth0 due to resource unavailability
+2024-06-18T13:00:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2616|LOG_INFO|MGMD|-|IGMP/MLD Resource utilization has exceeded the supported limits on the system. Membership reports for the new groups will be dropped.
+2024-06-18T13:01:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2617|LOG_INFO|MGMD|-|IGMP/MLD Resource utilization has reached 90 percent of the supported limits on the system.
+2024-06-18T13:02:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2618|LOG_INFO|MGMD|-|IGMP snooping is enabled on VLAN 10.
+2024-06-18T13:03:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2619|LOG_INFO|MGMD|-|Received IGMPv3 query from 192.168.1.1 when the device is configured for IGMPv2.
+2024-06-18T13:04:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2620|LOG_INFO|MGMD|-|Received MLDV1 query from 192.168.1.1 when the device is configured for MLDV2.
+2024-06-18T13:05:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2621|LOG_INFO|MGMD|-|Received MLDV2 query from 192.168.1.1 when the device is configured for MLDV1.
+2024-06-18T13:06:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2622|LOG_INFO|MGMD|-|Flood mode is temporarily activated on ERPS ports eth0 and eth1 as ring state for ring id 1 changed to idle.
 2024-06-18T12:45:38.182641-05:00 8360-Primaire loopprotect[1234]: Event|2801|LOG_WARN|LOOPPROTECT|-|Port eth0 is disabled by Loop-protection after loop detection on VLAN 10
 2024-06-18T12:46:38.182641-05:00 8360-Primaire loopprotect[1234]: Event|2802|LOG_WARN|LOOPPROTECT|-|Ports TX eth1 and RX eth2 are disabled by Loop-protect after loop detection on VLAN 20
 2024-06-18T12:47:38.182641-05:00 8360-Primaire loopprotect[1234]: Event|2803|LOG_WARN|LOOPPROTECT|-|Loop detected on port eth3 on VLAN 30
@@ -174,6 +196,46 @@
 2024-06-19T14:22:07.025548-05:00 8360-Primaire acctd[358]: Event|3011|LOG_WARN|AMM|1/1|Socket mock_socket correctable memory error count 1 exceeded threshold 1
 2024-06-19T14:22:07.025548-05:00 8360-Primaire acctd[358]: Event|3012|LOG_WARN|AMM|1/1|Module mock_channel correctable memory error count 2 exceeded threshold 1
 2024-06-19T14:22:07.025548-05:00 8360-Primaire acctd[358]: Event|3013|LOG_WARN|AMM|1/1|Page mock_page correctable memory error count 2 exceeded threshold 1 and 3
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3201|LOG_INFO|Module|-|Ethernet module eth0 inserted
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3202|LOG_WARN|Module|-|Ethernet module eth0 removed
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3203|LOG_INFO|Module|-|Initiating Ethernet module eth0 reboot
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3204|LOG_INFO|Module|-|Ethernet module eth0 is ready
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3205|LOG_INFO|Module|-|Ethernet module eth0 is down: hardware failure
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3206|LOG_INFO|Module|-|Ethernet module eth0 is in diagnostics mode
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3207|LOG_ERR|Module|-|Ethernet module eth0 has failed: hardware failure
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3208|LOG_INFO|Module|-|Ethernet module eth0 admin state set to up
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3209|LOG_INFO|Module|-|Ethernet module eth0 admin state set to down
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3210|LOG_INFO|Module|-|Ethernet module eth0 admin state set to diagnostics
+2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3211|LOG_INFO|Module|-|Ethernet module eth0 ISP passed
+2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3212|LOG_ERR|Module|-|Ethernet module eth0 ISP failed
+2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3213|LOG_WARN|Module|-|Ethernet module eth0 ISP skipped
+2024-06-18T12:58:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3214|LOG_INFO|Module|-|Ethernet module eth0 has enabled standby power
+2024-06-18T12:59:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3215|LOG_INFO|Module|-|Ethernet module eth0 is requesting to power on with priority high
+2024-06-18T13:00:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3216|LOG_INFO|Module|-|Ethernet module eth0 power request has been granted
+2024-06-18T13:01:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3217|LOG_ERR|Module|-|Ethernet module eth0 power request has been denied
+2024-06-18T13:02:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3218|LOG_INFO|Module|-|Ethernet module eth0 enabling main power
+2024-06-18T13:03:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3219|LOG_INFO|Module|-|Ethernet module eth0 main power enabled
+2024-06-18T13:04:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3220|LOG_ERR|Module|-|Ethernet module eth0 main power failed
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3221|LOG_INFO|Module|-|Ethernet module eth0 device initialization started
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3222|LOG_INFO|Module|-|Ethernet module eth0 device initialization passed
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3223|LOG_ERR|Module|-|Ethernet module eth0 device initialization failed: hardware error
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3224|LOG_INFO|Module|-|Ethernet module eth0 ASIC initialization started
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3225|LOG_INFO|Module|-|Ethernet module eth0 ASIC initialization completed
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3226|LOG_ERR|Module|-|Ethernet module eth0 ASIC initialization failed: hardware error
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3227|LOG_INFO|Module|-|Ethernet module eth0 ASIC deinitialization started
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3228|LOG_INFO|Module|-|Ethernet module eth0 ASIC deinitialization completed
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3229|LOG_ERR|Module|-|Ethernet module eth0 ASIC deinitialization failed: hardware error
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3230|LOG_INFO|Module|-|mock_name is starting zeroization
+2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3231|LOG_INFO|Module|-|mock_name zeroization completed
+2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3232|LOG_ERR|Module|-|mock_name zeroization failed
+2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3233|LOG_INFO|Module|-|Ethernet module eth0 configured with product number 12345
+2024-06-18T12:58:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3234|LOG_INFO|Module|-|Ethernet module eth0 has been unconfigured
+2024-06-18T12:59:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3235|LOG_INFO|Module|-|Ethernet module eth0 initiating failover
+2024-06-18T13:00:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3236|LOG_INFO|Module|-|Ethernet module eth0 failover completed
+2024-06-18T13:01:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3237|LOG_INFO|Module|-|Ethernet module eth0 initiating ISP
+2024-06-18T13:02:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3238|LOG_INFO|Module|-|Ethernet module eth0 enabling front-end power
+2024-06-18T13:03:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3239|LOG_WARN|Module|-|Ethernet module eth0 disabling front-end power: power failure
+2024-06-18T13:04:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3240|LOG_ERR|Module|-|Ethernet module eth0 has persistent hardware error
 2024-06-21T18:32:07.025548-05:00 8360-Primaire dhcpd[999]: Event|3401|LOG_INFO|DHCPD|-|DHCP Relay Enabled
 2024-06-21T18:32:07.025548-05:00 8360-Primaire dhcpd[999]: Event|3402|LOG_INFO|DHCPD|-|DHCP Relay Disabled
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-irdp[1234]: Event|3501|LOG_INFO|IRDP|-|IRDP enabled on interface eth0
@@ -196,6 +258,10 @@
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3917|LOG_INFO|IPV6ROUTER|-|RDNSS is deleted on interface: eth0
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3918|LOG_INFO|IPV6ROUTER|-|DNSSL is added on interface: eth0
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3919|LOG_INFO|IPV6ROUTER|-|DNSSL is deleted on interface: eth0
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-multicast[1234]: Event|4001|LOG_WARN|MULTICAST|-|The Multicast L3 Bridge Control Forwarding entries limit was reached: 100
+2023-11-30T11:09:33.733026-05:00 8360-Primaire ops_mgmtintfcfg[3485]: Event|4302|LOG_INFO|AMM|-|MGMT_INTF: Static parameter : [{"ip": "127.0.0.1", "hostname": "8360-ServerName", "domain_name": "", "default_gateway": "127.0.0.1"}]
+2023-11-30T11:09:33.733026-05:00 8360-Primaire ops_mgmtintfcfg[3485]: Event|4302|LOG_INFO|AMM|-|MGMT_INTF: Link state is down.
+2023-11-30T11:09:33.733026-05:00 8360-Primaire ops_mgmtintfcfg[3485]: Event|4303|LOG_INFO|AMM|-|MGMT_INTF: Static parameter : [{"ip": "127.0.0.1", "hostname": "8360-ServerName", "domain_name": "", "default_gateway": "127.0.0.1"}] is updated in ovsdb.
 2024-06-20T14:00:38.324517-05:00 8360-Primaire hpe-firmware[1989034]: Event|4401|LOG_INFO|AMM|-|User admin: primary image updated via TFTP from 192.168.1.1. Firmware version, Before Update: 1.0.0 After Update: 1.1.0
 2024-06-20T14:01:38.324517-05:00 8360-Primaire hpe-firmware[1989034]: Event|4402|LOG_INFO|AMM|-|User admin: secondary image updated via USB. Firmware version, Before Update: 1.0.0 After Update: 1.1.0
 2024-06-20T14:02:38.324517-05:00 8360-Primaire hpe-firmware[1989034]: Event|4403|LOG_ERR|AMM|-|User admin: primary image update failed via TFTP from 192.168.1.1
@@ -203,6 +269,11 @@
 2024-06-20T14:04:38.324517-05:00 8360-Primaire hpe-firmware[1989034]: Event|4405|LOG_ERR|AMM|-|Firmware image signature not valid
 2024-06-20T14:05:38.324517-05:00 8360-Primaire hpe-firmware[1989034]: Event|4406|LOG_ERR|AMM|-|Firmware image is not compatible with hardware
 2024-06-20T14:06:38.324517-05:00 8360-Primaire hpe-firmware[1989034]: Event|4407|LOG_ERR|AMM|-|Firmware image is invalid
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4801|LOG_INFO|MACLEARN|-|MAC 00:1A:2B:3C:4D:5E moved from port eth0 to port eth1 on VLAN 10
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4802|LOG_INFO|MACLEARN|-|All dynamic MAC addresses on VLAN 10 were flushed
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4803|LOG_INFO|MACLEARN|-|All dynamic MAC addresses on port eth0 were flushed
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4804|LOG_INFO|MACLEARN|-|All dynamic MAC addresses on port eth1 were flushed
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4805|LOG_INFO|MACLEARN|-|All dynamic MAC addresses on VLAN 20 were flushed
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5601|LOG_INFO|HTTPSSERVER|-|User admin has enabled read-only for REST mode
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5602|LOG_INFO|HTTPSSERVER|-|User admin has enabled HTTPS Server on VRF default
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5603|LOG_INFO|HTTPSSERVER|-|User admin closed all HTTPS sessions
@@ -216,6 +287,12 @@
 2024-06-20T15:52:07.025548-05:00 8360-Primaire credmgrd[456]: Event|6507|LOG_ERR|CREDMGR|-|Failed to write SSH authorized keys for user myUser
 2024-06-20T15:52:07.025548-05:00 8360-Primaire credmgrd[456]: Event|6508|LOG_INFO|CREDMGR|-|SSH authorized keys deleted for user myUser
 2024-06-20T15:52:07.025548-05:00 8360-Primaire credmgrd[456]: Event|6509|LOG_ERR|CREDMGR|-|User myUser has configured an invalid SSH authorized key with key identifier myKeyIdentifier
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-mirroring[1234]: Event|6701|LOG_ERR|Mirroring|-|Failed to create mirror session 1
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-mirroring[1234]: Event|6702|LOG_INFO|Mirroring|-|Mirror session 1 created
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-mirroring[1234]: Event|6703|LOG_ERR|Mirroring|-|Failed to delete mirror session 1
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-mirroring[1234]: Event|6704|LOG_INFO|Mirroring|-|Mirror session 1 deleted
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-mirroring[1234]: Event|6705|LOG_ERR|Mirroring|-|Failed to update mirror session 1
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-mirroring[1234]: Event|6706|LOG_INFO|Mirroring|-|Mirror session 1 updated
 2024-08-15T15:41:15.858927+03:00 Switchname hpe-restd[2226]: Event|6803|LOG_INFO|AMM|-|config_management_event_type:config_management_event_value
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|6804|LOG_ERR|AMM|-|Error while copying configs. Error: error_message
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|6805|LOG_INFO|AMM|-|Information while copying configs. Info: info_message
@@ -296,6 +373,14 @@
 2024-06-19T13:54:24.900661-05:00 8360-Primaire hpe-restd[1956]: Event|8512|LOG_INFO|ERPS|-|some_port_name is already configured as RPL port for instance some_instance_id
 2024-06-19T13:54:24.900661-05:00 8360-Primaire hpe-restd[1956]: Event|8513|LOG_INFO|ERPS|-|RPL configuration is not allowed on ISL port some_interface_name
 2024-06-19T13:54:24.900661-05:00 8360-Primaire hpe-restd[1956]: Event|8515|LOG_INFO|ERPS|-|Operational state of the ring some_ring_id, instance some_instance_id changed to Initializing with reason some_reason
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-msdp[1234]: Event|8601|LOG_INFO|MSDP|-|Router MSDP is up on VRF default
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-msdp[1234]: Event|8602|LOG_INFO|MSDP|-|Forwarding state of interface eth0 has been changed to up
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-msdp[1234]: Event|8603|LOG_INFO|MSDP|-|MSDP Peer 192.168.1.1(TCP) with connection source eth0 has entered established state
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-msdp[1234]: Event|8604|LOG_INFO|MSDP|-|Port 8080 is added to MSDP Peer 192.168.1.1
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-msdp[1234]: Event|8606|LOG_INFO|MSDP|-|MSDP Peer 192.168.1.1 is enabled on VRF default. Interface eth0 is added to the Peer
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-msdp[1234]: Event|8607|LOG_INFO|MSDP|-|Start server role for MSDP peer 192.168.1.1
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-msdp[1234]: Event|8608|LOG_INFO|MSDP|-|Finish packet was received on MSDP Peer 192.168.1.1
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-msdp[1234]: Event|8609|LOG_WARN|MSDP|-|Failed to add SA Cache entry: S=192.168.1.1, G=224.0.0.1, R=192.168.1.2 for Peer 192.168.1.3 as MSDP SA Cache Limit is reached
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8801|LOG_INFO|AMM|-|Hardware VTEP DB setup is completed
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8802|LOG_INFO|AMM|-|Physical Port eth0 is created in Hardware VTEP DB
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8803|LOG_INFO|AMM|-|Physical Port eth0 is deleted from Hardware VTEP DB
@@ -371,6 +456,9 @@
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-l3encap[1234]: Event|10603|LOG_ERR|L3ENCAP|-|Out of L3 resources critical for neighbor and route forwarding. Used: 100, Available: 0
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-dpsed[1234]: Event|10901|LOG_CRIT|DPSE|-|Line card module R0X39B triggered backplane sequence recovery
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-dpsed[1234]: Event|10904|LOG_CRIT|DPSE|-|Line card module R0X39B completed backplane sequence recovery
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|11001|LOG_INFO|MACCONFIG|-|The MAC Address configured mode changed from static to dynamic
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|11002|LOG_INFO|MACCONFIG|-|The MAC Address operational mode changed from static to dynamic
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|11003|LOG_WARN|MACCONFIG|-|Station MAC add failure due to hardware full, mac=00:1A:2B:3C:4D:5E vlan=10
 2024-06-19T13:57:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|11101|LOG_WARN|AMM|-|Interface eth0: link fault detected
 2024-06-19T13:58:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|11102|LOG_WARN|AMM|-|Interface eth1: link fault detected and port disabled
 2024-06-19T13:59:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|11103|LOG_INFO|AMM|-|Interface eth2: link fault re-enable time expired, port enabled
@@ -381,6 +469,10 @@
 2024-06-19T14:04:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|11108|LOG_INFO|AMM|-|MAC Lockout packet drop detected for AA:BB:CC:DD:EE:FF as destination address: 3.
 2024-06-19T14:05:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|11109|LOG_INFO|AMM|-|MAC Lockout packet drop detected for AA:BB:CC:DD:EE:FF as source: 5 and destination: 3 address.
 2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-l3resmgr[1234]: Event|11501|LOG_WARN|L3RSMGR|-|IPv6 route prefix FE80::C000:1DFF:FEE0:C01/64 is not supported on this platform.
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-macsec[1234]: Event|11201|LOG_INFO|MACsec|-|MACsec session established on Rx Secure Channel 00:11:22:33:44:55 on interface eth0.
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-macsec[1234]: Event|11202|LOG_INFO|MACsec|-|MKA session secured for Connectivity Association 1234 on interface eth0.
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-macsec[1234]: Event|11203|LOG_INFO|MACsec|-|Secure Association key updated for Connectivity Association 1234 on interface eth0 - Latest AN/KN 1/2, Old AN/KN 3/4.
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-macsec[1234]: Event|11204|LOG_INFO|MACsec|-|Possible replay attempt detected on the Secure Channel 00:11:22:33:44:55.
 2024-06-20T13:54:38.182641-05:00 8360-Primaire hpe-cfmd[1204]: Event|11601|LOG_ERR|CFM|-|Connection lost for Maintenance Endpoint myEndpointId on eth0.
 2024-06-20T13:55:38.182641-05:00 8360-Primaire hpe-cfmd[1204]: Event|11602|LOG_INFO|CFM|-|Connection restored for Maintenance Endpoint myEndpointId on eth0.
 2024-06-21T13:56:38.182641-05:00 8360-Primaire hpe-container[1255]: Event|11801|LOG_INFO|CONTAINER|-|Container myContainerName is created

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
@@ -46,19 +46,6 @@
 2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1311|LOG_WARN|LACP|-|Partner is lost (timed out) for interface eth1 LAG 1. State: down
 2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1312|LOG_ERR|LACP|-|Failed to create LAG 1
 2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1313|LOG_INFO|LACP|-|LAG 1 set as VSX
-2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1301|LOG_INFO|LACP|-|Dynamic LAG 1 created
-2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1302|LOG_INFO|LACP|-|Dynamic LAG 1 deleted
-2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1303|LOG_INFO|LACP|-|Interface eth1 added to LAG 1. Existing configuration on interface eth1 will be removed.
-2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1304|LOG_INFO|LACP|-|Interface eth1 removed from LAG 1. It will be set with default configuration with admin down state.
-2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1305|LOG_INFO|LACP|-|LACP system priority set to 100
-2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1306|LOG_INFO|LACP|-|LACP mode set to active for LAG 1
-2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1307|LOG_INFO|LACP|-|LACP system ID set to 00:11:22:33:44:55
-2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1308|LOG_INFO|LACP|-|LACP rate set to fast for LAG 1
-2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1310|LOG_WARN|LACP|-|Partner is out of sync for interface eth1 LAG 1. Actor state: up, partner state down
-2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1311|LOG_WARN|LACP|-|Partner is lost (timed out) for interface eth1 LAG 1. State: down
-2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1312|LOG_ERR|LACP|-|Failed to create LAG 1
-2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1313|LOG_INFO|LACP|-|LAG 1 set as VSX
-2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1314|LOG_INFO|LACP|-|LAG 1 not sending LACPDUs through interface eth0 because VSX information is not complete
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1315|LOG_ERR|LACP|-|LACP fallback mode set to active for lag 1
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1316|LOG_ERR|LACP|-|LACP fallback timeout set to 30 for lag 1
 2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1317|LOG_ERR|LACP|-|LACP fallback timeout 30 expired for lag 1
@@ -100,7 +87,7 @@
 2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1704|LOG_ERR|LAYER3INTF|-|Failed to create 100 for layer 3 interface eth0
 2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1705|LOG_ERR|LAYER3INTF|-|Failed to destroy layer 3 interface eth0 vlan 100, error: some_error
 2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1706|LOG_ERR|LAYER3INTF|-|Failed to delete an l3 interface eth0, error: some_error
-2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1707|LOG_ERR|LAYER3INTF|-|Failed to add L3 host entry for ip 192.168.1.1, error: some_error' throttle_count: 1
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1707|LOG_ERR|LAYER3INTF|-|Failed to add L3 host entry for ip 192.168.1.1, error: some_error
 2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1708|LOG_INFO|LAYER3INTF|-|Added L3 host entry for ip 192.168.1.1
 2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1709|LOG_ERR|LAYER3INTF|-|Failed to delete L3 host entry for ip 192.168.1.1, error: some_error
 2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1710|LOG_INFO|LAYER3INTF|-|Deleted L3 host entry for ip 192.168.1.1
@@ -112,7 +99,7 @@
 2024-06-18T13:00:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1716|LOG_INFO|LAYER3INTF|-|Update: route state: up
 2024-06-18T13:01:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1717|LOG_INFO|LAYER3INTF|-|Delete route 192.168.1.0/24
 2024-06-18T13:02:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1718|LOG_ERR|LAYER3INTF|-|Delete route 192.168.1.0/24, error: some_error
-2024-06-18T13:03:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1719|LOG_ERR|LAYER3INTF|-|Add route 192.168.1.0/24, error: some_error' throttle_count: 1
+2024-06-18T13:03:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1719|LOG_ERR|LAYER3INTF|-|Add route 192.168.1.0/24, error: some_error
 2024-06-18T13:04:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1720|LOG_ERR|LAYER3INTF|-|Error creating egress object for port eth1, error: some_error
 2024-06-18T13:05:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1721|LOG_INFO|LAYER3INTF|-|Created L3 egress ID 1001 for port eth1 intf eth0
 2024-06-18T13:06:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1722|LOG_ERR|LAYER3INTF|-|Error deleting egress object for port eth1, error: some_error

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -1475,7 +1475,7 @@
                     "id": "eth0"
                 },
                 "sequence": "-",
-                "status": ""
+                "status": "up"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -1744,7 +1744,7 @@
                     "id": "eth1"
                 },
                 "lacp": {
-                    "fsm_state": ""
+                    "fsm_state": "down"
                 },
                 "sequence": "-"
             },
@@ -1781,7 +1781,7 @@
                     "device": "8360-Primaire"
                 },
                 "instance": {
-                    "id": ""
+                    "id": "1"
                 },
                 "sequence": "-"
             },
@@ -1840,516 +1840,6 @@
                 }
             },
             "message": "LAG 1 set as VSX",
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "@timestamp": "2024-06-18T12:57:38.182641-05:00",
-            "aruba": {
-                "component": {
-                    "category": "LACP"
-                },
-                "event_type": "Event",
-                "hardware": {
-                    "device": "8360-Primaire"
-                },
-                "instance": {
-                    "id": "1"
-                },
-                "sequence": "-"
-            },
-            "ecs": {
-                "version": "8.11.0"
-            },
-            "event": {
-                "category": [
-                    "network"
-                ],
-                "code": "1301",
-                "original": "2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1301|LOG_INFO|LACP|-|Dynamic LAG 1 created"
-            },
-            "log": {
-                "level": "LOG_INFO",
-                "syslog": {
-                    "appname": "hpe-lacp",
-                    "procid": "1234"
-                }
-            },
-            "message": "Dynamic LAG 1 created",
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
-            "aruba": {
-                "component": {
-                    "category": "LACP"
-                },
-                "event_type": "Event",
-                "hardware": {
-                    "device": "8360-Primaire"
-                },
-                "instance": {
-                    "id": "1"
-                },
-                "sequence": "-"
-            },
-            "ecs": {
-                "version": "8.11.0"
-            },
-            "event": {
-                "category": [
-                    "network"
-                ],
-                "code": "1302",
-                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1302|LOG_INFO|LACP|-|Dynamic LAG 1 deleted"
-            },
-            "log": {
-                "level": "LOG_INFO",
-                "syslog": {
-                    "appname": "hpe-lacp",
-                    "procid": "1234"
-                }
-            },
-            "message": "Dynamic LAG 1 deleted",
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
-            "aruba": {
-                "component": {
-                    "category": "LACP"
-                },
-                "event_type": "Event",
-                "hardware": {
-                    "device": "8360-Primaire"
-                },
-                "instance": {
-                    "id": "1"
-                },
-                "interface": {
-                    "id": "eth1",
-                    "prev_id": "eth1"
-                },
-                "sequence": "-"
-            },
-            "ecs": {
-                "version": "8.11.0"
-            },
-            "event": {
-                "category": [
-                    "network"
-                ],
-                "code": "1303",
-                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1303|LOG_INFO|LACP|-|Interface eth1 added to LAG 1. Existing configuration on interface eth1 will be removed."
-            },
-            "log": {
-                "level": "LOG_INFO",
-                "syslog": {
-                    "appname": "hpe-lacp",
-                    "procid": "1234"
-                }
-            },
-            "message": "Interface eth1 added to LAG 1. Existing configuration on interface eth1 will be removed.",
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
-            "aruba": {
-                "component": {
-                    "category": "LACP"
-                },
-                "event_type": "Event",
-                "hardware": {
-                    "device": "8360-Primaire"
-                },
-                "instance": {
-                    "id": "1"
-                },
-                "interface": {
-                    "id": "eth1"
-                },
-                "sequence": "-"
-            },
-            "ecs": {
-                "version": "8.11.0"
-            },
-            "event": {
-                "category": [
-                    "network"
-                ],
-                "code": "1304",
-                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1304|LOG_INFO|LACP|-|Interface eth1 removed from LAG 1. It will be set with default configuration with admin down state."
-            },
-            "log": {
-                "level": "LOG_INFO",
-                "syslog": {
-                    "appname": "hpe-lacp",
-                    "procid": "1234"
-                }
-            },
-            "message": "Interface eth1 removed from LAG 1. It will be set with default configuration with admin down state.",
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
-            "aruba": {
-                "component": {
-                    "category": "LACP"
-                },
-                "event_type": "Event",
-                "hardware": {
-                    "device": "8360-Primaire"
-                },
-                "lacp": {
-                    "system_priority": "100"
-                },
-                "sequence": "-"
-            },
-            "ecs": {
-                "version": "8.11.0"
-            },
-            "event": {
-                "category": [
-                    "network"
-                ],
-                "code": "1305",
-                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1305|LOG_INFO|LACP|-|LACP system priority set to 100"
-            },
-            "log": {
-                "level": "LOG_INFO",
-                "syslog": {
-                    "appname": "hpe-lacp",
-                    "procid": "1234"
-                }
-            },
-            "message": "LACP system priority set to 100",
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
-            "aruba": {
-                "component": {
-                    "category": "LACP"
-                },
-                "event_type": "Event",
-                "hardware": {
-                    "device": "8360-Primaire"
-                },
-                "instance": {
-                    "id": "1"
-                },
-                "lacp": {
-                    "mode": "active"
-                },
-                "sequence": "-"
-            },
-            "ecs": {
-                "version": "8.11.0"
-            },
-            "event": {
-                "category": [
-                    "network"
-                ],
-                "code": "1306",
-                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1306|LOG_INFO|LACP|-|LACP mode set to active for LAG 1"
-            },
-            "log": {
-                "level": "LOG_INFO",
-                "syslog": {
-                    "appname": "hpe-lacp",
-                    "procid": "1234"
-                }
-            },
-            "message": "LACP mode set to active for LAG 1",
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
-            "aruba": {
-                "component": {
-                    "category": "LACP"
-                },
-                "event_type": "Event",
-                "hardware": {
-                    "device": "8360-Primaire"
-                },
-                "lacp": {
-                    "system_id": "00:11:22:33:44:55"
-                },
-                "sequence": "-"
-            },
-            "ecs": {
-                "version": "8.11.0"
-            },
-            "event": {
-                "category": [
-                    "network"
-                ],
-                "code": "1307",
-                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1307|LOG_INFO|LACP|-|LACP system ID set to 00:11:22:33:44:55"
-            },
-            "log": {
-                "level": "LOG_INFO",
-                "syslog": {
-                    "appname": "hpe-lacp",
-                    "procid": "1234"
-                }
-            },
-            "message": "LACP system ID set to 00:11:22:33:44:55",
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
-            "aruba": {
-                "component": {
-                    "category": "LACP"
-                },
-                "event_type": "Event",
-                "hardware": {
-                    "device": "8360-Primaire"
-                },
-                "instance": {
-                    "id": "1"
-                },
-                "lacp": {
-                    "rate": "fast"
-                },
-                "sequence": "-"
-            },
-            "ecs": {
-                "version": "8.11.0"
-            },
-            "event": {
-                "category": [
-                    "network"
-                ],
-                "code": "1308",
-                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1308|LOG_INFO|LACP|-|LACP rate set to fast for LAG 1"
-            },
-            "log": {
-                "level": "LOG_INFO",
-                "syslog": {
-                    "appname": "hpe-lacp",
-                    "procid": "1234"
-                }
-            },
-            "message": "LACP rate set to fast for LAG 1",
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
-            "aruba": {
-                "component": {
-                    "category": "LACP"
-                },
-                "event_type": "Event",
-                "hardware": {
-                    "device": "8360-Primaire"
-                },
-                "instance": {
-                    "id": "1"
-                },
-                "interface": {
-                    "id": "eth1"
-                },
-                "lacp": {
-                    "actor_state": "up",
-                    "partner_state": "down"
-                },
-                "sequence": "-"
-            },
-            "ecs": {
-                "version": "8.11.0"
-            },
-            "event": {
-                "category": [
-                    "network"
-                ],
-                "code": "1310",
-                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1310|LOG_WARN|LACP|-|Partner is out of sync for interface eth1 LAG 1. Actor state: up, partner state down"
-            },
-            "log": {
-                "level": "LOG_WARN",
-                "syslog": {
-                    "appname": "hpe-lacp",
-                    "procid": "1234"
-                }
-            },
-            "message": "Partner is out of sync for interface eth1 LAG 1. Actor state: up, partner state down",
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
-            "aruba": {
-                "component": {
-                    "category": "LACP"
-                },
-                "event_type": "Event",
-                "hardware": {
-                    "device": "8360-Primaire"
-                },
-                "instance": {
-                    "id": "1"
-                },
-                "interface": {
-                    "id": "eth1"
-                },
-                "lacp": {
-                    "fsm_state": ""
-                },
-                "sequence": "-"
-            },
-            "ecs": {
-                "version": "8.11.0"
-            },
-            "event": {
-                "category": [
-                    "network"
-                ],
-                "code": "1311",
-                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1311|LOG_WARN|LACP|-|Partner is lost (timed out) for interface eth1 LAG 1. State: down"
-            },
-            "log": {
-                "level": "LOG_WARN",
-                "syslog": {
-                    "appname": "hpe-lacp",
-                    "procid": "1234"
-                }
-            },
-            "message": "Partner is lost (timed out) for interface eth1 LAG 1. State: down",
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "@timestamp": "2024-06-18T12:56:38.182641-05:00",
-            "aruba": {
-                "component": {
-                    "category": "LACP"
-                },
-                "event_type": "Event",
-                "hardware": {
-                    "device": "8360-Primaire"
-                },
-                "instance": {
-                    "id": ""
-                },
-                "sequence": "-"
-            },
-            "ecs": {
-                "version": "8.11.0"
-            },
-            "event": {
-                "category": [
-                    "network"
-                ],
-                "code": "1312",
-                "original": "2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1312|LOG_ERR|LACP|-|Failed to create LAG 1"
-            },
-            "log": {
-                "level": "LOG_ERR",
-                "syslog": {
-                    "appname": "hpe-lacp",
-                    "procid": "1234"
-                }
-            },
-            "message": "Failed to create LAG 1",
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "@timestamp": "2024-06-18T12:57:38.182641-05:00",
-            "aruba": {
-                "component": {
-                    "category": "LACP"
-                },
-                "event_type": "Event",
-                "hardware": {
-                    "device": "8360-Primaire"
-                },
-                "instance": {
-                    "id": "1"
-                },
-                "sequence": "-"
-            },
-            "ecs": {
-                "version": "8.11.0"
-            },
-            "event": {
-                "category": [
-                    "network"
-                ],
-                "code": "1313",
-                "original": "2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1313|LOG_INFO|LACP|-|LAG 1 set as VSX"
-            },
-            "log": {
-                "level": "LOG_INFO",
-                "syslog": {
-                    "appname": "hpe-lacp",
-                    "procid": "1234"
-                }
-            },
-            "message": "LAG 1 set as VSX",
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
-            "aruba": {
-                "component": {
-                    "category": "LACP"
-                },
-                "event_type": "Event",
-                "hardware": {
-                    "device": "8360-Primaire"
-                },
-                "instance": {
-                    "id": "1"
-                },
-                "interface": {
-                    "id": "eth0"
-                },
-                "sequence": "-"
-            },
-            "ecs": {
-                "version": "8.11.0"
-            },
-            "event": {
-                "category": [
-                    "network"
-                ],
-                "code": "1314",
-                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1314|LOG_INFO|LACP|-|LAG 1 not sending LACPDUs through interface eth0 because VSX information is not complete"
-            },
-            "log": {
-                "level": "LOG_INFO",
-                "syslog": {
-                    "appname": "hpe-lacp",
-                    "procid": "1234"
-                }
-            },
-            "message": "LAG 1 not sending LACPDUs through interface eth0 because VSX information is not complete",
             "tags": [
                 "preserve_original_event"
             ]
@@ -2598,7 +2088,7 @@
                     "device": "8360-Primaire"
                 },
                 "interface": {
-                    "id": "eth0"
+                    "name": "eth0"
                 },
                 "lacp": {
                     "lag_number": 1,
@@ -2640,7 +2130,7 @@
                     "device": "8360-Primaire"
                 },
                 "instance": {
-                    "id": ""
+                    "id": "1"
                 },
                 "lacp": {
                     "fallback": "enabled"
@@ -3961,8 +3451,8 @@
                     "network"
                 ],
                 "code": "1707",
-                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1707|LOG_ERR|LAYER3INTF|-|Failed to add L3 host entry for ip 192.168.1.1, error: some_error' throttle_count: 1",
-                "reason": "some_error' throttle_count: 1"
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1707|LOG_ERR|LAYER3INTF|-|Failed to add L3 host entry for ip 192.168.1.1, error: some_error",
+                "reason": "some_error"
             },
             "host": {
                 "ip": [
@@ -3976,7 +3466,7 @@
                     "procid": "1234"
                 }
             },
-            "message": "Failed to add L3 host entry for ip 192.168.1.1, error: some_error' throttle_count: 1",
+            "message": "Failed to add L3 host entry for ip 192.168.1.1, error: some_error",
             "tags": [
                 "preserve_original_event"
             ]
@@ -4266,7 +3756,7 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "prefix": "",
+                "prefix": "192.168.1.0/24",
                 "sequence": "-"
             },
             "ecs": {
@@ -4336,7 +3826,7 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "prefix": "",
+                "prefix": "192.168.1.0/24",
                 "sequence": "-"
             },
             "ecs": {
@@ -4371,7 +3861,7 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "prefix": "",
+                "prefix": "192.168.1.0/24",
                 "sequence": "-"
             },
             "ecs": {
@@ -4382,7 +3872,8 @@
                     "network"
                 ],
                 "code": "1718",
-                "original": "2024-06-18T13:02:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1718|LOG_ERR|LAYER3INTF|-|Delete route 192.168.1.0/24, error: some_error"
+                "original": "2024-06-18T13:02:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1718|LOG_ERR|LAYER3INTF|-|Delete route 192.168.1.0/24, error: some_error",
+                "reason": "some_error"
             },
             "log": {
                 "level": "LOG_ERR",
@@ -4406,7 +3897,7 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "prefix": "",
+                "prefix": "192.168.1.0/24",
                 "sequence": "-"
             },
             "ecs": {
@@ -4417,7 +3908,8 @@
                     "network"
                 ],
                 "code": "1719",
-                "original": "2024-06-18T13:03:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1719|LOG_ERR|LAYER3INTF|-|Add route 192.168.1.0/24, error: some_error' throttle_count: 1"
+                "original": "2024-06-18T13:03:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1719|LOG_ERR|LAYER3INTF|-|Add route 192.168.1.0/24, error: some_error",
+                "reason": "some_error"
             },
             "log": {
                 "level": "LOG_ERR",
@@ -4426,7 +3918,7 @@
                     "procid": "1234"
                 }
             },
-            "message": "Add route 192.168.1.0/24, error: some_error' throttle_count: 1",
+            "message": "Add route 192.168.1.0/24, error: some_error",
             "tags": [
                 "preserve_original_event"
             ]
@@ -4477,7 +3969,10 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "port": "",
+                "interface": {
+                    "id": "eth0"
+                },
+                "port": "eth1",
                 "sequence": "-"
             },
             "ecs": {
@@ -4555,7 +4050,7 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "port": "",
+                "port": "eth1",
                 "sequence": "-"
             },
             "ecs": {
@@ -5924,7 +5419,7 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "port": "",
+                "port": "eth7",
                 "sequence": "-"
             },
             "ecs": {
@@ -7503,7 +6998,6 @@
             "aruba": {
                 "component": {
                     "category": "IRDP"
-                    "category": "IPV6ROUTER"
                 },
                 "event_type": "Event",
                 "hardware": {
@@ -7523,8 +7017,6 @@
                 ],
                 "code": "3501",
                 "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-irdp[1234]: Event|3501|LOG_INFO|IRDP|-|IRDP enabled on interface eth0"
-                "code": "3901",
-                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3901|LOG_INFO|IPV6ROUTER|-|ipv6 ra enabled on interface: eth0"
             },
             "log": {
                 "level": "LOG_INFO",
@@ -7534,6 +7026,38 @@
                 }
             },
             "message": "IRDP enabled on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IPV6ROUTER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3901",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-ipv6ra[1234]: Event|3901|LOG_INFO|IPV6ROUTER|-|ipv6 ra enabled on interface: eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
                     "appname": "hpe-ipv6ra",
                     "procid": "1234"
                 }

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -2207,7 +2207,7 @@
                     "id": "1001"
                 },
                 "sequence": "-",
-                "unit": 1
+                "unit": "1"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -2245,7 +2245,7 @@
                     "id": "1001"
                 },
                 "sequence": "-",
-                "unit": 1
+                "unit": "1"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -2287,7 +2287,7 @@
                     "id": "1001"
                 },
                 "sequence": "-",
-                "unit": 1
+                "unit": "1"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -2327,7 +2327,7 @@
                 },
                 "port": "2",
                 "sequence": "-",
-                "unit": 1
+                "unit": "1"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -2505,7 +2505,7 @@
                     "psc": "2"
                 },
                 "sequence": "-",
-                "unit": 1
+                "unit": "1"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -5185,6 +5185,872 @@
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",
             "aruba": {
                 "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mgmd": {
+                    "pkt_type": "multicast"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2601",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2601|LOG_ERR|MGMD|-|Failed to alloc a multicast pkt(interface vlan10)"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to alloc a multicast pkt(interface vlan10)",
+            "network": {
+                "vlan": {
+                    "id": "vlan10"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2602",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2602|LOG_INFO|MGMD|-|Received IGMPv1 query from 192.168.1.1 when the device is configured for IGMPv2."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Received IGMPv1 query from 192.168.1.1 when the device is configured for IGMPv2.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "len": 1024,
+                "sequence": "-",
+                "subsystem": "subsystem1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2603",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2603|LOG_ERR|MGMD|-|Unable to alloc a buf of size 1024 for subsystem1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Unable to alloc a buf of size 1024 for subsystem1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "mgmd": {
+                    "mgmd_type": "IGMP"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2604",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2604|LOG_INFO|MGMD|-|Interface eth0: Other Querier detected for IGMP"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface eth0: Other Querier detected for IGMP",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "mgmd": {
+                    "mgmd_type": "IGMP"
+                },
+                "sequence": "-"
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2605",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2605|LOG_INFO|MGMD|-|IGMP Querier Election in progress for interface eth0 with IP address 192.168.1.1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "IGMP Querier Election in progress for interface eth0 with IP address 192.168.1.1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "mgmd": {
+                    "mgmd_type": "IGMP"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2606",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2606|LOG_INFO|MGMD|-|Interface eth0: End IGMP Querier role"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface eth0: End IGMP Querier role",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "mgmd": {
+                    "mgmd_type": "IGMP"
+                },
+                "sequence": "-"
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2607",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2607|LOG_INFO|MGMD|-|Interface eth0: Start IGMP Querier role addr: 192.168.1.1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface eth0: Start IGMP Querier role addr: 192.168.1.1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mgmd": {
+                    "mgmd_type": "11"
+                },
+                "port": "8080",
+                "sequence": "-"
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2608",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2608|LOG_WARN|MGMD|-|Received packet from 192.168.1.1, type 11, on invalid port 8080"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Received packet from 192.168.1.1, type 11, on invalid port 8080",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2609",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2609|LOG_INFO|MGMD|-|Received IGMPv1 query from 192.168.1.1 when the device is configured for IGMPv3."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Received IGMPv1 query from 192.168.1.1 when the device is configured for IGMPv3.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2610",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2610|LOG_INFO|MGMD|-|Received IGMPv2 query from 192.168.1.1 when the device is configured for IGMPv3."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Received IGMPv2 query from 192.168.1.1 when the device is configured for IGMPv3.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mgmd": {
+                    "mgmd_type": "IGMP"
+                },
+                "sequence": "-",
+                "status": "enabled"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2611",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2611|LOG_INFO|MGMD|-|IGMP snooping is enabled on VLAN 10."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "IGMP snooping is enabled on VLAN 10.",
+            "network": {
+                "vlan": {
+                    "id": ""
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:56:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "mgmd": {
+                    "mgmd_type": "IGMP"
+                },
+                "sequence": "-",
+                "status": "enabled"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2612",
+                "original": "2024-06-18T12:56:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2612|LOG_INFO|MGMD|-|IGMP is enabled on Interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "IGMP is enabled on Interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:57:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mgmd": {
+                    "mgmd_type": ""
+                },
+                "port": "eth0",
+                "sequence": "-",
+                "status": "enabled"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2613",
+                "original": "2024-06-18T12:57:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2613|LOG_INFO|MGMD|-|Port eth0 on vlan 10 is set to enabled mode for IGMP."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Port eth0 on vlan 10 is set to enabled mode for IGMP.",
+            "network": {
+                "vlan": {
+                    "id": "10"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:58:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mgmd": {
+                    "mgmd_type": "IGMP"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2614",
+                "original": "2024-06-18T12:58:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2614|LOG_ERR|MGMD|-|IGMP is not operational on VLAN 10 due to resource unavailability"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "IGMP is not operational on VLAN 10 due to resource unavailability",
+            "network": {
+                "vlan": {
+                    "id": "10"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:59:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mgmd": {
+                    "l3_port": "eth0",
+                    "mgmd_type": "IGMP"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2615",
+                "original": "2024-06-18T12:59:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2615|LOG_ERR|MGMD|-|IGMP is not operational on interface eth0 due to resource unavailability"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "IGMP is not operational on interface eth0 due to resource unavailability",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:00:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2616",
+                "original": "2024-06-18T13:00:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2616|LOG_INFO|MGMD|-|IGMP/MLD Resource utilization has exceeded the supported limits on the system. Membership reports for the new groups will be dropped."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "IGMP/MLD Resource utilization has exceeded the supported limits on the system. Membership reports for the new groups will be dropped.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:01:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2617",
+                "original": "2024-06-18T13:01:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2617|LOG_INFO|MGMD|-|IGMP/MLD Resource utilization has reached 90 percent of the supported limits on the system."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "IGMP/MLD Resource utilization has reached 90 percent of the supported limits on the system.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:02:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mgmd": {
+                    "mgmd_type": "IGMP"
+                },
+                "sequence": "-",
+                "status": "enabled"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2618",
+                "original": "2024-06-18T13:02:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2618|LOG_INFO|MGMD|-|IGMP snooping is enabled on VLAN 10."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "IGMP snooping is enabled on VLAN 10.",
+            "network": {
+                "vlan": {
+                    "id": "10"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:03:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2619",
+                "original": "2024-06-18T13:03:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2619|LOG_INFO|MGMD|-|Received IGMPv3 query from 192.168.1.1 when the device is configured for IGMPv2."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Received IGMPv3 query from 192.168.1.1 when the device is configured for IGMPv2.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:04:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2620",
+                "original": "2024-06-18T13:04:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2620|LOG_INFO|MGMD|-|Received MLDV1 query from 192.168.1.1 when the device is configured for MLDV2."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Received MLDV1 query from 192.168.1.1 when the device is configured for MLDV2.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:05:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2621",
+                "original": "2024-06-18T13:05:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2621|LOG_INFO|MGMD|-|Received MLDV2 query from 192.168.1.1 when the device is configured for MLDV1."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Received MLDV2 query from 192.168.1.1 when the device is configured for MLDV1.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:06:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mgmd": {
+                    "port1": "eth1",
+                    "ring_id": "1"
+                },
+                "port": "eth0",
+                "sequence": "-",
+                "status": "idle"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2622",
+                "original": "2024-06-18T13:06:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2622|LOG_INFO|MGMD|-|Flood mode is temporarily activated on ERPS ports eth0 and eth1 as ring state for ring id 1 changed to idle."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Flood mode is temporarily activated on ERPS ports eth0 and eth1 as ring state for ring id 1 changed to idle.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
                     "category": "LOOPPROTECT"
                 },
                 "event_type": "Event",
@@ -6926,6 +7792,1531 @@
             ]
         },
         {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3201",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3201|LOG_INFO|Module|-|Ethernet module eth0 inserted"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 inserted",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3202",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3202|LOG_WARN|Module|-|Ethernet module eth0 removed"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 removed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Initiating Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3203",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3203|LOG_INFO|Module|-|Initiating Ethernet module eth0 reboot"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Initiating Ethernet module eth0 reboot",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3204",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3204|LOG_INFO|Module|-|Ethernet module eth0 is ready"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 is ready",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3205",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3205|LOG_INFO|Module|-|Ethernet module eth0 is down: hardware failure",
+                "reason": "hardware failure"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 is down: hardware failure",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3206",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3206|LOG_INFO|Module|-|Ethernet module eth0 is in diagnostics mode"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 is in diagnostics mode",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3207",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3207|LOG_ERR|Module|-|Ethernet module eth0 has failed: hardware failure",
+                "reason": "hardware failure"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 has failed: hardware failure",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3208",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3208|LOG_INFO|Module|-|Ethernet module eth0 admin state set to up"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 admin state set to up",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3209",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3209|LOG_INFO|Module|-|Ethernet module eth0 admin state set to down"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 admin state set to down",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3210",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3210|LOG_INFO|Module|-|Ethernet module eth0 admin state set to diagnostics"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 admin state set to diagnostics",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3211",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3211|LOG_INFO|Module|-|Ethernet module eth0 ISP passed"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 ISP passed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:56:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3212",
+                "original": "2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3212|LOG_ERR|Module|-|Ethernet module eth0 ISP failed"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 ISP failed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:57:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3213",
+                "original": "2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3213|LOG_WARN|Module|-|Ethernet module eth0 ISP skipped"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 ISP skipped",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:58:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3214",
+                "original": "2024-06-18T12:58:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3214|LOG_INFO|Module|-|Ethernet module eth0 has enabled standby power"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 has enabled standby power",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:59:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "priority": "high",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3215",
+                "original": "2024-06-18T12:59:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3215|LOG_INFO|Module|-|Ethernet module eth0 is requesting to power on with priority high"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 is requesting to power on with priority high",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:00:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3216",
+                "original": "2024-06-18T13:00:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3216|LOG_INFO|Module|-|Ethernet module eth0 power request has been granted"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 power request has been granted",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:01:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3217",
+                "original": "2024-06-18T13:01:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3217|LOG_ERR|Module|-|Ethernet module eth0 power request has been denied"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 power request has been denied",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:02:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3218",
+                "original": "2024-06-18T13:02:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3218|LOG_INFO|Module|-|Ethernet module eth0 enabling main power"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 enabling main power",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:03:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3219",
+                "original": "2024-06-18T13:03:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3219|LOG_INFO|Module|-|Ethernet module eth0 main power enabled"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 main power enabled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:04:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3220",
+                "original": "2024-06-18T13:04:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3220|LOG_ERR|Module|-|Ethernet module eth0 main power failed"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 main power failed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3221",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3221|LOG_INFO|Module|-|Ethernet module eth0 device initialization started"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 device initialization started",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3222",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3222|LOG_INFO|Module|-|Ethernet module eth0 device initialization passed"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 device initialization passed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3223",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3223|LOG_ERR|Module|-|Ethernet module eth0 device initialization failed: hardware error",
+                "reason": "hardware error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 device initialization failed: hardware error",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3224",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3224|LOG_INFO|Module|-|Ethernet module eth0 ASIC initialization started"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 ASIC initialization started",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3225",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3225|LOG_INFO|Module|-|Ethernet module eth0 ASIC initialization completed"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 ASIC initialization completed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3226",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3226|LOG_ERR|Module|-|Ethernet module eth0 ASIC initialization failed: hardware error",
+                "reason": "hardware error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 ASIC initialization failed: hardware error",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3227",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3227|LOG_INFO|Module|-|Ethernet module eth0 ASIC deinitialization started"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 ASIC deinitialization started",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3228",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3228|LOG_INFO|Module|-|Ethernet module eth0 ASIC deinitialization completed"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 ASIC deinitialization completed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3229",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3229|LOG_ERR|Module|-|Ethernet module eth0 ASIC deinitialization failed: hardware error",
+                "reason": "hardware error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 ASIC deinitialization failed: hardware error",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "mock_name"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3230",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3230|LOG_INFO|Module|-|mock_name is starting zeroization"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "mock_name is starting zeroization",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "mock_name"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3231",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3231|LOG_INFO|Module|-|mock_name zeroization completed"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "mock_name zeroization completed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:56:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "mock_name"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3232",
+                "original": "2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3232|LOG_ERR|Module|-|mock_name zeroization failed"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "mock_name zeroization failed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:57:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-",
+                "unit": "12345"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3233",
+                "original": "2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3233|LOG_INFO|Module|-|Ethernet module eth0 configured with product number 12345"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 configured with product number 12345",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:58:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3234",
+                "original": "2024-06-18T12:58:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3234|LOG_INFO|Module|-|Ethernet module eth0 has been unconfigured"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 has been unconfigured",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:59:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3235",
+                "original": "2024-06-18T12:59:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3235|LOG_INFO|Module|-|Ethernet module eth0 initiating failover"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 initiating failover",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:00:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3236",
+                "original": "2024-06-18T13:00:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3236|LOG_INFO|Module|-|Ethernet module eth0 failover completed"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 failover completed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:01:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3237",
+                "original": "2024-06-18T13:01:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3237|LOG_INFO|Module|-|Ethernet module eth0 initiating ISP"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 initiating ISP",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:02:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3238",
+                "original": "2024-06-18T13:02:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3238|LOG_INFO|Module|-|Ethernet module eth0 enabling front-end power"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 enabling front-end power",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:03:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3239",
+                "original": "2024-06-18T13:03:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3239|LOG_WARN|Module|-|Ethernet module eth0 disabling front-end power: power failure",
+                "reason": "power failure"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 disabling front-end power: power failure",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:04:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "eth0",
+                    "type": "Ethernet"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3240",
+                "original": "2024-06-18T13:04:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3240|LOG_ERR|Module|-|Ethernet module eth0 has persistent hardware error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ethernet module eth0 has persistent hardware error",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-06-21T18:32:07.025548-05:00",
             "aruba": {
                 "component": {
@@ -7744,6 +10135,164 @@
             ]
         },
         {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MULTICAST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "limit": 100,
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4001",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-multicast[1234]: Event|4001|LOG_WARN|MULTICAST|-|The Multicast L3 Bridge Control Forwarding entries limit was reached: 100"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-multicast",
+                    "procid": "1234"
+                }
+            },
+            "message": "The Multicast L3 Bridge Control Forwarding entries limit was reached: 100",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-11-30T11:09:33.733026-05:00",
+            "_temp": {},
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mgmt": {
+                    "config_err": {
+                        "default_gateway": "127.0.0.1",
+                        "domain_name": "",
+                        "hostname": "8360-ServerName",
+                        "ip": "127.0.0.1"
+                    }
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4302",
+                "original": "2023-11-30T11:09:33.733026-05:00 8360-Primaire ops_mgmtintfcfg[3485]: Event|4302|LOG_INFO|AMM|-|MGMT_INTF: Static parameter : [{\"ip\": \"127.0.0.1\", \"hostname\": \"8360-ServerName\", \"domain_name\": \"\", \"default_gateway\": \"127.0.0.1\"}]"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "ops_mgmtintfcfg",
+                    "procid": "3485"
+                }
+            },
+            "message": "MGMT_INTF: Static parameter : [{\"ip\": \"127.0.0.1\", \"hostname\": \"8360-ServerName\", \"domain_name\": \"\", \"default_gateway\": \"127.0.0.1\"}]",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-11-30T11:09:33.733026-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mgmt": {
+                    "config_err": "Link state is down."
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4302",
+                "original": "2023-11-30T11:09:33.733026-05:00 8360-Primaire ops_mgmtintfcfg[3485]: Event|4302|LOG_INFO|AMM|-|MGMT_INTF: Link state is down."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "ops_mgmtintfcfg",
+                    "procid": "3485"
+                }
+            },
+            "message": "MGMT_INTF: Link state is down.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-11-30T11:09:33.733026-05:00",
+            "_temp": {},
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mgmt": {
+                    "config_crit": {
+                        "default_gateway": "127.0.0.1",
+                        "domain_name": "",
+                        "hostname": "8360-ServerName",
+                        "ip": "127.0.0.1"
+                    }
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4303",
+                "original": "2023-11-30T11:09:33.733026-05:00 8360-Primaire ops_mgmtintfcfg[3485]: Event|4303|LOG_INFO|AMM|-|MGMT_INTF: Static parameter : [{\"ip\": \"127.0.0.1\", \"hostname\": \"8360-ServerName\", \"domain_name\": \"\", \"default_gateway\": \"127.0.0.1\"}] is updated in ovsdb."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "ops_mgmtintfcfg",
+                    "procid": "3485"
+                }
+            },
+            "message": "MGMT_INTF: Static parameter : [{\"ip\": \"127.0.0.1\", \"hostname\": \"8360-ServerName\", \"domain_name\": \"\", \"default_gateway\": \"127.0.0.1\"}] is updated in ovsdb.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-06-20T14:00:38.324517-05:00",
             "aruba": {
                 "component": {
@@ -8015,6 +10564,204 @@
                 }
             },
             "message": "Firmware image is invalid",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACLEARN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth1",
+                    "prev_id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4801",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4801|LOG_INFO|MACLEARN|-|MAC 00:1A:2B:3C:4D:5E moved from port eth0 to port eth1 on VLAN 10"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-mac",
+                    "procid": "1234"
+                }
+            },
+            "message": "MAC 00:1A:2B:3C:4D:5E moved from port eth0 to port eth1 on VLAN 10",
+            "network": {
+                "vlan": {
+                    "id": "10"
+                }
+            },
+            "server": {
+                "mac": "00-1A-2B-3C-4D-5E"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACLEARN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4802",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4802|LOG_INFO|MACLEARN|-|All dynamic MAC addresses on VLAN 10 were flushed"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-mac",
+                    "procid": "1234"
+                }
+            },
+            "message": "All dynamic MAC addresses on VLAN 10 were flushed",
+            "network": {
+                "vlan": {
+                    "id": "10"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACLEARN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4803",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4803|LOG_INFO|MACLEARN|-|All dynamic MAC addresses on port eth0 were flushed"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-mac",
+                    "procid": "1234"
+                }
+            },
+            "message": "All dynamic MAC addresses on port eth0 were flushed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACLEARN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth1"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4804",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4804|LOG_INFO|MACLEARN|-|All dynamic MAC addresses on port eth1 were flushed"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-mac",
+                    "procid": "1234"
+                }
+            },
+            "message": "All dynamic MAC addresses on port eth1 were flushed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACLEARN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4805",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4805|LOG_INFO|MACLEARN|-|All dynamic MAC addresses on VLAN 20 were flushed"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-mac",
+                    "procid": "1234"
+                }
+            },
+            "message": "All dynamic MAC addresses on VLAN 20 were flushed",
+            "network": {
+                "vlan": {
+                    "id": "20"
+                }
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -8509,6 +11256,228 @@
                 "id": "myKeyIdentifier",
                 "name": "myUser"
             }
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Mirroring"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "session": {
+                    "id": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "6701",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-mirroring[1234]: Event|6701|LOG_ERR|Mirroring|-|Failed to create mirror session 1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-mirroring",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to create mirror session 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Mirroring"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "session": {
+                    "id": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "6702",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-mirroring[1234]: Event|6702|LOG_INFO|Mirroring|-|Mirror session 1 created"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-mirroring",
+                    "procid": "1234"
+                }
+            },
+            "message": "Mirror session 1 created",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Mirroring"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "session": {
+                    "id": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "6703",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-mirroring[1234]: Event|6703|LOG_ERR|Mirroring|-|Failed to delete mirror session 1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-mirroring",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to delete mirror session 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Mirroring"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "session": {
+                    "id": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "6704",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-mirroring[1234]: Event|6704|LOG_INFO|Mirroring|-|Mirror session 1 deleted"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-mirroring",
+                    "procid": "1234"
+                }
+            },
+            "message": "Mirror session 1 deleted",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Mirroring"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "session": {
+                    "id": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "6705",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-mirroring[1234]: Event|6705|LOG_ERR|Mirroring|-|Failed to update mirror session 1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-mirroring",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to update mirror session 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Mirroring"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "session": {
+                    "id": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "6706",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-mirroring[1234]: Event|6706|LOG_INFO|Mirroring|-|Mirror session 1 updated"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-mirroring",
+                    "procid": "1234"
+                }
+            },
+            "message": "Mirror session 1 updated",
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "@timestamp": "2024-08-15T15:41:15.858927+03:00",
@@ -11653,6 +14622,330 @@
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",
             "aruba": {
                 "component": {
+                    "category": "MSDP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "status": "up",
+                "vrf": {
+                    "name": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8601",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-msdp[1234]: Event|8601|LOG_INFO|MSDP|-|Router MSDP is up on VRF default"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-msdp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Router MSDP is up on VRF default",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MSDP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                },
+                "sequence": "-",
+                "status": "up"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8602",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-msdp[1234]: Event|8602|LOG_INFO|MSDP|-|Forwarding state of interface eth0 has been changed to up"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-msdp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Forwarding state of interface eth0 has been changed to up",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MSDP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                },
+                "msdp": {
+                    "tcp_entity": "TCP"
+                },
+                "sequence": "-",
+                "status": "established"
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8603",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-msdp[1234]: Event|8603|LOG_INFO|MSDP|-|MSDP Peer 192.168.1.1(TCP) with connection source eth0 has entered established state"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-msdp",
+                    "procid": "1234"
+                }
+            },
+            "message": "MSDP Peer 192.168.1.1(TCP) with connection source eth0 has entered established state",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MSDP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "8080",
+                "sequence": "-",
+                "status": "added"
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8604",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-msdp[1234]: Event|8604|LOG_INFO|MSDP|-|Port 8080 is added to MSDP Peer 192.168.1.1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-msdp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Port 8080 is added to MSDP Peer 192.168.1.1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MSDP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                },
+                "sequence": "-",
+                "status": "enabled",
+                "vrf": {
+                    "name": "default"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8606",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-msdp[1234]: Event|8606|LOG_INFO|MSDP|-|MSDP Peer 192.168.1.1 is enabled on VRF default. Interface eth0 is added to the Peer"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-msdp",
+                    "procid": "1234"
+                }
+            },
+            "message": "MSDP Peer 192.168.1.1 is enabled on VRF default. Interface eth0 is added to the Peer",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MSDP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "msdp": {
+                    "tcp_entity": "server"
+                },
+                "sequence": "-"
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8607",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-msdp[1234]: Event|8607|LOG_INFO|MSDP|-|Start server role for MSDP peer 192.168.1.1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-msdp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Start server role for MSDP peer 192.168.1.1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MSDP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8608",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-msdp[1234]: Event|8608|LOG_INFO|MSDP|-|Finish packet was received on MSDP Peer 192.168.1.1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-msdp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Finish packet was received on MSDP Peer 192.168.1.1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MSDP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "msdp": {
+                    "grp_ip": "224.0.0.1",
+                    "rp_ip": "192.168.1.2"
+                },
+                "sequence": "-"
+            },
+            "client": {
+                "ip": "192.168.1.3"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8609",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-msdp[1234]: Event|8609|LOG_WARN|MSDP|-|Failed to add SA Cache entry: S=192.168.1.1, G=224.0.0.1, R=192.168.1.2 for Peer 192.168.1.3 as MSDP SA Cache Limit is reached"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-msdp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to add SA Cache entry: S=192.168.1.1, G=224.0.0.1, R=192.168.1.2 for Peer 192.168.1.3 as MSDP SA Cache Limit is reached",
+            "source": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
                     "category": "AMM"
                 },
                 "event_type": "Event",
@@ -14652,6 +17945,124 @@
             ]
         },
         {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACCONFIG"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mac": {
+                    "new_mode": "dynamic",
+                    "old_mode": "static"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11001",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|11001|LOG_INFO|MACCONFIG|-|The MAC Address configured mode changed from static to dynamic"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-mac",
+                    "procid": "1234"
+                }
+            },
+            "message": "The MAC Address configured mode changed from static to dynamic",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACCONFIG"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mac": {
+                    "new_mode": "dynamic",
+                    "old_mode": "static"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11002",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|11002|LOG_INFO|MACCONFIG|-|The MAC Address operational mode changed from static to dynamic"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-mac",
+                    "procid": "1234"
+                }
+            },
+            "message": "The MAC Address operational mode changed from static to dynamic",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACCONFIG"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11003",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|11003|LOG_WARN|MACCONFIG|-|Station MAC add failure due to hardware full, mac=00:1A:2B:3C:4D:5E vlan=10"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-mac",
+                    "procid": "1234"
+                }
+            },
+            "message": "Station MAC add failure due to hardware full, mac=00:1A:2B:3C:4D:5E vlan=10",
+            "network": {
+                "vlan": {
+                    "id": "10"
+                }
+            },
+            "server": {
+                "mac": "00-1A-2B-3C-4D-5E"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-06-19T13:57:38.182641-05:00",
             "aruba": {
                 "component": {
@@ -15040,6 +18451,167 @@
                 }
             },
             "message": "IPv6 route prefix FE80::C000:1DFF:FEE0:C01/64 is not supported on this platform.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACsec"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0."
+                },
+                "mac": {
+                    "sci": "00:11:22:33:44:55"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11201",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-macsec[1234]: Event|11201|LOG_INFO|MACsec|-|MACsec session established on Rx Secure Channel 00:11:22:33:44:55 on interface eth0."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-macsec",
+                    "procid": "1234"
+                }
+            },
+            "message": "MACsec session established on Rx Secure Channel 00:11:22:33:44:55 on interface eth0.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACsec"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0."
+                },
+                "mac": {
+                    "ckn": "1234"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11202",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-macsec[1234]: Event|11202|LOG_INFO|MACsec|-|MKA session secured for Connectivity Association 1234 on interface eth0."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-macsec",
+                    "procid": "1234"
+                }
+            },
+            "message": "MKA session secured for Connectivity Association 1234 on interface eth0.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACsec"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                },
+                "mac": {
+                    "ckn": "1234",
+                    "latest_an": "1",
+                    "latest_kn": "2",
+                    "old_an": "3",
+                    "old_kn": "4."
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11203",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-macsec[1234]: Event|11203|LOG_INFO|MACsec|-|Secure Association key updated for Connectivity Association 1234 on interface eth0 - Latest AN/KN 1/2, Old AN/KN 3/4."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-macsec",
+                    "procid": "1234"
+                }
+            },
+            "message": "Secure Association key updated for Connectivity Association 1234 on interface eth0 - Latest AN/KN 1/2, Old AN/KN 3/4.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACsec"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mac": {
+                    "sci": "00:11:22:33:44:55"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11204",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-macsec[1234]: Event|11204|LOG_INFO|MACsec|-|Possible replay attempt detected on the Secure Channel 00:11:22:33:44:55."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-macsec",
+                    "procid": "1234"
+                }
+            },
+            "message": "Possible replay attempt detected on the Secure Channel 00:11:22:33:44:55.",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -1,6 +1,290 @@
 {
     "expected": [
         {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "101",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire lldpd[1234]: Event|101|LOG_INFO|AMM|-|LLDP Enabled"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "lldpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "LLDP Enabled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "102",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire lldpd[1234]: Event|102|LOG_INFO|AMM|-|LLDP Disabled"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "lldpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "LLDP Disabled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "lldp": {
+                    "tx_timer": 30
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "103",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire lldpd[1234]: Event|103|LOG_INFO|AMM|-|Configured LLDP tx-timer to 30"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "lldpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Configured LLDP tx-timer to 30",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "107",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire lldpd[1234]: Event|107|LOG_INFO|AMM|-|Configured LLDP Management IP 192.168.1.1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "lldpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Configured LLDP Management IP 192.168.1.1",
+            "server": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "lldp": {
+                    "tx_hold": 4
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "108",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire lldpd[1234]: Event|108|LOG_INFO|AMM|-|Configured LLDP tx-hold to 4"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "lldpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Configured LLDP tx-hold to 4",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "lldp": {
+                    "reinit_delay": 1
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "110",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire lldpd[1234]: Event|110|LOG_INFO|AMM|-|Configured LLDP reinit-delay to 1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "lldpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Configured LLDP reinit-delay to 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "111",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire lldpd[1234]: Event|111|LOG_INFO|AMM|-|LLDP statistics cleared"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "lldpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "LLDP statistics cleared",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:56:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "112",
+                "original": "2024-06-18T12:56:38.182641-05:00 8360-Primaire lldpd[1234]: Event|112|LOG_INFO|AMM|-|LLDP neighbor info cleared"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "lldpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "LLDP neighbor info cleared",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-06-18T12:44:38.182641-05:00",
             "aruba": {
                 "component": {
@@ -844,6 +1128,1973 @@
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",
             "aruba": {
                 "component": {
+                    "category": "LED"
+                },
+                "count": 5,
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "subsystem": "A"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "501",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-led[1234]: Event|501|LOG_INFO|LED|-|There are 5 LED types in subsystem A"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-led",
+                    "procid": "1234"
+                }
+            },
+            "message": "There are 5 LED types in subsystem A",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LED"
+                },
+                "count": 10,
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "subsystem": "B"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "502",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-led[1234]: Event|502|LOG_INFO|LED|-|There are 10 LED configs in subsystem B"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-led",
+                    "procid": "1234"
+                }
+            },
+            "message": "There are 10 LED configs in subsystem B",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LOOPBACK"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "901",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire loopback[1234]: Event|901|LOG_INFO|LOOPBACK|-|Loopback Interface eth0, created"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "loopback",
+                    "procid": "1234"
+                }
+            },
+            "message": "Loopback Interface eth0, created",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LOOPBACK"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "902",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire loopback[1234]: Event|902|LOG_INFO|LOOPBACK|-|Loopback Interface eth0, deleted"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "loopback",
+                    "procid": "1234"
+                }
+            },
+            "message": "Loopback Interface eth0, deleted",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LOOPBACK"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-",
+                "status": ""
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "903",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire loopback[1234]: Event|903|LOG_INFO|LOOPBACK|-|Loopback Interface eth0, configured administratively up"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "loopback",
+                    "procid": "1234"
+                }
+            },
+            "message": "Loopback Interface eth0, configured administratively up",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1301",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1301|LOG_INFO|LACP|-|Dynamic LAG 1 created"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Dynamic LAG 1 created",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1302",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1302|LOG_INFO|LACP|-|Dynamic LAG 1 deleted"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Dynamic LAG 1 deleted",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "lacp": {
+                    "system_priority": "100"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1305",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1305|LOG_INFO|LACP|-|LACP system priority set to 100"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "LACP system priority set to 100",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "lacp": {
+                    "mode": "active"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1306",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1306|LOG_INFO|LACP|-|LACP mode set to active for LAG 1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "LACP mode set to active for LAG 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "lacp": {
+                    "system_id": "00:11:22:33:44:55"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1307",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1307|LOG_INFO|LACP|-|LACP system ID set to 00:11:22:33:44:55"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "LACP system ID set to 00:11:22:33:44:55",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "lacp": {
+                    "rate": "fast"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1308",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1308|LOG_INFO|LACP|-|LACP rate set to fast for LAG 1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "LACP rate set to fast for LAG 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth1"
+                },
+                "lacp": {
+                    "fsm_state": ""
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1311",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1311|LOG_WARN|LACP|-|Partner is lost (timed out) for interface eth1 LAG 1. State: down"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Partner is lost (timed out) for interface eth1 LAG 1. State: down",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:56:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": ""
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1312",
+                "original": "2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1312|LOG_ERR|LACP|-|Failed to create LAG 1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to create LAG 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:57:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1313",
+                "original": "2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1313|LOG_INFO|LACP|-|LAG 1 set as VSX"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "LAG 1 set as VSX",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:57:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1301",
+                "original": "2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1301|LOG_INFO|LACP|-|Dynamic LAG 1 created"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Dynamic LAG 1 created",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1302",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1302|LOG_INFO|LACP|-|Dynamic LAG 1 deleted"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Dynamic LAG 1 deleted",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth1",
+                    "prev_id": "eth1"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1303",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1303|LOG_INFO|LACP|-|Interface eth1 added to LAG 1. Existing configuration on interface eth1 will be removed."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface eth1 added to LAG 1. Existing configuration on interface eth1 will be removed.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth1"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1304",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1304|LOG_INFO|LACP|-|Interface eth1 removed from LAG 1. It will be set with default configuration with admin down state."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface eth1 removed from LAG 1. It will be set with default configuration with admin down state.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "lacp": {
+                    "system_priority": "100"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1305",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1305|LOG_INFO|LACP|-|LACP system priority set to 100"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "LACP system priority set to 100",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "lacp": {
+                    "mode": "active"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1306",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1306|LOG_INFO|LACP|-|LACP mode set to active for LAG 1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "LACP mode set to active for LAG 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "lacp": {
+                    "system_id": "00:11:22:33:44:55"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1307",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1307|LOG_INFO|LACP|-|LACP system ID set to 00:11:22:33:44:55"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "LACP system ID set to 00:11:22:33:44:55",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "lacp": {
+                    "rate": "fast"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1308",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1308|LOG_INFO|LACP|-|LACP rate set to fast for LAG 1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "LACP rate set to fast for LAG 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth1"
+                },
+                "lacp": {
+                    "actor_state": "up",
+                    "partner_state": "down"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1310",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1310|LOG_WARN|LACP|-|Partner is out of sync for interface eth1 LAG 1. Actor state: up, partner state down"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Partner is out of sync for interface eth1 LAG 1. Actor state: up, partner state down",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth1"
+                },
+                "lacp": {
+                    "fsm_state": ""
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1311",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1311|LOG_WARN|LACP|-|Partner is lost (timed out) for interface eth1 LAG 1. State: down"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Partner is lost (timed out) for interface eth1 LAG 1. State: down",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:56:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": ""
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1312",
+                "original": "2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1312|LOG_ERR|LACP|-|Failed to create LAG 1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to create LAG 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:57:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1313",
+                "original": "2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1313|LOG_INFO|LACP|-|LAG 1 set as VSX"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "LAG 1 set as VSX",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1314",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1314|LOG_INFO|LACP|-|LAG 1 not sending LACPDUs through interface eth0 because VSX information is not complete"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "LAG 1 not sending LACPDUs through interface eth0 because VSX information is not complete",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "lacp": {
+                    "fallback_mode": "active"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1315",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1315|LOG_ERR|LACP|-|LACP fallback mode set to active for lag 1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "LACP fallback mode set to active for lag 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "sequence": "-",
+                "timeout": 30
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1316",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1316|LOG_ERR|LACP|-|LACP fallback timeout set to 30 for lag 1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "LACP fallback timeout set to 30 for lag 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "sequence": "-",
+                "timeout": 30
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1317",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1317|LOG_ERR|LACP|-|LACP fallback timeout 30 expired for lag 1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "LACP fallback timeout 30 expired for lag 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1318",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1318|LOG_ERR|LACP|-|Interface eth0 enabled by fallback for lag 1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface eth0 enabled by fallback for lag 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "lacp": {
+                    "mode": "src-dst-ip"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1319",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1319|LOG_INFO|LACP|-|LAG global load balancing mode is set to src-dst-ip"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "LAG global load balancing mode is set to src-dst-ip",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "lacp": {
+                    "mode": "src-dst-ip"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1320",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1320|LOG_INFO|LACP|-|LAG load balancing mode is set to src-dst-ip for lag 1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "LAG load balancing mode is set to src-dst-ip for lag 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "lacp": {
+                    "lag_number": 1,
+                    "lag_speed": 100,
+                    "port_speed": 1000
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1322",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1322|LOG_INFO|LACP|-|Interface eth0 cannot be part of Lag 1. Speed mismatched (Interface speed 1000Mbps Lag base speed 100Mbps). throttle_count: 100"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface eth0 cannot be part of Lag 1. Speed mismatched (Interface speed 1000Mbps Lag base speed 100Mbps). throttle_count: 100",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": ""
+                },
+                "lacp": {
+                    "fallback": "enabled"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1323",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1323|LOG_INFO|LACP|-|Fallback is enabled for LAG 1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Fallback is enabled for LAG 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LACP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1324",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1324|LOG_INFO|LACP|-|LACP Graceful Shut is initiated"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lacp",
+                    "procid": "1234"
+                }
+            },
+            "message": "LACP Graceful Shut is initiated",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAG"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1001"
+                },
+                "sequence": "-",
+                "unit": 1
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1401",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1401|LOG_INFO|LAG|-|Trunk set succeeds unit 1 lag_id 1001"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lag",
+                    "procid": "1234"
+                }
+            },
+            "message": "Trunk set succeeds unit 1 lag_id 1001",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAG"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1001"
+                },
+                "sequence": "-",
+                "unit": 1
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "error": {
+                "code": "1"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1402",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1402|LOG_ERR|LAG|-|Lag creation failed unit 1 lag_id 1001 rc 1 error some_error",
+                "reason": "some_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-lag",
+                    "procid": "1234"
+                }
+            },
+            "message": "Lag creation failed unit 1 lag_id 1001 rc 1 error some_error",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAG"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1001"
+                },
+                "sequence": "-",
+                "unit": 1
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "error": {
+                "code": "1"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1403",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1403|LOG_ERR|LAG|-|Destroy lag failed on unit 1 lag_id 1001 rc 1 error some_error",
+                "reason": "some_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-lag",
+                    "procid": "1234"
+                }
+            },
+            "message": "Destroy lag failed on unit 1 lag_id 1001 rc 1 error some_error",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAG"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "2",
+                "sequence": "-",
+                "unit": 1
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1404",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1404|LOG_INFO|LAG|-|Trunk member add port succeeds on unit 1 hw_port 2 tid 3"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lag",
+                    "procid": "1234"
+                }
+            },
+            "message": "Trunk member add port succeeds on unit 1 hw_port 2 tid 3",
+            "process": {
+                "thread": {
+                    "id": 3
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAG"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "2",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "error": {
+                "code": "1"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1405",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1405|LOG_ERR|LAG|-|Trunk port attach error on hw_port 2 tid 3 rc 1 some_error",
+                "reason": "some_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-lag",
+                    "procid": "1234"
+                }
+            },
+            "message": "Trunk port attach error on hw_port 2 tid 3 rc 1 some_error",
+            "process": {
+                "thread": {
+                    "id": 3
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAG"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "2",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "error": {
+                "code": "1"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1406",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1406|LOG_ERR|LAG|-|Failed to set egress enable on hw_port 2 tid 3 rc 1 error some_error",
+                "reason": "some_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-lag",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to set egress enable on hw_port 2 tid 3 rc 1 error some_error",
+            "process": {
+                "thread": {
+                    "id": 3
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAG"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "2",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "error": {
+                "code": "1"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1407",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1407|LOG_ERR|LAG|-|Failed to delete hw_port 2 from tid 3 rc 1 error some_error",
+                "reason": "some_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-lag",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to delete hw_port 2 from tid 3 rc 1 error some_error",
+            "process": {
+                "thread": {
+                    "id": 3
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAG"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1001"
+                },
+                "lag": {
+                    "psc": "2"
+                },
+                "sequence": "-",
+                "unit": 1
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "error": {
+                "code": "1"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1408",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1408|LOG_ERR|LAG|-|Trunk psc set failed on unit 1 lag_id 1001 psc 2 rc 1 error some_error",
+                "reason": "some_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-lag",
+                    "procid": "1234"
+                }
+            },
+            "message": "Trunk psc set failed on unit 1 lag_id 1001 psc 2 rc 1 error some_error",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAG"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "lag": {
+                    "mode": "src-dst-ip"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1409",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1409|LOG_INFO|LAG|-|LAG eth0, set to load balance mode to src-dst-ip"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lag",
+                    "procid": "1234"
+                }
+            },
+            "message": "LAG eth0, set to load balance mode to src-dst-ip",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAG"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "port": "eth1",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1410",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1410|LOG_INFO|LAG|-|Add port eth1 to LAG eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lag",
+                    "procid": "1234"
+                }
+            },
+            "message": "Add port eth1 to LAG eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAG"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "port": "eth1",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1411",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1411|LOG_INFO|LAG|-|Remove port eth1 from LAG eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lag",
+                    "procid": "1234"
+                }
+            },
+            "message": "Remove port eth1 from LAG eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:56:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAG"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "port": "eth1",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1412",
+                "original": "2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1412|LOG_INFO|LAG|-|Add port eth1 to vlan 10 for L3 LAG eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lag",
+                    "procid": "1234"
+                }
+            },
+            "message": "Add port eth1 to vlan 10 for L3 LAG eth0",
+            "network": {
+                "vlan": {
+                    "id": "10"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:57:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAG"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "port": "eth1",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1413",
+                "original": "2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1413|LOG_INFO|LAG|-|Remove port eth1 to vlan 10 for L3 LAG eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lag",
+                    "procid": "1234"
+                }
+            },
+            "message": "Remove port eth1 to vlan 10 for L3 LAG eth0",
+            "network": {
+                "vlan": {
+                    "id": "10"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:58:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAG"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1414",
+                "original": "2024-06-18T12:58:38.182641-05:00 8360-Primaire hpe-lag[1234]: Event|1414|LOG_INFO|LAG|-|Destroy L3 LAG interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-lag",
+                    "procid": "1234"
+                }
+            },
+            "message": "Destroy L3 LAG interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
                     "category": "COPP"
                 },
                 "event_type": "Event",
@@ -1298,6 +3549,1165 @@
                 }
             },
             "message": "Failed to retrieve CoPP statistics from slot 3 class myClass",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1701",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1701|LOG_INFO|LAYER3INTF|-|L3-Interface eth0, created"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "L3-Interface eth0, created",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1702",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1702|LOG_INFO|LAYER3INTF|-|L3-Interface eth0, deleted"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "L3-Interface eth0, deleted",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1704",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1704|LOG_ERR|LAYER3INTF|-|Failed to create 100 for layer 3 interface eth0"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to create 100 for layer 3 interface eth0",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1705",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1705|LOG_ERR|LAYER3INTF|-|Failed to destroy layer 3 interface eth0 vlan 100, error: some_error",
+                "reason": "some_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to destroy layer 3 interface eth0 vlan 100, error: some_error",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1706",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1706|LOG_ERR|LAYER3INTF|-|Failed to delete an l3 interface eth0, error: some_error",
+                "reason": "some_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to delete an l3 interface eth0, error: some_error",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1707",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1707|LOG_ERR|LAYER3INTF|-|Failed to add L3 host entry for ip 192.168.1.1, error: some_error' throttle_count: 1",
+                "reason": "some_error' throttle_count: 1"
+            },
+            "host": {
+                "ip": [
+                    "192.168.1.1"
+                ]
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to add L3 host entry for ip 192.168.1.1, error: some_error' throttle_count: 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1708",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1708|LOG_INFO|LAYER3INTF|-|Added L3 host entry for ip 192.168.1.1"
+            },
+            "host": {
+                "ip": [
+                    "192.168.1.1"
+                ]
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Added L3 host entry for ip 192.168.1.1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1709",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1709|LOG_ERR|LAYER3INTF|-|Failed to delete L3 host entry for ip 192.168.1.1, error: some_error",
+                "reason": "some_error"
+            },
+            "host": {
+                "ip": [
+                    "192.168.1.1"
+                ]
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to delete L3 host entry for ip 192.168.1.1, error: some_error",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1710",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1710|LOG_INFO|LAYER3INTF|-|Deleted L3 host entry for ip 192.168.1.1"
+            },
+            "host": {
+                "ip": [
+                    "192.168.1.1"
+                ]
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Deleted L3 host entry for ip 192.168.1.1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1711",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1711|LOG_ERR|LAYER3INTF|-|Failed to get L3 host hit for ip 192.168.1.1"
+            },
+            "host": {
+                "ip": [
+                    "192.168.1.1"
+                ]
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to get L3 host hit for ip 192.168.1.1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:56:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1712",
+                "original": "2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1712|LOG_ERR|LAYER3INTF|-|L3 interface error: some_error",
+                "reason": "some_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "L3 interface error: some_error",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:57:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "l3": {
+                    "nexthop": "192.168.1.2"
+                },
+                "prefix": "192.168.1.0/24",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1713",
+                "original": "2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1713|LOG_INFO|LAYER3INTF|-|Added Nexthop 192.168.1.2, egress_id 1001, for route 192.168.1.0/24"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Added Nexthop 192.168.1.2, egress_id 1001, for route 192.168.1.0/24",
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "id": "1001"
+                    }
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:58:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "l3": {
+                    "nexthop": "192.168.1.2"
+                },
+                "prefix": "192.168.1.0/24",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1714",
+                "original": "2024-06-18T12:58:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1714|LOG_INFO|LAYER3INTF|-|Delete Nexthop 192.168.1.2 for route 192.168.1.0/24"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Delete Nexthop 192.168.1.2 for route 192.168.1.0/24",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:59:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "prefix": "",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1715",
+                "original": "2024-06-18T12:59:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1715|LOG_INFO|LAYER3INTF|-|Added route 192.168.1.0/24"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Added route 192.168.1.0/24",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:00:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-",
+                "status": "up"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1716",
+                "original": "2024-06-18T13:00:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1716|LOG_INFO|LAYER3INTF|-|Update: route state: up"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Update: route state: up",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:01:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "prefix": "",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1717",
+                "original": "2024-06-18T13:01:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1717|LOG_INFO|LAYER3INTF|-|Delete route 192.168.1.0/24"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Delete route 192.168.1.0/24",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:02:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "prefix": "",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1718",
+                "original": "2024-06-18T13:02:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1718|LOG_ERR|LAYER3INTF|-|Delete route 192.168.1.0/24, error: some_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Delete route 192.168.1.0/24, error: some_error",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:03:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "prefix": "",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1719",
+                "original": "2024-06-18T13:03:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1719|LOG_ERR|LAYER3INTF|-|Add route 192.168.1.0/24, error: some_error' throttle_count: 1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Add route 192.168.1.0/24, error: some_error' throttle_count: 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:04:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth1",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1720",
+                "original": "2024-06-18T13:04:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1720|LOG_ERR|LAYER3INTF|-|Error creating egress object for port eth1, error: some_error",
+                "reason": "some_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Error creating egress object for port eth1, error: some_error",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:05:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1721",
+                "original": "2024-06-18T13:05:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1721|LOG_INFO|LAYER3INTF|-|Created L3 egress ID 1001 for port eth1 intf eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Created L3 egress ID 1001 for port eth1 intf eth0",
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "id": "1001"
+                    }
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:06:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth1",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1722",
+                "original": "2024-06-18T13:06:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1722|LOG_ERR|LAYER3INTF|-|Error deleting egress object for port eth1, error: some_error",
+                "reason": "some_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Error deleting egress object for port eth1, error: some_error",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:07:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1723",
+                "original": "2024-06-18T13:07:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1723|LOG_INFO|LAYER3INTF|-|Deleted L3 egress ID 1001 for port eth1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Deleted L3 egress ID 1001 for port eth1",
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "id": "1001"
+                    }
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:08:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1724",
+                "original": "2024-06-18T13:08:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1724|LOG_INFO|LAYER3INTF|-|Interface eth0, configured with ipv4 address 192.168.1.1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface eth0, configured with ipv4 address 192.168.1.1",
+            "server": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:09:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1725",
+                "original": "2024-06-18T13:09:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1725|LOG_INFO|LAYER3INTF|-|Interface eth0, configured with ipv6 address FE80::C000:1DFF:FEE0:C01/64"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface eth0, configured with ipv6 address FE80::C000:1DFF:FEE0:C01/64",
+            "server": {
+                "ip": "FE80::C000:1DFF:FEE0:C01"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:10:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1726",
+                "original": "2024-06-18T13:10:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1726|LOG_INFO|LAYER3INTF|-|Interface eth0, ipv4 address deleted 192.168.1.1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface eth0, ipv4 address deleted 192.168.1.1",
+            "server": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:11:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1727",
+                "original": "2024-06-18T13:11:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1727|LOG_INFO|LAYER3INTF|-|Interface eth0, ipv6 address deleted FE80::C000:1DFF:FEE0:C01/64"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface eth0, ipv6 address deleted FE80::C000:1DFF:FEE0:C01/64",
+            "server": {
+                "ip": "FE80::C000:1DFF:FEE0:C01"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:12:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-",
+                "status": "active"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1728",
+                "original": "2024-06-18T13:12:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1728|LOG_INFO|LAYER3INTF|-|IPv6 Address Status: Interface eth0, address 2001:db8:3333:4444:5555:6666:7777:8888, status active"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "IPv6 Address Status: Interface eth0, address 2001:db8:3333:4444:5555:6666:7777:8888, status active",
+            "server": {
+                "address": "2001:db8:3333:4444:5555:6666:7777:8888"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:13:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1729",
+                "original": "2024-06-18T13:13:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1729|LOG_INFO|LAYER3INTF|-|Interface eth0, configured with secondary ipv4 address 192.168.1.2"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface eth0, configured with secondary ipv4 address 192.168.1.2",
+            "server": {
+                "ip": "192.168.1.2"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:14:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1730",
+                "original": "2024-06-18T13:14:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1730|LOG_INFO|LAYER3INTF|-|Interface eth0, secondary ipv4 address deleted 192.168.1.2"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface eth0, secondary ipv4 address deleted 192.168.1.2",
+            "server": {
+                "ip": "192.168.1.2"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:15:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LAYER3INTF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mtu": "1500",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1731",
+                "original": "2024-06-18T13:15:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1731|LOG_ERR|LAYER3INTF|-|IP MTU 1500 not applied due to hardware resource limitation"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-l3interface",
+                    "procid": "1234"
+                }
+            },
+            "message": "IP MTU 1500 not applied due to hardware resource limitation",
             "tags": [
                 "preserve_original_event"
             ]
@@ -2081,6 +5491,307 @@
             "server": {
                 "address": "127.0.0.1"
             },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LOOPPROTECT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2801",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire loopprotect[1234]: Event|2801|LOG_WARN|LOOPPROTECT|-|Port eth0 is disabled by Loop-protection after loop detection on VLAN 10"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "loopprotect",
+                    "procid": "1234"
+                }
+            },
+            "message": "Port eth0 is disabled by Loop-protection after loop detection on VLAN 10",
+            "network": {
+                "vlan": {
+                    "id": "10"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LOOPPROTECT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "loop": {
+                    "rx_port": "eth2",
+                    "tx_port": "eth1"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2802",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire loopprotect[1234]: Event|2802|LOG_WARN|LOOPPROTECT|-|Ports TX eth1 and RX eth2 are disabled by Loop-protect after loop detection on VLAN 20"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "loopprotect",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ports TX eth1 and RX eth2 are disabled by Loop-protect after loop detection on VLAN 20",
+            "network": {
+                "vlan": {
+                    "id": "20"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LOOPPROTECT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth3",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2803",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire loopprotect[1234]: Event|2803|LOG_WARN|LOOPPROTECT|-|Loop detected on port eth3 on VLAN 30"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "loopprotect",
+                    "procid": "1234"
+                }
+            },
+            "message": "Loop detected on port eth3 on VLAN 30",
+            "network": {
+                "vlan": {
+                    "id": "30"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LOOPPROTECT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth4",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2804",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire loopprotect[1234]: Event|2804|LOG_INFO|LOOPPROTECT|-|Port eth4 enabled after disable time expired"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "loopprotect",
+                    "procid": "1234"
+                }
+            },
+            "message": "Port eth4 enabled after disable time expired",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LOOPPROTECT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth5",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2805",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire loopprotect[1234]: Event|2805|LOG_INFO|LOOPPROTECT|-|Port eth5 added for loop-protection"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "loopprotect",
+                    "procid": "1234"
+                }
+            },
+            "message": "Port eth5 added for loop-protection",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LOOPPROTECT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth6",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2806",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire loopprotect[1234]: Event|2806|LOG_INFO|LOOPPROTECT|-|Port eth6 deleted from loop-protection"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "loopprotect",
+                    "procid": "1234"
+                }
+            },
+            "message": "Port eth6 deleted from loop-protection",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LOOPPROTECT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2807",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire loopprotect[1234]: Event|2807|LOG_INFO|LOOPPROTECT|-|Loop-Protection stats cleared for port eth7"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "loopprotect",
+                    "procid": "1234"
+                }
+            },
+            "message": "Loop-Protection stats cleared for port eth7",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "LOOPPROTECT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "loop": {
+                    "rx_port": "eth9",
+                    "tx_port": "eth8"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2808",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire loopprotect[1234]: Event|2808|LOG_INFO|LOOPPROTECT|-|Ports TX eth8 and RX eth9 are involved during TX port disabling"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "loopprotect",
+                    "procid": "1234"
+                }
+            },
+            "message": "Ports TX eth8 and RX eth9 are involved during TX port disabling",
             "tags": [
                 "preserve_original_event"
             ]
@@ -3592,6 +7303,43 @@
                 }
             },
             "message": "DHCP Relay Disabled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "IRDP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3501",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-irdp[1234]: Event|3501|LOG_INFO|IRDP|-|IRDP enabled on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-irdp",
+                    "procid": "1234"
+                }
+            },
+            "message": "IRDP enabled on interface eth0",
             "tags": [
                 "preserve_original_event"
             ]
@@ -7764,6 +11512,120 @@
             ]
         },
         {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "L3ENCAP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "l3": {
+                    "encaps_allocated": "80",
+                    "encaps_free": "20"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "10601",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-l3encap[1234]: Event|10601|LOG_WARN|L3ENCAP|-|L3 resources critical for neighbor and route forwarding are low. Used: 80, Available: 20"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-l3encap",
+                    "procid": "1234"
+                }
+            },
+            "message": "L3 resources critical for neighbor and route forwarding are low. Used: 80, Available: 20",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "L3ENCAP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "l3": {
+                    "encaps_allocated": "50",
+                    "encaps_free": "50"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "10602",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-l3encap[1234]: Event|10602|LOG_INFO|L3ENCAP|-|L3 resources critical for neighbor and route forwarding are at safe levels. Used: 50, Available: 50"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-l3encap",
+                    "procid": "1234"
+                }
+            },
+            "message": "L3 resources critical for neighbor and route forwarding are at safe levels. Used: 50, Available: 50",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "L3ENCAP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "l3": {
+                    "encaps_allocated": "100",
+                    "encaps_free": "0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "10603",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-l3encap[1234]: Event|10603|LOG_ERR|L3ENCAP|-|Out of L3 resources critical for neighbor and route forwarding. Used: 100, Available: 0"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-l3encap",
+                    "procid": "1234"
+                }
+            },
+            "message": "Out of L3 resources critical for neighbor and route forwarding. Used: 100, Available: 0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-06-19T13:53:38.182641-05:00",
             "aruba": {
                 "component": {
@@ -8191,6 +12053,41 @@
                 }
             },
             "message": "MAC Lockout packet drop detected for AA:BB:CC:DD:EE:FF as source: 5 and destination: 3 address.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "L3RSMGR"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "prefix": "FE80::C000:1DFF:FEE0:C01/64",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11501",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-l3resmgr[1234]: Event|11501|LOG_WARN|L3RSMGR|-|IPv6 route prefix FE80::C000:1DFF:FEE0:C01/64 is not supported on this platform."
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-l3resmgr",
+                    "procid": "1234"
+                }
+            },
+            "message": "IPv6 route prefix FE80::C000:1DFF:FEE0:C01/64 is not supported on this platform.",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -1472,10 +1472,10 @@
                     "device": "8360-Primaire"
                 },
                 "interface": {
-                    "id": "eth0"
+                    "id": "eth0",
+                    "state": "up"
                 },
-                "sequence": "-",
-                "status": "up"
+                "sequence": "-"
             },
             "ecs": {
                 "version": "8.11.0"

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -279,34 +279,61 @@ processors:
     # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LACP.htm
   - grok:
       field: message
-      tag: lacp_event_1301_through_1323
-      description: "Dynamic LAG has event has been raised"
-      if: "['1301','1302','1303','1304','1305','1306','1307','1308','1309','1310','1311','1312','1313','1314','1315','1316','1317','1318','1319','1320','1321','1322','1323'].contains(ctx.event?.code)"
+      tag: lacp_event_1301_1302_1312_1313
+      description: "Dynamic LAG|VSX has been created|deleted"
+      if: "['1301','1302', '1312', '1313'].contains(ctx.event?.code)"
       patterns:
-        - "^Dynamic %{LAG_ID} (created|deleted)"
-        - "^%{INTF_ID} added to %{LAG_ID}. Existing configuration on interface %{DATA:aruba.interface.prev_id} will be removed"
-        - "^%{INTF_ID} removed from %{LAG_ID}. It will be set with default configuration with admin down state"
-        - "^LACP system priority set to %{GREEDYDATA:aruba.lacp.system_priority}"
-        - "^LACP mode set to %{DATA:aruba.lacp.mode} for %{LAG_ID_GREEDY}"
-        - "^LACP system ID set to %{GREEDYDATA:aruba.lacp.system_id}"
-        - "^LACP rate set to %{DATA:aruba.lacp.rate} for %{LAG_ID_GREEDY}"
-        - "^Partner is detected for %{INTF_ID} %{LAG_ID}\\s?: %{DATA:aruba.lacp.partner_sys_id}. %{ACTOR_STATE}, %{PARTNER_STATE}"
-        - "^Partner is out of sync for %{INTF_ID} %{LAG_ID}. %{ACTOR_STATE}, %{PARTNER_STATE}"
-        - "^Partner is lost \\(timed out\\) for %{INTF_ID} %{LAG_ID}. State: %{GREEDYDATA:aruba.lacp.fsm_state}"
-        - "^Failed to create %{LAG_ID_GREEDY}"
-        - "^%{LAG_ID} set as VSX"
-        - "^%{LAG_ID} not sending LACPDUs through %{INTF_ID} because VSX information is not complete"
+        - "^(Dynamic )?LAG %{DATA:aruba.instance.id} (created|deleted|set as VSX)"
+        - "^Failed to create LAG %{GREEDYDATA:aruba.instance.id}"
+  - dissect:
+      field: message
+      tag: lacp_event_1305
+      description: "Log when LACP system priority is set"
+      if: "['1305'].contains(ctx.event?.code)"
+      pattern: "LACP system priority set to %{aruba.lacp.system_priority}"
+  - dissect:
+      field: message
+      tag: lacp_event_1307
+      description: "Log when LACP system ID is set"
+      if: "['1307'].contains(ctx.event?.code)"
+      pattern: "LACP system ID set to %{aruba.lacp.system_id}"
+  - grok:
+      field: message
+      tag: lacp_event_1303_1304_1311_1314_1318
+      description: "Log when interface has been added|removed to LAG"
+      if: "['1303','1304','1311','1314','1318'].contains(ctx.event?.code)"
+      patterns:
+        - "^Interface %{DATA:aruba.interface.id} added to LAG %{DATA:aruba.instance.id}. Existing configuration on interface %{DATA:aruba.interface.prev_id} will be removed"
+        - "^Interface %{DATA:aruba.interface.id} removed from LAG %{DATA:aruba.instance.id}. It will be set with default configuration with admin down state"
+        - "^Partner is lost \\(timed out\\) for interface %{DATA:aruba.interface.id} LAG %{DATA:aruba.instance.id}. State: %{GREEDYDATA:aruba.lacp.fsm_state}"
+        - "^LAG %{DATA:aruba.instance.id} not sending LACPDUs through interface %{DATA:aruba.interface.id} because VSX information is not complete"
+        - "^Interface %{DATA:aruba.interface.id} enabled by fallback for lag %{GREEDYDATA:aruba.instance.id}"
+  - grok:
+      field: message
+      tag: lacp_event_1306_1308_1315_1316_1317_1320_1323
+      description: "Log when LACP mode|rate|mode|timeout is set|expired | Logs to set global load balancing mode for LAG interfaces | Logs to capture if fallback is changed for LAG interface"
+      if: "['1306','1308','1315','1316','1317','1320','1323'].contains(ctx.event?.code)"
+      patterns:
+        - "^LACP (mode set to %{DATA:aruba.lacp.mode}|rate set to %{DATA:aruba.lacp.rate}) for %{LAG_ID_GREEDY}"
         - "^LACP fallback mode set to %{DATA:aruba.lacp.fallback_mode} for %{LAG_ID_GREEDY}"
         - "^LACP fallback timeout( set to)? %{NUMBER:aruba.timeout:long}( expired)? for %{LAG_ID_GREEDY}"
-        - "^%{INTF_ID} enabled by fallback for lag %{GREEDYDATA:aruba.instance.id}"
-        - "^LAG global load balancing mode is set to %{GREEDYDATA:aruba.lacp.mode}"
         - "^LAG load balancing mode is set to %{DATA:aruba.lacp.mode} for %{LAG_ID_GREEDY}"
-        - "^%{LAG_ID} State change for interface %{DATA:aruba.interface.id}: %{ACTOR_STATE}, %{PARTNER_STATE}"
-        - "^%{INTF_NAME} cannot be part of Lag %{NUMBER:aruba.lacp.lag_number:long}. Speed mismatched \\(Interface speed %{NUMBER:aruba.lacp.port_speed:long}Mbps Lag base speed %{NUMBER:aruba.lacp.lag_speed:long}Mbps\\)."
         - "^Fallback is %{DATA:aruba.lacp.fallback} for %{LAG_ID_GREEDY}"
       pattern_definitions:
-        LAG_ID: "(LAG|lag) %{DATA:aruba.instance.id}"
         LAG_ID_GREEDY: "(LAG|lag) %{GREEDYDATA:aruba.instance.id}"
+  - grok:
+      field: message
+      tag: lacp_event_1309_1310_1319_1321_1322
+      description: "Dynamic LAG has event has been raised"
+      if: "['1309','1310','1319','1321','1322'].contains(ctx.event?.code)"
+      patterns:
+        - "^Partner is detected for %{INTF_ID} %{LAG_ID}\\s?: %{DATA:aruba.lacp.partner_sys_id}. %{ACTOR_STATE}, %{PARTNER_STATE}"
+        - "^Partner is out of sync for %{INTF_ID} %{LAG_ID}. %{ACTOR_STATE}, %{PARTNER_STATE}"
+        - "^LAG global load balancing mode is set to %{GREEDYDATA:aruba.lacp.mode}"
+        - "^%{LAG_ID} State change for interface %{DATA:aruba.interface.id}: %{ACTOR_STATE}, %{PARTNER_STATE}"
+        - "^%{INTF_NAME} cannot be part of Lag %{NUMBER:aruba.lacp.lag_number:long}. Speed mismatched \\(Interface speed %{NUMBER:aruba.lacp.port_speed:long}Mbps Lag base speed %{NUMBER:aruba.lacp.lag_speed:long}Mbps\\)."
+      pattern_definitions:
+        LAG_ID: "(LAG|lag) %{DATA:aruba.instance.id}"
         INTF_ID: "(I|i)nterface %{DATA:aruba.interface.id}"
         INTF_NAME: "(I|i)nterface %{DATA:aruba.interface.name}"
         ACTOR_STATE: "Actor state: %{DATA:aruba.lacp.actor_state}"
@@ -401,37 +428,62 @@ processors:
     # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3INTERFACE.htm
   - grok:
       field: message
-      tag: l3_event_1701_through_1731
-      description: "Logs to L3 interface events"
-      if: "['1701','1702','1703','1704','1705','1706','1707','1708','1709','1710','1711','1712','1713','1714','1715','1716','1717','1718','1719','1720','1721','1722','1723','1724','1725','1726','1727','1728','1729','1730','1731'].contains(ctx.event?.code)"
+      tag: l3_event_1701_1702
+      description: "logs to create|deleted L3 interface"
+      if: "['1701','1702'].contains(ctx.event?.code)"
       patterns:
-        - "^L3-%{INTERFACE}, (created|deleted)"
-        - "^%{INTERFACE}, configured administratively %{GREEDYDATA:aruba.status}"
-        - "^Failed to create %{DATA:network.vlan.id} for layer 3 %{INTERFACE_GREEDY}"
-        - "^Failed to (destroy layer |delete an l)3 %{INTERFACE}( vlan %{DATA:network.vlan.id})?, %{ERROR}"
+        - "^L3-Interface %{DATA:aruba.interface.id}, (created|deleted)"
+  - dissect:
+      field: message
+      tag: l3_event_1703
+      description: "logs for admin state of L3 interface"
+      if: "['1703'].contains(ctx.event?.code)"
+      pattern: "Interface %{aruba.interface.id}, configured administratively %{aruba.status}"
+  - dissect:
+      field: message
+      tag: l3_event_1704
+      description: "logs errors while creating vlan for layer 3 interfaces."
+      if: "['1704'].contains(ctx.event?.code)"
+      pattern: "Failed to create %{network.vlan.id} for layer 3 interface %{aruba.interface.id}"
+  - grok:
+      field: message
+      tag: l3_event_1705_1706
+      description: "logs errors while destroying vlan for layer 3 interfaces | logs errors while destroying layer 3 interface."
+      if: "['1705','1706'].contains(ctx.event?.code)"
+      patterns:
+        - "^Failed to (destroy layer |delete an l)3 interface %{DATA:aruba.interface.id}( vlan %{DATA:network.vlan.id})?, error: %{GREEDYDATA:event.reason}"
+  - grok:
+      field: message
+      tag: l3_event_1707_1708_1709_1710_1711_1712_1715_1716_1717_1718_1719_1720_1722
+      description: "adding l3 hosts | deleting l3 hosts | [adding|deleted|failed] to get l3 hosts | "
+      if: "['1707','1708','1709','1710','1711','1712','1715','1716','1717','1718','1719','1720','1722'].contains(ctx.event?.code)"
+      patterns:
         - "^Failed to (delete|add) %{HOST_IP}, %{ERROR}"
         - "^(Added|Deleted|Failed to get) %{HOST_IP}"
         - "^L3 interface %{ERROR}"
-        - "^(Delete|Added) %{NEXTHOP}(, egress_id %{DATA:observer.egress.interface.id},)? for route %{GREEDYDATA:aruba.prefix}"
         # Note: sequence matters here, putting greedy data at the end
         - "^(Delete|Added|Add) route (%{DATA:aruba.prefix}, %{ERROR}|%{GREEDYDATA:aruba.prefix})"
         - "^Update: route state: %{GREEDYDATA:aruba.status}"
-        - "^Error (deleting|creating) egress object for %{PORT}, %{ERROR}"
-        - "^(Deleted|Created) L3 egress ID %{DATA:observer.egress.interface.id} for (%{PORT} intf %{GREEDYDATA:aruba.interface.id}|%{PORT_GREEDY})"
+        - "^Error (deleting|creating) egress object for port %{DATA:aruba.port}, %{ERROR}"
+      pattern_definitions:
+        HOST_IP: "L3 host (entry|hit) for ip %{IP:host.ip}"
+        ERROR: "error: %{GREEDYDATA:event.reason}"
+  - grok:
+      field: message
+      tag: l3_event_1713_1714_1721_1723_1724_1725_1726_1727_1728_1729_1730_1731
+      description: "nexthop [addition|deletion] | egress object [creation|deletion] | [ipv4|ipv6] address [update|delete] on interface | configuring hardware for IPMTU"
+      if: "['1713','1714','1721','1723','1724','1725','1726','1727','1728','1729','1730','1731'].contains(ctx.event?.code)"
+      patterns:
+        - "^(Delete|Added) Nexthop %{IP:aruba.l3.nexthop}(, egress_id %{DATA:observer.egress.interface.id},)? for route %{GREEDYDATA:aruba.prefix}"
+        - "^(Deleted|Created) L3 egress ID %{DATA:observer.egress.interface.id} for port (%{DATA:aruba.port} intf %{GREEDYDATA:aruba.interface.id}|%{GREEDYDATA:aruba.port})"
         - "^%{INTERFACE},( configured with)? %{SERVER_IP}"
         - "^IPv6 Address Status: %{INTERFACE}, address %{IPORHOST:server.address}, status %{GREEDYDATA:aruba.status}"
         - "^%{INTERFACE}, configured with secondary %{SERVER_IP}"
         - "^%{INTERFACE}, secondary %{SERVER_IP}"
         - "^IP MTU %{DATA:aruba.mtu} not applied due to hardware resource limitation"
       pattern_definitions:
-        HOST_IP: "L3 host (entry|hit) for ip %{IP:host.ip}"
         SERVER_IP: "(ipv6|ipv4) address( deleted)? %{IP:server.ip}"
-        ERROR: "error: %{GREEDYDATA:event.reason}"
         INTERFACE: "(I|i)nterface %{DATA:aruba.interface.id}"
-        INTERFACE_GREEDY: "(I|i)nterface %{GREEDYDATA:aruba.interface.id}"
-        NEXTHOP: "Nexthop %{IP:aruba.l3.nexthop}"
-        PORT: "port %{DATA:aruba.port}"
-        PORT_GREEDY: "port %{GREEDYDATA:aruba.port}"
 
   # ECMP Events (18xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ECMP.htm

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -273,7 +273,7 @@ processors:
       description: "Log when loopback interface event is triggered"
       if: "['901','902','903'].contains(ctx.event?.code)"
       patterns:
-        - "^Loopback Interface %{DATA:aruba.interface.id}, (created|deleted|configured administratively %{GREEDYDATA:aruba.status})"
+        - "^Loopback Interface %{DATA:aruba.interface.id}, (created|deleted|configured administratively %{GREEDYDATA:aruba.interface.state})"
 
     # LACP events (13xx)
     # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LACP.htm

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -338,7 +338,7 @@ processors:
         PORT: "(hw_)?port %{DATA:aruba.port}"
         RC: "rc %{DATA:error.code}"
         TID: "tid %{NUMBER:process.thread.id:long}"
-        UNIT: "unit %{NUMBER:aruba.unit:long}"
+        UNIT: "unit %{DATA:aruba.unit}"
 
     # CoPP Events (15xx)
     # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/COPP.htm
@@ -538,7 +538,43 @@ processors:
       description: "Logs changes in TACACS server reachability status"
       pattern: "TACACS server host %{server.address} port %{aruba.port} vrf %{aruba.vrf.id} %{aruba.status}"
 
-    # Loop Protect events (280X)
+    # MGMD events (26xx)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LOOP-PROTECT.htm
+  - grok:
+      field: message
+      tag: mgmd_event_2601_through_2622
+      description: "The following are the events related to MGMD"
+      if: "['2601','2602','2603','2604','2605','2606','2607','2608','2609','2610','2611','2612','2613','2614','2619','2620','2621','2622'].contains(ctx.event?.code)"
+      patterns:
+        - "^Failed to alloc a %{DATA:aruba.mgmd.pkt_type} pkt\\(%{VLAN}\\)"
+        - "^Received (IGMPv1|IGMPv2|MLDV1|MLDV2) query from %{IP:client.ip} when the device is configured for"
+        - "^Unable to alloc a buf of size %{NUMBER:aruba.len:long} for %{GREEDYDATA:aruba.subsystem}"
+        - "^%{INTERFACE}: Other Querier detected for %{GREEDYDATA:aruba.mgmd.mgmd_type}"
+        - "^%{INTERFACE}: End %{DATA:aruba.mgmd.mgmd_type} Querier role"
+        - "^%{DATA:aruba.mgmd.mgmd_type} Querier Election in progress for %{INTERFACE} with IP address %{IP:client.ip}"
+        - "^%{INTERFACE}: Start %{DATA:aruba.mgmd.mgmd_type} Querier role addr: %{IP:client.ip}"
+        - "^Received packet from %{IP:client.ip}, type %{DATA:aruba.mgmd.mgmd_type}, on invalid port %{GREEDYDATA:aruba.port}"
+        - "^%{DATA:aruba.mgmd.mgmd_type} snooping is %{DATA:aruba.status} on %{VLAN}."
+        - "^%{DATA:aruba.mgmd.mgmd_type} is %{DATA:aruba.status} on %{INTERFACE_GREEDY}"
+        - "^Port %{DATA:aruba.port} on %{VLAN} is set to %{DATA:aruba.status} mode for %{DATA:aruba.mgmd.mgmd_type}."
+        - "^%{DATA:aruba.mgmd.mgmd_type} is not operational on VLAN %{DATA:network.vlan.id} due to resource unavailability"
+        - "^Received IGMPv3 query from %{IP:client.ip} when the device is configured for IGMPv2"
+        - "^Flood mode is temporarily activated on ERPS ports %{DATA:aruba.port} and %{DATA:aruba.mgmd.port1} as ring state for ring id %{DATA:aruba.mgmd.ring_id} changed to %{GREEDYDATA:aruba.status}."
+      pattern_definitions:
+        VLAN: "(vlan|VLAN|interface) %{DATA:network.vlan.id}"
+        VLAN_GREEDY: "(vlan|VLAN|interface) %{GREEDYDATA:network.vlan.id}"
+        INTERFACE: "(I|i)nterface %{DATA:aruba.interface.id}"
+        INTERFACE_GREEDY: "(I|i)nterface %{GREEDYDATA:aruba.interface.id}"
+  - grok:
+      field: message
+      tag: mgmd_event_2615_2618
+      description: "IGMP/MLD is disabled on a L3 interface due to internal errors | IGMP/MLD snooping is operational"
+      if: "['2615','2618'].contains(ctx.event?.code)"
+      patterns:
+        - "^%{DATA:aruba.mgmd.mgmd_type} is not operational on interface %{DATA:aruba.mgmd.l3_port} due to resource unavailability"
+        - "^%{DATA:aruba.mgmd.mgmd_type} snooping is %{DATA:aruba.status} on VLAN %{GREEDYDATA:network.vlan.id}."
+
+    # Loop Protect events (280x)
     # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LOOP-PROTECT.htm
   - grok:
       field: message
@@ -719,6 +755,30 @@ processors:
         3011_3012_3013_COMMON: "correctable memory error count %{NUMBER:aruba.hardware.cecount:long} exceeded threshold %{NUMBER:aruba.limit:long}(?:%{3011_3012_3013_OPTIONAL})?"
         3011_3012_3013_OPTIONAL: " and %{NUMBER:aruba.hardware.offlined:long}"
 
+    # Module events (32xx)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MODULE.htm
+  - grok:
+      field: message
+      tag: module_event_3201_through_3240_common
+      description: "The following are the events related to module."
+      if: "['3201','3202','3203','3204','3206','3208','3209','3210','3211','3212','3213','3214','3216','3217','3218','3219','3220','3221','3222','3224','3225','3227','3228','3234','3235','3236','3237','3238','3240'].contains(ctx.event?.code)"
+      patterns:
+        - "%{DATA:aruba.module.type} module %{DATA:aruba.module.name}\\s"
+  - grok:
+      field: message
+      tag: module_event_3205_3207_3215_3223_3226_3229_3230_3231_3232_3233_3239
+      description: "The following are the events related to module that exhibit extra fields other than module type and name."
+      if: "['3205','3207','3215','3223','3226','3229','3230','3231','3232','3233','3239'].contains(ctx.event?.code)"
+      patterns:
+        - "^%{DATA:aruba.module.type} module %{DATA:aruba.module.name} (is down|has failed): %{GREEDYDATA:event.reason}"
+        - "^%{DATA:aruba.module.type} module %{DATA:aruba.module.name} device initialization failed: %{GREEDYDATA:event.reason}"
+        - "^%{DATA:aruba.module.type} module %{DATA:aruba.module.name} ASIC (denitialization|deinitialization|initialization) failed: %{GREEDYDATA:event.reason}"
+        - "^%{DATA:aruba.module.type} module %{DATA:aruba.module.name} disabling front-end power: %{GREEDYDATA:event.reason}"
+        - "^%{DATA:aruba.module.type} module %{DATA:aruba.module.name} configured with product number %{GREEDYDATA:aruba.unit}"
+        - "^%{DATA:aruba.module.type} module %{DATA:aruba.module.name} is requesting to power on with priority %{GREEDYDATA:aruba.priority}"
+        - "^%{DATA:aruba.module.name} is starting zeroization"
+        - "^%{DATA:aruba.module.name} zeroization (completed|failed)"
+
   # IRDP events (350x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IRDP.htm
   - grok:
@@ -745,6 +805,51 @@ processors:
         - "^default prefix is configured on interface %{GREEDYDATA:aruba.interface.id}"
         - "^(RDNSS|DNSSL) is (added|deleted) on interface: %{GREEDYDATA:aruba.interface.id}"
 
+    # Multicast Traffic Manager events (400x)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MTM.htm
+  - dissect:
+      field: message
+      tag: multicast_traffic_mgr_event_4001
+      description: "Event raised when the maximum number of multicast L3 Bridge Control Forwarding entries is reached"
+      if: "ctx.event?.code == '4001'"
+      pattern: "The Multicast L3 Bridge Control Forwarding entries limit was reached: %{aruba.limit}"
+
+    # Management events (430x)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MGMT.htm
+  - grok:
+      field: message
+      tag: mgmt_event_4301
+      description: "Logs related to management interface configurations"
+      if: "ctx.event?.code == '4301'"
+      patterns: 
+        - "MGMT_INTF: (Static parameter : \\[%{GREEDYDATA:_temp.config}\\]|%{GREEDYDATA:aruba.mgmt.config_param})"
+  - grok:
+      field: message
+      tag: mgmt_event_4302
+      description: "Logs related to management interface configurations"
+      if: "ctx.event?.code == '4302'"
+      patterns: 
+        - "MGMT_INTF: (Static parameter : \\[%{GREEDYDATA:_temp.config}\\]|%{GREEDYDATA:aruba.mgmt.config_err})"
+  - grok:
+      field: message
+      tag: mgmt_event_4303
+      description: "Logs related to management interface configurations"
+      if: "ctx.event?.code == '4303'"
+      patterns: 
+        - "MGMT_INTF: (Static parameter : \\[%{GREEDYDATA:_temp.config}\\]|%{GREEDYDATA:aruba.mgmt.config_crit})"
+  - json:
+      if: "ctx.event?.code == '4301' && ctx._temp?.config != null"
+      field: _temp.config
+      target_field: aruba.mgmt.config_param
+  - json:
+      if: "ctx.event?.code == '4302' && ctx._temp?.config != null"
+      field: _temp.config
+      target_field: aruba.mgmt.config_err
+  - json:
+      if: "ctx.event?.code == '4303' && ctx._temp?.config != null"
+      field: _temp.config
+      target_field: aruba.mgmt.config_crit
+
   # Firmware Update events (44xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/FIRMWARE_UPDATE.htm
   # Following events do not need further processing
@@ -765,6 +870,18 @@ processors:
       description: "Indicates that a switch firmware update failed from a remote or local source"
       patterns:
         - "^User %{DATA:user.name}: %{DATA:aruba.firmware.image_profile} image update failed via %{DATA:aruba.firmware.dnld_type}( from %{HOSTNAME:source.address})?$"
+
+    # MAC Learning events (480x)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MAC-LEARN.htm
+  - grok:
+      field: message
+      tag: mac_learn_event_4801_through_4805
+      description: "The following are the events related to MAC learning."
+      if: "['4801','4802','4803','4804','4805'].contains(ctx.event?.code)"
+      patterns:
+        - "^MAC %{MAC:server.mac} moved from port %{DATA:aruba.interface.prev_id} to port %{DATA:aruba.interface.id} on VLAN %{GREEDYDATA:network.vlan.id}"
+        - "^All dynamic MAC addresses on VLAN %{DATA:network.vlan.id} were flushed"
+        - "^All dynamic MAC addresses on port %{DATA:aruba.interface.id} were flushed"
 
   # HTTPS Server events (560x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/HTTPS_SERVER.htm
@@ -814,6 +931,17 @@ processors:
       field: "message"
       description: "Logs a message when SSH authorized key fails validation check"
       pattern: "User %{user.name} has configured an invalid SSH authorized key with key identifier %{user.id}"
+
+    # Mirroring events (670x)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MIRRORING.htm
+  - grok:
+      field: message
+      tag: mirror_event_6701_through_6706
+      description: "The following are the events related to mirroring."
+      if: "['6701','6702','6703','6704','6705','6706'].contains(ctx.event?.code)"
+      patterns:
+        - "session %{DATA:aruba.session.id} (created|deleted|updated)"
+        - "session %{GREEDYDATA:aruba.session.id}"
 
   # Config Management events (68xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CONFIG_MGMT.htm
@@ -1178,6 +1306,22 @@ processors:
       if: "ctx.event?.code == '8515'"
       pattern: "Operational state of the ring %{aruba.erps.ring_id}, instance %{aruba.instance.id} changed to Initializing with reason %{event.reason}"
 
+    # MSDP events (860x)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MSDP.htm
+  - grok:
+      field: message
+      tag: msdp_event_8601_through_8609
+      description: "The following are the events related to MSDP"
+      if: "['8601','8602','8603','8604','8605','8606','8607','8608','8609'].contains(ctx.event?.code)"
+      patterns:
+        - "^Router MSDP is %{DATA:aruba.status} on VRF %{GREEDYDATA:aruba.vrf.name}"
+        - "^Forwarding state of interface %{DATA:aruba.interface.name} has been changed to %{GREEDYDATA:aruba.status}"
+        - "^MSDP Peer %{IP:client.ip}\\(%{DATA:aruba.msdp.tcp_entity}\\) with connection source %{DATA:aruba.interface.name} has entered %{DATA:aruba.status} state"
+        - "^Port %{DATA:aruba.port} is %{DATA:aruba.status} to MSDP Peer %{IP:client.ip}"
+        - "^MSDP Peer %{IP:client.ip} is %{DATA:aruba.status} on VRF %{DATA:aruba.vrf.name}. Interface %{DATA:aruba.interface.name} is added to the Peer"
+        - "^Start %{DATA:aruba.msdp.tcp_entity} role for MSDP peer %{IP:client.ip}"
+        - "^Finish packet was received on MSDP Peer %{IP:client.ip}"
+        - "^Failed to add SA Cache entry: S=%{IP:source.ip}, G=%{IP:aruba.msdp.grp_ip}, R=%{IP:aruba.msdp.rp_ip} for Peer %{IP:client.ip} as MSDP SA Cache Limit is reached"
 
   # Hardware switch controller sync events (88xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/HSC-SYNCD.htm
@@ -1429,6 +1573,17 @@ processors:
       if: "ctx.event?.code == '10904'"
       pattern: "Line card module %{aruba.dpse.linecard_name} completed backplane sequence recovery"
 
+  # MAC Address mode configuration events (1100x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/FAULT_MONITOR.htm
+  - grok:
+      field: message
+      tag: mac_event_11001_11002_11003
+      description: "The following are the events related to MAC Address mode configuration"
+      if: "['11001','11002','11003'].contains(ctx.event?.code)"
+      patterns:
+        - "^The MAC Address (configured|operational) mode changed from %{DATA:aruba.mac.old_mode} to %{GREEDYDATA:aruba.mac.new_mode}"
+        - "^Station MAC add failure due to hardware full, mac=%{MAC:server.mac} vlan=%{GREEDYDATA:network.vlan.id}"
+
   # Fault Monitor Events (111xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/FAULT_MONITOR.htm
   - grok:
@@ -1489,6 +1644,19 @@ processors:
       if: "ctx.event?.code == '11109'"
       patterns:
           - "^MAC Lockout packet drop detected for %{MAC:client.mac} as source: %{NUMBER:aruba.fault.sa_diff_count:long} and destination: %{NUMBER:aruba.fault.da_diff_count:long} address"
+
+    # MACsec events (1120x)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MACSEC.htm
+  - grok:
+      field: message
+      tag: macsec_event_11201_through_11204
+      description: "The following are the events related to MACsec"
+      if: "['11201','11202','11203','11204'].contains(ctx.event?.code)"
+      patterns:
+        - "^MACsec session established on Rx Secure Channel %{DATA:aruba.mac.sci} on interface %{GREEDYDATA:aruba.interface.name}"
+        - "^MKA session secured for Connectivity Association %{DATA:aruba.mac.ckn} on interface %{GREEDYDATA:aruba.interface.name}"
+        - "^Secure Association key updated for Connectivity Association %{DATA:aruba.mac.ckn} on interface %{DATA:aruba.interface.name} - Latest AN/KN %{DATA:aruba.mac.latest_an}/%{DATA:aruba.mac.latest_kn}, Old AN/KN %{DATA:aruba.mac.old_an}/%{GREEDYDATA:aruba.mac.old_kn}"
+        - "^Possible replay attempt detected on the Secure Channel %{GREEDYDATA:aruba.mac.sci}."
 
   # L3 Resource Manager events (1150x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3_RESMGR.htm
@@ -1581,14 +1749,22 @@ processors:
       value: ['{{{host.mac}}}']
       if: ctx.host?.mac instanceof String
 
-  # Convert aruba.slot from a string to a long
-  # Dissect processor sets everything to a string type
+  # Convert due to dissect processing
+  # - aruba.slot
+  # - aruba.limit
   - convert:
-      tag: convert_aruba_slot
       field: aruba.slot
       type: long
       ignore_missing: true
+  - convert:
+      field: aruba.limit
+      type: long
+      ignore_missing: true
 
+  - remove:
+      field:
+        - _temp.config
+      ignore_missing: true
 
 on_failure:
   - set:

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -45,7 +45,24 @@ processors:
       tag: lowercase_event_kind
       ignore_missing: true
 
-
+    # LLDP events (1xx)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LLDP.htm
+  - grok:
+      field: message
+      tag: lldp_event_101_through_113
+      description: "Logs event when LLDP (Link Layer Discovery Protocol) feature"
+      if: "['103','104','105','106','107','108','109','110','113'].contains(ctx.event?.code)"
+      patterns:
+        - "^LLDP neighbor %{DATA:aruba.instance.id} (added|updated|deleted) on %{GREEDYDATA:aruba.interface.id}"
+        - "^Configured LLDP (%{TX_TIMER}|%{TX_HOLD}|%{TX_DELAY}|%{REINIT_DELAY}|%{MANAGEMENT_IP})"
+        - "^PVID mismatch on %{DATA:aruba.interface.id} pvid = %{NUMBER:aruba.lldp.pvid:long}, Neighbor %{DATA:aruba.instance.id} port_id = %{DATA:aruba.lldp.ninterface} pvid = %{NUMBER:aruba.lldp.npvid:long}"
+      pattern_definitions:
+        TX_TIMER: "tx-timer to %{NUMBER:aruba.lldp.tx_timer:long}"
+        TX_HOLD: "tx-hold to %{NUMBER:aruba.lldp.tx_hold:long}"
+        TX_DELAY: "tx-delay to %{NUMBER:aruba.lldp.tx_delay:long}"
+        REINIT_DELAY: "reinit-delay to %{NUMBER:aruba.lldp.reinit_delay:long}"
+        MANAGEMENT_IP: "Management IP %{IP:server.ip}"
+  
   # Fan Events (2xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/FAN.htm
   # * 212 is not included as it does not require further processing.
@@ -212,9 +229,92 @@ processors:
       pattern_definitions:
         FAN_STATUS: "[-_0-9a-zA-Z]+"
 
+    # LED events (50x)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LED.htm
+  - grok:
+      field: message
+      tag: led_event_501_502
+      description: "Log about number of LED [types|config] in subsystem"
+      if: "['501','502'].contains(ctx.event?.code)"
+      patterns:
+        - "^There are %{NUMBER:aruba.count:long} LED (types|configs) in subsystem %{GREEDYDATA:aruba.subsystem}"
+
+    # Loopback events (90x)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LOOPBACK.htm
+  - grok:
+      field: message
+      tag: loop_901_902_903
+      description: "Log when loopback interface event is triggered"
+      if: "['901','902','903'].contains(ctx.event?.code)"
+      patterns:
+        - "^Loopback Interface %{DATA:aruba.interface.id}, (created|deleted|configured administratively %{DATA:aruba.status})"
+
+    # LACP events (13xx)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LACP.htm
+  - grok:
+      field: message
+      tag: lacp_event_1301_through_1323
+      description: "Dynamic LAG has event has been raised"
+      if: "['1301','1302','1303','1304','1305','1306','1307','1308','1309','1310','1311','1312','1313','1314','1315','1316','1317','1318','1319','1320','1321','1322','1323'].contains(ctx.event?.code)"
+      patterns:
+        - "^Dynamic %{LAG_ID} (created|deleted)"
+        - "^%{INTF_ID} added to %{LAG_ID}. Existing configuration on interface %{DATA:aruba.interface.prev_id} will be removed"
+        - "^%{INTF_ID} removed from %{LAG_ID}. It will be set with default configuration with admin down state"
+        - "^LACP system priority set to %{GREEDYDATA:aruba.lacp.system_priority}"
+        - "^LACP mode set to %{DATA:aruba.lacp.mode} for %{LAG_ID_GREEDY}"
+        - "^LACP system ID set to %{GREEDYDATA:aruba.lacp.system_id}"
+        - "^LACP rate set to %{DATA:aruba.lacp.rate} for %{LAG_ID_GREEDY}"
+        - "^Partner is detected for %{INTF_ID} %{LAG_ID}\\s?: %{DATA:aruba.lacp.partner_sys_id}. %{ACTOR_STATE}, %{PARTNER_STATE}"
+        - "^Partner is out of sync for %{INTF_ID} %{LAG_ID}. %{ACTOR_STATE}, %{PARTNER_STATE}"
+        - "^Partner is lost \\(timed out\\) for %{INTF_ID} %{LAG_ID}. State: %{DATA:aruba.lacp.fsm_state}"
+        - "^Failed to create %{LAG_ID}"
+        - "^%{LAG_ID} set as VSX"
+        - "^%{LAG_ID} not sending LACPDUs through %{INTF_ID} because VSX information is not complete"
+        - "^LACP fallback mode set to %{DATA:aruba.lacp.fallback_mode} for %{LAG_ID_GREEDY}"
+        - "^LACP fallback timeout( set to)? %{NUMBER:aruba.timeout:long}( expired)? for %{LAG_ID_GREEDY}"
+        - "^%{INTF_ID} enabled by fallback for lag %{GREEDYDATA:aruba.instance.id}"
+        - "^LAG global load balancing mode is set to %{GREEDYDATA:aruba.lacp.mode}"
+        - "^LAG load balancing mode is set to %{DATA:aruba.lacp.mode} for %{LAG_ID_GREEDY}"
+        - "^%{LAG_ID} State change for interface %{DATA:aruba.interface.id}: %{ACTOR_STATE}, %{PARTNER_STATE}"
+        - "^%{INTF_ID} cannot be part of Lag %{NUMBER:aruba.lacp.lag_number:long}. Speed mismatched \\(Interface speed %{NUMBER:aruba.lacp.port_speed:long}Mbps Lag base speed %{NUMBER:aruba.lacp.lag_speed:long}Mbps\\)."
+        - "^Fallback is %{DATA:aruba.lacp.fallback} for %{LAG_ID}"
+      pattern_definitions:
+        LAG_ID: "(LAG|lag) %{DATA:aruba.instance.id}"
+        LAG_ID_GREEDY: "(LAG|lag) %{GREEDYDATA:aruba.instance.id}"
+        INTF_ID: "(I|i)nterface %{DATA:aruba.interface.id}"
+        ACTOR_STATE: "Actor state: %{DATA:aruba.lacp.actor_state}"
+        PARTNER_STATE: "(P|p)artner state %{GREEDYDATA:aruba.lacp.partner_state}"
+
+    # LAG events (14xx)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LAG.htm
+  - grok:
+      field: message
+      tag: lacp_event_1401_through_1414
+      description: "Dynamic LAG has event has been raised"
+      if: "['1401','1402','1403','1404','1405','1406','1407','1408','1409','1410','1411','1412','1413','1414'].contains(ctx.event?.code)"
+      patterns:
+        - "^Trunk set succeeds %{UNIT} %{LAG_ID_GREEDY}"
+        - "^(Lag creation|Destroy lag) failed( on)? %{UNIT} %{LAG_ID} %{RC} %{ERROR}"
+        - "^Trunk member add port succeeds on %{UNIT} %{PORT} %{TID}"
+        - "^(Trunk port attach error on|Failed to set egress enable on|Failed to delete) %{PORT}( from)? %{TID} %{RC} %{ERROR}"
+        - "^Trunk psc set failed on %{UNIT} %{LAG_ID} psc %{DATA:aruba.lag.psc} %{RC} %{ERROR}"
+        - "^%{LAG_INTERFACE}, set to load balance mode to %{GREEDYDATA:aruba.lag.mode}"
+        - "^(Remove|Add) %{PORT} (from|to) %{LAG_INTERFACE_GREEDY}"
+        - "^(Remove|Add) %{PORT} to vlan %{DATA:network.vlan.id} for L3 %{LAG_INTERFACE_GREEDY}"
+        - "^Destroy L3 %{LAG_INTERFACE_GREEDY}"
+      pattern_definitions:
+        ERROR: "(error )?%{GREEDYDATA:event.reason}"
+        LAG_ID: "lag_id %{DATA:aruba.instance.id}"
+        LAG_ID_GREEDY: "lag_id %{GREEDYDATA:aruba.instance.id}"
+        LAG_INTERFACE: "LAG( interface)? %{DATA:aruba.interface.id}"
+        LAG_INTERFACE_GREEDY: "LAG( interface)? %{GREEDYDATA:aruba.interface.id}"
+        PORT: "(hw_)?port %{DATA:aruba.port}"
+        RC: "rc %{DATA:error.code}"
+        TID: "tid %{NUMBER:process.thread.id:long}"
+        UNIT: "unit %{NUMBER:aruba.unit:long}"
+
     # CoPP Events (15xx)
     # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/COPP.htm
-
     # The following Event IDs do not need further processing
     # * 1501
     # * 1502
@@ -270,6 +370,39 @@ processors:
       if: "ctx.event?.code == '1513'"
       pattern: "Failed to retrieve CoPP statistics from slot %{aruba.slot} class %{aruba.copp.class}"
 
+    # Layer 3 Interface events (17xx)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LAG.htm
+  - grok:
+      field: message
+      tag: lacp_event_1401_through_1414
+      description: "Dynamic LAG has event has been raised"
+      if: "['1701','1702','1703','1704','1705','1706','1707','1708','1709','1710','1711','1712','1713','1714','1715','1716','1717','1718','1719','1720','1721','1722','1723','1724','1725','1726','1727','1728','1729','1730','1731'].contains(ctx.event?.code)"
+      patterns:
+        - "^L3-%{INTERFACE}, (created|deleted)"
+        - "^%{INTERFACE}, configured administratively %{GREEDYDATA:aruba.status}"
+        - "^Failed to create %{DATA:network.vlan.id} for layer 3 %{INTERFACE_GREEDY}"
+        - "^Failed to (destroy layer |delete an l)3 %{INTERFACE}( vlan %{DATA:network.vlan.id})?, %{ERROR}"
+        - "^Failed to (delete|add) %{HOST_IP}, %{ERROR}"
+        - "^(Added|Deleted|Failed to get) %{HOST_IP}"
+        - "^L3 interface %{ERROR}"
+        - "^(Delete|Added) %{NEXTHOP}(, egress_id %{DATA:observer.egress.interface.id},)? for route %{GREEDYDATA:aruba.prefix}"
+        - "^(Delete|Added|Add) route %{DATA:aruba.prefix}(, %{ERROR})?"
+        - "^Update: route state: %{GREEDYDATA:aruba.status}"
+        - "^Error (deleting|creating) egress object for %{PORT}, %{ERROR}"
+        - "^(Deleted|Created) L3 egress ID %{DATA:observer.egress.interface.id} for %{PORT}( intf %{DATA:aruba.interface.id})?"
+        - "^%{INTERFACE},( configured with)? %{SERVER_IP}"
+        - "^IPv6 Address Status: %{INTERFACE}, address %{IPORHOST:server.address}, status %{GREEDYDATA:aruba.status}"
+        - "^%{INTERFACE}, configured with secondary %{SERVER_IP}"
+        - "^%{INTERFACE}, secondary %{SERVER_IP}"
+        - "^IP MTU %{DATA:aruba.mtu} not applied due to hardware resource limitation"
+      pattern_definitions:
+        HOST_IP: "L3 host (entry|hit) for ip %{IP:host.ip}"
+        SERVER_IP: "(ipv6|ipv4) address( deleted)? %{IP:server.ip}"
+        ERROR: "error: %{GREEDYDATA:event.reason}"
+        INTERFACE: "(I|i)nterface %{DATA:aruba.interface.id}"
+        INTERFACE_GREEDY: "(I|i)nterface %{GREEDYDATA:aruba.interface.id}"
+        NEXTHOP: "Nexthop %{IP:aruba.l3.nexthop}"
+        PORT: "port %{DATA:aruba.port}"
 
   # ECMP Events (18xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ECMP.htm
@@ -375,6 +508,21 @@ processors:
       field: "message"
       description: "Logs changes in TACACS server reachability status"
       pattern: "TACACS server host %{server.address} port %{aruba.port} vrf %{aruba.vrf.id} %{aruba.status}"
+
+    # Loop Protect events (280X)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LOOP-PROTECT.htm
+  - grok:
+      field: message
+      tag: loop_protect_event_2801_through_2808
+      description: "Logs event when LLDP (Link Layer Discovery Protocol) feature"
+      if: "['2801','2802','2803','2804','2805','2806','2807','2808'].contains(ctx.event?.code)"
+      patterns:
+        - "^Ports TX %{DATA:aruba.loop.tx_port} and RX %{DATA:aruba.loop.rx_port} are disabled by Loop-protect after loop detection on VLAN %{GREEDYDATA:network.vlan.id}"
+        - "^(Loop detected on port|Port) %{DATA:aruba.port}( is disabled by Loop-protection after loop detection)? on VLAN %{GREEDYDATA:network.vlan.id}"
+        - "^Port %{DATA:aruba.port} enabled after disable time expired"
+        - "^Port %{DATA:aruba.port} (added for|deleted from) loop-protection"
+        - "^Loop-Protection stats cleared for port %{DATA:aruba.port}"
+        - "^Ports TX %{DATA:aruba.loop.tx_port} and RX %{DATA:aruba.loop.rx_port} are involved during TX port disabling"
 
   # BGP events (29xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/BGP.htm
@@ -541,6 +689,16 @@ processors:
       pattern_definitions:
         3011_3012_3013_COMMON: "correctable memory error count %{NUMBER:aruba.hardware.cecount:long} exceeded threshold %{NUMBER:aruba.limit:long}(?:%{3011_3012_3013_OPTIONAL})?"
         3011_3012_3013_OPTIONAL: " and %{NUMBER:aruba.hardware.offlined:long}"
+
+  # IRDP events (350x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IRDP.htm
+  - grok:
+      if: "['3501', '3502'].contains(ctx.event?.code)"
+      tag: firmware_update_event_3501_3502
+      field: "message"
+      description: "This command [enables|disable] the IRDP (ICMP Router Discovery Protocol) feature on interface."
+      patterns:
+        - "^IRDP (en|dis)abled on interface %{GREEDYDATA:aruba.interface.id}"
 
   # Firmware Update events (44xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/FIRMWARE_UPDATE.htm
@@ -1037,6 +1195,19 @@ processors:
         - "^ARP inspection %{DATA:aruba.status} on vlan %{GREEDYDATA:network.vlan.id}."
         - "^ARP inspection %{DATA:aruba.status} on port %{GREEDYDATA:aruba.port}."
 
+  # L3 Encap capacity events (1060x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3_ENCAP.htm
+  - grok:
+      field: message
+      tag: l3_event_10601_10602_10603
+      description: "Logs event when a L3 encapsulation is added to a port"
+      if: "['10601', '10602', '10603'].contains(ctx.event?.code)"
+      patterns:
+        - "^L3 resources critical for neighbor and route forwarding are (at safe levels|low). %{L3_ENCAP_COMMON}"
+        - "^Out of L3 resources critical for neighbor and route forwarding. %{L3_ENCAP_COMMON}"
+      pattern_definitions:
+        L3_ENCAP_COMMON: "Used: %{DATA:aruba.l3.encaps_allocated}, Available: %{GREEDYDATA:aruba.l3.encaps_free}"
+
   # DPSE Events (109xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DPSE.htm
   - dissect:
@@ -1112,6 +1283,14 @@ processors:
       if: "ctx.event?.code == '11109'"
       patterns:
           - "^MAC Lockout packet drop detected for %{MAC:client.mac} as source: %{NUMBER:aruba.fault.sa_diff_count:long} and destination: %{NUMBER:aruba.fault.da_diff_count:long} address"
+
+  # L3 Resource Manager events (1150x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3_RESMGR.htm
+  - dissect:
+      field: message
+      tag: l3_rsmgr_event_11501
+      if: "ctx.event?.code == '11501'"
+      pattern: "IPv6 route prefix %{aruba.prefix} is not supported on this platform"
 
   # CFM Events (116xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ETH_OAM_CFM.htm

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -49,7 +49,7 @@ processors:
     # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LLDP.htm
   - grok:
       field: message
-      tag: lldp_event_101_through_113
+      tag: lldp_event_103_through_113
       description: "Logs event when LLDP (Link Layer Discovery Protocol) feature"
       if: "['103','104','105','106','107','108','109','110','113'].contains(ctx.event?.code)"
       patterns:
@@ -273,7 +273,7 @@ processors:
       description: "Log when loopback interface event is triggered"
       if: "['901','902','903'].contains(ctx.event?.code)"
       patterns:
-        - "^Loopback Interface %{DATA:aruba.interface.id}, (created|deleted|configured administratively %{DATA:aruba.status})"
+        - "^Loopback Interface %{DATA:aruba.interface.id}, (created|deleted|configured administratively %{GREEDYDATA:aruba.status})"
 
     # LACP events (13xx)
     # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LACP.htm
@@ -292,8 +292,8 @@ processors:
         - "^LACP rate set to %{DATA:aruba.lacp.rate} for %{LAG_ID_GREEDY}"
         - "^Partner is detected for %{INTF_ID} %{LAG_ID}\\s?: %{DATA:aruba.lacp.partner_sys_id}. %{ACTOR_STATE}, %{PARTNER_STATE}"
         - "^Partner is out of sync for %{INTF_ID} %{LAG_ID}. %{ACTOR_STATE}, %{PARTNER_STATE}"
-        - "^Partner is lost \\(timed out\\) for %{INTF_ID} %{LAG_ID}. State: %{DATA:aruba.lacp.fsm_state}"
-        - "^Failed to create %{LAG_ID}"
+        - "^Partner is lost \\(timed out\\) for %{INTF_ID} %{LAG_ID}. State: %{GREEDYDATA:aruba.lacp.fsm_state}"
+        - "^Failed to create %{LAG_ID_GREEDY}"
         - "^%{LAG_ID} set as VSX"
         - "^%{LAG_ID} not sending LACPDUs through %{INTF_ID} because VSX information is not complete"
         - "^LACP fallback mode set to %{DATA:aruba.lacp.fallback_mode} for %{LAG_ID_GREEDY}"
@@ -302,12 +302,13 @@ processors:
         - "^LAG global load balancing mode is set to %{GREEDYDATA:aruba.lacp.mode}"
         - "^LAG load balancing mode is set to %{DATA:aruba.lacp.mode} for %{LAG_ID_GREEDY}"
         - "^%{LAG_ID} State change for interface %{DATA:aruba.interface.id}: %{ACTOR_STATE}, %{PARTNER_STATE}"
-        - "^%{INTF_ID} cannot be part of Lag %{NUMBER:aruba.lacp.lag_number:long}. Speed mismatched \\(Interface speed %{NUMBER:aruba.lacp.port_speed:long}Mbps Lag base speed %{NUMBER:aruba.lacp.lag_speed:long}Mbps\\)."
-        - "^Fallback is %{DATA:aruba.lacp.fallback} for %{LAG_ID}"
+        - "^%{INTF_NAME} cannot be part of Lag %{NUMBER:aruba.lacp.lag_number:long}. Speed mismatched \\(Interface speed %{NUMBER:aruba.lacp.port_speed:long}Mbps Lag base speed %{NUMBER:aruba.lacp.lag_speed:long}Mbps\\)."
+        - "^Fallback is %{DATA:aruba.lacp.fallback} for %{LAG_ID_GREEDY}"
       pattern_definitions:
         LAG_ID: "(LAG|lag) %{DATA:aruba.instance.id}"
         LAG_ID_GREEDY: "(LAG|lag) %{GREEDYDATA:aruba.instance.id}"
         INTF_ID: "(I|i)nterface %{DATA:aruba.interface.id}"
+        INTF_NAME: "(I|i)nterface %{DATA:aruba.interface.name}"
         ACTOR_STATE: "Actor state: %{DATA:aruba.lacp.actor_state}"
         PARTNER_STATE: "(P|p)artner state %{GREEDYDATA:aruba.lacp.partner_state}"
 
@@ -397,11 +398,11 @@ processors:
       pattern: "Failed to retrieve CoPP statistics from slot %{aruba.slot} class %{aruba.copp.class}"
 
     # Layer 3 Interface events (17xx)
-    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LAG.htm
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3INTERFACE.htm
   - grok:
       field: message
-      tag: lacp_event_1401_through_1414
-      description: "Dynamic LAG has event has been raised"
+      tag: l3_event_1701_through_1731
+      description: "Logs to L3 interface events"
       if: "['1701','1702','1703','1704','1705','1706','1707','1708','1709','1710','1711','1712','1713','1714','1715','1716','1717','1718','1719','1720','1721','1722','1723','1724','1725','1726','1727','1728','1729','1730','1731'].contains(ctx.event?.code)"
       patterns:
         - "^L3-%{INTERFACE}, (created|deleted)"
@@ -412,10 +413,11 @@ processors:
         - "^(Added|Deleted|Failed to get) %{HOST_IP}"
         - "^L3 interface %{ERROR}"
         - "^(Delete|Added) %{NEXTHOP}(, egress_id %{DATA:observer.egress.interface.id},)? for route %{GREEDYDATA:aruba.prefix}"
-        - "^(Delete|Added|Add) route %{DATA:aruba.prefix}(, %{ERROR})?"
+        # Note: sequence matters here, putting greedy data at the end
+        - "^(Delete|Added|Add) route (%{DATA:aruba.prefix}, %{ERROR}|%{GREEDYDATA:aruba.prefix})"
         - "^Update: route state: %{GREEDYDATA:aruba.status}"
         - "^Error (deleting|creating) egress object for %{PORT}, %{ERROR}"
-        - "^(Deleted|Created) L3 egress ID %{DATA:observer.egress.interface.id} for %{PORT}( intf %{DATA:aruba.interface.id})?"
+        - "^(Deleted|Created) L3 egress ID %{DATA:observer.egress.interface.id} for (%{PORT} intf %{GREEDYDATA:aruba.interface.id}|%{PORT_GREEDY})"
         - "^%{INTERFACE},( configured with)? %{SERVER_IP}"
         - "^IPv6 Address Status: %{INTERFACE}, address %{IPORHOST:server.address}, status %{GREEDYDATA:aruba.status}"
         - "^%{INTERFACE}, configured with secondary %{SERVER_IP}"
@@ -429,6 +431,7 @@ processors:
         INTERFACE_GREEDY: "(I|i)nterface %{GREEDYDATA:aruba.interface.id}"
         NEXTHOP: "Nexthop %{IP:aruba.l3.nexthop}"
         PORT: "port %{DATA:aruba.port}"
+        PORT_GREEDY: "port %{GREEDYDATA:aruba.port}"
 
   # ECMP Events (18xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ECMP.htm
@@ -540,14 +543,14 @@ processors:
   - grok:
       field: message
       tag: loop_protect_event_2801_through_2808
-      description: "Logs event when LLDP (Link Layer Discovery Protocol) feature"
+      description: "Logs Loop protect events"
       if: "['2801','2802','2803','2804','2805','2806','2807','2808'].contains(ctx.event?.code)"
       patterns:
         - "^Ports TX %{DATA:aruba.loop.tx_port} and RX %{DATA:aruba.loop.rx_port} are disabled by Loop-protect after loop detection on VLAN %{GREEDYDATA:network.vlan.id}"
         - "^(Loop detected on port|Port) %{DATA:aruba.port}( is disabled by Loop-protection after loop detection)? on VLAN %{GREEDYDATA:network.vlan.id}"
         - "^Port %{DATA:aruba.port} enabled after disable time expired"
         - "^Port %{DATA:aruba.port} (added for|deleted from) loop-protection"
-        - "^Loop-Protection stats cleared for port %{DATA:aruba.port}"
+        - "^Loop-Protection stats cleared for port %{GREEDYDATA:aruba.port}"
         - "^Ports TX %{DATA:aruba.loop.tx_port} and RX %{DATA:aruba.loop.rx_port} are involved during TX port disabling"
 
   # BGP events (29xx)

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -161,6 +161,9 @@
         - name: class
           type: keyword
           description: "Control Plane Policing (CoPP) class"
+    - name: count
+      type: long
+      description: ""
     - name: cpu_rx
       type: group
       fields:
@@ -437,6 +440,9 @@
         - name: name
           type: keyword
           description: ""
+        - name: prev_id
+          type: keyword
+          description: ""
     - name: ip_sla
       type: group
       fields:
@@ -452,6 +458,9 @@
         - name: encaps_free
           type: keyword
           description: ""
+        - name: nexthop
+          type: keyword
+          description: ""
     - name: lacp
       type: group
       fields:
@@ -464,14 +473,8 @@
         - name: fsm_state
           type: keyword
           description: ""
-        - name: lacp_fallback_mode
+        - name: fallback_mode
           type: keyword
-          description: ""
-        - name: lacp_mode
-          type: keyword
-          description: ""
-        - name: lacp_rate
-          type: long
           description: ""
         - name: lag_number
           type: long
@@ -486,13 +489,16 @@
           type: keyword
           description: ""
         - name: partner_sys_id
-          type: long
+          type: keyword
           description: ""
         - name: port_speed
           type: long
           description: ""
+        - name: rate
+          type: keyword
+          description: ""
         - name: system_id
-          type: long
+          type: keyword
           description: ""
         - name: system_priority
           type: keyword
@@ -500,46 +506,10 @@
     - name: lag
       type: group
       fields:
-        - name: actor_state
-          type: keyword
-          description: ""
-        - name: fallback
-          type: keyword
-          description: ""
-        - name: fsm_state
-          type: keyword
-          description: ""
-        - name: lacp_fallback_mode
-          type: keyword
-          description: ""
-        - name: lacp_mode
-          type: keyword
-          description: ""
-        - name: lacp_rate
-          type: long
-          description: ""
-        - name: lag_number
-          type: long
-          description: ""
-        - name: lag_speed
-          type: long
-          description: ""
         - name: mode
           type: keyword
           description: ""
-        - name: partner_state
-          type: keyword
-          description: ""
-        - name: partner_sys_id
-          type: long
-          description: ""
-        - name: port_speed
-          type: long
-          description: ""
-        - name: system_id
-          type: long
-          description: ""
-        - name: system_priority
+        - name: psc
           type: keyword
           description: ""
     - name: lldp
@@ -549,6 +519,9 @@
           type: keyword
           description: ""
         - name: npvid
+          type: long
+          description: ""
+        - name: pvid
           type: long
           description: ""
         - name: reinit_delay
@@ -567,10 +540,10 @@
       type: group
       fields:
         - name: rx_port
-          type: long
+          type: keyword
           description: ""
         - name: tx_port
-          type: long
+          type: keyword
           description: ""
     - name: mac
       type: group
@@ -761,6 +734,9 @@
         - name: seconds
           type: long
           description: ""
+    - name: timeout
+      type: long
+      description: ""
     - name: tunnel
       type: group
       fields:
@@ -770,6 +746,9 @@
         - name: type
           type: keyword
           description: ""
+    - name: unit
+      type: long
+      description: ""
     - name: vrf
       type: group
       fields:

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -587,11 +587,56 @@
     - name: mgmd
       type: group
       fields:
-        - name: l3Port
-          type: long
+        - name: l3_port
+          type: keyword
+          description: ""
+        - name: mgmd_type
+          type: keyword
           description: ""
         - name: pkt_type
           type: keyword
+          description: ""
+        - name: port1
+          type: keyword
+          description: ""
+        - name: ring_id
+          type: keyword
+          description: ""
+        - name: type
+          type: keyword
+          description: ""
+    - name: mgmt
+      type: group
+      fields:
+        - name: config_crit
+          type: object
+          enabled: false
+        - name: config_err
+          type: object
+          enabled: false
+        - name: config_param
+          type: object
+          enabled: false
+    - name: module
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: ""
+        - name: type
+          type: keyword
+          description: ""
+    - name: msdp
+      type: group
+      fields:
+        - name: tcp_entity
+          type: keyword
+          description: ""
+        - name: grp_ip
+          type: ip
+          description: ""
+        - name: rp_ip
+          type: ip
           description: ""
     - name: mstp
       type: group
@@ -680,6 +725,9 @@
     - name: prefix
       type: keyword
       description: ""
+    - name: priority
+      type: keyword
+      description: ""
     - name: sequence
       type: keyword
       description: ""
@@ -762,7 +810,7 @@
           type: keyword
           description: ""
     - name: unit
-      type: long
+      type: keyword
       description: ""
     - name: vrf
       type: group

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -454,8 +454,8 @@ Note: Descriptions have not been filled out
 | <prefixlen> | aruba.len            |
 
 #### [IRDP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IRDP.htm)
-| Docs Field | Schema Mapping       |
-|------------|----------------------|
+| Docs Field  | Schema Mapping       |
+|-------------|----------------------|
 | <interface> | aruba.interface.id   |
 
 #### [L3 Encap capacity events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3_ENCAP.htm)
@@ -470,26 +470,27 @@ Note: Descriptions have not been filled out
 | <prefix>   | aruba.prefix    |
 
 #### [LACP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LACP.htm)
-| Docs Field              | Schema Mapping            |
-|-------------------------|---------------------------|
-| <actor_state>           | aruba.lacp.actor_state    |
-| <fallback>              | aruba.lacp.fallback       |
-| <fsm_state>             | aruba.lacp.fsm_state      |
-| <intf_id>               | aruba.interface.id        |
-| <intf_id>               | aruba.interface.prev_id   |
-| <lacp_fallback_mode>    | aruba.lacp.fallback_mode  |
-| <lacp_fallback_timeout> | aruba.timeout             |
-| <mode>                  | aruba.lacp.mode           |
-| <lacp_rate>             | aruba.lacp.rate           |
-| <lag_id>                | aruba.instance.id         |
-| <lag_number>            | aruba.lacp.lag_number     |
-| <lag_speed>             | aruba.lacp.lag_speed      |
-| <lacp_mode>             | aruba.lacp.lacp_mode      |
-| <partner_state>         | aruba.lacp.partner_state  |
-| <partner_sys_id>        | aruba.lacp.partner_sys_id |
-| <port_speed>            | aruba.lacp.port_speed     |
-| <system_id>             | aruba.lacp.system_id      |
-| <system_priority>       | aruba.lacp.system_priority|
+| Docs Field              | Schema Mapping             |
+|-------------------------|----------------------------|
+| <actor_state>           | aruba.lacp.actor_state     |
+| <fallback>              | aruba.lacp.fallback        |
+| <fsm_state>             | aruba.lacp.fsm_state       |
+| <intf_id>               | aruba.interface.id         |
+| <intf_id>               | aruba.interface.prev_id    |
+| <intf_name>             | aruba.interface.name       |
+| <lacp_fallback_mode>    | aruba.lacp.fallback_mode   |
+| <lacp_fallback_timeout> | aruba.timeout              |
+| <mode>                  | aruba.lacp.mode            |
+| <lacp_rate>             | aruba.lacp.rate            |
+| <lag_id>                | aruba.instance.id          |
+| <lag_number>            | aruba.lacp.lag_number      |
+| <lag_speed>             | aruba.lacp.lag_speed       |
+| <lacp_mode>             | aruba.lacp.lacp_mode       |
+| <partner_state>         | aruba.lacp.partner_state   |
+| <partner_sys_id>        | aruba.lacp.partner_sys_id  |
+| <port_speed>            | aruba.lacp.port_speed      |
+| <system_id>             | aruba.lacp.system_id       |
+| <system_priority>       | aruba.lacp.system_priority |
 
 #### [LAG events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LAG.htm)
 | Docs Field | Schema Mapping               |
@@ -507,20 +508,22 @@ Note: Descriptions have not been filled out
 | <vlan>     | network.vlan.id              |
 
 #### [Layer 3 Interface events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3INTERFACE.htm)
-| Field               | Description | Type | Common                       |
-|---------------------|-------------|------|------------------------------|
-| aruba.l3.addr       |             |      | destination.address          |
-| aruba.l3.addr_status|             |      | aruba.status                 |
-| aruba.l3.egress_id  |             |      | observer.egress.interface.id |
-| aruba.l3.err        |             |      | error.message                |
-| aruba.l3.interface  |             |      | observer.ingress.interface.name |
-| aruba.l3.ipaddr     |             |      | destination.ip               |
-| aruba.l3.mtu        |             |      | aruba.mtu                    |
-| aruba.l3.nexthop    |             |      | destination.address          |
-| aruba.l3.port       |             |      | server.port                  |
-| aruba.l3.prefix     |             |      | aruba.prefix                 |
-| aruba.l3.state      |             |      | aruba.status                 |
-| aruba.l3.vlanid     |             |      | network.vlan.id              |
+| Docs Field      | Schema Mapping               |
+|----------------|-------------------------------|
+| <addr>        | server.address                 |
+| <addr_status> | aruba.status                   |
+| <egress_id>   | observer.egress.interface.id   |
+| <err>         | event.reason                   |
+| <interface>   | aruba.interface.id             |
+| <intf>        | aruba.interface.id             |
+| <ipaddr>      | host.ip                        |
+| <mtu>         | aruba.mtu                      |
+| <nexthop>     | aruba.l3.nexthop               |
+| <port>        | aruba.port                     |
+| <prefix>      | aruba.prefix                   |
+| <state>       | aruba.status                   |
+| <value>       | server.ip                      |
+| <vlanid>      | network.vlan.id                |
 
 #### [LED events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LED.htm)
 | Docs Field  | Schema Mapping         |
@@ -1403,8 +1406,8 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.interface.id |  | keyword |
 | aruba.interface.name |  | keyword |
 | aruba.interface.port_speed |  | long |
-| aruba.interface.state |  | keyword |
 | aruba.interface.prev_id |  | keyword |
+| aruba.interface.state |  | keyword |
 | aruba.ip_sla.name |  | keyword |
 | aruba.l3.encaps_allocated |  | keyword |
 | aruba.l3.encaps_free |  | keyword |
@@ -1485,6 +1488,8 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.system.pass |  | keyword |
 | aruba.system.time |  | long |
 | aruba.time.seconds |  | long |
+| aruba.timeout |  | long |
+| aruba.tunnel.name |  | keyword |
 | aruba.tunnel.ttl |  | keyword |
 | aruba.tunnel.type |  | keyword |
 | aruba.unit |  | long |

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -451,56 +451,57 @@ Note: Descriptions have not been filled out
 | aruba.ipv6_router.prefixlen |             |      | aruba.len                    |
 
 #### [IRDP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IRDP.htm)
-| Field                       | Description | Type | Common                       |
-|-----------------------------|-------------|------|------------------------------|
-| aruba.irdp.interface        |             |      | observer.ingress.interface.name |
+| Docs Field | Schema Mapping       |
+|------------|----------------------|
+| <interface> | aruba.interface.id   |
 
 #### [L3 Encap capacity events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3_ENCAP.htm)
-| Field                       | Description | Type | Common                       |
-|-----------------------------|-------------|------|------------------------------|
-| aruba.l3.encaps_allocated   |             |      |                              |
-| aruba.l3.encaps_free        |             |      |                              |
+| Docs Field          | Schema Mapping               |
+|---------------------|------------------------------|
+| <encaps_allocated>  | aruba.l3.encaps_allocated    |
+| <encaps_free>       | aruba.l3.encaps_free         |
 
 #### [L3 Resource Manager events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3_RESMGR.htm)
-| Field                       | Description | Type | Common                       |
-|-----------------------------|-------------|------|------------------------------|
-| aruba.l3.prefix             |             |      | aruba.prefix                 |
+| Docs Field | Schema Mapping  |
+|------------|-----------------|
+| <prefix>   | aruba.prefix    |
 
 #### [LACP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LACP.htm)
-| Field                       | Description | Type | Common                       |
-|-----------------------------|-------------|------|------------------------------|
-| aruba.lacp.actor_state      |             |      |                              |
-| aruba.lacp.fallback         |             |      |                              |
-| aruba.lacp.fsm_state        |             |      |                              |
-| aruba.lacp.intf_id          |             |      | observer.ingress.interface.id|
-| aruba.lacp.lacp_fallback_mode |           |      |                              |
-| aruba.lacp.lacp_fallback_timeout |        |      | aruba.timeout                |
-| aruba.lacp.lacp_mode        |             |      |                              |
-| aruba.lacp.lacp_rate        |             |      |                              |
-| aruba.lacp.lag_id           |             |      | aruba.instance.id            |
-| aruba.lacp.lag_number       |             |      |                              |
-| aruba.lacp.lag_speed        |             |      |                              |
-| aruba.lacp.mode             |             |      |                              |
-| aruba.lacp.partner_state    |             |      |                              |
-| aruba.lacp.partner_sys_id   |             |      |                              |
-| aruba.lacp.port_speed       |             |      |                              |
-| aruba.lacp.system_id        |             |      |                              |
-| aruba.lacp.system_priority  |             |      |                              |
+| Docs Field              | Schema Mapping            |
+|-------------------------|---------------------------|
+| <actor_state>           | aruba.lacp.actor_state    |
+| <fallback>              | aruba.lacp.fallback       |
+| <fsm_state>             | aruba.lacp.fsm_state      |
+| <intf_id>               | aruba.interface.id        |
+| <intf_id>               | aruba.interface.prev_id   |
+| <lacp_fallback_mode>    | aruba.lacp.fallback_mode  |
+| <lacp_fallback_timeout> | aruba.timeout             |
+| <mode>                  | aruba.lacp.mode           |
+| <lacp_rate>             | aruba.lacp.rate           |
+| <lag_id>                | aruba.instance.id         |
+| <lag_number>            | aruba.lacp.lag_number     |
+| <lag_speed>             | aruba.lacp.lag_speed      |
+| <lacp_mode>             | aruba.lacp.lacp_mode      |
+| <partner_state>         | aruba.lacp.partner_state  |
+| <partner_sys_id>        | aruba.lacp.partner_sys_id |
+| <port_speed>            | aruba.lacp.port_speed     |
+| <system_id>             | aruba.lacp.system_id      |
+| <system_priority>       | aruba.lacp.system_priority|
 
 #### [LAG events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LAG.htm)
-| Field               | Description | Type | Common                       |
-|---------------------|-------------|------|------------------------------|
-| aruba.lag.error     |             |      | error.message                |
-| aruba.lag.hw_port   |             |      | server.port                  |
-| aruba.lag.interface |             |      | observer.ingress.interface.name |
-| aruba.lag.lag_id    |             |      | aruba.instance.id            |
-| aruba.lag.mode      |             |      | event.type                   |
-| aruba.lag.port      |             |      | server.port                  |
-| aruba.lag.psc       |             |      |                              |
-| aruba.lag.rc        |             |      | error.code                   |
-| aruba.lag.tid       |             |      | process.thread.id            |
-| aruba.lag.unit      |             |      | aruba.unit                   |
-| aruba.lag.vlan      |             |      | network.vlan.id              |
+| Docs Field | Schema Mapping               |
+|------------|------------------------------|
+| <error>    | event.reason                 |
+| <hw_port>  | aruba.port                   |
+| <interface>| aruba.interface.id           |
+| <lag_id>   | aruba.instance.id            |
+| <mode>     | aruba.lag.mode               |
+| <port>     | aruba.port                   |
+| <psc>      | aruba.lag.psc                |
+| <rc>       | error.code                   |
+| <tid>      | process.thread.id            |
+| <unit>     | aruba.unit                   |
+| <vlan>     | network.vlan.id              |
 
 #### [Layer 3 Interface events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3INTERFACE.htm)
 | Field               | Description | Type | Common                       |
@@ -519,40 +520,39 @@ Note: Descriptions have not been filled out
 | aruba.l3.vlanid     |             |      | network.vlan.id              |
 
 #### [LED events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LED.htm)
-| Field               | Description | Type | Common                       |
-|---------------------|-------------|------|------------------------------|
-| aruba.led.count     |             |      | aruba.count                  |
-| aruba.led.subsystem |             |      | aruba.subsystem              |
+| Docs Field  | Schema Mapping         |
+|-------------|------------------------|
+| <count>     | aruba.count            |
+| <subsystem> | aruba.subsystem        |
 
 #### [LLDP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LLDP.htm)
-| Field                  | Description | Type | Common                       |
-|------------------------|-------------|------|------------------------------|
-| aruba.lldp.chassisid   |             |      | aruba.instance.id            |
-| aruba.lldp.interface   |             |      | observer.ingress.interface.name |
-| aruba.lldp.ip          |             |      | source.ip                    |
-| aruba.lldp.ninterface  |             |      |                              |
-| aruba.lldp.npvid       |             |      |                              |
-| aruba.lldp.port        |             |      | server.port                  |
-| aruba.lldp.pvid        |             |      | network.vlan.id              |
-| aruba.lldp.reinit_delay|             |      |                              |
-| aruba.lldp.tx_delay    |             |      |                              |
-| aruba.lldp.tx_hold     |             |      |                              |
-| aruba.lldp.tx_timer    |             |      |                              |
+| Docs Field   | Schema Mapping               |
+|--------------|------------------------------|
+| <chassisid>  | aruba.instance.id            |
+| <interface>  | aruba.interface.id           |
+| <ninterface> | aruba.lldp.ninterface        |
+| <npvid>      | aruba.lldp.npvid             |
+| <pvid>       | aruba.lldp.pvid              |
+| <hold>       | aruba.lldp.tx_hold           |
+| <value>      | aruba.lldp.tx_delay          |
+| <value>      | aruba.lldp.reinit_delay      |
+| <value>      | aruba.lldp.tx_timer          |
+| <value>      | server.ip                    |
 
 
 #### [Loop Protect events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LOOP-PROTECT.htm)
-| Field                  | Description | Type | Common                       |
-|------------------------|-------------|------|------------------------------|
-| aruba.loop.portName    |             |      | source.port                  |
-| aruba.loop.rx_port     |             |      |                              |
-| aruba.loop.tx_port     |             |      |                              |
-| aruba.loop.vlan        |             |      | network.vlan.id              |
+| Docs Field   | Schema Mapping         |
+|--------------|------------------------|
+| <portName>   | aruba.port             |
+| <rxportName> | aruba.loop.rx_port     |
+| <txportName> | aruba.loop.tx_port     |
+| <vlan>       | network.vlan.id        |
 
 #### [Loopback events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LOOPBACK.htm)
-| Field                  | Description | Type | Common                       |
-|------------------------|-------------|------|------------------------------|
-| aruba.loopback.interface |           |      | observer.ingress.interface.name |
-| aruba.loopback.status  |             |      | aruba.status                 |
+| Docs Field | Schema Mapping       |
+|------------|----------------------|
+| <interface> | aruba.interface.id   |
+| <state>     | aruba.status         |
 
 
 #### [MAC Address mode configuration events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3_MAC_ADDRESS_CONFIGURATION.htm)
@@ -1321,6 +1321,7 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.config.type |  | keyword |
 | aruba.config.value |  | keyword |
 | aruba.copp.class | Control Plane Policing (CoPP) class | keyword |
+| aruba.count |  | long |
 | aruba.cpu_rx.filter_description |  | keyword |
 | aruba.dcbx.intf_name | Interface name as reported by the system | keyword |
 | aruba.dhcp.config |  | keyword |
@@ -1398,47 +1399,37 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.instance.id |  | keyword |
 | aruba.interface.id |  | keyword |
 | aruba.interface.name |  | keyword |
+| aruba.interface.prev_id |  | keyword |
 | aruba.ip_sla.name |  | keyword |
 | aruba.l3.encaps_allocated |  | keyword |
 | aruba.l3.encaps_free |  | keyword |
+| aruba.l3.nexthop |  | keyword |
 | aruba.lacp.actor_state |  | keyword |
 | aruba.lacp.fallback |  | keyword |
+| aruba.lacp.fallback_mode |  | keyword |
 | aruba.lacp.fsm_state |  | keyword |
-| aruba.lacp.lacp_fallback_mode |  | keyword |
-| aruba.lacp.lacp_mode |  | keyword |
-| aruba.lacp.lacp_rate |  | long |
 | aruba.lacp.lag_number |  | long |
 | aruba.lacp.lag_speed |  | long |
 | aruba.lacp.mode |  | keyword |
 | aruba.lacp.partner_state |  | keyword |
-| aruba.lacp.partner_sys_id |  | long |
+| aruba.lacp.partner_sys_id |  | keyword |
 | aruba.lacp.port_speed |  | long |
-| aruba.lacp.system_id |  | long |
+| aruba.lacp.rate |  | keyword |
+| aruba.lacp.system_id |  | keyword |
 | aruba.lacp.system_priority |  | keyword |
-| aruba.lag.actor_state |  | keyword |
-| aruba.lag.fallback |  | keyword |
-| aruba.lag.fsm_state |  | keyword |
-| aruba.lag.lacp_fallback_mode |  | keyword |
-| aruba.lag.lacp_mode |  | keyword |
-| aruba.lag.lacp_rate |  | long |
-| aruba.lag.lag_number |  | long |
-| aruba.lag.lag_speed |  | long |
 | aruba.lag.mode |  | keyword |
-| aruba.lag.partner_state |  | keyword |
-| aruba.lag.partner_sys_id |  | long |
-| aruba.lag.port_speed |  | long |
-| aruba.lag.system_id |  | long |
-| aruba.lag.system_priority |  | keyword |
+| aruba.lag.psc |  | keyword |
 | aruba.len |  | long |
 | aruba.limit |  | long |
 | aruba.lldp.ninterface |  | keyword |
 | aruba.lldp.npvid |  | long |
+| aruba.lldp.pvid |  | long |
 | aruba.lldp.reinit_delay |  | long |
 | aruba.lldp.tx_delay |  | long |
 | aruba.lldp.tx_hold |  | long |
 | aruba.lldp.tx_timer |  | long |
-| aruba.loop.rx_port |  | long |
-| aruba.loop.tx_port |  | long |
+| aruba.loop.rx_port |  | keyword |
+| aruba.loop.tx_port |  | keyword |
 | aruba.mac.ckn |  | keyword |
 | aruba.mac.latest_an |  | keyword |
 | aruba.mac.latest_kn |  | keyword |
@@ -1487,8 +1478,10 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.system.numdevs |  | long |
 | aruba.system.time |  | date |
 | aruba.time.seconds |  | long |
+| aruba.timeout |  | long |
 | aruba.tunnel.ttl |  | keyword |
 | aruba.tunnel.type |  | keyword |
+| aruba.unit |  | long |
 | aruba.vrf.id |  | keyword |
 | aruba.vrf.name |  | keyword |
 | aruba.zero_touch.central_location |  | keyword |

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -562,91 +562,96 @@ Note: Descriptions have not been filled out
 
 
 #### [MAC Address mode configuration events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3_MAC_ADDRESS_CONFIGURATION.htm)
-| Field               | Description | Type | Common                       |
-|---------------------|-------------|------|------------------------------|
-| aruba.mac.mac       |             |      | server.mac                   |
-| aruba.mac.new_mode  |             |      |                              |
-| aruba.mac.old_mode  |             |      |                              |
-| aruba.mac.vlan      |             |      | network.vlan.id              |
+| Docs Field | Schema Mapping       |
+|------------|----------------------|
+| <mac>      | server.mac           |
+| <new_mode> | aruba.mac.new_mode   |
+| <old_mode> | aruba.mac.old_mode   |
+| <vlan>     | network.vlan.id      |
 
 #### [MAC Learning events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MAC-LEARN.htm)
-| Field               | Description | Type | Common                       |
-|---------------------|-------------|------|------------------------------|
-| aruba.mac.from-intf |             |      | observer.ingress.interface.name |
-| aruba.mac.mac       |             |      | server.mac                   |
-| aruba.mac.to-intf   |             |      | observer.egress.interface.name |
-| aruba.mac.vlan      |             |      | network.vlan.id              |
+| Docs Field  | Schema Mapping               |
+|-------------|------------------------------|
+| <from-intf> | aruba.interface.prev_id      |
+| <intf>      | aruba.interface.id           |
+| <mac>       | server.mac                   |
+| <to-intf>   | aruba.mac.interface.id       |
+| <vlan>      | network.vlan.id              |
 
 #### [MACsec events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MACSEC.htm)
-| Field               | Description | Type | Common                       |
-|---------------------|-------------|------|------------------------------|
-| aruba.mac.ckn       |             |      |                              |
-| aruba.mac.ifname    |             |      | observer.ingress.interface.name |
-| aruba.mac.latest_an |             |      |                              |
-| aruba.mac.latest_kn |             |      |                              |
-| aruba.mac.old_an    |             |      |                              |
-| aruba.mac.old_kn    |             |      |                              |
-| aruba.mac.sci       |             |      |                              |
+| Docs Field   | Schema Mapping               |
+|--------------|------------------------------|
+| <ckn>        | aruba.mac.ckn                |
+| <ifname>     | aruba.interface.name         |
+| <latest_an>  | aruba.mac.latest_an          |
+| <latest_kn>  | aruba.mac.latest_kn          |
+| <old_an>     | aruba.mac.old_an             |
+| <old_kn>     | aruba.mac.old_kn             |
+| <sci>        | aruba.mac.sci                |
 
 #### [Management events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MGMT.htm)
-| Field                                      | Description | Type | Common                       |
-|--------------------------------------------|-------------|------|------------------------------|
-| aruba.management.mgmt_intf_config_crit     |             |      | log.syslog.severity.name     |
-| aruba.management.mgmt_intf_config_err      |             |      | error.message                |
-| aruba.management.config_param              |             |      |                              |
+| Docs Field                  | Schema Mapping           |
+|-----------------------------|--------------------------|
+| <mgmt_intf_config_crit>     | aruba.mgmt.config_crit   |
+| <mgmt_intf_config_err>      | aruba.mgmt.config_err    |
+| <mgmt_intf_config_param>    | aruba.mgmt.config_param  |
 
 #### [MDNS events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MDNS.htm)
-| Field                                      | Description | Type | Common                       |
-|--------------------------------------------|-------------|------|------------------------------|
+| Docs Field                  | Schema Mapping           |
+|-----------------------------|--------------------------|
 
 
 #### [MGMD events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MGMD.htm)
-| Field                  | Description | Type | Common                       |
-|------------------------|-------------|------|------------------------------|
-| aruba.mgmd.if_name     |             |      | observer.ingress.interface.name |
-| aruba.mgmd.ip_address  |             |      | client.ip                    |
-| aruba.mgmd.l3Port      |             |      |                              |
-| aruba.mgmd.pkt_type    |             |      |                              |
-| aruba.mgmd.port        |             |      | server.port                  |
-| aruba.mgmd.ring_id     |             |      | aruba.instance.id            |
-| aruba.mgmd.size_value  |             |      | aruba.len                    |
-| aruba.mgmd.state       |             |      | aruba.status                 |
-| aruba.mgmd.status      |             |      | aruba.status                 |
-| aruba.mgmd.sub_system  |             |      | aruba.subsystem              |
-| aruba.mgmd.vlan        |             |      | network.vlan.id              |
+| Docs Field  | Schema Mapping              |
+|-------------|-----------------------------|
+| <if_name>   | aruba.interface.name        |
+| <ip_address>| client.ip                   |
+| <l3Port>    | aruba.mgmd.l3_port          |
+| <mgmd_type> | aruba.mgmd.mgmd_type        |
+| <pkt_type>  | aruba.mgmd.pkt_type         |
+| <port>      | aruba.port                  |
+| <port0>     | aruba.port                  |
+| <port1>     | aruba.mgmd.port1            |
+| <ring_id>   | aruba.mgmd.ring_id          |
+| <size_value>| aruba.len                   |
+| <state>     | aruba.status                |
+| <status>    | aruba.status                |
+| <sub_system>| aruba.subsystem             |
+| <type>      | aruba.mgmd.type             |
+| <vlan>      | network.vlan.id             |
 
 #### [Mirroring events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MIRRORING.htm)
-| Field                  | Description | Type | Common                       |
-|------------------------|-------------|------|------------------------------|
-| aruba.mirroring.session|             |      | aruba.session.id             |
+| Docs Field | Schema Mapping       |
+|------------|----------------------|
+| <number>   | aruba.session.id     |
 
 #### [Module events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MODULE.htm)
-| Field                  | Description | Type | Common                       |
-|------------------------|-------------|------|------------------------------|
-| aruba.module.name      |             |      | observer.ingress.interface.name |
-| aruba.module.part_number |           |      | aruba.unit                   |
-| aruba.module.priority  |             |      | aruba.priority               |
-| aruba.module.reason    |             |      | event.reason                 |
-| aruba.module.type      |             |      |                              |
+| Docs Field    | Schema Mapping         |
+|---------------|------------------------|
+| <name>        | aruba.module.name      |
+| <part_number> | aruba.unit             |
+| <priority>    | aruba.priority         |
+| <reason>      | event.reason           |
+| <type>        | aruba.module.type      |
 
 #### [MSDP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MSDP.htm)
-| Field                  | Description | Type | Common                       |
-|------------------------|-------------|------|------------------------------|
-| aruba.msdp.grp_ip      |             |      |                              |
-| aruba.msdp.if_name     |             |      | observer.ingress.interface.name |
-| aruba.msdp.peer_ip     |             |      | client.ip                    |
-| aruba.msdp.port        |             |      | server.port                  |
-| aruba.msdp.rp_ip       |             |      |                              |
-| aruba.msdp.src_ip      |             |      | source.ip                    |
-| aruba.msdp.state       |             |      | aruba.status                 |
-| aruba.msdp.status      |             |      | aruba.status                 |
-| aruba.msdp.tcp_entity  |             |      |                              |
-| aruba.msdp.vrf_name    |             |      | aruba.vrf.name               |
+| Docs Field  | Schema Mapping               |
+|-------------|------------------------------|
+| <grp_ip>    | aruba.msdp.grp_ip            |
+| <if_name>   | aruba.interface.name         |
+| <peer_ip>   | client.ip                    |
+| <port>      | aruba.port                   |
+| <rp_ip>     | aruba.msdp.rp_ip             |
+| <src_ip>    | source.ip                    |
+| <state>     | aruba.status                 |
+| <status>    | aruba.status                 |
+| <tcp_entity>| aruba.msdp.tcp_entity        |
+| <vrf_name>  | aruba.vrf.name               |
 
 #### [Multicast Traffic Manager events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MTM.htm)
-| Field                  | Description | Type | Common                       |
-|------------------------|-------------|------|------------------------------|
-| aruba.multicast.limit  |             |      | aruba.limit                  |
+| Docs Field | Schema Mapping |
+|------------|----------------|
+| <limit>    | aruba.limit    |
 
 #### [Multiple spanning tree protocol events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MSTP.htm)
 | Field                       | Description | Type | Common                       |
@@ -1447,8 +1452,20 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.mac.old_mode |  | keyword |
 | aruba.mac.sci |  | keyword |
 | aruba.management.config_param |  | keyword |
-| aruba.mgmd.l3Port |  | long |
+| aruba.mgmd.l3_port |  | keyword |
+| aruba.mgmd.mgmd_type |  | keyword |
 | aruba.mgmd.pkt_type |  | keyword |
+| aruba.mgmd.port1 |  | keyword |
+| aruba.mgmd.ring_id |  | keyword |
+| aruba.mgmd.type |  | keyword |
+| aruba.mgmt.config_crit |  | object |
+| aruba.mgmt.config_err |  | object |
+| aruba.mgmt.config_param |  | object |
+| aruba.module.name |  | keyword |
+| aruba.module.type |  | keyword |
+| aruba.msdp.grp_ip |  | ip |
+| aruba.msdp.rp_ip |  | ip |
+| aruba.msdp.tcp_entity |  | keyword |
 | aruba.mstp.config_parameter |  | keyword |
 | aruba.mstp.config_value |  | keyword |
 | aruba.mstp.new_mode |  | keyword |
@@ -1471,6 +1488,7 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.ndm.role2 |  | keyword |
 | aruba.port |  | keyword |
 | aruba.prefix |  | keyword |
+| aruba.priority |  | keyword |
 | aruba.sequence |  | keyword |
 | aruba.server.mode |  | keyword |
 | aruba.server.sessions |  | long |
@@ -1487,12 +1505,13 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.system.numdevs |  | long |
 | aruba.system.pass |  | keyword |
 | aruba.system.time |  | long |
+| aruba.temp.config |  | keyword |
 | aruba.time.seconds |  | long |
 | aruba.timeout |  | long |
 | aruba.tunnel.name |  | keyword |
 | aruba.tunnel.ttl |  | keyword |
 | aruba.tunnel.type |  | keyword |
-| aruba.unit |  | long |
+| aruba.unit |  | keyword |
 | aruba.vrf.id |  | keyword |
 | aruba.vrf.name |  | keyword |
 | aruba.zero_touch.central_location |  | keyword |

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -555,10 +555,10 @@ Note: Descriptions have not been filled out
 | <vlan>       | network.vlan.id        |
 
 #### [Loopback events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LOOPBACK.htm)
-| Docs Field | Schema Mapping       |
-|------------|----------------------|
-| <interface> | aruba.interface.id   |
-| <state>     | aruba.status         |
+| Docs Field  | Schema Mapping        |
+|-------------|-----------------------|
+| <interface> | aruba.interface.id    |
+| <state>     | aruba.interface.state |
 
 
 #### [MAC Address mode configuration events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3_MAC_ADDRESS_CONFIGURATION.htm)
@@ -1505,7 +1505,6 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.system.numdevs |  | long |
 | aruba.system.pass |  | keyword |
 | aruba.system.time |  | long |
-| aruba.temp.config |  | keyword |
 | aruba.time.seconds |  | long |
 | aruba.timeout |  | long |
 | aruba.tunnel.name |  | keyword |


### PR DESCRIPTION
Github Tracking Issue:
https://github.com/elastic/integrations/issues/11880 and https://github.com/elastic/integrations/issues/11906

Change Log:
Added parsing logic, doc, pipeline tests for:

- IRDP events
- L3 Encap capacity events
- L3 Resource Manager events
- LACP events
- LAG Events
- Layer 3 Interface Events
- LED Events
- LLDP Events
- Loop Protection Events
- Loopback Events
- MAC Address mode configuration events
- MAC Learning events
- MACsec events
- Management events
- MDNS events
- MGMD events
- Mirroring events
- Module events
- MSDP events
- Multicast Traffic Manager events

Test Cases:
- reviewed each log message added was processed properly within the pipeline tests
