### PR TITLE
qualys_vmdr: Cleanup duplicate processors and update documentation

### DIFF
--- a/packages/qualys_vmdr/_dev/build/docs/README.md
+++ b/packages/qualys_vmdr/_dev/build/docs/README.md
@@ -44,7 +44,29 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-The minimum **kibana.version** required is **8.9.0**.
+### Permissions
+
+#### Asset Host Detection
+
+| Role                    | Permission                                     |
+|-------------------------|------------------------------------------------|
+| _Managers_              | All VM scanned hosts in subscription           |
+| _Unit Managers_         | VM scanned hosts in user’s business unit       |
+| _Scanners_              | VM scanned hosts in user’s account             |
+| _Readers_               | VM scanned hosts in user’s account             |
+
+#### Knowledge Base
+
+_Managers_, _Unit Managers_, _Scanners_, _Readers_ have permission to download vulnerability data from the KnowledgeBase.
+
+#### User Activity Log
+
+| Role                    | Permission                                     |
+|-------------------------|------------------------------------------------|
+| _Managers_              | All actions taken by all users                 |
+| _Unit Managers_         | Actions taken by users in their business unit  |
+| _Scanners_              | Own actions only                               |
+| _Readers_               | Own actions only                               |
 
 ## Setup
 

--- a/packages/qualys_vmdr/changelog.yml
+++ b/packages/qualys_vmdr/changelog.yml
@@ -1,4 +1,15 @@
 # newer versions go on top
+- version: "5.3.0"
+  changes:
+    - description: Document required user role permissions to each API.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
+    - description: Cleanup duplicate processors in asset host detection.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
+    - description: Remove stale kibana.version requirement from README
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "5.2.2"
   changes:
     - description: Handle _LIST fields as array in knowledge_base data-stream.

--- a/packages/qualys_vmdr/changelog.yml
+++ b/packages/qualys_vmdr/changelog.yml
@@ -3,13 +3,13 @@
   changes:
     - description: Document required user role permissions to each API.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/11927
     - description: Cleanup duplicate processors in asset host detection.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/11927
     - description: Remove stale kibana.version requirement from README
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/11927
 - version: "5.2.2"
   changes:
     - description: Handle _LIST fields as array in knowledge_base data-stream.

--- a/packages/qualys_vmdr/data_stream/asset_host_detection/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/qualys_vmdr/data_stream/asset_host_detection/elasticsearch/ingest_pipeline/default.yml
@@ -413,6 +413,11 @@ processors:
           tag: rename_qualys_vmdr_asset_host_detection_metadata_ec2_attribute_LAST_STATUS_1
           target_field: _ingest._value.last.status
           ignore_missing: true
+  - rename:
+      field: qualys_vmdr.asset_host_detection.metadata.ec2.attribute.LAST_STATUS
+      tag: rename_qualys_vmdr_asset_host_detection_metadata_ec2_attribute_LAST_STATUS_2
+      target_field: qualys_vmdr.asset_host_detection.metadata.ec2.attribute.last.status
+      ignore_missing: true
   - foreach:
       field: qualys_vmdr.asset_host_detection.metadata.ec2.attribute
       if: ctx.qualys_vmdr?.asset_host_detection?.metadata?.ec2?.attribute instanceof List
@@ -427,11 +432,6 @@ processors:
       field: qualys_vmdr.asset_host_detection.metadata.ec2.attribute.VALUE
       tag: rename_qualys_vmdr_asset_host_detection_metadata_ec2_attribute_VALUE_2
       target_field: qualys_vmdr.asset_host_detection.metadata.ec2.attribute.value
-      ignore_missing: true
-  - rename:
-      field: qualys_vmdr.asset_host_detection.metadata.ec2.attribute.LAST_STATUS
-      tag: rename_qualys_vmdr_asset_host_detection_metadata_ec2_attribute_LAST_STATUS_2
-      target_field: qualys_vmdr.asset_host_detection.metadata.ec2.attribute.last.status
       ignore_missing: true
   - foreach:
       field: qualys_vmdr.asset_host_detection.metadata.ec2.attribute
