### PR TITLE
[citrix_adc] Ensure time zone setting is applied properly

### DIFF
--- a/packages/citrix_adc/changelog.yml
+++ b/packages/citrix_adc/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.1"
+  changes:
+    - description: "Ensure time zone setting is applied properly"
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.12.0"
   changes:
     - description: "Support parsing additional sslvpn log messages"

--- a/packages/citrix_adc/changelog.yml
+++ b/packages/citrix_adc/changelog.yml
@@ -2,8 +2,8 @@
 - version: "1.12.1"
   changes:
     - description: "Ensure time zone setting is applied properly"
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11990
 - version: "1.12.0"
   changes:
     - description: "Support parsing additional sslvpn log messages"

--- a/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native-config-time.json
+++ b/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native-config-time.json
@@ -1,0 +1,13 @@
+{
+    "events": [
+        {
+            "event": {
+                "timezone": "-07:00"
+            },
+            "message": "<123> 10/08/2024:09:38:41  SYSLOGHOST 0-PPE-1 : default TCP CONN_TERMINATE 6715345 0 :  Source 127.1.2.1:80 - Destination 127.1.1.2:20714 - Start Time 10/08/2024:09:37:54  - End Time 10/08/2024:09:38:41  - Total_bytes_send 1 - Total_bytes_recv 1 \n"
+        },
+        {
+            "message": "<123> 10/08/2024:09:38:41  SYSLOGHOST 0-PPE-1 : default TCP CONN_TERMINATE 6715345 0 :  Source 127.1.2.1:80 - Destination 127.1.1.2:20714 - Start Time 10/08/2024:09:37:54  - End Time 10/08/2024:09:38:41  - Total_bytes_send 1 - Total_bytes_recv 1 \n"
+        }
+    ]
+}

--- a/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native-config-time.json-config.yml
+++ b/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native-config-time.json-config.yml
@@ -1,0 +1,6 @@
+fields:
+  tags:
+    - preserve_original_event
+    - preserve_duplicate_custom_fields
+  _conf:
+    tz_offset: America/New_York

--- a/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native-config-time.json-expected.json
+++ b/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native-config-time.json-expected.json
@@ -1,0 +1,96 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2024-10-08T09:38:41.000-04:00",
+            "citrix": {
+                "cef_format": false,
+                "default_class": true,
+                "detail": "<123> 10/08/2024:09:38:41  SYSLOGHOST 0-PPE-1 : default TCP CONN_TERMINATE 6715345 0 :  Source 127.1.2.1:80 - Destination 127.1.1.2:20714 - Start Time 10/08/2024:09:37:54  - End Time 10/08/2024:09:38:41  - Total_bytes_send 1 - Total_bytes_recv 1 ",
+                "device_event_class_id": "TCP",
+                "extended": {
+                    "message": "Source 127.1.2.1:80 - Destination 127.1.1.2:20714 - Start Time 10/08/2024:09:37:54  - End Time 10/08/2024:09:38:41  - Total_bytes_send 1 - Total_bytes_recv 1 "
+                },
+                "host": "SYSLOGHOST",
+                "name": "CONN_TERMINATE"
+            },
+            "citrix_adc": {
+                "log": {
+                    "message": "Source 127.1.2.1:80 - Destination 127.1.1.2:20714 - Start Time 10/08/2024:09:37:54  - End Time 10/08/2024:09:38:41  - Total_bytes_send 1 - Total_bytes_recv 1 "
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "id": "6715345",
+                "kind": "event",
+                "original": "<123> 10/08/2024:09:38:41  SYSLOGHOST 0-PPE-1 : default TCP CONN_TERMINATE 6715345 0 :  Source 127.1.2.1:80 - Destination 127.1.1.2:20714 - Start Time 10/08/2024:09:37:54  - End Time 10/08/2024:09:38:41  - Total_bytes_send 1 - Total_bytes_recv 1 \n",
+                "severity": 0,
+                "timezone": "America/New_York",
+                "type": [
+                    "end",
+                    "connection"
+                ]
+            },
+            "observer": {
+                "hostname": "SYSLOGHOST",
+                "product": "Netscaler",
+                "type": "firewall",
+                "vendor": "Citrix"
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ]
+        },
+        {
+            "@timestamp": "2024-10-08T09:38:41.000-04:00",
+            "citrix": {
+                "cef_format": false,
+                "default_class": true,
+                "detail": "<123> 10/08/2024:09:38:41  SYSLOGHOST 0-PPE-1 : default TCP CONN_TERMINATE 6715345 0 :  Source 127.1.2.1:80 - Destination 127.1.1.2:20714 - Start Time 10/08/2024:09:37:54  - End Time 10/08/2024:09:38:41  - Total_bytes_send 1 - Total_bytes_recv 1 ",
+                "device_event_class_id": "TCP",
+                "extended": {
+                    "message": "Source 127.1.2.1:80 - Destination 127.1.1.2:20714 - Start Time 10/08/2024:09:37:54  - End Time 10/08/2024:09:38:41  - Total_bytes_send 1 - Total_bytes_recv 1 "
+                },
+                "host": "SYSLOGHOST",
+                "name": "CONN_TERMINATE"
+            },
+            "citrix_adc": {
+                "log": {
+                    "message": "Source 127.1.2.1:80 - Destination 127.1.1.2:20714 - Start Time 10/08/2024:09:37:54  - End Time 10/08/2024:09:38:41  - Total_bytes_send 1 - Total_bytes_recv 1 "
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "id": "6715345",
+                "kind": "event",
+                "original": "<123> 10/08/2024:09:38:41  SYSLOGHOST 0-PPE-1 : default TCP CONN_TERMINATE 6715345 0 :  Source 127.1.2.1:80 - Destination 127.1.1.2:20714 - Start Time 10/08/2024:09:37:54  - End Time 10/08/2024:09:38:41  - Total_bytes_send 1 - Total_bytes_recv 1 \n",
+                "severity": 0,
+                "timezone": "America/New_York",
+                "type": [
+                    "end",
+                    "connection"
+                ]
+            },
+            "observer": {
+                "hostname": "SYSLOGHOST",
+                "product": "Netscaler",
+                "type": "firewall",
+                "vendor": "Citrix"
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ]
+        }
+    ]
+}

