### PR TITLE
#11921-1 Multiple spanning tree protocol events (20xx)

### DIFF
--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -654,25 +654,26 @@ Note: Descriptions have not been filled out
 | <limit>    | aruba.limit    |
 
 #### [Multiple spanning tree protocol events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MSTP.htm)
-| Field                       | Description | Type | Common                       |
-|-----------------------------|-------------|------|------------------------------|
-| aruba.mstp.config_parameter |             |      |                              |
-| aruba.mstp.config_value     |             |      |                              |
-| aruba.mstp.instance         |             |      | aruba.instance.id            |
-| aruba.mstp.mac              |             |      | source.mac                   |
-| aruba.mstp.new_mac          |             |      | source.mac                   |
-| aruba.mstp.new_mode         |             |      |                              |
-| aruba.mstp.new_priority     |             |      | aruba.priority               |
-| aruba.mstp.old_mac          |             |      |                              |
-| aruba.mstp.old_mode         |             |      |                              |
-| aruba.mstp.old_priority     |             |      |                              |
-| aruba.mstp.pk_type          |             |      |                              |
-| aruba.mstp.port             |             |      | server.port                  |
-| aruba.mstp.priority_mac     |             |      | source.mac                   |
-| aruba.mstp.proto            |             |      |                              |
-| aruba.mstp.reconfig_parameter |           |      |                              |
-| aruba.mstp.state            |             |      | aruba.status                 |
-
+| Docs Field          | Schema Mapping               |
+|---------------------|------------------------------|
+| <config_parameter>  | aruba.mstp.config_parameter  |
+| <instance>          | aruba.instance.id            |
+| <mac>               | source.mac                   |
+| <new_mac>           | source.mac                   |
+| <new_mode>          | aruba.mstp.new_mode          |
+| <new_port>          | aruba.port                   |
+| <new_priority>      | aruba.priority               |
+| <old_mac>           | aruba.mstp.old_mac           |
+| <old_mode>          | aruba.mstp.old_mode          |
+| <old_port>          | aruba.mstp.old_port          |
+| <old_priority>      | aruba.mstp.old_priority      |
+| <pkt_type>          | aruba.mstp.pkt_type          |
+| <port>              | aruba.port                   |
+| <priority_mac>      | aruba.mstp.priority_mac      |
+| <proto>             | aruba.mstp.proto             |
+| <reconfig_parameter>| aruba.mstp.reconfig_parameter|
+| <state>             | aruba.status                 |
+| <value>             | aruba.mstp.config_value      |
 
 #### [MVRP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MVRP.htm)
 | Field               | Description | Type | Common                       |

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
@@ -256,7 +256,12 @@
                 "hardware": {
                     "device": "6000RCSE4802"
                 },
-                "sequence": "1/1"
+                "mstp": {
+                    "proto": "CIST"
+                },
+                "port": "1/1/38",
+                "sequence": "1/1",
+                "status": "forwarding"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -871,6 +876,10 @@
                 "hardware": {
                     "device": "6300-DIST-RDL"
                 },
+                "mstp": {
+                    "proto": "MSTI 17"
+                },
+                "port": "1/1/6",
                 "sequence": "1"
             },
             "ecs": {
@@ -891,6 +900,9 @@
                 }
             },
             "message": "Topology Change received on port 1/1/6 for MSTI 17 from source: ab:cd:ef:12:34:56",
+            "source": {
+                "mac": "AB-CD-EF-12-34-56"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -905,7 +917,12 @@
                 "hardware": {
                     "device": "6300-DIST-RDL"
                 },
-                "sequence": "2"
+                "mstp": {
+                    "proto": "CIST"
+                },
+                "port": "1/1/11",
+                "sequence": "2",
+                "status": "forwarding"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -3194,6 +3211,12 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "mstp": {
+                    "old_mac": "AB-CD-EF-12-34-56",
+                    "old_priority": "4096",
+                    "proto": "CST "
+                },
+                "priority": "0",
                 "sequence": "1/1"
             },
             "ecs": {
@@ -3215,6 +3238,9 @@
                 }
             },
             "message": "CST  - Root changed from 4096: ab:cd:ef:12:34:56 to 0: ab:cd:ef:12:34:56",
