### PR TITLE
[Juniper SRX] Populate event fields for system log

### DIFF
--- a/packages/juniper_srx/changelog.yml
+++ b/packages/juniper_srx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.21.3"
+  changes:
+    - description: Populated event.outcome and event.category to system log on SSH login failure.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/11834
 - version: "1.21.2"
   changes:
     - description: Use triple-brace Mustache templating when referencing variables in ingest pipelines.

--- a/packages/juniper_srx/changelog.yml
+++ b/packages/juniper_srx/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.21.3"
   changes:
-    - description: Populated event.outcome and event.category to system log on SSH login failure.
+    - description: Populated event.outcome and event.category to system log on SSH login failure and added host.name field to system log.
       type: enhancement
       link: https://github.com/elastic/integrations/issues/11834
 - version: "1.21.2"

--- a/packages/juniper_srx/data_stream/log/_dev/test/pipeline/test-system.log-expected.json
+++ b/packages/juniper_srx/data_stream/log/_dev/test/pipeline/test-system.log-expected.json
@@ -19,6 +19,9 @@
                 "original": "<30>1 2023-05-04T15:27:30.846+10:00 AB1234-ABC2-AB-AB01C-ABC kmd 8961 KMD_PM_SA_ESTABLISHED [junos@1111.1.1.1.1.111 local-address=\"89.160.20.112\" remote-address=\"67.43.156.0\" local-initiator=\"ipv4(89.160.20.112-89.160.20.114)\" remote-responder=\"ipv4(67.43.156.0)\" argument1=\"outbound\" index1=\"36090046\" index2=\"0\" mode=\"Tunnel\" type=\"dynamic\" traffic-selector-name=\"ASJLKN_JKHA\" first-forwarding-class=\"\"] ",
                 "severity": 30
             },