--- a/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native-local-time.json
+++ b/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native-local-time.json
@@ -1,0 +1,10 @@
+{
+    "events": [
+        {
+            "event": {
+                "timezone": "-07:00"
+            },
+            "message": "<123> 10/08/2024:09:38:41  SYSLOGHOST 0-PPE-1 : default TCP CONN_TERMINATE 6715345 0 :  Source 127.1.2.1:80 - Destination 127.1.1.2:20714 - Start Time 10/08/2024:09:37:54  - End Time 10/08/2024:09:38:41  - Total_bytes_send 1 - Total_bytes_recv 1 \n"
+        }
+    ]
+}

--- a/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native-local-time.json-config.yml
+++ b/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native-local-time.json-config.yml
@@ -1,0 +1,6 @@
+fields:
+  tags:
+    - preserve_original_event
+    - preserve_duplicate_custom_fields
+  _conf:
+    tz_offset: local

--- a/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native-local-time.json-config.yml
+++ b/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native-local-time.json-config.yml
@@ -3,4 +3,4 @@ fields:
     - preserve_original_event
     - preserve_duplicate_custom_fields
   _conf:
-    tz_offset: local
+    tz_offset: null

--- a/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native-local-time.json-expected.json
+++ b/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native-local-time.json-expected.json
@@ -1,0 +1,50 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2024-10-08T09:38:41.000-07:00",
+            "citrix": {
+                "cef_format": false,
+                "default_class": true,
+                "detail": "<123> 10/08/2024:09:38:41  SYSLOGHOST 0-PPE-1 : default TCP CONN_TERMINATE 6715345 0 :  Source 127.1.2.1:80 - Destination 127.1.1.2:20714 - Start Time 10/08/2024:09:37:54  - End Time 10/08/2024:09:38:41  - Total_bytes_send 1 - Total_bytes_recv 1 ",
+                "device_event_class_id": "TCP",
+                "extended": {
+                    "message": "Source 127.1.2.1:80 - Destination 127.1.1.2:20714 - Start Time 10/08/2024:09:37:54  - End Time 10/08/2024:09:38:41  - Total_bytes_send 1 - Total_bytes_recv 1 "
+                },
+                "host": "SYSLOGHOST",
+                "name": "CONN_TERMINATE"
+            },
+            "citrix_adc": {
+                "log": {
+                    "message": "Source 127.1.2.1:80 - Destination 127.1.1.2:20714 - Start Time 10/08/2024:09:37:54  - End Time 10/08/2024:09:38:41  - Total_bytes_send 1 - Total_bytes_recv 1 "
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "id": "6715345",
+                "kind": "event",
+                "original": "<123> 10/08/2024:09:38:41  SYSLOGHOST 0-PPE-1 : default TCP CONN_TERMINATE 6715345 0 :  Source 127.1.2.1:80 - Destination 127.1.1.2:20714 - Start Time 10/08/2024:09:37:54  - End Time 10/08/2024:09:38:41  - Total_bytes_send 1 - Total_bytes_recv 1 \n",
+                "severity": 0,
+                "timezone": "-07:00",
+                "type": [
+                    "end",
+                    "connection"
+                ]
+            },
+            "observer": {
+                "hostname": "SYSLOGHOST",
+                "product": "Netscaler",
+                "type": "firewall",
+                "vendor": "Citrix"
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ]
+        }
+    ]
+}