+            "source": {
+                "mac": "AB-CD-EF-12-34-56"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -3229,6 +3255,12 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "mstp": {
+                    "old_mac": "AB-CD-EF-12-34-56",
+                    "old_priority": "8192",
+                    "proto": "CST "
+                },
+                "priority": "4096",
                 "sequence": "1/1"
             },
             "ecs": {
@@ -3250,6 +3282,9 @@
                 }
             },
             "message": "CST  - Root changed from 8192: ab:cd:ef:12:34:56 to 4096: ab:cd:ef:12:34:56",
+            "source": {
+                "mac": "AB-CD-EF-12-34-56"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -3264,6 +3299,7 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "port": "1/1/37",
                 "sequence": "1/1"
             },
             "ecs": {
@@ -3299,6 +3335,12 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "mstp": {
+                    "pkt_type": "BPDU Rx",
+                    "priority_mac": "0:0008e3-fffc28",
+                    "proto": "CIST"
+                },
+                "port": "1/1/42",
                 "sequence": "1/1"
             },
             "ecs": {
@@ -3334,6 +3376,12 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "mstp": {
+                    "pkt_type": "BPDU Rx",
+                    "priority_mac": "4096:0008e3-fffd94",
+                    "proto": "CIST"
+                },
+                "port": "lag47",
                 "sequence": "1/1"
             },
             "ecs": {
@@ -3369,6 +3417,10 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "mstp": {
+                    "proto": "CIST"
+                },
+                "port": "1/1/9",
                 "sequence": "1/1"
             },
             "ecs": {
@@ -3390,6 +3442,9 @@
                 }
             },
             "message": "Topology Change received on port 1/1/9 for CIST from source: ab:cd:ef:12:34:56",
