### PR TITLE
#11921-9/10 OSPFv2 events (2401) and OSPFv3 events (490x)

### DIFF
--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -747,41 +747,45 @@ Note: Descriptions have not been filled out
 | aruba.ntp.untrusted_keys |           |      |                              |
 
 #### [OSPFv2 events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/OSPFv2.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.ospf.action         |             |      | event.action                 |
-| aruba.ospf.area           |             |      |                              |
-| aruba.ospf.destination    |             |      | destination.address          |
-| aruba.ospf.err            |             |      | error.message                |
-| aruba.ospf.event          |             |      | event.code                   |
-| aruba.ospf.fp_id          |             |      |                              |
-| aruba.ospf.group_id       |             |      | group.id                     |
-| aruba.ospf.input          |             |      |                              |
-| aruba.ospf.nexthops       |             |      |                              |
-| aruba.ospf.old_router_id  |             |      |                              |
-| aruba.ospf.old_state      |             |      | aruba.status                 |
-| aruba.ospf.ospf_interface |             |      | observer.ingress.interface.name |
-| aruba.ospf.router_id      |             |      |                              |
-| aruba.ospf.rule           |             |      | rule.name                    |
-| aruba.ospf.state          |             |      | aruba.status                 |
-| aruba.ospf.stats_id       |             |      |                              |
+| Docs Field       | Schema Mapping                      |
+|------------------|-------------------------------------|
+| <action>         | event.action                        |
+| <area>           | aruba.ospf.area                     |
+| <destination>    | destination.address                 |
+| <err>            | event.reason                        |
+| <event>          | aruba.ospf.event                    |
+| <fp_id>          | aruba.ospf.fp_id                    |
+| <group_id>       | group.id                            |
+| <input>          | aruba.ospf.input                    |
+| <interface>      | aruba.interface.id                  |
+| <new>            | aruba.ospf.router_id                |
+| <new_state>      | aruba.status                        |
+| <next_state>     | aruba.status                        |
+| <nexthops>       | aruba.ospf.nexthops                 |
+| <old>            | aruba.ospf.old_router_id            |
+| <old_state>      | aruba.ospf.old_state                |
+| <ospf-interface> | aruba.interface.id                  |
+| <router-id>      | aruba.ospf.router_id                |
+| <rule>           | rule.name                           |
+| <state>          | aruba.status / aruba.ospf.old_state |
+| <stats_id>       | aruba.ospf.stats_id                 |
 
 #### [OSPFv3 events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/OSPFv3.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.ospf.action         |             |      | event.action                 |