+            "host": {
+                "name": "AB1234-ABC2-AB-AB01C-ABC"
+            },
             "juniper": {
                 "srx": {
                     "argument1": "outbound",
@@ -82,6 +85,9 @@
                 "kind": "event",
                 "original": "<30>1 2023-05-04T15:27:26.461+10:00 AB1234-A-AB-AB01C-ABC kmd 13862 KMD_PM_SA_ESTABLISHED [junos@1111.1.1.1.1.111 local-address=\"89.160.20.112\" remote-address=\"67.43.156.0\" local-initiator=\"ipv4_subnet(any:0,[0..7\\]=89.160.20.112/29)\" remote-responder=\"ipv4_subnet(any:0,[0..7\\]=67.43.156.0/24)\" argument1=\"outbound\" index1=\"3700499780\" index2=\"0\" mode=\"Tunnel\" type=\"dynamic\" traffic-selector-name=\"\" first-forwarding-class=\"\"] Local gateway: 89.160.20.115, Remote gateway: 67.43.156.1, Local ID: ipv4_subnet(any:0,[0..7]=89.160.20.114/29), Remote ID: ipv4_subnet(any:0,[0..7]=67.43.156.1/24), Direction: outbound, SPI: 0xdc912544, AUX-SPI: 0, Mode: Tunnel, Type: dynamic, Traffic-selector: FC Name:",
                 "severity": 30
+            },
+            "host": {
+                "name": "AB1234-A-AB-AB01C-ABC"
             },
             "juniper": {
                 "srx": {
@@ -156,6 +162,9 @@
                 "original": "<27>1 2023-05-04T15:19:33.984+10:00 AB1234-A-AB-AB01C-ABC kmd 9159 - - IKE negotiation failed with error: Timed out. IKE Version: 1, VPN: IPSEC-AAAAA-AAA1-PROD-VPN Gateway: IKE-AAAAA-AAA1-GW, Local: 89.160.20.112/500, Remote: 67.43.156.1/500, Local IKE-ID: Not-Available, Remote IKE-ID: Not-Available, VR-ID: 5: Role: Initiator",
                 "severity": 27
             },
+            "host": {
+                "name": "AB1234-A-AB-AB01C-ABC"
+            },
             "juniper": {
                 "srx": {
                     "log_type": "system",
@@ -205,6 +214,9 @@
                 "original": "<27>1 2023-05-04T15:19:33.984+10:00 AB1234-A-AB-AB01C-ABC kmd 9159 asd2 - IKE negotiation failed with error: Timed out. IKE Version: 1, VPN: IPSEC-AAAAA-AAA1-PROD-VPN Gateway: IKE-AAAAA-AAA1-GW, Local: 89.160.20.112/500, Remote: 67.43.156.1/500, Local IKE-ID: Not-Available, Remote IKE-ID: Not-Available, VR-ID: 5: Role: Initiator",
                 "severity": 27
             },
+            "host": {
+                "name": "AB1234-A-AB-AB01C-ABC"
+            },
             "juniper": {
                 "srx": {
                     "log_type": "system",
@@ -253,6 +265,9 @@
                 "kind": "event",
                 "original": "<27>1 2023-07-04T12:22:36.461+10:00 AC004-PR-VPN01-DMZ kmd 9812 - - IKE negotiation failed with error: Timed out. IKE Version: 1, VPN: IPSEC-HORSEFACTS-TUN1-PROD-VPN Gateway: IKE-HORSEFACTS-TUN1-GW, Local: 10.11.22.444/500, Remote: 198.1.124.8/500, Local IKE-ID: Not-Available, Remote IKE-ID: Not-Available, VR-ID: 5, Role: Initiator",
                 "severity": 27
+            },
+            "host": {
+                "name": "AC004-PR-VPN01-DMZ"
             },
             "juniper": {
                 "srx": {
@@ -304,6 +319,9 @@
                 "original": "<30>1 2023-07-04T10:21:11.590+10:00 AC004-PR-VPN01-DMZ kmd 9812 - - IKE negotiation successfully completed. IKE Version: 1, VPN: IPSEC-NIKON-TUN1-PROD-VPN Gateway: IKE-NIKON-TUN1-GW, Local: 10.8.10.115/9001, Remote: 89.160.20.112/9001, Local IKE-ID: 81.2.69.192, Remote IKE-ID: 89.160.20.112, VR-ID: 6, Role: Responder",
                 "severity": 30
             },
+            "host": {
+                "name": "AC004-PR-VPN01-DMZ"
+            },
             "juniper": {
                 "srx": {
                     "log_type": "system",
@@ -354,6 +372,9 @@
                 "kind": "event",
                 "original": "<27>1 2023-07-04T11:48:31.702+10:00 AC004-PR-VPN01-DMZ kmd 9812 - - IPSec negotiation failed with error: Peer proposed traffic-selectors are not in configured range. IKE Version: 2, VPN: IPSEC-INT-ORMB-TUN2-VPN Gateway: IKE-INT-ORMB-TUN2-GW, Local: 10.32.64.128/9001, Remote: 89.160.20.112/9001, Local IKE-ID: 89.160.20.112, Remote IKE-ID: 89.160.20.112, VR-ID: 6",
                 "severity": 27
+            },
+            "host": {
+                "name": "AC004-PR-VPN01-DMZ"
             },
             "juniper": {
                 "srx": {
@@ -416,6 +437,9 @@
                 "type": [
                     "allowed"
                 ]
+            },
+            "host": {
+                "name": "AB1234-ABC2-AB-AB01C-ABC"
             },
             "juniper": {
                 "srx": {
@@ -487,6 +511,9 @@
                     "allowed"
                 ]
             },
+            "host": {
+                "name": "AB1234-ABC2-AB-AB01C-ABC"
+            },
             "juniper": {
                 "srx": {
                     "log_type": "system",
@@ -555,6 +582,9 @@
                     "allowed"
                 ]
             },
+            "host": {
+                "name": "AAAA-A-AA-AAAAAA-AAAAAA-AAA"
+            },
             "juniper": {
                 "srx": {
                     "log_type": "system",
@@ -614,6 +644,9 @@
                     "info"
                 ]
             },
+            "host": {
+                "name": "AB1234-A-AB-AB01C-ABC"
+            },
             "juniper": {
                 "srx": {
                     "log_type": "system",
@@ -661,6 +694,9 @@
                 "kind": "event",
                 "original": "<37>1 2023-05-10T00:10:24.232+10:00 AB1234-A-AB-AB01C-ABC snmpd 8959 SNMPD_AUTH_FAILURE [junos@1111.1.1.1.1.111 function-name=\"nsa_log_community\" message=\"unauthorized SNMP community\" source-address=\"216.160.83.56\" destination-address=\"89.160.20.128\" index1=\"j5Cx6eSkKF7A\"]",
                 "severity": 37
+            },
+            "host": {
+                "name": "AB1234-A-AB-AB01C-ABC"
             },
             "juniper": {
                 "srx": {
@@ -714,6 +750,9 @@
                 "original": "<166>1 2023-05-10T09:50:54.371+10:00 AB1234-A-AB-AB01C-ABC - - - - AB1234-A-AB-AB01C-ABC ip_mon_reth_scan: interface st0.60 trigger reth_scan",
                 "severity": 166
             },
+            "host": {
+                "name": "AB1234-A-AB-AB01C-ABC"
+            },
             "juniper": {
                 "srx": {
                     "ip_mon_reth_scan": {
@@ -755,6 +794,9 @@
                 "original": "<167>1 2023-05-09T22:26:57.174+10:00 AB1234-ABC2-AB-AB01C-ABC - - - - AB1234-ABC2-AB-AB01C-ABC ha_rto_stats_handler: Sending RTO counters to RE ",
                 "severity": 167
             },
+            "host": {
+                "name": "AB1234-ABC2-AB-AB01C-ABC"
+            },
             "juniper": {
                 "srx": {
                     "log_type": "system",
@@ -787,6 +829,9 @@
                 "kind": "event",
                 "original": "<30>1 2023-05-09T23:03:52.466+10:00 AB1234-A-AB-AB01C-ABC mib2d 8956 SNMP_TRAP_LINK_UP [junos@1111.1.1.1.1.111 snmp-interface-index=\"508\" admin-status=\"up(1)\" operational-status=\"up(1)\" interface-name=\"st0.60\"]",
                 "severity": 30
+            },
+            "host": {
+                "name": "AB1234-A-AB-AB01C-ABC"
             },
             "juniper": {
                 "srx": {
@@ -832,6 +877,9 @@
                 "kind": "event",
                 "original": "<28>1 2023-05-08T14:25:07.466+10:00 AB1234-A-AB-AB01C-ABC mib2d 8956 SNMP_TRAP_LINK_DOWN [junos@1111.1.1.1.1.111 snmp-interface-index=\"508\" admin-status=\"up(1)\" operational-status=\"down(2)\" interface-name=\"st0.60\"]",
                 "severity": 28
+            },
+            "host": {
+                "name": "AB1234-A-AB-AB01C-ABC"
             },
             "juniper": {
                 "srx": {
@@ -883,6 +931,9 @@
                 "outcome": "failure",
                 "severity": 37
             },
+            "host": {
+                "name": "AC1234-ABC3-AB-FW01A-ABC"
+            },
             "juniper": {
                 "srx": {
                     "log_type": "system",
@@ -933,6 +984,9 @@
                 "original": "<166>1 2023-05-08T10:54:24.821+10:00 AB1234-A-AB-AB01C-ABC - - - - AB1234-A-AB-AB01C-ABC dpdk_eth_devstart (pid=0x4c6b17c0): port 8 has already been started, dpdk_port_state=2 dpdk_swt_port_state 1",
                 "severity": 166
             },
+            "host": {
+                "name": "AB1234-A-AB-AB01C-ABC"
+            },
             "juniper": {
                 "srx": {
                     "dpdk": {
@@ -973,6 +1027,9 @@
                 "kind": "event",
                 "original": "<166>1 2023-05-08T10:54:24.821+10:00 AB1234-A-AB-AB01C-ABC - - - - AB1234-A-AB-AB01C-ABC dpdk_eth_devstart (pid=0x4c6a1bc0): port 7 ifd xe-0/0/7, new dpdk_port_state=2 dpdk_swt_port_state 1",
                 "severity": 166
+            },
+            "host": {
+                "name": "AB1234-A-AB-AB01C-ABC"
             },
             "juniper": {
                 "srx": {
@@ -1020,6 +1077,9 @@
                 "original": "<166>1 2023-05-08T10:54:24.756+10:00 AB1234-A-AB-AB01C-ABC - - - - AB1234-A-AB-AB01C-ABC nh_fabric_fill_jnhinfo: Storing nh_id as 0x2dd and jnh as 0x58e302",
                 "severity": 166
             },
+            "host": {
+                "name": "AB1234-A-AB-AB01C-ABC"
+            },
             "juniper": {
                 "srx": {
                     "log_type": "system",
@@ -1053,6 +1113,9 @@
                 "original": "<167>1 2023-05-08T10:54:24.704+10:00 AB1234-A-AB-AB01C-ABC - - - - AB1234-A-AB-AB01C-ABC Copying remote chassis chassis 1, IP: 81.2.69.192",
                 "severity": 167
             },
+            "host": {
+                "name": "AB1234-A-AB-AB01C-ABC"
+            },
             "juniper": {
                 "srx": {
                     "log_type": "system"
@@ -1076,6 +1139,9 @@
             "@timestamp": "2023-05-08T00:54:24.756Z",
             "ecs": {
                 "version": "8.11.0"
+            },
+            "host": {
+                "name": "AB1234-A-AB-AB01C-ABC"
             },
             "event": {
                 "category": [

--- a/packages/juniper_srx/data_stream/log/_dev/test/pipeline/test-system.log-expected.json
+++ b/packages/juniper_srx/data_stream/log/_dev/test/pipeline/test-system.log-expected.json
@@ -875,10 +875,12 @@
             },
             "event": {
                 "category": [
-                    "network"
+                    "network",
+                    "authentication"
                 ],
                 "kind": "event",
                 "original": "<37>1 2023-05-09T15:00:06.756+10:00 AC1234-ABC3-AB-FW01A-ABC sshd - SSHD_LOGIN_FAILED [junos@1111.1.1.1.1.111 username=\"aaaaa\" source-address=\"175.16.199.0\"]",
+                "outcome": "failure",
                 "severity": 37
             },
             "juniper": {

--- a/packages/juniper_srx/data_stream/log/elasticsearch/ingest_pipeline/system.yml
+++ b/packages/juniper_srx/data_stream/log/elasticsearch/ingest_pipeline/system.yml
@@ -741,6 +741,11 @@ processors:
     field: related.ip
     value: '{{{juniper.srx.system.remote_gateway}}}'
     allow_duplicates: false
+- append:
+    if: 'ctx.source?.user?.name != null'
+    field: related.user
+    value: '{{{source.user.name}}}'
+    allow_duplicates: false
 
 ######################
 ## ECS Observer Mapping ##

--- a/packages/juniper_srx/data_stream/log/elasticsearch/ingest_pipeline/system.yml
+++ b/packages/juniper_srx/data_stream/log/elasticsearch/ingest_pipeline/system.yml
@@ -414,6 +414,10 @@ processors:
     field: event.outcome
     value: success
     if: ctx.juniper?.srx?.ping_test != null
+- set:
+    field: event.outcome
+    value: failure
+    if: ctx.juniper?.srx?.tag == "SSHD_LOGIN_FAILED"
 
 ####################################
 ## ECS Server/Destination Mapping ##

--- a/packages/juniper_srx/data_stream/log/elasticsearch/ingest_pipeline/system.yml
+++ b/packages/juniper_srx/data_stream/log/elasticsearch/ingest_pipeline/system.yml
@@ -762,6 +762,11 @@ processors:
     target_field: observer.name
     ignore_missing: true
     if: "ctx.syslog_hostname != null && ctx.observer?.name == null"
+- set:
+    copy_from: observer.name
+    field: host.name
+    ignore_empty_value: true
+
 ######################
 ## ECS Rule Mapping ##
 ######################

--- a/packages/juniper_srx/data_stream/log/elasticsearch/ingest_pipeline/system.yml
+++ b/packages/juniper_srx/data_stream/log/elasticsearch/ingest_pipeline/system.yml
@@ -749,11 +749,6 @@ processors:
     field: related.ip
     value: '{{{juniper.srx.system.remote_gateway}}}'
     allow_duplicates: false
-- append:
-    if: 'ctx.source?.user?.name != null'
-    field: related.user
-    value: '{{{source.user.name}}}'
-    allow_duplicates: false
 
 ######################
 ## ECS Observer Mapping ##

--- a/packages/juniper_srx/data_stream/log/elasticsearch/ingest_pipeline/system.yml
+++ b/packages/juniper_srx/data_stream/log/elasticsearch/ingest_pipeline/system.yml
@@ -377,6 +377,10 @@ processors:
     field: event.category
     value: network
 - append:
+    field: event.category
+    value: authentication
+    if: ctx.juniper?.srx?.tag == "SSHD_LOGIN_FAILED"
+- append:
     field: event.type
     value: allowed
     if: ctx.juniper?.srx?.firewall?.filter_action == 'A'

--- a/packages/juniper_srx/manifest.yml
+++ b/packages/juniper_srx/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: juniper_srx
 title: Juniper SRX
-version: "1.21.2"
+version: "1.21.3"
 description: Collect logs from Juniper SRX devices with Elastic Agent.
 categories: ["network", "security", "firewall_security"]
 type: integration


### PR DESCRIPTION
<!-- Type of change
- Enhancement
-->

## Proposed commit message
The purpose of this code change is to make failed SSH login attempts to Juniper equipment visible in Elastic Security.
To this end, we populate the following fields on a failed SSH login attempt in the system logging pipeline.

(if SSH login failed)
- event.outcome: failure
- event.category: authentication (append)

(no conditions)
- observer.name -> host.name (copy)
<!-- Mandatory


-->

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [X] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- `elastic-package test` in the package directory.
## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.
-->
- Closes #11834
- Closes #11835

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