--- a/packages/citrix_adc/data_stream/log/agent/stream/stream.yml.hbs
+++ b/packages/citrix_adc/data_stream/log/agent/stream/stream.yml.hbs
@@ -17,7 +17,9 @@ tags:
 publisher_pipeline.disable_host: true
 {{/contains}}
 processors:
+{{#unless tz_offset}}
 - add_locale: ~
+{{/unless}}
 {{#if processors}}
 {{processors}}
 {{/if}}

--- a/packages/citrix_adc/data_stream/log/agent/stream/tcp.yml.hbs
+++ b/packages/citrix_adc/data_stream/log/agent/stream/tcp.yml.hbs
@@ -16,7 +16,9 @@ publisher_pipeline.disable_host: true
 ssl: {{ssl}}
 {{/if}}
 processors:
+{{#unless tz_offset}}
 - add_locale: ~
+{{/unless}}
 {{#if processors}}
 {{processors}}
 {{/if}}

--- a/packages/citrix_adc/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/citrix_adc/data_stream/log/agent/stream/udp.yml.hbs
@@ -13,7 +13,9 @@ tags:
 publisher_pipeline.disable_host: true
 {{/contains}}
 processors:
+{{#unless tz_offset}}
 - add_locale: ~
+{{/unless}}
 {{#if processors}}
 {{processors}}
 {{/if}}

--- a/packages/citrix_adc/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/citrix_adc/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -59,7 +59,7 @@ processors:
       field: _tmp.tz
       copy_from: _conf.tz_offset
       override: false
-      if: ctx._conf?.tz_offset != null && ctx._conf.tz_offset != 'local'
+      ignore_empty_value: true
   - set:
       field: _tmp.tz
       copy_from: event.timezone

--- a/packages/citrix_adc/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/citrix_adc/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -34,7 +34,7 @@ processors:
         LEVEL: '<?%{IDENT:citrix.facility:keyword}\.%{IDENT:citrix.priority:keyword}>?'
         IDENT: '[a-zA-Z][a-zA-Z0-9]*'
         SYSLOG_TIMESTAMP: '(?:%{SYSLOGTIMESTAMP:_tmp.syslog_timestamp}|%{TIMESTAMP_ISO8601:_tmp.syslog_timestamp8601})'
-        TIMESTAMP_ISO8601: '%{YEAR}-%{MONTHNUM}-%{MONTHDAY}[T ]%{HOUR}:?%{MINUTE}(?::?%{SECOND})?%{ISO8601_TIMEZONE:event.timezone}?'
+        TIMESTAMP_ISO8601: '%{YEAR}-%{MONTHNUM}-%{MONTHDAY}[T ]%{HOUR}:?%{MINUTE}(?::?%{SECOND})?%{ISO8601_TIMEZONE:_tmp.tz}?'
   - pipeline:
       name: '{{ IngestPipeline "cef" }}'
       tag: pipeline_cef
@@ -49,18 +49,29 @@ processors:
       type: long
       ignore_missing: true
 
-# Time zone
+# Time zone (in order: log, config, locale, default to UTC).
 
   - set:
-      field: _conf.tz_offset
-      tag: set_tz_offset_utc
+      field: _tmp.tz
+      value: UTC
+      if: ctx._tmp?.tz == 'Z'
+  - set:
+      field: _tmp.tz
+      copy_from: _conf.tz_offset
+      override: false
+      if: ctx._conf?.tz_offset != null && ctx._conf.tz_offset != 'local'
+  - set:
+      field: _tmp.tz
+      copy_from: event.timezone
+      override: false
+      if: ctx.event?.timezone != null
+  - set:
+      field: _tmp.tz
       value: UTC
       override: false
   - set:
       field: event.timezone
-      tag: set_event_timezone_from_tz_offset
-      copy_from: _conf.tz_offset
-      if: ctx.event?.timezone == null || ctx.event?.timezone == ""
+      copy_from: _tmp.tz
 
 # Syslog timestamp
 
@@ -163,6 +174,7 @@ processors:
       tag: date_timestamp_native
       field: _tmp.timestamp_native
       target_field: citrix_adc.log.timestamp_native
+      timezone: '{{{event.timezone}}}'
       if: ctx._tmp?.timestamp_native != null && ctx.citrix_adc?.log?.timestamp_native == null
       formats:
         - ISO8601
@@ -178,6 +190,7 @@ processors:
       tag: date_timestamp
       field: _tmp.timestamp
       target_field: citrix_adc.log.timestamp
+      timezone: '{{{event.timezone}}}'
       if: ctx._tmp?.timestamp != null && ctx.citrix_adc?.log?.timestamp == null
       formats:
         - ISO8601
@@ -193,6 +206,7 @@ processors:
       tag: date_start_time
       field: _tmp.start_time
       target_field: citrix_adc.log.start_time
+      timezone: '{{{event.timezone}}}'
       if: ctx._tmp?.start_time != null && ctx.citrix_adc?.log?.start_time == null
       formats:
         - ISO8601
@@ -207,6 +221,7 @@ processors:
   - date:
       tag: date_end_time
       field: _tmp.end_time
+      timezone: '{{{event.timezone}}}'
       target_field: citrix_adc.log.end_time
       if: ctx._tmp?.end_time != null && ctx.citrix_adc?.log?.end_time == null
       formats:
@@ -223,6 +238,7 @@ processors:
       tag: date_delink_time
       field: _tmp.delink_time
       target_field: citrix_adc.log.delink_time
+      timezone: '{{{event.timezone}}}'
       if: ctx._tmp?.delink_time != null && ctx.citrix_adc?.log?.delink_time == null
       formats:
         - ISO8601

--- a/packages/citrix_adc/data_stream/log/manifest.yml
+++ b/packages/citrix_adc/data_stream/log/manifest.yml
@@ -75,7 +75,7 @@ streams:
         required: false
         show_user: false
         default: UTC
-        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
+        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone. Use `local` to use the time zone from Elastic Agent.
       - name: custom_date_format
         type: text
         title: Custom Date Format
@@ -190,7 +190,7 @@ streams:
         required: false
         show_user: false
         default: UTC
-        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
+        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone. Use `local` to use the time zone from Elastic Agent.
       - name: custom_date_format
         type: text
         title: Custom Date Format
@@ -257,7 +257,7 @@ streams:
         required: false
         show_user: false
         default: UTC
-        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
+        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone. Use `local` to use the time zone from Elastic Agent.
       - name: custom_date_format
         type: text
         title: Custom Date Format

--- a/packages/citrix_adc/data_stream/log/manifest.yml
+++ b/packages/citrix_adc/data_stream/log/manifest.yml
@@ -75,7 +75,7 @@ streams:
         required: false
         show_user: false
         default: UTC
-        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone. Use `local` to use the time zone from Elastic Agent.
+        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
       - name: custom_date_format
         type: text
         title: Custom Date Format
@@ -190,7 +190,7 @@ streams:
         required: false
         show_user: false
         default: UTC
-        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone. Use `local` to use the time zone from Elastic Agent.
+        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
       - name: custom_date_format
         type: text
         title: Custom Date Format
@@ -257,7 +257,7 @@ streams:
         required: false
         show_user: false
         default: UTC
-        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone. Use `local` to use the time zone from Elastic Agent.
+        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
       - name: custom_date_format
         type: text
         title: Custom Date Format

--- a/packages/citrix_adc/manifest.yml
+++ b/packages/citrix_adc/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: citrix_adc
 title: Citrix ADC
-version: "1.12.0"
+version: "1.12.1"
 description: This Elastic integration collects logs and metrics from Citrix ADC product.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- Reworked how time zones are applied to ensure time zones values are applied in the proper order.
- The order is: from log, from config, from add_locale, and fallback to UTC.
- If tz_offset is null/empty string, the `add_locale` processor is not run.
- Add test cases

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- ~~[ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

## How to test this PR locally

```
cd packages/citrix_adc
elastic-package test
```