+            "source": {
+                "mac": "AB-CD-EF-12-34-56"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -3404,7 +3459,12 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "sequence": "1/1"
+                "mstp": {
+                    "proto": "CIST"
+                },
+                "port": "1/1/6",
+                "sequence": "1/1",
+                "status": "forwarding"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -3439,7 +3499,12 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "sequence": "1/1"
+                "mstp": {
+                    "proto": "MSTI 10"
+                },
+                "port": "1/1/26",
+                "sequence": "1/1",
+                "status": "forwarding"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -3474,6 +3539,7 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "port": "1/1/37",
                 "sequence": "1/1"
             },
             "ecs": {
@@ -3509,6 +3575,7 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "port": "1/1/42",
                 "sequence": "1/1"
             },
             "ecs": {
@@ -3544,6 +3611,7 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "port": "1/1/42",
                 "sequence": "1/1"
             },
             "ecs": {

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
@@ -128,6 +128,17 @@
 2024-07-22T19:59:24.900661-05:00 8360-Primaire dhcpd[1979]: Event|1909|LOG_ERR|DHCP|-|Invalid DHCP configuration: myConfig provided on DHCP Server instance running on VRF myVrf. Ignoring this config.
 2024-07-22T19:59:24.900661-05:00 8360-Primaire dhcpd[1979]: Event|1910|LOG_INFO|DHCP|-|DHCP Server Lease cleared on vrf myVrf.
 2024-07-22T19:59:24.900661-05:00 8360-Primaire dhcpd[1979]: Event|1910|LOG_INFO|DHCP|-|DHCPv6 Server Lease cleared on vrf myVrf.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2001|LOG_INFO|MSTP|-|MSTP Enabled
+2024-06-18T12:46:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2002|LOG_INFO|MSTP|-|MSTP Disabled
+2024-06-18T12:47:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2003|LOG_WARN|MSTP|-|mstp_config should be enabled
+2024-06-18T12:48:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2004|LOG_WARN|MSTP|-|BPDU has invalid_config from port eth0
+2024-06-18T12:49:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2005|LOG_WARN|MSTP|-|Bad reconfiguration request: invalid_reconfig
+2024-06-18T12:53:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2009|LOG_INFO|MSTP|-|BPDU loss- port eth3 moved to inconsistent state for MSTP
+2024-06-18T12:54:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2010|LOG_INFO|MSTP|-|Port eth4 moved out of inconsistent state for MSTP
+2024-06-18T12:58:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2016|LOG_INFO|MSTP|-|Port eth8 blocked on MST1
+2024-06-18T12:59:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2017|LOG_INFO|MSTP|-|Port eth9 unblocked on MST1
+2024-06-18T13:00:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2018|LOG_INFO|MSTP|-|MSTP Root Port changed from eth10 to eth11
+2024-06-18T13:01:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2019|LOG_INFO|MSTP|-|spanning tree mode changed from RSTP to MSTP, it will trigger the reconvergence
 2024-06-19T14:22:07.025544-05:00 8360-Primaire acctd[358]: Event|2303|LOG_INFO|AMM|1/1|RADIUS radius type radius_action: radius_event
 2024-06-19T14:22:07.025546-05:00 8360-Primaire acctd[358]: Event|2304|LOG_INFO|AMM|1/1|RADIUS Server with Address: 127.0.0.1, Authport:1/1/6, VRF_ID:vpn-Internet is "aruba_status"
 2024-06-19T14:22:07.025547-05:00 8360-Primaire acctd[358]: Event|2305|LOG_INFO|AMM|1/1|TACACS server host 127.0.0.1 port 1/1/6 vrf vpn-Internet aruba_status

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -5056,6 +5056,416 @@
             ]
         },
         {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MSTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2001",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2001|LOG_INFO|MSTP|-|MSTP Enabled"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mstpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "MSTP Enabled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MSTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2002",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2002|LOG_INFO|MSTP|-|MSTP Disabled"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mstpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "MSTP Disabled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MSTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mstp": {
+                    "config_parameter": "mstp_config",
+                    "config_value": "enabled"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2003",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2003|LOG_WARN|MSTP|-|mstp_config should be enabled"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "mstpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "mstp_config should be enabled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MSTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mstp": {
+                    "config_parameter": "invalid_config",
+                    "config_value": "eth0"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2004",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2004|LOG_WARN|MSTP|-|BPDU has invalid_config from port eth0"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "mstpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "BPDU has invalid_config from port eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MSTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mstp": {
+                    "reconfig_parameter": "invalid_reconfig"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2005",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2005|LOG_WARN|MSTP|-|Bad reconfiguration request: invalid_reconfig"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "mstpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Bad reconfiguration request: invalid_reconfig",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MSTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mstp": {
+                    "proto": "MSTP"
+                },
+                "port": "eth3",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2009",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2009|LOG_INFO|MSTP|-|BPDU loss- port eth3 moved to inconsistent state for MSTP"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mstpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "BPDU loss- port eth3 moved to inconsistent state for MSTP",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MSTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mstp": {
+                    "proto": "MSTP"
+                },
+                "port": "eth4",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2010",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2010|LOG_INFO|MSTP|-|Port eth4 moved out of inconsistent state for MSTP"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mstpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Port eth4 moved out of inconsistent state for MSTP",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:58:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MSTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "port": "eth8",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2016",
+                "original": "2024-06-18T12:58:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2016|LOG_INFO|MSTP|-|Port eth8 blocked on MST1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mstpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Port eth8 blocked on MST1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:59:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MSTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "port": "eth9",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2017",
+                "original": "2024-06-18T12:59:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2017|LOG_INFO|MSTP|-|Port eth9 unblocked on MST1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mstpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Port eth9 unblocked on MST1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:00:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MSTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mstp": {
+                    "old_port": "eth10",
+                    "proto": "MSTP"
+                },
+                "port": "eth11",
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2018",
+                "original": "2024-06-18T13:00:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2018|LOG_INFO|MSTP|-|MSTP Root Port changed from eth10 to eth11"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mstpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "MSTP Root Port changed from eth10 to eth11",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:01:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MSTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mstp": {
+                    "new_mode": "MSTP",
+                    "old_mode": "RSTP"
+                },
+                "sequence": "-"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2019",
+                "original": "2024-06-18T13:01:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2019|LOG_INFO|MSTP|-|spanning tree mode changed from RSTP to MSTP, it will trigger the reconvergence"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mstpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "spanning tree mode changed from RSTP to MSTP, it will trigger the reconvergence",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-06-19T14:22:07.025544-05:00",
             "aruba": {
                 "aaa": {

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -554,6 +554,51 @@ processors:
       patterns:
         - "^(DHCP|DHCPv6) Server Lease cleared on vrf %{DATA:aruba.vrf.name}\\.$"
 
+    # Multiple spanning tree protocol events (20xx)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MSTP.htm
+  - grok:
+      field: message
+      tag: mstp_event_2003_2004
+      description: "the MSTP config parameter is bad | switch received a BPDU with a bad config"
+      if: "['2003','2004'].contains(ctx.event?.code)"
+      patterns:
+        - "^(BPDU has )?%{DATA:aruba.mstp.config_parameter} (should be|from port) %{GREEDYDATA:aruba.mstp.config_value}"
+  - dissect:
+      field: message
+      tag: mstp_event_2005
+      description: "the MSTP reconfig parameter is bad"
+      if: "['2005'].contains(ctx.event?.code)"
+      pattern: "Bad reconfiguration request: %{aruba.mstp.reconfig_parameter}"
+  - grok:
+      field: message
+      tag: mstp_event_2006_2008_2018
+      description: "MSTP root has changed | Rx queue is starved in the paticular port | root port has changed"
+      if: "['2006','2008','2018'].contains(ctx.event?.code)"
+      patterns:
+        - "^%{DATA:aruba.mstp.proto} - Root changed from %{DATA:aruba.mstp.old_priority}: %{MAC:aruba.mstp.old_mac} to %{DATA:aruba.priority}: %{MAC:source.mac}"
+        # variation between customer logs and documentation
+        - "^%{DATA:aruba.mstp.proto} starved for (a)? %{DATA:aruba.mstp.pkt_type} on port %{DATA:aruba.port} from %{GREEDYDATA:aruba.mstp.priority_mac}"
+        - "^%{DATA:aruba.mstp.proto} Root Port changed from %{DATA:aruba.mstp.old_port} to %{GREEDYDATA:aruba.port}"
+  - grok:
+      field: message
+      tag: mstp_event_2007_2009_2010_2011_2012_2013_2014_2015_2016_2017
+      description: "BPDU was received on protected port | [port|MSTP] is in inconsistent state | topology change is [received|generated] on port | BPDU received on admin edge port | port is blocked"
+      if: "['2007','2009','2010','2011','2012','2013','2014','2015','2016','2017'].contains(ctx.event?.code)"
+      patterns:
+        - "^Port %{DATA:aruba.port} disabled - BPDU received on protected port"
+        - "^(BPDU loss- p|P)ort %{DATA:aruba.port} moved (to|out of) inconsistent state for %{GREEDYDATA:aruba.mstp.proto}"
+        - "^Topology Change received on port %{DATA:aruba.port} for %{DATA:aruba.mstp.proto} from source: %{MAC:source.mac}"
+        - "^%{DATA:aruba.mstp.proto} - Topology Change generated on port %{DATA:aruba.port} going in to %{GREEDYDATA:aruba.status}"
+        - "^BPDU received on admin edge port %{GREEDYDATA:aruba.port}"
+        - "^Port %{DATA:aruba.port} (un)?blocked on CIST"
+        - "^Port %{DATA:aruba.port} (un)?blocked on MST%{GREEDYDATA:aruba.instance.id}"
+  - dissect:
+      field: message
+      tag: mstp_event_2019
+      description: "the spanning tree mode is changed"
+      if: "['2019'].contains(ctx.event?.code)"
+      pattern: "spanning tree mode changed from %{aruba.mstp.old_mode} to %{aruba.mstp.new_mode}, it will trigger the reconvergence"
+
   # AAA events (23xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/AAA.htm
   - grok:
@@ -1899,6 +1944,14 @@ processors:
       ignore_missing: true
   - gsub:
       field: destination.mac
+      pattern: "[:.]"
+      replacement: "-"
+      ignore_missing: true
+  - uppercase:
+      field: aruba.mstp.old_mac
+      ignore_missing: true
+  - gsub:
+      field: aruba.mstp.old_mac
       pattern: "[:.]"
       replacement: "-"
       ignore_missing: true

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -662,10 +662,16 @@
         - name: old_mode
           type: keyword
           description: ""
+        - name: old_port
+          type: keyword
+          description: ""
         - name: old_priority
           type: keyword
           description: ""
-        - name: pk_type
+        - name: pkt_type
+          type: keyword
+          description: ""
+        - name: priority_mac
           type: keyword
           description: ""
         - name: proto

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -518,6 +518,12 @@
         - name: psc
           type: keyword
           description: ""
+    - name: len
+      type: long
+      description: ""
+    - name: limit
+      type: long
+      description: ""
     - name: lldp
       type: group
       fields:
@@ -638,18 +644,6 @@
         - name: rp_ip
           type: ip
           description: ""
-    - name: mstp
-      type: group
-      fields:
-        - name: psc
-          type: keyword
-          description: ""
-    - name: len
-      type: long
-      description: ""
-    - name: limit
-      type: long
-      description: ""
     - name: mstp
       type: group
       fields:

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -654,25 +654,26 @@ Note: Descriptions have not been filled out
 | <limit>    | aruba.limit    |
 
 #### [Multiple spanning tree protocol events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MSTP.htm)
-| Field                       | Description | Type | Common                       |
-|-----------------------------|-------------|------|------------------------------|
-| aruba.mstp.config_parameter |             |      |                              |
-| aruba.mstp.config_value     |             |      |                              |
-| aruba.mstp.instance         |             |      | aruba.instance.id            |
-| aruba.mstp.mac              |             |      | source.mac                   |
-| aruba.mstp.new_mac          |             |      | source.mac                   |
-| aruba.mstp.new_mode         |             |      |                              |
-| aruba.mstp.new_priority     |             |      | aruba.priority               |
-| aruba.mstp.old_mac          |             |      |                              |
-| aruba.mstp.old_mode         |             |      |                              |
-| aruba.mstp.old_priority     |             |      |                              |
-| aruba.mstp.pk_type          |             |      |                              |
-| aruba.mstp.port             |             |      | server.port                  |
-| aruba.mstp.priority_mac     |             |      | source.mac                   |
-| aruba.mstp.proto            |             |      |                              |
-| aruba.mstp.reconfig_parameter |           |      |                              |
-| aruba.mstp.state            |             |      | aruba.status                 |
-
+| Docs Field          | Schema Mapping               |
+|---------------------|------------------------------|
+| <config_parameter>  | aruba.mstp.config_parameter  |
+| <instance>          | aruba.instance.id            |
+| <mac>               | source.mac                   |
+| <new_mac>           | source.mac                   |
+| <new_mode>          | aruba.mstp.new_mode          |
+| <new_port>          | aruba.port                   |
+| <new_priority>      | aruba.priority               |
+| <old_mac>           | aruba.mstp.old_mac           |
+| <old_mode>          | aruba.mstp.old_mode          |
+| <old_port>          | aruba.mstp.old_port          |
+| <old_priority>      | aruba.mstp.old_priority      |
+| <pkt_type>          | aruba.mstp.pkt_type          |
+| <port>              | aruba.port                   |
+| <priority_mac>      | aruba.mstp.priority_mac      |
+| <proto>             | aruba.mstp.proto             |
+| <reconfig_parameter>| aruba.mstp.reconfig_parameter|
+| <state>             | aruba.status                 |
+| <value>             | aruba.mstp.config_value      |
 
 #### [MVRP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MVRP.htm)
 | Field               | Description | Type | Common                       |
@@ -1474,7 +1475,6 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.mstp.old_priority |  | keyword |
 | aruba.mstp.pk_type |  | keyword |
 | aruba.mstp.proto |  | keyword |
-| aruba.mstp.psc |  | keyword |
 | aruba.mstp.reconfig_parameter |  | keyword |
 | aruba.mtu |  | keyword |
 | aruba.nae.action_type |  | keyword |

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -1474,8 +1474,10 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.mstp.new_mode |  | keyword |
 | aruba.mstp.old_mac |  | keyword |
 | aruba.mstp.old_mode |  | keyword |
+| aruba.mstp.old_port |  | keyword |
 | aruba.mstp.old_priority |  | keyword |
-| aruba.mstp.pk_type |  | keyword |
+| aruba.mstp.pkt_type |  | keyword |
+| aruba.mstp.priority_mac |  | keyword |
 | aruba.mstp.proto |  | keyword |
 | aruba.mstp.reconfig_parameter |  | keyword |
 | aruba.mtu |  | keyword |


### PR DESCRIPTION
Change Log:
- added doc, pipeline tests and `default.yml` logic to parse the log lines
- moved fields to alphabetical order (len and limit)

Note: for parsing log events [2006, 2008, 2018], there were variations between recorded logs and the documentation
noted as a comment in the parsing logic