-| aruba.ospf.area           |             |      |                              |
-| aruba.ospf.err            |             |      | error.message                |
-| aruba.ospf.fp_id          |             |      |                              |
-| aruba.ospf.group_id       |             |      | group.id                     |
-| aruba.ospf.input          |             |      |                              |
-| aruba.ospf.interface      |             |      | observer.ingress.interface.name |
-| aruba.ospf.link_local     |             |      |                              |
-| aruba.ospf.old_state      |             |      |                              |
-| aruba.ospf.router_id      |             |      |                              |
-| aruba.ospf.rule           |             |      | rule.name                    |
-| aruba.ospf.state          |             |      | aruba.status                 |
-| aruba.ospf.stats_id       |             |      |                              |
+| Docs Field       | Schema Mapping                      |
+|------------------|-------------------------------------|
+| <action>         | event.action                        |
+| <area>           | aruba.ospf.area                     |
+| <err>            | event.reason                        |
+| <fp_id>          | aruba.ospf.fp_id                    |
+| <group_id>       | group.id                            |
+| <input>          | aruba.ospf.input                    |
+| <interface>      | aruba.interface.id                  |
+| <link-local>     | aruba.ospf.link_local               |
+| <new_state>      | aruba.status                        |
+| <old_state>      | aruba.ospf.old_state                |
+| <router-id>      | aruba.ospf.router_id                |
+| <rule>           | rule.name                           |
+| <stats_id>       | aruba.ospf.stats_id                 |
 
 #### [Password Reset events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PASSWD_RESET.htm)
 | Field                     | Description | Type | Common                       |

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
@@ -142,6 +142,14 @@
 2024-06-19T14:22:07.025544-05:00 8360-Primaire acctd[358]: Event|2303|LOG_INFO|AMM|1/1|RADIUS radius type radius_action: radius_event
 2024-06-19T14:22:07.025546-05:00 8360-Primaire acctd[358]: Event|2304|LOG_INFO|AMM|1/1|RADIUS Server with Address: 127.0.0.1, Authport:1/1/6, VRF_ID:vpn-Internet is "aruba_status"
 2024-06-19T14:22:07.025547-05:00 8360-Primaire acctd[358]: Event|2305|LOG_INFO|AMM|1/1|TACACS server host 127.0.0.1 port 1/1/6 vrf vpn-Internet aruba_status
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-ospf[1234]: Event|2401|LOG_INFO|OSPFv2|-|AdjChg: Nbr 192.168.1.1 on eth0(0.0.0.0): INIT -> FULL
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-ospf[1234]: Event|2402|LOG_INFO|OSPFv2|-|Interface eth0(0.0.0.0) changed from DOWN to UP, input: 1
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-ospf[1234]: Event|2403|LOG_INFO|OSPFv2|-|ROUTE_ADD with 192.168.1.0/24 2
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-ospf[1234]: Event|2404|LOG_INFO|OSPFv2|-|AdjChg: Nbr 192.168.1.1 on eth0: FULL -> DOWN (KILL)
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-ospf[1234]: Event|2405|LOG_INFO|OSPFv2|-|Router-id updated from 1.1.1.1 to 2.2.2.2
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-ospf[1234]: Event|2406|LOG_ERR|OSPFv2|-|Failed to install rule error: No space left on device
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-ospf[1234]: Event|2407|LOG_INFO|OSPFv2|-|OSPF all routers field entry added: group_id=1 fp_id=2 stat_id=3
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-ospf[1234]: Event|2408|LOG_INFO|OSPFv2|-|OSPF designated routers field entry added: group_id=1 fp_id=2 stat_id=3
 2024-06-18T12:45:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2601|LOG_ERR|MGMD|-|Failed to alloc a multicast pkt(interface vlan10)
 2024-06-18T12:46:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2602|LOG_INFO|MGMD|-|Received IGMPv1 query from 192.168.1.1 when the device is configured for IGMPv2.
 2024-06-18T12:47:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2603|LOG_ERR|MGMD|-|Unable to alloc a buf of size 1024 for subsystem1