@@ -535,6 +535,11 @@ processors:
           tag: rename_qualys_vmdr_asset_host_detection_metadata_google_attribute_LAST_STATUS_1
           target_field: _ingest._value.last.status
           ignore_missing: true
+  - rename:
+      field: qualys_vmdr.asset_host_detection.metadata.google.attribute.LAST_STATUS
+      tag: rename_qualys_vmdr_asset_host_detection_metadata_google_attribute_LAST_STATUS_2
+      target_field: qualys_vmdr.asset_host_detection.metadata.google.attribute.last.status
+      ignore_missing: true
   - foreach:
       field: qualys_vmdr.asset_host_detection.metadata.google.attribute
       if: ctx.qualys_vmdr?.asset_host_detection?.metadata?.google?.attribute instanceof List
@@ -549,11 +554,6 @@ processors:
       field: qualys_vmdr.asset_host_detection.metadata.google.attribute.VALUE
       tag: rename_qualys_vmdr_asset_host_detection_metadata_google_attribute_VALUE_2
       target_field: qualys_vmdr.asset_host_detection.metadata.google.attribute.value
-      ignore_missing: true
-  - rename:
-      field: qualys_vmdr.asset_host_detection.metadata.google.attribute.LAST_STATUS
-      tag: rename_qualys_vmdr_asset_host_detection_metadata_google_attribute_LAST_STATUS_2
-      target_field: qualys_vmdr.asset_host_detection.metadata.google.attribute.last.status
       ignore_missing: true
   - foreach:
       field: qualys_vmdr.asset_host_detection.metadata.google.attribute
@@ -657,6 +657,11 @@ processors:
           tag: rename_qualys_vmdr_asset_host_detection_metadata_azure_attribute_LAST_STATUS_1
           target_field: _ingest._value.last.status
           ignore_missing: true
+  - rename:
+      field: qualys_vmdr.asset_host_detection.metadata.azure.attribute.LAST_STATUS
+      tag: rename_qualys_vmdr_asset_host_detection_metadata_azure_attribute_LAST_STATUS_2
+      target_field: qualys_vmdr.asset_host_detection.metadata.azure.attribute.last.status
+      ignore_missing: true
   - foreach:
       field: qualys_vmdr.asset_host_detection.metadata.azure.attribute
       if: ctx.qualys_vmdr?.asset_host_detection?.metadata?.azure?.attribute instanceof List
@@ -671,11 +676,6 @@ processors:
       field: qualys_vmdr.asset_host_detection.metadata.azure.attribute.VALUE
       tag: rename_qualys_vmdr_asset_host_detection_metadata_azure_attribute_VALUE_2
       target_field: qualys_vmdr.asset_host_detection.metadata.azure.attribute.value
-      ignore_missing: true
-  - rename:
-      field: qualys_vmdr.asset_host_detection.metadata.azure.attribute.LAST_STATUS
-      tag: rename_qualys_vmdr_asset_host_detection_metadata_azure_attribute_LAST_STATUS_2
-      target_field: qualys_vmdr.asset_host_detection.metadata.azure.attribute.last.status
       ignore_missing: true
   - foreach:
       field: qualys_vmdr.asset_host_detection.metadata.azure.attribute
@@ -1288,28 +1288,6 @@ processors:
       tag: rename_qualys_vmdr_asset_host_detection_vulnerability_qds_factors_#text_2
       target_field: qualys_vmdr.asset_host_detection.vulnerability.qds_factors.text
       ignore_missing: true
