### PR TITLE
Fix broken link for the Abnormal Security integration

### DIFF
--- a/packages/abnormal_security/_dev/build/docs/README.md
+++ b/packages/abnormal_security/_dev/build/docs/README.md
@@ -18,7 +18,7 @@ The Abnormal Security integration collects four types of logs:
 
 ## Requirements
 
-Elastic Agent must be installed. For more details, check the instructions on how to [install Elastic Agents](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
+You need to install Elastic Agent. For detailed guidance, refer to the Elastic Agent [installation instructions](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
 ### Installing and managing an Elastic Agent
 

--- a/packages/abnormal_security/_dev/build/docs/README.md
+++ b/packages/abnormal_security/_dev/build/docs/README.md
@@ -18,25 +18,25 @@ The Abnormal Security integration collects four types of logs:
 
 ## Requirements
 
-Elastic Agent must be installed. For more details and installation instructions, please refer to the [Elastic Agent Installation Guide](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
+Elastic Agent must be installed. For more details, check the instructions on how to [install Elastic Agents](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-### Installing and managing an Elastic Agent:
+### Installing and managing an Elastic Agent
 
 There are several options for installing and managing Elastic Agent:
 
-### Install a Fleet-managed Elastic Agent (recommended):
+#### Install a Fleet-managed Elastic Agent (recommended)
 
 With this approach, you install Elastic Agent and use Fleet in Kibana to define, configure, and manage your agents in a central location. We recommend using Fleet management because it makes the management and upgrade of your agents considerably easier.
 
-### Install Elastic Agent in standalone mode (advanced users):
+#### Install Elastic Agent in standalone mode (advanced users)
 
 With this approach, you install Elastic Agent and manually configure the agent locally on the system where it’s installed. You are responsible for managing and upgrading the agents. This approach is reserved for advanced users only.
 
-### Install Elastic Agent in a containerized environment:
+#### Install Elastic Agent in a containerized environment
 
 You can run Elastic Agent inside a container, either with Fleet Server or standalone. Docker images for all versions of Elastic Agent are available from the Elastic Docker registry, and we provide deployment manifests for running on Kubernetes.
 
-Please note, there are minimum requirements for running Elastic Agent. For more information, refer to the  [Elastic Agent Minimum Requirements](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html#elastic-agent-installation-minimum-requirements).
+Before installing the Elastic Agent, check the [minimum requirements](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
 ## Setup
 

--- a/packages/abnormal_security/_dev/build/docs/README.md
+++ b/packages/abnormal_security/_dev/build/docs/README.md
@@ -18,7 +18,7 @@ The Abnormal Security integration collects four types of logs:
 
 ## Requirements
 
-You need to install Elastic Agent. For detailed guidance, refer to the Elastic Agent [installation instructions](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
+You need to have Elastic Agent installed. For detailed guidance, refer to the Elastic Agent [installation instructions](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
 ### Installing and managing an Elastic Agent
 

--- a/packages/abnormal_security/changelog.yml
+++ b/packages/abnormal_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Fix broken link for the Abnormal Security integration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11928
 - version: "1.0.0"
   changes:
     - description: Release package as GA.

--- a/packages/abnormal_security/docs/README.md
+++ b/packages/abnormal_security/docs/README.md
@@ -18,7 +18,7 @@ The Abnormal Security integration collects four types of logs:
 
 ## Requirements
 
-Elastic Agent must be installed. For more details, check the instructions on how to [install Elastic Agents](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
+You need to install Elastic Agent. For detailed guidance, refer to the Elastic Agent [installation instructions](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
 ### Installing and managing an Elastic Agent
 

--- a/packages/abnormal_security/docs/README.md
+++ b/packages/abnormal_security/docs/README.md
@@ -18,25 +18,25 @@ The Abnormal Security integration collects four types of logs:
 
 ## Requirements
 
-Elastic Agent must be installed. For more details and installation instructions, please refer to the [Elastic Agent Installation Guide](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
+Elastic Agent must be installed. For more details, check the instructions on how to [install Elastic Agents](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-### Installing and managing an Elastic Agent:
+### Installing and managing an Elastic Agent
 
 There are several options for installing and managing Elastic Agent:
 
-### Install a Fleet-managed Elastic Agent (recommended):
+#### Install a Fleet-managed Elastic Agent (recommended)
 
 With this approach, you install Elastic Agent and use Fleet in Kibana to define, configure, and manage your agents in a central location. We recommend using Fleet management because it makes the management and upgrade of your agents considerably easier.
 
-### Install Elastic Agent in standalone mode (advanced users):
+#### Install Elastic Agent in standalone mode (advanced users)
 
 With this approach, you install Elastic Agent and manually configure the agent locally on the system where it’s installed. You are responsible for managing and upgrading the agents. This approach is reserved for advanced users only.
 
-### Install Elastic Agent in a containerized environment:
+#### Install Elastic Agent in a containerized environment
 
 You can run Elastic Agent inside a container, either with Fleet Server or standalone. Docker images for all versions of Elastic Agent are available from the Elastic Docker registry, and we provide deployment manifests for running on Kubernetes.
 
-Please note, there are minimum requirements for running Elastic Agent. For more information, refer to the  [Elastic Agent Minimum Requirements](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html#elastic-agent-installation-minimum-requirements).
+Before installing the Elastic Agent, check the [minimum requirements](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
 ## Setup
 

--- a/packages/abnormal_security/docs/README.md
+++ b/packages/abnormal_security/docs/README.md
@@ -18,7 +18,7 @@ The Abnormal Security integration collects four types of logs:
 
 ## Requirements
 
-You need to install Elastic Agent. For detailed guidance, refer to the Elastic Agent [installation instructions](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
+You need to have Elastic Agent installed. For detailed guidance, refer to the Elastic Agent [installation instructions](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
 ### Installing and managing an Elastic Agent
 

--- a/packages/abnormal_security/manifest.yml
+++ b/packages/abnormal_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: abnormal_security
 title: Abnormal Security
-version: 1.0.0
+version: 1.0.1
 description: Collect logs from Abnormal Security with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
This PR:

- fixes a broken link to https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html
- adjusts heading levels
- edits the text where needed

Relates https://github.com/elastic/integration-docs/issues/586