### PR TITLE
Fix broken link for Microsoft SQL Server Integration

### DIFF
--- a/packages/microsoft_sqlserver/_dev/build/docs/README.md
+++ b/packages/microsoft_sqlserver/_dev/build/docs/README.md
@@ -117,7 +117,7 @@ MSSQL supports a limited set of regular expressions. For more details, refer to 
 
 > Note: Dynamic counters will go through some basic ingest pipeline post-processing to make counter names in lowercase and remove special characters and these fields will not have any static field mappings.
 
-The feature `merge_results` has been introduced in 8.4 beats which creates a single event by combining the metrics in a single event. For more details, refer to [SQL module](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-sql.html#_example_merge_multiple_queries_to_single_event).
+The feature `merge_results` has been introduced in 8.4 beats which creates a single event by combining the metrics in a single event. For more details, refer to [SQL module](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-sql.html#_example_merge_multiple_queries_into_a_single_event).
 
 Read more in [instructions about each performance counter metrics](https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-performance-counters-transact-sql?view=sql-server-ver15).
 

--- a/packages/microsoft_sqlserver/changelog.yml
+++ b/packages/microsoft_sqlserver/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.9.4"
+  changes:
+    - description: Fix broken link for Microsoft SQL Server Integration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11924
 - version: "2.9.3"
   changes:
     - description: Improve documentation to add more information about required permissions.

--- a/packages/microsoft_sqlserver/docs/README.md
+++ b/packages/microsoft_sqlserver/docs/README.md
@@ -117,7 +117,7 @@ MSSQL supports a limited set of regular expressions. For more details, refer to 
 
 > Note: Dynamic counters will go through some basic ingest pipeline post-processing to make counter names in lowercase and remove special characters and these fields will not have any static field mappings.
 
-The feature `merge_results` has been introduced in 8.4 beats which creates a single event by combining the metrics in a single event. For more details, refer to [SQL module](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-sql.html#_example_merge_multiple_queries_to_single_event).
+The feature `merge_results` has been introduced in 8.4 beats which creates a single event by combining the metrics in a single event. For more details, refer to [SQL module](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-sql.html#_example_merge_multiple_queries_into_a_single_event).
 
 Read more in [instructions about each performance counter metrics](https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-performance-counters-transact-sql?view=sql-server-ver15).
 

--- a/packages/microsoft_sqlserver/manifest.yml
+++ b/packages/microsoft_sqlserver/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: microsoft_sqlserver
 title: "Microsoft SQL Server"
-version: "2.9.3"
+version: "2.9.4"
 description: Collect events from Microsoft SQL Server with Elastic Agent
 type: integration
 categories:


### PR DESCRIPTION
This PR fixes a broken link to the SQL module example.

Relates https://github.com/elastic/integration-docs/issues/586