-  - rename:
-      if: ctx.qualys_vmdr?.asset_host_detection?.vulnerability?.QDS_FACTORS?.QDS_FACTOR != null
-      field: qualys_vmdr.asset_host_detection.vulnerability.QDS_FACTORS.QDS_FACTOR
-      tag: rename_qualys_vmdr_asset_host_detection_vulnerability_QDS_FACTORS_QDS_FACTOR_2
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.qds_factors
-      ignore_missing: true
-  - rename:
-      if: ctx.qualys_vmdr?.asset_host_detection?.vulnerability?.qds_factors != null
-      field: qualys_vmdr.asset_host_detection.vulnerability.qds_factors.#text
-      tag: rename_qualys_vmdr_asset_host_detection_vulnerability_qds_factors_#text_3
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.qds_factors.text
-      ignore_missing: true
-  - foreach:
-      field: qualys_vmdr.asset_host_detection.vulnerability.qds_factors
-      if: (!(ctx.qualys_vmdr?.asset_host_detection?.vulnerability != null)) && ctx.qualys_vmdr?.asset_host_detection?.list?.qds_factors instanceof List
-      tag: foreach_rename_#text
-      processor:
-        rename:
-          field: _ingest._value.#text
-          tag: rename_qualys_vmdr_asset_host_detection_vulnerability_qds_factors_#text_4
-          target_field: _ingest._value.text
-          ignore_missing: true
   - script:
       lang: painless
       tag: script_to_assign_vulnerability_score_base
@@ -1403,281 +1381,6 @@ processors:
         else if (ctx.vulnerability.score.base == 0) {
           ctx.vulnerability.severity = "none";
         }
