### PR TITLE
Fix broken link for the Barracuda integration

### DIFF
--- a/packages/barracuda/_dev/build/docs/README.md
+++ b/packages/barracuda/_dev/build/docs/README.md
@@ -24,7 +24,7 @@ You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommen
 
 ### Setup
 
-For step-by-step instructions on how to set up an integration, see the
+For step-by-step instructions on how to set up an integration, check the
 [Getting started](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) guide.
 
 ### WAF Events

--- a/packages/barracuda/_dev/build/docs/README.md
+++ b/packages/barracuda/_dev/build/docs/README.md
@@ -9,7 +9,7 @@ Use the Barracuda WAF data stream to ingest log data. Then visualize that data i
 
 ## Upgrade
 
-The Technical preview `spamfirewall` data stream has been deprecated and removed, as of v1.0 of this integration. As we work on a replacement for the Spam Firewall integration, you can continue to use the [Spam Firewall filebeat module](https://www.elastic.co/guide/en/beats/filebeat/8.15/filebeat-module-barracuda.html).
+The Technical preview `spamfirewall` data stream has been deprecated and removed, as of v1.0 of this integration. As we work on a replacement for the Spam Firewall integration, you can continue to use the [Spam Firewall filebeat module](https://www.elastic.co/guide/en/beats/filebeat/8.13/filebeat-module-barracuda.html).
 
 ## WAF
 

--- a/packages/barracuda/changelog.yml
+++ b/packages/barracuda/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.2"
+  changes:
+    - description: Fix broken link for the Barracuda integration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11926
 - version: "1.16.1"
   changes:
     - description: Fix broken links for Barracuda integrations.

--- a/packages/barracuda/docs/README.md
+++ b/packages/barracuda/docs/README.md
@@ -24,7 +24,7 @@ You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommen
 
 ### Setup
 
-For step-by-step instructions on how to set up an integration, see the
+For step-by-step instructions on how to set up an integration, check the
 [Getting started](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) guide.
 
 ### WAF Events

--- a/packages/barracuda/docs/README.md
+++ b/packages/barracuda/docs/README.md
@@ -9,7 +9,7 @@ Use the Barracuda WAF data stream to ingest log data. Then visualize that data i
 
 ## Upgrade
 
-The Technical preview `spamfirewall` data stream has been deprecated and removed, as of v1.0 of this integration. As we work on a replacement for the Spam Firewall integration, you can continue to use the [Spam Firewall filebeat module](https://www.elastic.co/guide/en/beats/filebeat/8.15/filebeat-module-barracuda.html).
+The Technical preview `spamfirewall` data stream has been deprecated and removed, as of v1.0 of this integration. As we work on a replacement for the Spam Firewall integration, you can continue to use the [Spam Firewall filebeat module](https://www.elastic.co/guide/en/beats/filebeat/8.13/filebeat-module-barracuda.html).
 
 ## WAF
 

--- a/packages/barracuda/manifest.yml
+++ b/packages/barracuda/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: barracuda
 title: "Barracuda Web Application Firewall"
-version: "1.16.1"
+version: "1.16.2"
 description: "Collect logs from Barracuda Web Application Firewall with Elastic Agent."
 type: integration
 source:


### PR DESCRIPTION
This PR  replaces `8.15` with `8.13` for the link https://www.elastic.co/guide/en/beats/filebeat/8.13/filebeat-module-barracuda.html