@@ -292,6 +300,11 @@
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4803|LOG_INFO|MACLEARN|-|All dynamic MAC addresses on port eth0 were flushed
 2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4804|LOG_INFO|MACLEARN|-|All dynamic MAC addresses on port eth1 were flushed
 2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4805|LOG_INFO|MACLEARN|-|All dynamic MAC addresses on VLAN 20 were flushed
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-ospfv3[1234]: Event|4901|LOG_ERR|OSPFv3|-|Failed to install rule error: No space left on device
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-ospfv3[1234]: Event|4902|LOG_INFO|OSPFv3|-|OSPF3 all routers field entry added: group_id=1 fp_id=2 stat_id=3
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-ospfv3[1234]: Event|4903|LOG_INFO|OSPFv3|-|OSPF3 designated routers field entry added: group_id=1 fp_id=2 stat_id=3
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-ospfv3[1234]: Event|4904|LOG_INFO|OSPFv3|-|AdjChg: Nbr 192.168.1.1 on interface fe80::1 on eth0(0.0.0.0): INIT -> FULL
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-ospfv3[1234]: Event|4905|LOG_INFO|OSPFv3|-|Interface fe80::1 on eth0(0.0.0.0) changed from DOWN to UP, input: 1
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5601|LOG_INFO|HTTPSSERVER|-|User admin has enabled read-only for REST mode
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5602|LOG_INFO|HTTPSSERVER|-|User admin has enabled HTTPS Server on VRF default
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5603|LOG_INFO|HTTPSSERVER|-|User admin closed all HTTPS sessions

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -5480,6 +5480,327 @@
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",
             "aruba": {
                 "component": {
+                    "category": "OSPFv2"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "ospf": {
+                    "area": "0.0.0.0",
+                    "old_state": "INIT",
+                    "router_id": "192.168.1.1"
+                },
+                "status": "FULL"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2401",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-ospf[1234]: Event|2401|LOG_INFO|OSPFv2|-|AdjChg: Nbr 192.168.1.1 on eth0(0.0.0.0): INIT -> FULL"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ospf",
+                    "procid": "1234"
+                }
+            },
+            "message": "AdjChg: Nbr 192.168.1.1 on eth0(0.0.0.0): INIT -> FULL",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "OSPFv2"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "ospf": {
+                    "area": "0.0.0.0",
+                    "input": "1",
+                    "old_state": "DOWN"
+                },
+                "status": "UP"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2402",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-ospf[1234]: Event|2402|LOG_INFO|OSPFv2|-|Interface eth0(0.0.0.0) changed from DOWN to UP, input: 1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ospf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface eth0(0.0.0.0) changed from DOWN to UP, input: 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "OSPFv2"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "ospf": {
+                    "event": "ROUTE_ADD",
+                    "nexthops": "2"
+                }
+            },
+            "destination": {
+                "address": "192.168.1.0/24"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2403",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-ospf[1234]: Event|2403|LOG_INFO|OSPFv2|-|ROUTE_ADD with 192.168.1.0/24 2"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ospf",
+                    "procid": "1234"
+                }
+            },
+            "message": "ROUTE_ADD with 192.168.1.0/24 2",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "OSPFv2"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "ospf": {
+                    "event": "KILL",
+                    "old_state": "FULL",
+                    "router_id": "192.168.1.1"
+                },
+                "status": "DOWN"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2404",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-ospf[1234]: Event|2404|LOG_INFO|OSPFv2|-|AdjChg: Nbr 192.168.1.1 on eth0: FULL -> DOWN (KILL)"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ospf",
+                    "procid": "1234"
+                }
+            },
+            "message": "AdjChg: Nbr 192.168.1.1 on eth0: FULL -> DOWN (KILL)",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "OSPFv2"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "ospf": {
+                    "old_router_id": "1.1.1.1",
+                    "router_id": "2.2.2.2"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2405",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-ospf[1234]: Event|2405|LOG_INFO|OSPFv2|-|Router-id updated from 1.1.1.1 to 2.2.2.2"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ospf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Router-id updated from 1.1.1.1 to 2.2.2.2",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "OSPFv2"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "install",
+                "category": [
+                    "network"
+                ],
+                "code": "2406",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-ospf[1234]: Event|2406|LOG_ERR|OSPFv2|-|Failed to install rule error: No space left on device",
+                "reason": "No space left on device"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-ospf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to install rule error: No space left on device",
+            "rule": {
+                "name": "rule"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "OSPFv2"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "ospf": {
+                    "fp_id": "2",
+                    "stats_id": "3"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2407",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-ospf[1234]: Event|2407|LOG_INFO|OSPFv2|-|OSPF all routers field entry added: group_id=1 fp_id=2 stat_id=3"
+            },
+            "group": {
+                "id": "1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ospf",
+                    "procid": "1234"
+                }
+            },
+            "message": "OSPF all routers field entry added: group_id=1 fp_id=2 stat_id=3",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "OSPFv2"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "ospf": {
+                    "fp_id": "2",
+                    "stats_id": "3"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2408",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-ospf[1234]: Event|2408|LOG_INFO|OSPFv2|-|OSPF designated routers field entry added: group_id=1 fp_id=2 stat_id=3"
+            },
+            "group": {
+                "id": "1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ospf",
+                    "procid": "1234"
+                }
+            },
+            "message": "OSPF designated routers field entry added: group_id=1 fp_id=2 stat_id=3",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
                     "category": "MGMD"
                 },
                 "event_type": "Event",
@@ -11190,6 +11511,210 @@
                     "id": "20"
                 }
             },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "OSPFv3"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "install",