-      on_failure:
-        - append:
-            field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - rename:
-      if: ctx.qualys_vmdr?.asset_host_detection?.vulnerability?.QDS != null
-      field: qualys_vmdr.asset_host_detection.vulnerability.QDS
-      tag: rename_qualys_vmdr_asset_host_detection_vulnerability_QDS_2
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.qds
-      ignore_missing: true
-  - rename:
-      if: ctx.qualys_vmdr?.asset_host_detection?.vulnerability?.qds != null
-      field: qualys_vmdr.asset_host_detection.vulnerability.qds.#text
-      tag: rename_qualys_vmdr_asset_host_detection_vulnerability_qds_#text_2
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.qds.score
-      ignore_missing: true
-  - convert:
-      field: qualys_vmdr.asset_host_detection.vulnerability.qds.score
-      tag: convert_qualys_vmdr_asset_host_detection_vulnerability_qds_score_2_to_integer
-      type: integer
-      ignore_missing: true
-      on_failure:
-        - append:
-            field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - convert:
-      field: qualys_vmdr.asset_host_detection.vulnerability.PORT
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.port
-      tag: convert_qualys_vmdr_asset_host_detection_vulnerability_PORT_to_long_2
-      type: long
-      ignore_missing: true
-      if: (!(ctx.qualys_vmdr?.asset_host_detection?.vulnerability != null)) && ctx.qualys_vmdr?.asset_host_detection?.list?.PORT != ''
-      on_failure:
-        - append:
-            field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - convert:
-      field: qualys_vmdr.asset_host_detection.vulnerability.TIMES_FOUND
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.times.found
-      tag: convert_qualys_vmdr_asset_host_detection_vulnerability_TIMES_FOUND_to_long_2
-      type: long
-      ignore_missing: true
-      if: (!(ctx.qualys_vmdr?.asset_host_detection?.vulnerability != null)) && ctx.qualys_vmdr?.asset_host_detection?.list?.TIMES_FOUND != ''
-      on_failure:
-        - append:
-            field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - convert:
-      field: qualys_vmdr.asset_host_detection.vulnerability.TIMES_REOPENED
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.times.reopened
-      tag: convert_qualys_vmdr_asset_host_detection_vulnerability_TIMES_REOPENED_to_long_2
-      type: long
-      ignore_missing: true
-      if: (!(ctx.qualys_vmdr?.asset_host_detection?.vulnerability != null)) && ctx.qualys_vmdr?.asset_host_detection?.list?.TIMES_REOPENED != ''
-      on_failure:
-        - append:
-            field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - convert:
-      field: qualys_vmdr.asset_host_detection.vulnerability.SEVERITY
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.severity
-      tag: convert_qualys_vmdr_asset_host_detection_vulnerability_SEVERITY_to_long_2
-      type: long
-      ignore_missing: true
-      if: (!(ctx.qualys_vmdr?.asset_host_detection?.vulnerability != null)) && ctx.qualys_vmdr?.asset_host_detection?.list?.SEVERITY != ''
-      on_failure:
-        - append:
-            field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - date:
-      field: qualys_vmdr.asset_host_detection.vulnerability.LAST_UPDATE_DATETIME
-      tag: date_qualys_vmdr_asset_host_detection_vulnerability_LAST_UPDATE_DATETIME_2
-      if: (!(ctx.qualys_vmdr?.asset_host_detection?.vulnerability != null)) && ctx.qualys_vmdr?.asset_host_detection?.list?.LAST_UPDATE_DATETIME != null && ctx.qualys_vmdr.asset_host_detection.vulnerability.LAST_UPDATE_DATETIME != ''
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.last_update_datetime
-      formats:
-        - ISO8601
-      on_failure:
-        - append:
-            field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - date:
-      field: qualys_vmdr.asset_host_detection.vulnerability.LAST_FIXED_DATETIME
-      tag: date_qualys_vmdr_asset_host_detection_vulnerability_LAST_FIXED_DATETIME_2
-      if: (!(ctx.qualys_vmdr?.asset_host_detection?.vulnerability != null)) && ctx.qualys_vmdr?.asset_host_detection?.list?.LAST_FIXED_DATETIME != null && ctx.qualys_vmdr.asset_host_detection.vulnerability.LAST_FIXED_DATETIME != ''
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.last_fixed_datetime
-      formats:
-        - ISO8601
-      on_failure:
-        - append:
-            field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - date:
-      field: qualys_vmdr.asset_host_detection.vulnerability.LAST_TEST_DATETIME
-      tag: date_qualys_vmdr_asset_host_detection_vulnerability_LAST_TEST_DATETIME_2
-      if: (!(ctx.qualys_vmdr?.asset_host_detection?.vulnerability != null)) && ctx.qualys_vmdr?.asset_host_detection?.list?.LAST_TEST_DATETIME != null && ctx.qualys_vmdr.asset_host_detection.vulnerability.LAST_TEST_DATETIME != ''
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.last_test_datetime
-      formats:
-        - ISO8601
-      on_failure:
-        - append:
-            field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - date:
-      field: qualys_vmdr.asset_host_detection.vulnerability.LAST_PROCESSED_DATETIME
-      tag: date_qualys_vmdr_asset_host_detection_vulnerability_LAST_PROCESSED_DATETIME_2
-      if: (!(ctx.qualys_vmdr?.asset_host_detection?.vulnerability != null)) && ctx.qualys_vmdr?.asset_host_detection?.list?.LAST_PROCESSED_DATETIME != null && ctx.qualys_vmdr.asset_host_detection.vulnerability.LAST_PROCESSED_DATETIME != ''
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.last_processed_datetime
-      formats:
-        - ISO8601
-      on_failure:
-        - append:
-            field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - date:
-      field: qualys_vmdr.asset_host_detection.vulnerability.LAST_FOUND_DATETIME
-      tag: date_qualys_vmdr_asset_host_detection_vulnerability_LAST_FOUND_DATETIME_2
-      if: (!(ctx.qualys_vmdr?.asset_host_detection?.vulnerability != null)) && ctx.qualys_vmdr?.asset_host_detection?.list?.LAST_FOUND_DATETIME != null && ctx.qualys_vmdr.asset_host_detection.vulnerability.LAST_FOUND_DATETIME != ''
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.last_found_datetime
-      formats:
-        - ISO8601
-      on_failure:
-        - append:
-            field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - date:
-      field: qualys_vmdr.asset_host_detection.vulnerability.LAST_REOPENED_DATETIME
-      tag: date_qualys_vmdr_asset_host_detection_vulnerability_LAST_REOPENED_DATETIME_2
-      if: (!(ctx.qualys_vmdr?.asset_host_detection?.vulnerability != null)) && ctx.qualys_vmdr?.asset_host_detection?.list?.LAST_REOPENED_DATETIME != null && ctx.qualys_vmdr.asset_host_detection.vulnerability.LAST_REOPENED_DATETIME != ''
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.last_reopened_datetime
-      formats:
-        - ISO8601
-      on_failure:
-        - append:
-            field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - date:
-      field: qualys_vmdr.asset_host_detection.vulnerability.FIRST_FOUND_DATETIME
-      tag: date_qualys_vmdr_asset_host_detection_vulnerability_FIRST_FOUND_DATETIME_2
-      if: (!(ctx.qualys_vmdr?.asset_host_detection?.vulnerability != null)) && ctx.qualys_vmdr?.asset_host_detection?.list?.FIRST_FOUND_DATETIME != null && ctx.qualys_vmdr.asset_host_detection.vulnerability.FIRST_FOUND_DATETIME != ''
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.first_found_datetime
-      formats:
-        - ISO8601
-      on_failure:
-        - append:
-            field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - date:
-      field: qualys_vmdr.asset_host_detection.vulnerability.FIRST_REOPENED_DATETIME
-      tag: date_qualys_vmdr_asset_host_detection_vulnerability_FIRST_REOPENED_DATETIME_2
-      if: (!(ctx.qualys_vmdr?.asset_host_detection?.vulnerability != null)) && ctx.qualys_vmdr?.asset_host_detection?.list?.FIRST_REOPENED_DATETIME != null && ctx.qualys_vmdr.asset_host_detection.vulnerability.FIRST_REOPENED_DATETIME != ''
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.first_reopened_datetime
-      formats:
-        - ISO8601
-      on_failure:
-        - append:
-            field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - rename:
-      field: qualys_vmdr.asset_host_detection.vulnerability.SSL
-      tag: rename_qualys_vmdr_asset_host_detection_vulnerability_SSL_2
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.ssl
-      ignore_missing: true
-  - rename:
-      field: qualys_vmdr.asset_host_detection.vulnerability.TYPE
-      tag: rename_qualys_vmdr_asset_host_detection_vulnerability_TYPE_2
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.type
-      ignore_missing: true
-  - rename:
-      field: qualys_vmdr.asset_host_detection.vulnerability.STATUS
-      tag: rename_qualys_vmdr_asset_host_detection_vulnerability_STATUS_2
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.status
-      ignore_missing: true
-  - rename:
-      field: qualys_vmdr.asset_host_detection.vulnerability.RESULTS
-      tag: rename_qualys_vmdr_asset_host_detection_vulnerability_RESULTS_2
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.results
-      ignore_missing: true
-  - rename:
-      field: qualys_vmdr.asset_host_detection.vulnerability.QID
-      tag: rename_qualys_vmdr_asset_host_detection_vulnerability_QID_2
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.qid
-      ignore_missing: true
-  - convert:
-      field: qualys_vmdr.asset_host_detection.vulnerability.qid
-      tag: convert_qualys_vmdr_asset_host_detection_vulnerability_QID_2_to_long
-      type: long
-      ignore_missing: true
-      on_failure:
-        - append:
-            field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - rename:
-      field: qualys_vmdr.asset_host_detection.vulnerability.PROTOCOL
-      tag: rename_qualys_vmdr_asset_host_detection_vulnerability_PROTOCOL_2
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.protocol
-      ignore_missing: true
-  - rename:
-      field: qualys_vmdr.asset_host_detection.vulnerability.FQDN
-      tag: rename_qualys_vmdr_asset_host_detection_vulnerability_FQDN_2
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.fqdn
-      ignore_missing: true
-  - append:
-      field: related.hosts
-      tag: append_qualys_vmdr_asset_host_detection_vulnerability_fqdn_into_related_hosts_2
-      value: '{{{qualys_vmdr.asset_host_detection.vulnerability.fqdn}}}'
-      allow_duplicates: false
-      if: (!(ctx.qualys_vmdr?.asset_host_detection?.vulnerability != null)) && ctx.qualys_vmdr?.asset_host_detection?.list?.fqdn != null
-  - rename:
-      field: qualys_vmdr.asset_host_detection.vulnerability.INSTANCE
-      tag: rename_qualys_vmdr_asset_host_detection_vulnerability_INSTANCE_2
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.instance
-      ignore_missing: true
-  - rename:
-      field: qualys_vmdr.asset_host_detection.vulnerability.SERVICE
-      tag: rename_qualys_vmdr_asset_host_detection_vulnerability_SERVICE_2
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.service
-      ignore_missing: true
-  - rename:
-      field: qualys_vmdr.asset_host_detection.vulnerability.AFFECT_RUNNING_KERNEL
-      tag: rename_qualys_vmdr_asset_host_detection_vulnerability_AFFECT_RUNNING_KERNEL_2
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.affect_running_kernel
-      ignore_missing: true
-  - rename:
-      field: qualys_vmdr.asset_host_detection.vulnerability.AFFECT_RUNNING_SERVICE
-      tag: rename_qualys_vmdr_asset_host_detection_vulnerability_AFFECT_RUNNING_SERVICE_2
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.affect_running_service
-      ignore_missing: true
-  - rename:
-      field: qualys_vmdr.asset_host_detection.vulnerability.AFFECT_EXPLOITABLE_CONFIG
-      tag: rename_qualys_vmdr_asset_host_detection_vulnerability_AFFECT_EXPLOITABLE_CONFIG_2
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.affect_exploitable_config
-      ignore_missing: true
-  - rename:
-      field: qualys_vmdr.asset_host_detection.vulnerability.ASSET_CVE
-      tag: rename_qualys_vmdr_asset_host_detection_vulnerability_ASSET_CVE_2
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.asset_cve
-      ignore_missing: true
-  - set:
-      field: qualys_vmdr.asset_host_detection.vulnerability.IS_DISABLED
-      tag: set_qualys_vmdr_asset_host_detection_vulnerability_IS_DISABLED_true
-      value: true
-      if: (!(ctx.qualys_vmdr?.asset_host_detection?.vulnerability != null)) && ctx.qualys_vmdr?.asset_host_detection?.list?.IS_DISABLED == '1'
-  - set:
-      field: qualys_vmdr.asset_host_detection.vulnerability.IS_DISABLED
-      tag: set_qualys_vmdr_asset_host_detection_vulnerability_IS_DISABLED_false
-      value: false
-      if: (!(ctx.qualys_vmdr?.asset_host_detection?.vulnerability != null)) && ctx.qualys_vmdr?.asset_host_detection?.list?.IS_DISABLED == '0'
-  - convert:
-      field: qualys_vmdr.asset_host_detection.vulnerability.IS_DISABLED
-      tag: convert_IS_DISABLED_to_boolean
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.is_disabled
-      type: boolean
-      ignore_missing: true
-      if: (!(ctx.qualys_vmdr?.asset_host_detection?.vulnerability != null)) && ctx.qualys_vmdr?.asset_host_detection?.list?.IS_DISABLED != ''
-      on_failure:
-        - append:
-            field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - set:
-      field: qualys_vmdr.asset_host_detection.vulnerability.IS_IGNORED
-      tag: set_qualys_vmdr_asset_host_detection_vulnerability_IS_IGNORED_true
-      value: true
-      if: (!(ctx.qualys_vmdr?.asset_host_detection?.vulnerability != null)) && ctx.qualys_vmdr?.asset_host_detection?.list?.IS_IGNORED == '1'
-  - set:
-      field: qualys_vmdr.asset_host_detection.vulnerability.IS_IGNORED
-      tag: set_qualys_vmdr_asset_host_detection_vulnerability_IS_IGNORED_false
-      value: false
-      if: (!(ctx.qualys_vmdr?.asset_host_detection?.vulnerability != null)) && ctx.qualys_vmdr?.asset_host_detection?.list?.IS_IGNORED == '0'
-  - convert:
-      field: qualys_vmdr.asset_host_detection.vulnerability.IS_IGNORED
-      tag: convert_IS_IGNORED_to_boolean
-      target_field: qualys_vmdr.asset_host_detection.vulnerability.is_ignored
-      type: boolean
-      ignore_missing: true
-      if: (!(ctx.qualys_vmdr?.asset_host_detection?.vulnerability != null)) && ctx.qualys_vmdr?.asset_host_detection?.list?.IS_IGNORED != ''
       on_failure:
         - append:
             field: error.message

