### PR TITLE
[servicenow] Replace dropdown with textbox for timezone offset parameter

### DIFF
--- a/packages/servicenow/_dev/build/docs/README.md
+++ b/packages/servicenow/_dev/build/docs/README.md
@@ -101,7 +101,7 @@ There are some minimum requirements for running Elastic Agent. For more informat
    - While creating `event notification` select the event type as s3:ObjectCreated:*, destination type SQS Queue, and select the queue name created in Step 2.
 
 ### Time Zone Selection:
-- In the Data Collection section, use the `Timezone of ServiceNow Instance` dropdown to select your preferred timezone. The `.value` field for date data will always be in UTC, while the `.display_value` field can reflect your instance's selected timezone. The system default is set to America/Los_Angeles, but you can change this in your ServiceNow profile settings.
+- In the Data Collection section, use the `Time Zone Offset` field to set your preferred timezone. The `.value` field for date data will always be in UTC, while the `.display_value` field can reflect your instance's selected timezone. The system default is set to America/Los_Angeles, but you can change this in your ServiceNow profile settings.
 - Steps to See/Update the timezone in ServiceNow Instance:
   1. Click the user icon in the top-right corner of the ServiceNow interface.
   2. Select Profile from the dropdown menu.
@@ -120,7 +120,7 @@ There are some minimum requirements for running Elastic Agent. For more informat
    - password
    - table name
    - timestamp field
-   - timezone
+   - timezone offset
 
    or if you want to collect logs via AWS S3, then you have to put the following details:
    - collect logs via S3 Bucket toggled on
@@ -129,7 +129,7 @@ There are some minimum requirements for running Elastic Agent. For more informat
    - bucket arn
    - table name
    - timestamp field
-   - timezone
+   - timezone offset
 
    or if you want to collect logs via AWS SQS, then you have to put the following details:
    - collect logs via S3 Bucket toggled off
@@ -138,7 +138,7 @@ There are some minimum requirements for running Elastic Agent. For more informat
    - queue url
    - table name
    - timestamp field
-   - timezone
+   - timezone offset
 6. Click on "Save and Continue" to save the integration.
 
 **Note**: To fetch parquet file data, enable the toggle, `Parquet Codec`

--- a/packages/servicenow/changelog.yml
+++ b/packages/servicenow/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Replace dropdown with the textbox for the timezone offset parameter.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/11945
 - version: "0.3.0"
   changes:
     - description: Retain the `servicenow.event.table_name` field.

--- a/packages/servicenow/changelog.yml
+++ b/packages/servicenow/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: Replace dropdown with the textbox for the timezone offset parameter.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.3.0"
   changes:
     - description: Retain the `servicenow.event.table_name` field.

--- a/packages/servicenow/data_stream/event/_dev/test/pipeline/test-common-config.yml
+++ b/packages/servicenow/data_stream/event/_dev/test/pipeline/test-common-config.yml
@@ -4,5 +4,5 @@ fields:
     - preserve_duplicate_custom_fields
     - hide_sensitive
   _conf:
-    timezone: America/Los_Angeles
+    tz_offset: America/Los_Angeles
     timestamp_field: sys_updated_on

--- a/packages/servicenow/data_stream/event/agent/stream/aws-s3.yml.hbs
+++ b/packages/servicenow/data_stream/event/agent/stream/aws-s3.yml.hbs
@@ -108,7 +108,7 @@ publisher_pipeline.disable_host: true
 fields_under_root: true
 fields:
   _conf:
-    timezone: {{timezone}}
+    tz_offset: {{tz_offset}}
     timestamp_field: {{timestamp_field}}
     table_name: {{table_name}}
 {{#if processors}}

--- a/packages/servicenow/data_stream/event/agent/stream/cel.yml.hbs
+++ b/packages/servicenow/data_stream/event/agent/stream/cel.yml.hbs
@@ -103,7 +103,7 @@ fields_under_root: true
 fields:
   _conf:
     timestamp_field: {{timestamp_field}}
-    timezone: {{timezone}}
+    tz_offset: {{tz_offset}}
 {{#if processors}}
 processors:
 {{processors}}

--- a/packages/servicenow/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/servicenow/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -156,9 +156,10 @@ processors:
           ctx.servicenow.event.table_name == 'cmdb_ci_hyper_v_server'
         )
   - rename:
-      field: _conf.timezone
-      tag: rename_timezone
+      field: _conf.tz_offset
+      tag: rename_tz_offset
       target_field: event.timezone
+      if: ctx._conf?.tz_offset != null
       ignore_missing: true
   - set:
       field: event.timezone

--- a/packages/servicenow/data_stream/event/manifest.yml
+++ b/packages/servicenow/data_stream/event/manifest.yml
@@ -75,66 +75,15 @@ streams:
         required: false
         show_user: false
         default: true
-      - name: timezone
-        type: select
-        title: Timezone of ServiceNow Instance
+      - name: tz_offset
+        type: text
+        title: Time Zone Offset
         multi: false
         required: true
         show_user: true
         default: America/Los_Angeles
         description: >-
-          The timezone of the ServiceNow instance, used for interpreting timestamps in the logs.
-        options:
-          - value: America/Los_Angeles
-            text: America/Los_Angeles
-          - value: Canada/Atlantic
-            text: Canada/Atlantic
-          - value: Canada/Central
-            text: Canada/Central
-          - value: Canada/Eastern
-            text: Canada/Eastern
-          - value: Canada/Mountain
-            text: Canada/Mountain
-          - value: Canada/Pacific
-            text: Canada/Pacific
-          - value: Europe/Amsterdam
-            text: Europe/Amsterdam
-          - value: Europe/Berlin
-            text: Europe/Berlin
-          - value: Europe/Brussels
-            text: Europe/Brussels
-          - value: Europe/Copenhagen
-            text: Europe/Copenhagen
-          - value: Europe/Dublin
-            text: Europe/Dublin
-          - value: Europe/London
-            text: Europe/London
-          - value: Europe/Madrid
-            text: Europe/Madrid
-          - value: Europe/Paris
-            text: Europe/Paris
-          - value: Europe/Rome
-            text: Europe/Rome
-          - value: Europe/Stockholm
-            text: Europe/Stockholm
-          - value: Europe/Zurich
-            text: Europe/Zurich
-          - value: GMT
-            text: GMT
-          - value: Hongkong
-            text: Hongkong
-          - value: US/Arizona
-            text: US/Arizona
-          - value: US/Central
-            text: US/Central
-          - value: US/Eastern
-            text: US/Eastern
-          - value: US/Hawaii
-            text: US/Hawaii
-          - value: US/Mountain
-            text: US/Mountain
-          - value: US/Pacific
-            text: US/Pacific
+          By default, datetimes in the logs without a time zone will be interpreted as relative to the time zone configured in the host where the agent is running. If ingesting logs from a different time zone, use this field to set the time zone offset so that datetimes are correctly parsed. Acceptable time zone formats are: a canonical ID (e.g. "Europe/Amsterdam"), or an HH:mm differential (e.g. "-05:00") from UTC.
       - name: http_client_timeout
         type: text
         title: HTTP Client Timeout
@@ -371,66 +320,15 @@ streams:
         required: false
         show_user: false
         default: true
-      - name: timezone
-        type: select
-        title: Timezone of ServiceNow Instance
+      - name: tz_offset
+        type: text
+        title: Time Zone Offset
         multi: false
         required: true
         show_user: true
         default: America/Los_Angeles
         description: >-
-          The timezone of the ServiceNow instance, used for interpreting timestamps in the logs.
-        options:
-          - value: America/Los_Angeles
-            text: America/Los_Angeles
-          - value: Canada/Atlantic
-            text: Canada/Atlantic
-          - value: Canada/Central
-            text: Canada/Central
-          - value: Canada/Eastern
-            text: Canada/Eastern
-          - value: Canada/Mountain
-            text: Canada/Mountain
-          - value: Canada/Pacific
-            text: Canada/Pacific
-          - value: Europe/Amsterdam
-            text: Europe/Amsterdam
-          - value: Europe/Berlin
-            text: Europe/Berlin
-          - value: Europe/Brussels
-            text: Europe/Brussels
-          - value: Europe/Copenhagen
-            text: Europe/Copenhagen
-          - value: Europe/Dublin
-            text: Europe/Dublin
-          - value: Europe/London
-            text: Europe/London
-          - value: Europe/Madrid
-            text: Europe/Madrid
-          - value: Europe/Paris
-            text: Europe/Paris
-          - value: Europe/Rome
-            text: Europe/Rome
-          - value: Europe/Stockholm
-            text: Europe/Stockholm
-          - value: Europe/Zurich
-            text: Europe/Zurich
-          - value: GMT
-            text: GMT
-          - value: Hongkong
-            text: Hongkong
-          - value: US/Arizona
-            text: US/Arizona
-          - value: US/Central
-            text: US/Central
-          - value: US/Eastern
-            text: US/Eastern
-          - value: US/Hawaii
-            text: US/Hawaii
-          - value: US/Mountain
-            text: US/Mountain
-          - value: US/Pacific
-            text: US/Pacific
+          By default, datetimes in the logs without a time zone will be interpreted as relative to the time zone configured in the host where the agent is running. If ingesting logs from a different time zone, use this field to set the time zone offset so that datetimes are correctly parsed. Acceptable time zone formats are: a canonical ID (e.g. "Europe/Amsterdam"), or an HH:mm differential (e.g. "-05:00") from UTC.
       - name: shared_credential_file
         type: text
         title: Shared Credential File

--- a/packages/servicenow/data_stream/event/sample_event.json
+++ b/packages/servicenow/data_stream/event/sample_event.json
@@ -1,22 +1,22 @@
 {
     "@timestamp": "2024-09-24T05:39:40.000Z",
     "agent": {
-        "ephemeral_id": "dbb2059a-3aaa-4bcb-abd4-7685e8b9f7e5",
-        "id": "9fef3fff-5365-4b70-a28a-260b4fdeffac",
-        "name": "elastic-agent-99156",
+        "ephemeral_id": "121d1e8c-0c94-4812-a446-4e8c339cbf5e",
+        "id": "744b1c23-395c-4123-9b8a-7e975ed7b1f8",
+        "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.14.0"
     },
     "data_stream": {
         "dataset": "servicenow.event",
-        "namespace": "62419",
+        "namespace": "28538",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "9fef3fff-5365-4b70-a28a-260b4fdeffac",
+        "id": "744b1c23-395c-4123-9b8a-7e975ed7b1f8",
         "snapshot": false,
         "version": "8.14.0"
     },
@@ -29,7 +29,7 @@
         "created": "2016-12-12T15:19:57.000Z",
         "dataset": "servicenow.event",
         "id": "1c741bd70b2322007518478d83673af3",
-        "ingested": "2024-11-27T06:15:07Z",
+        "ingested": "2024-12-02T12:33:55Z",
         "kind": "event",
         "severity": 3,
         "timezone": "America/Los_Angeles",

--- a/packages/servicenow/docs/README.md
+++ b/packages/servicenow/docs/README.md
@@ -101,7 +101,7 @@ There are some minimum requirements for running Elastic Agent. For more informat
    - While creating `event notification` select the event type as s3:ObjectCreated:*, destination type SQS Queue, and select the queue name created in Step 2.
 
 ### Time Zone Selection:
-- In the Data Collection section, use the `Timezone of ServiceNow Instance` dropdown to select your preferred timezone. The `.value` field for date data will always be in UTC, while the `.display_value` field can reflect your instance's selected timezone. The system default is set to America/Los_Angeles, but you can change this in your ServiceNow profile settings.
+- In the Data Collection section, use the `Time Zone Offset` field to set your preferred timezone. The `.value` field for date data will always be in UTC, while the `.display_value` field can reflect your instance's selected timezone. The system default is set to America/Los_Angeles, but you can change this in your ServiceNow profile settings.
 - Steps to See/Update the timezone in ServiceNow Instance:
   1. Click the user icon in the top-right corner of the ServiceNow interface.
   2. Select Profile from the dropdown menu.
@@ -120,7 +120,7 @@ There are some minimum requirements for running Elastic Agent. For more informat
    - password
    - table name
    - timestamp field
-   - timezone
+   - timezone offset
 
    or if you want to collect logs via AWS S3, then you have to put the following details:
    - collect logs via S3 Bucket toggled on
@@ -129,7 +129,7 @@ There are some minimum requirements for running Elastic Agent. For more informat
    - bucket arn
    - table name
    - timestamp field
-   - timezone
+   - timezone offset
 
    or if you want to collect logs via AWS SQS, then you have to put the following details:
    - collect logs via S3 Bucket toggled off
@@ -138,7 +138,7 @@ There are some minimum requirements for running Elastic Agent. For more informat
    - queue url
    - table name
    - timestamp field
-   - timezone
+   - timezone offset
 6. Click on "Save and Continue" to save the integration.
 
 **Note**: To fetch parquet file data, enable the toggle, `Parquet Codec`
@@ -157,22 +157,22 @@ An example event for `event` looks as following:
 {
     "@timestamp": "2024-09-24T05:39:40.000Z",
     "agent": {
-        "ephemeral_id": "dbb2059a-3aaa-4bcb-abd4-7685e8b9f7e5",
-        "id": "9fef3fff-5365-4b70-a28a-260b4fdeffac",
-        "name": "elastic-agent-99156",
+        "ephemeral_id": "121d1e8c-0c94-4812-a446-4e8c339cbf5e",
+        "id": "744b1c23-395c-4123-9b8a-7e975ed7b1f8",
+        "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.14.0"
     },
     "data_stream": {
         "dataset": "servicenow.event",
-        "namespace": "62419",
+        "namespace": "28538",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "9fef3fff-5365-4b70-a28a-260b4fdeffac",
+        "id": "744b1c23-395c-4123-9b8a-7e975ed7b1f8",
         "snapshot": false,
         "version": "8.14.0"
     },
@@ -185,7 +185,7 @@ An example event for `event` looks as following:
         "created": "2016-12-12T15:19:57.000Z",
         "dataset": "servicenow.event",
         "id": "1c741bd70b2322007518478d83673af3",
-        "ingested": "2024-11-27T06:15:07Z",
+        "ingested": "2024-12-02T12:33:55Z",
         "kind": "event",
         "severity": 3,
         "timezone": "America/Los_Angeles",

--- a/packages/servicenow/manifest.yml
+++ b/packages/servicenow/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: servicenow
 title: "ServiceNow"
-version: 0.3.0
+version: 0.4.0
 description: "Collect logs from ServiceNow with Elastic Agent."
 type: integration
 categories:


### PR DESCRIPTION
Type of change
- Enhancement

## Proposed commit message

Users can now set their time zone offset using either of two formats: a canonical ID (e.g., "Europe/Amsterdam") or an HH:mm offset (e.g., "-05:00").

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots
![tz-before](https://github.com/user-attachments/assets/77af962b-a5ff-4cdb-a894-f06ca992329c)
![tz-after](https://github.com/user-attachments/assets/3172f47b-e7d8-4aea-8399-3fe65496a6e4)