+                "category": [
+                    "network"
+                ],
+                "code": "4901",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-ospfv3[1234]: Event|4901|LOG_ERR|OSPFv3|-|Failed to install rule error: No space left on device",
+                "reason": "No space left on device"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-ospfv3",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to install rule error: No space left on device",
+            "rule": {
+                "name": "rule"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "OSPFv3"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "ospf": {
+                    "fp_id": "2",
+                    "stats_id": "3"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4902",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-ospfv3[1234]: Event|4902|LOG_INFO|OSPFv3|-|OSPF3 all routers field entry added: group_id=1 fp_id=2 stat_id=3"
+            },
+            "group": {
+                "id": "1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ospfv3",
+                    "procid": "1234"
+                }
+            },
+            "message": "OSPF3 all routers field entry added: group_id=1 fp_id=2 stat_id=3",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "OSPFv3"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "ospf": {
+                    "fp_id": "2",
+                    "stats_id": "3"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4903",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-ospfv3[1234]: Event|4903|LOG_INFO|OSPFv3|-|OSPF3 designated routers field entry added: group_id=1 fp_id=2 stat_id=3"
+            },
+            "group": {
+                "id": "1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ospfv3",
+                    "procid": "1234"
+                }
+            },
+            "message": "OSPF3 designated routers field entry added: group_id=1 fp_id=2 stat_id=3",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "OSPFv3"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "ospf": {
+                    "area": "0.0.0.0",
+                    "link_local": "fe80::1",
+                    "old_state": "INIT",
+                    "router_id": " 192.168.1.1"
+                },
+                "status": "FULL"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4904",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-ospfv3[1234]: Event|4904|LOG_INFO|OSPFv3|-|AdjChg: Nbr 192.168.1.1 on interface fe80::1 on eth0(0.0.0.0): INIT -> FULL"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ospfv3",
+                    "procid": "1234"
+                }
+            },
+            "message": "AdjChg: Nbr 192.168.1.1 on interface fe80::1 on eth0(0.0.0.0): INIT -> FULL",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "OSPFv3"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "ospf": {
+                    "area": "0.0.0.0",
+                    "input": "1",
+                    "link_local": "fe80::1",
+                    "old_state": "DOWN"
+                },
+                "status": "UP"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4905",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-ospfv3[1234]: Event|4905|LOG_INFO|OSPFv3|-|Interface fe80::1 on eth0(0.0.0.0) changed from DOWN to UP, input: 1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-ospfv3",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface fe80::1 on eth0(0.0.0.0) changed from DOWN to UP, input: 1",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -635,6 +635,47 @@ processors:
       description: "Logs changes in TACACS server reachability status"
       pattern: "TACACS server host %{server.address} port %{aruba.port} vrf %{aruba.vrf.id} %{aruba.status}"
 
+    # OSPFv2 events (2401)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/OSPFv2.htm
+  - grok:
+      field: message
+      tag: ospfv2_event_2401_2402_2404
+      description: "Logs the changes in OSPFv2 neighbour state machine | changes in the interface FSM state."
+      if: "['2401','2402','2404'].contains(ctx.event?.code)"
+      patterns:
+        - "%{ADJCHG}%{AREA}: %{STATE_CHANGE}"
+        - "%{ADJCHG}: %{STATE_CHANGE} \\(%{DATA:aruba.ospf.event}\\)"
+        - "^Interface %{DATA:aruba.interface.id}%{AREA} changed from %{STATE_CHANGE}, input: %{GREEDYDATA:aruba.ospf.input}"
+      pattern_definitions:
+        ADJCHG: "^AdjChg: Nbr %{DATA:aruba.ospf.router_id} on %{DATA:aruba.interface.id}"
+        AREA: "\\(%{DATA:aruba.ospf.area}\\)"
+        STATE_CHANGE: "%{DATA:aruba.ospf.old_state} (->|to) %{GREEDYDATA:aruba.status}"
+  - dissect:
+      field: message
+      tag: ospfv2_event_2403
+      description: "Logs OSPFv2 route add and delete."
+      if: "['2403'].contains(ctx.event?.code)"
+      pattern: "%{aruba.ospf.event} with %{destination.address} %{aruba.ospf.nexthops}"
+  - dissect:
+      field: message
+      tag: ospfv2_event_2405
+      description: "Logs the changes in the router-id."
+      if: "['2405'].contains(ctx.event?.code)"
+      pattern: "Router-id updated from %{aruba.ospf.old_router_id} to %{aruba.ospf.router_id}"
+  - dissect:
+      field: message
+      tag: ospfv2_event_2406
+      description: "Logs failed action with rule error"
+      if: "['2406'].contains(ctx.event?.code)"
+      pattern: "Failed to %{event.action} %{rule.name} error: %{event.reason}"
+  - grok:
+      field: message
+      tag: ospfv2_event_2407_2408
+      description: "Logs for OSPFv2 [FP|DR FP] creation/installation."
+      if: "['2407','2408'].contains(ctx.event?.code)"
+      patterns:
+        - "^OSPF (all|designated) routers field entry added: group_id=%{DATA:group.id} fp_id=%{DATA:aruba.ospf.fp_id} stat_id=%{GREEDYDATA:aruba.ospf.stats_id}"
+
     # MGMD events (26xx)
     # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LOOP-PROTECT.htm
   - grok:
@@ -994,6 +1035,27 @@ processors:
         - "^MAC %{MAC:server.mac} moved from port %{DATA:aruba.interface.prev_id} to port %{DATA:aruba.interface.id} on VLAN %{GREEDYDATA:network.vlan.id}"
         - "^All dynamic MAC addresses on VLAN %{DATA:network.vlan.id} were flushed"
         - "^All dynamic MAC addresses on port %{DATA:aruba.interface.id} were flushed"
+
+    # OSPFv3 events (490x)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/OSPFv3.htm
+  - dissect:
+      field: message
+      tag: ospfv3_event_4901
+      description: "Logs errors for OSPFv3 FP creation/installation."
+      if: "['4901'].contains(ctx.event?.code)"
+      pattern: "Failed to %{event.action} %{rule.name} error: %{event.reason}"
+  - grok:
+      field: message
+      tag: ospfv3_event_4902
+      description: "[DR FP|FP] creation/installation | changes to neighbour state machine | changes in the interface FSM state"
+      if: "['4902','4903','4904','4905'].contains(ctx.event?.code)"
+      patterns:
+        - "^OSPF3 (all|designated) routers field entry added: group_id=%{DATA:group.id} fp_id=%{DATA:aruba.ospf.fp_id} stat_id=%{GREEDYDATA:aruba.ospf.stats_id}"
+        - "^AdjChg: Nbr%{DATA:aruba.ospf.router_id} on %{INTERFACE_AREA}: %{STATE_CHANGE}"
+        - "^%{INTERFACE_AREA} changed from %{STATE_CHANGE}, input: %{GREEDYDATA:aruba.ospf.input}"
+      pattern_definitions:
+        INTERFACE_AREA: "(I|i)nterface %{DATA:aruba.ospf.link_local} on %{DATA:aruba.interface.id}\\(%{DATA:aruba.ospf.area}\\)"
+        STATE_CHANGE: "%{DATA:aruba.ospf.old_state} (->|to) %{GREEDYDATA:aruba.status}"
 
   # HTTPS Server events (560x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/HTTPS_SERVER.htm

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -722,6 +722,39 @@
         - name: role2
           type: keyword
           description: ""
+    - name: ospf
+      type: group
+      fields:
+        - name: area
+          type: keyword
+          description: ""
+        - name: event
+          type: keyword
+          description: ""
+        - name: fp_id
+          type: keyword
+          description: ""
+        - name: input
+          type: keyword
+          description: ""
+        - name: link_local
+          type: ip
+          description: ""
+        - name: router_id
+          type: keyword
+          description: ""
+        - name: nexthops
+          type: keyword
+          description: ""
+        - name: old_router_id
+          type: keyword
+          description: ""
+        - name: old_state
+          type: keyword
+          description: ""
+        - name: stats_id
+          type: keyword
+          description: ""
     - name: port
       type: keyword
       description: ""

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -747,41 +747,45 @@ Note: Descriptions have not been filled out
 | aruba.ntp.untrusted_keys |           |      |                              |
 
 #### [OSPFv2 events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/OSPFv2.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.ospf.action         |             |      | event.action                 |