--- a/packages/qualys_vmdr/docs/README.md
+++ b/packages/qualys_vmdr/docs/README.md
@@ -44,7 +44,29 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-The minimum **kibana.version** required is **8.9.0**.
+### Permissions
+
+#### Asset Host Detection
+
+| Role                    | Permission                                     |
+|-------------------------|------------------------------------------------|
+| _Managers_              | All VM scanned hosts in subscription           |
+| _Unit Managers_         | VM scanned hosts in user’s business unit       |
+| _Scanners_              | VM scanned hosts in user’s account             |
+| _Readers_               | VM scanned hosts in user’s account             |
+
+#### Knowledge Base
+
+_Managers_, _Unit Managers_, _Scanners_, _Readers_ have permission to download vulnerability data from the KnowledgeBase.
+
+#### User Activity Log
+
+| Role                    | Permission                                     |
+|-------------------------|------------------------------------------------|
+| _Managers_              | All actions taken by all users                 |
+| _Unit Managers_         | Actions taken by users in their business unit  |
+| _Scanners_              | Own actions only                               |
+| _Readers_               | Own actions only                               |
 
 ## Setup
 

--- a/packages/qualys_vmdr/manifest.yml
+++ b/packages/qualys_vmdr/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: qualys_vmdr
 title: Qualys VMDR
-version: "5.2.2"
+version: "5.3.0"
 description: Collect data from Qualys VMDR platform with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
After the split of vulnerability per host in https://github.com/elastic/integrations/pull/9293 in `asset_host_detection` data-stream, 
there are several duplicate processors handling same thing. 
This PR removes these duplicate processors.

Other changes:
- Document required user role permissions to each API.
- Remove stale `kibana.version` requirement from `README`


<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

After removing the duplicate processors, the pipeline tests should run successfully in `asset_host_detection`.

`cd packages/qualys_vmdr && eval "$(elastic-package stack shellinit)" && elastic-package test pipeline --generate -v --data-streams=asset_host_detection`
```
--- Test results for package: qualys_vmdr - START ---
╭─────────────┬──────────────────────┬───────────┬──────────────────────────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE     │ DATA STREAM          │ TEST TYPE │ TEST NAME                                                │ RESULT │ TIME ELAPSED │
├─────────────┼──────────────────────┼───────────┼──────────────────────────────────────────────────────────┼────────┼──────────────┤
│ qualys_vmdr │ asset_host_detection │ pipeline  │ (ingest pipeline warnings test-asset-host-detection.log) │ PASS   │ 346.280875ms │
│ qualys_vmdr │ asset_host_detection │ pipeline  │ test-asset-host-detection.log                            │ PASS   │ 201.109584ms │
╰─────────────┴──────────────────────┴───────────┴──────────────────────────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: qualys_vmdr - END   ---
Done
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/11673

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
<img width="1065" alt="Screenshot 2024-11-29 at 6 35 47 PM" src="https://github.com/user-attachments/assets/353e7a7a-b4a5-4a96-96a5-08de85b72bf1">