-| aruba.ospf.area           |             |      |                              |
-| aruba.ospf.destination    |             |      | destination.address          |
-| aruba.ospf.err            |             |      | error.message                |
-| aruba.ospf.event          |             |      | event.code                   |
-| aruba.ospf.fp_id          |             |      |                              |
-| aruba.ospf.group_id       |             |      | group.id                     |
-| aruba.ospf.input          |             |      |                              |
-| aruba.ospf.nexthops       |             |      |                              |
-| aruba.ospf.old_router_id  |             |      |                              |
-| aruba.ospf.old_state      |             |      | aruba.status                 |
-| aruba.ospf.ospf_interface |             |      | observer.ingress.interface.name |
-| aruba.ospf.router_id      |             |      |                              |
-| aruba.ospf.rule           |             |      | rule.name                    |
-| aruba.ospf.state          |             |      | aruba.status                 |
-| aruba.ospf.stats_id       |             |      |                              |
+| Docs Field       | Schema Mapping                      |
+|------------------|-------------------------------------|
+| <action>         | event.action                        |
+| <area>           | aruba.ospf.area                     |
+| <destination>    | destination.address                 |
+| <err>            | event.reason                        |
+| <event>          | aruba.ospf.event                    |
+| <fp_id>          | aruba.ospf.fp_id                    |
+| <group_id>       | group.id                            |
+| <input>          | aruba.ospf.input                    |
+| <interface>      | aruba.interface.id                  |
+| <new>            | aruba.ospf.router_id                |
+| <new_state>      | aruba.status                        |
+| <next_state>     | aruba.status                        |
+| <nexthops>       | aruba.ospf.nexthops                 |
+| <old>            | aruba.ospf.old_router_id            |
+| <old_state>      | aruba.ospf.old_state                |
+| <ospf-interface> | aruba.interface.id                  |
+| <router-id>      | aruba.ospf.router_id                |
+| <rule>           | rule.name                           |
+| <state>          | aruba.status / aruba.ospf.old_state |
+| <stats_id>       | aruba.ospf.stats_id                 |
 
 #### [OSPFv3 events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/OSPFv3.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.ospf.action         |             |      | event.action                 |
-| aruba.ospf.area           |             |      |                              |
-| aruba.ospf.err            |             |      | error.message                |
-| aruba.ospf.fp_id          |             |      |                              |
-| aruba.ospf.group_id       |             |      | group.id                     |
-| aruba.ospf.input          |             |      |                              |
-| aruba.ospf.interface      |             |      | observer.ingress.interface.name |
-| aruba.ospf.link_local     |             |      |                              |
-| aruba.ospf.old_state      |             |      |                              |
-| aruba.ospf.router_id      |             |      |                              |
-| aruba.ospf.rule           |             |      | rule.name                    |
-| aruba.ospf.state          |             |      | aruba.status                 |
-| aruba.ospf.stats_id       |             |      |                              |
+| Docs Field       | Schema Mapping                      |
+|------------------|-------------------------------------|
+| <action>         | event.action                        |
+| <area>           | aruba.ospf.area                     |
+| <err>            | event.reason                        |
+| <fp_id>          | aruba.ospf.fp_id                    |
+| <group_id>       | group.id                            |
+| <input>          | aruba.ospf.input                    |
+| <interface>      | aruba.interface.id                  |
+| <link-local>     | aruba.ospf.link_local               |
+| <new_state>      | aruba.status                        |
+| <old_state>      | aruba.ospf.old_state                |
+| <router-id>      | aruba.ospf.router_id                |
+| <rule>           | rule.name                           |
+| <stats_id>       | aruba.ospf.stats_id                 |
 
 #### [Password Reset events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PASSWD_RESET.htm)
 | Field                     | Description | Type | Common                       |
@@ -1491,6 +1495,16 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.ndm.old_mac |  | keyword |
 | aruba.ndm.role1 |  | keyword |
 | aruba.ndm.role2 |  | keyword |
+| aruba.ospf.area |  | keyword |
+| aruba.ospf.event |  | keyword |
+| aruba.ospf.fp_id |  | keyword |
+| aruba.ospf.input |  | keyword |
+| aruba.ospf.link_local |  | ip |
+| aruba.ospf.nexthops |  | keyword |
+| aruba.ospf.old_router_id |  | keyword |
+| aruba.ospf.old_state |  | keyword |
+| aruba.ospf.router_id |  | keyword |
+| aruba.ospf.stats_id |  | keyword |
 | aruba.port |  | keyword |
 | aruba.prefix |  | keyword |
 | aruba.priority |  | keyword |


### PR DESCRIPTION
Parent Ticket:
https://github.com/elastic/integrations/issues/11921

OSPFv2 events (2401) and OSPFv3 events (490x):
Adde documentation, pipeline fabricated logs and parsing logic

Test Cases:
validated all pipeline expected messages values documented are parsed into ecs fields

