### PR TITLE
[O11y][MySQL] Fix optional chaining in the replica_status data stream pipeline

### DIFF
--- a/packages/mysql/_dev/build/docs/README.md
+++ b/packages/mysql/_dev/build/docs/README.md
@@ -69,6 +69,8 @@ For MySQL, MariaDB and Percona the query to check replica status varies dependin
 
 The `error` dataset collects the MySQL error logs.
 
+{{event "error"}}
+
 **ECS Field Reference**
 
 Please refer to the following [document](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) for detailed information on ECS fields.
@@ -78,6 +80,8 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 ### Slow Log
 
 The `slowlog` dataset collects the MySQL slow logs.
+
+{{event "slowlog"}}
 
 **ECS Field Reference**
 

--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.25.2
+  changes:
+    - description: Fix optional chaining in the replica_status data stream pipeline.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1 #Fix Me
 - version: 1.25.1
   changes:
     - description: Update README to clarify the setup information for `replica_status` data stream.

--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix optional chaining in the replica_status data stream pipeline.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1 #Fix Me
+      link: https://github.com/elastic/integrations/pull/12028
 - version: 1.25.1
   changes:
     - description: Update README to clarify the setup information for `replica_status` data stream.

--- a/packages/mysql/data_stream/error/sample_event.json
+++ b/packages/mysql/data_stream/error/sample_event.json
@@ -1,0 +1,78 @@
+{
+    "@timestamp": "2024-12-09T06:18:16.552Z",
+    "agent": {
+        "ephemeral_id": "c74f8326-f9c7-4c1f-9dd6-5cd5efe550eb",
+        "id": "4c979ea6-18d4-4c0b-92ed-d363d23d90b1",
+        "name": "elastic-agent-73203",
+        "type": "filebeat",
+        "version": "8.17.0"
+    },
+    "data_stream": {
+        "dataset": "mysql.error",
+        "namespace": "79664",
+        "type": "logs"
+    },
+    "ecs": {
+        "version": "8.11.0"
+    },
+    "elastic_agent": {
+        "id": "4c979ea6-18d4-4c0b-92ed-d363d23d90b1",
+        "snapshot": true,
+        "version": "8.17.0"
+    },
+    "event": {
+        "agent_id_status": "verified",
+        "category": [
+            "database"
+        ],
+        "code": "MY-011068",
+        "created": "2024-12-09T06:18:37.565Z",
+        "dataset": "mysql.error",
+        "ingested": "2024-12-09T06:18:40Z",
+        "kind": "event",
+        "provider": "Server",
+        "timezone": "+00:00",
+        "type": [
+            "info"
+        ]
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": true,
+        "hostname": "elastic-agent-73203",
+        "ip": [
+            "192.168.255.2",
+            "192.168.247.4"
+        ],
+        "mac": [
+            "02-42-C0-A8-F7-04",
+            "02-42-C0-A8-FF-02"
+        ],
+        "name": "elastic-agent-73203",
+        "os": {
+            "family": "",
+            "kernel": "3.10.0-1160.92.1.el7.x86_64",
+            "name": "Wolfi",
+            "platform": "wolfi",
+            "type": "linux",
+            "version": "20230201"
+        }
+    },
+    "input": {
+        "type": "log"
+    },
+    "log": {
+        "file": {
+            "path": "/tmp/service_logs/mysql/05cec82c0c63-error.log"
+        },
+        "level": "Warning",
+        "offset": 0
+    },
+    "message": "[MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.",
+    "mysql": {
+        "thread_id": 0
+    },
+    "tags": [
+        "mysql-error"
+    ]
+}

--- a/packages/mysql/data_stream/replica_status/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/mysql/data_stream/replica_status/elasticsearch/ingest_pipeline/default.yml
@@ -110,7 +110,7 @@ processors:
       field: sql.metrics.string.last_io_error_timestamp
       tag: last_io_error_timestamp
       target_field: mysql.replica_status.last_error.io.timestamp
-      if: ctx.sql?.metrics?.string?.last_io_error_timestamp != null && ctx.sql?.metrics?.string?.last_io_error_timestamp != ''
+      if: ctx.sql?.metrics?.string?.last_io_error_timestamp != null && ctx.sql.metrics.string.last_io_error_timestamp != ''
       formats:
         - yyMMdd HH:mm:ss
         - yyMMdd H:m:s
@@ -123,7 +123,7 @@ processors:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
-      if: ctx.sql?.metrics?.string?.last_sql_error_timestamp != null && ctx.sql?.metrics?.string?.last_sql_error_timestamp != ''
+      if: ctx.sql?.metrics?.string?.last_sql_error_timestamp != null && ctx.sql.metrics.string.last_sql_error_timestamp != ''
       field: sql.metrics.string.last_sql_error_timestamp
       tag: last_sql_error_timestamp
       target_field: mysql.replica_status.last_error.sql.timestamp

--- a/packages/mysql/data_stream/replica_status/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/mysql/data_stream/replica_status/elasticsearch/ingest_pipeline/default.yml
@@ -24,32 +24,32 @@ processors:
       field: service.type
       value: "mysql"
   - set:
-      if: "ctx.sql.metrics.numeric.auto_position == 1"
+      if: ctx.sql?.metrics?.numeric?.auto_position == 1
       field: sql.metrics.numeric.auto_position
       value: true
       ignore_empty_value: true
   - set:
-      if: "ctx.sql.metrics.numeric.auto_position == 0"
+      if: ctx.sql?.metrics?.numeric?.auto_position == 0
       field: sql.metrics.numeric.auto_position
       value: false
       ignore_empty_value: true
   - set:
-      if: "ctx.sql.metrics.numeric.get_source_public_key == 1"
+      if: ctx.sql?.metrics?.numeric?.get_source_public_key == 1
       field: sql.metrics.numeric.get_source_public_key
       value: true
       ignore_empty_value: true
   - set:
-      if: "ctx.sql.metrics.numeric.get_source_public_key == 0"
+      if: ctx.sql?.metrics?.numeric?.get_source_public_key == 0
       field: sql.metrics.numeric.get_source_public_key
       value: false
       ignore_empty_value: true
   - set:
-      if: "ctx.sql.metrics.string.source_ssl_verify_server_cert == 'Yes'"
+      if: ctx.sql?.metrics?.string?.source_ssl_verify_server_cert == 'Yes'
       field: sql.metrics.string.source_ssl_verify_server_cert
       value: true
       ignore_empty_value: true
   - set:
-      if: "ctx.sql.metrics.string.source_ssl_verify_server_cert == 'No'"
+      if: ctx.sql?.metrics?.string?.source_ssl_verify_server_cert == 'No'
       field: sql.metrics.string.source_ssl_verify_server_cert
       value: false
       ignore_empty_value: true
@@ -110,7 +110,7 @@ processors:
       field: sql.metrics.string.last_io_error_timestamp
       tag: last_io_error_timestamp
       target_field: mysql.replica_status.last_error.io.timestamp
-      if: "ctx.sql?.metrics?.string?.last_io_error_timestamp != null && ctx.sql.metrics.string.last_io_error_timestamp != ''"
+      if: ctx.sql?.metrics?.string?.last_io_error_timestamp != null && ctx.sql?.metrics?.string?.last_io_error_timestamp != ''
       formats:
         - yyMMdd HH:mm:ss
         - yyMMdd H:m:s
@@ -123,7 +123,7 @@ processors:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
-      if: "ctx.sql?.metrics?.string?.last_sql_error_timestamp != null && ctx.sql.metrics.string.last_sql_error_timestamp != ''"
+      if: ctx.sql?.metrics?.string?.last_sql_error_timestamp != null && ctx.sql?.metrics?.string?.last_sql_error_timestamp != ''
       field: sql.metrics.string.last_sql_error_timestamp
       tag: last_sql_error_timestamp
       target_field: mysql.replica_status.last_error.sql.timestamp
@@ -358,22 +358,22 @@ processors:
       value: '{{sql.metrics.string.master_user}}'
       ignore_empty_value: true
   - set:
-      if: "ctx.sql.metrics.numeric.get_master_public_key == 1"
+      if: ctx.sql?.metrics?.numeric?.get_master_public_key == 1
       field: sql.metrics.numeric.get_master_public_key
       value: true
       ignore_empty_value: true
   - set:
-      if: "ctx.sql.metrics.numeric.get_master_public_key == 0"
+      if: ctx.sql?.metrics?.numeric?.get_master_public_key == 0
       field: sql.metrics.numeric.get_master_public_key
       value: false
       ignore_empty_value: true
   - set:
-      if: "ctx.sql.metrics.string.master_ssl_verify_server_cert == 'Yes'"
+      if: ctx.sql?.metrics?.string?.master_ssl_verify_server_cert == 'Yes'
       field: sql.metrics.string.master_ssl_verify_server_cert
       value: true
       ignore_empty_value: true
   - set:
-      if: "ctx.sql.metrics.string.master_ssl_verify_server_cert == 'No'"
+      if: ctx.sql?.metrics?.string?.master_ssl_verify_server_cert == 'No'
       field: sql.metrics.string.master_ssl_verify_server_cert
       value: false
       ignore_empty_value: true

--- a/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mariadb-10-1-21.log-expected.json
+++ b/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mariadb-10-1-21.log-expected.json
@@ -11,7 +11,7 @@
                     "database"
                 ],
                 "duration": 2000652000,
-                "ingested": "2024-06-18T05:50:00.806009554Z",
+                "ingested": "2024-12-10T06:12:45.755215784Z",
                 "kind": "event",
                 "original": "# User@Host: root[root] @ localhost [67.43.156.14]\n# Thread_id: 5  Schema:   QC_hit: No\n# Query_time: 2.000652  Lock_time: 0.000000  Rows_sent: 1  Rows_examined: 0\nSET timestamp=1528898676;\nselect sleep(2);",
                 "type": [
@@ -38,7 +38,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "root"
             }

--- a/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mariadb-10-2-12.log-expected.json
+++ b/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mariadb-10-2-12.log-expected.json
@@ -12,7 +12,7 @@
                     "database"
                 ],
                 "duration": 2000227000,
-                "ingested": "2024-06-18T05:50:00.904100356Z",
+                "ingested": "2024-12-10T06:12:46.334506629Z",
                 "kind": "event",
                 "original": "# User@Host: root[root] @ localhost []\n# Thread_id: 8  Schema:   QC_hit: No\n# Query_time: 2.000227  Lock_time: 0.000000  Rows_sent: 1  Rows_examined: 0\n# Rows_affected: 0\nSET timestamp=1547741043;\nselect sleep(2)\nAS foo;",
                 "type": [
@@ -39,7 +39,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "root"
             }
@@ -55,7 +54,7 @@
                     "database"
                 ],
                 "duration": 178306016000,
-                "ingested": "2024-06-18T05:50:00.904110503Z",
+                "ingested": "2024-12-10T06:12:46.334513249Z",
                 "kind": "event",
                 "original": "# User@Host: root[root] @  [192.168.0.10]\n# Thread_id: 25844  Schema: blah  QC_hit: No\n# Query_time: 178.306017  Lock_time: 0.000000  Rows_sent: 0  Rows_examined: 53022772\n# Rows_affected: 3062\n# Full_scan: Yes  Full_join: No  Tmp_table: Yes  Tmp_table_on_disk: No\n# Filesort: Yes  Filesort_on_disk: No  Merge_passes: 0  Priority_queue: No\nSET timestamp=1547741058;\ncall PROC('blah');",
                 "type": [
@@ -91,7 +90,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "root"
             }

--- a/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mariadb-10-3-13.log-expected.json
+++ b/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mariadb-10-3-13.log-expected.json
@@ -12,7 +12,7 @@
                     "database"
                 ],
                 "duration": 2461578000,
-                "ingested": "2024-06-18T05:50:01.010856673Z",
+                "ingested": "2024-12-10T06:12:46.911142897Z",
                 "kind": "event",
                 "original": "# User@Host: root[root] @ localhost []\n# Thread_id: 37  Schema: employees-test  QC_hit: No\n# Query_time: 2.461578  Lock_time: 0.000196  Rows_sent: 10  Rows_examined: 3145718\n# Rows_affected: 0  Bytes_sent: 319\n# Tmp_tables: 1  Tmp_disk_tables: 0  Tmp_table_sizes: 4026528\n# Full_scan: Yes  Full_join: No  Tmp_table: Yes  Tmp_table_on_disk: No\n# Filesort: Yes  Filesort_on_disk: No  Merge_passes: 0  Priority_queue: Yes\nuse employees-test;\nSET timestamp=1553443380;\nSELECT last_name, MAX(salary) AS salary FROM employees\n    INNER JOIN salaries ON employees.emp_no = salaries.emp_no\n    GROUP BY last_name\n    ORDER BY salary DESC\n    LIMIT 10;",
                 "type": [
@@ -52,7 +52,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "root"
             }

--- a/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mariadb-explain.log-expected.json
+++ b/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mariadb-explain.log-expected.json
@@ -11,7 +11,7 @@
                     "database"
                 ],
                 "duration": 5524103000,
-                "ingested": "2024-06-18T05:50:01.105803642Z",
+                "ingested": "2024-12-10T06:12:47.425640399Z",
                 "kind": "event",
                 "original": "# User@Host: root[root] @ localhost []\n# Thread_id: 2  Schema: dbt3sf1  QC_hit: No\n# Query_time: 5.524103  Lock_time: 0.000337  Rows_sent: 1  Rows_examined: 65633\n#\n# explain: id   select_type     table   type    possible_keys   key     key_len ref     rows    Extra\n# explain: 1    SIMPLE  nation  ref     PRIMARY,n_name  n_name  26      const   1       Using where; Using index\n# explain: 1    SIMPLE  customer        ref     PRIMARY,i_c_nationkey   i_c_nationkey   5       dbt3sf1.nation.n_nationkey      3145    Using index\n# explain: 1    SIMPLE  orders  ref     i_o_custkey     i_o_custkey     5       dbt3sf1.customer.c_custkey      7       Using index\n#\nSET timestamp=1384261412;\nselect count(*) from customer, orders, nation\n  where c_custkey=o_custkey\n    and c_nationkey=n_nationkey\n    and n_name='GERMANY';",
                 "type": [
@@ -38,7 +38,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "root"
             }

--- a/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-5-7-22.log-expected.json
+++ b/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-5-7-22.log-expected.json
@@ -11,7 +11,7 @@
                     "database"
                 ],
                 "duration": 15000223000,
-                "ingested": "2024-06-18T05:50:01.197469018Z",
+                "ingested": "2024-12-10T06:12:47.926788817Z",
                 "kind": "event",
                 "original": "# User@Host: root[root] @  [67.43.156.14]  Id:  7234\n# Query_time: 15.000223  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 0\nSET timestamp=1533630467;\nselect sleep(15);",
                 "type": [
@@ -36,7 +36,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "root"
             }
@@ -52,7 +51,7 @@
                     "database"
                 ],
                 "duration": 153000,
-                "ingested": "2024-06-18T05:50:01.197475716Z",
+                "ingested": "2024-12-10T06:12:47.926796147Z",
                 "kind": "event",
                 "original": "# User@Host: debian-sys-maint[debian-sys-maint] @ localhost []\n# Query_time: 0.000153  Lock_time: 0.000061 Rows_sent: 1  Rows_examined: 5\nSET timestamp=1533630467;\nSELECT count(*) FROM mysql.user WHERE user='root' and password='';",
                 "type": [
@@ -76,7 +75,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "debian-sys-maint"
             }
@@ -92,7 +90,7 @@
                     "database"
                 ],
                 "duration": 4071491000,
-                "ingested": "2024-06-18T05:50:01.197481452Z",
+                "ingested": "2024-12-10T06:12:47.926806012Z",
                 "kind": "event",
                 "original": "# User@Host: appuser[appuser] @ apphost [67.43.156.14]  Id: 10997316\n# Query_time: 4.071491  Lock_time: 0.000212 Rows_sent: 1000  Rows_examined: 1489615\nSET timestamp=1533630467;\nSELECT mcu.mcu_guid, mcu.cus_guid, mcu.mcu_url, mcu.mcu_crawlelements, mcu.mcu_order, GROUP_CONCAT(mca.mca_guid SEPARATOR \";\") as mca_guid\n                    FROM kat_mailcustomerurl mcu, kat_customer cus, kat_mailcampaign mca\n                    WHERE cus.cus_guid = mcu.cus_guid\n                        AND cus.pro_code = 'CYB'\n                        AND cus.cus_offline = 0\n                        AND mca.cus_guid = cus.cus_guid\n                        AND (mcu.mcu_date IS NULL OR mcu.mcu_date < CURDATE())\n                        AND mcu.mcu_crawlelements IS NOT NULL\n                    GROUP BY mcu.mcu_guid\n                    ORDER BY mcu.mcu_order ASC\n                    LIMIT 1000;",
                 "type": [
@@ -118,7 +116,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "appuser"
             }
@@ -134,7 +131,7 @@
                     "database"
                 ],
                 "duration": 10346539000,
-                "ingested": "2024-06-18T05:50:01.197487579Z",
+                "ingested": "2024-12-10T06:12:47.926811539Z",
                 "kind": "event",
                 "original": "# User@Host: appuser[appuser] @ apphost [67.43.156.14]  Id: 10999834\n# Query_time: 10.346539  Lock_time: 0.000036 Rows_sent: 0  Rows_examined: 4751313\nSET timestamp=1533630467;\ncall load_stats(1, '2017-04-28 00:00:00');",
                 "type": [
@@ -160,7 +157,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "appuser"
             }

--- a/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-darwin-brew-5-7-10.log-expected.json
+++ b/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-darwin-brew-5-7-10.log-expected.json
@@ -12,7 +12,7 @@
                     "database"
                 ],
                 "duration": 11004467000,
-                "ingested": "2024-06-18T05:50:01.320113470Z",
+                "ingested": "2024-12-10T06:12:48.428782083Z",
                 "kind": "event",
                 "original": "# User@Host: root[root] @ localhost []  Id:     2\n# Query_time: 11.004467  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 0\nSET timestamp=1481543656;\nselect sleep(11);",
                 "type": [
@@ -37,7 +37,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "root"
             }

--- a/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-debian-5-7-17.log-expected.json
+++ b/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-debian-5-7-17.log-expected.json
@@ -10,7 +10,7 @@
                     "database"
                 ],
                 "duration": 4071491000,
-                "ingested": "2024-06-18T05:50:01.411931208Z",
+                "ingested": "2024-12-10T06:12:48.925706829Z",
                 "kind": "event",
                 "original": "# User@Host: apphost[apphost] @ apphost [67.43.156.14]  Id: 10997316\n# Query_time: 4.071491  Lock_time: 0.000212 Rows_sent: 1000  Rows_examined: 1489615\nSET timestamp=1493370459;\nSELECT mcu.mcu_guid, mcu.cus_guid, mcu.mcu_url, mcu.mcu_crawlelements, mcu.mcu_order, GROUP_CONCAT(mca.mca_guid SEPARATOR \";\") as mca_guid\n                    FROM kat_mailcustomerurl mcu, kat_customer cus, kat_mailcampaign mca\n                    WHERE cus.cus_guid = mcu.cus_guid\n                        AND cus.pro_code = 'CYB'\n                        AND cus.cus_offline = 0\n                        AND mca.cus_guid = cus.cus_guid\n                        AND (mcu.mcu_date IS NULL OR mcu.mcu_date < CURDATE())\n                        AND mcu.mcu_crawlelements IS NOT NULL\n                    GROUP BY mcu.mcu_guid\n                    ORDER BY mcu.mcu_order ASC\n                    LIMIT 1000;",
                 "type": [
@@ -36,7 +36,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "apphost"
             }
@@ -52,7 +51,7 @@
                     "database"
                 ],
                 "duration": 10346539000,
-                "ingested": "2024-06-18T05:50:01.411968146Z",
+                "ingested": "2024-12-10T06:12:48.925733186Z",
                 "kind": "event",
                 "original": "# User@Host: apphost[apphost] @ apphost [67.43.156.14]  Id: 10999834\n# Query_time: 10.346539  Lock_time: 0.000036 Rows_sent: 0  Rows_examined: 4751313\nSET timestamp=1493370990;\ncall load_stats(1, '2017-04-28 00:00:00');",
                 "type": [
@@ -78,7 +77,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "apphost"
             }
@@ -94,7 +92,7 @@
                     "database"
                 ],
                 "duration": 10508030000,
-                "ingested": "2024-06-18T05:50:01.411977247Z",
+                "ingested": "2024-12-10T06:12:48.925739638Z",
                 "kind": "event",
                 "original": "# User@Host: apphost[apphost] @ apphost [67.43.156.14]  Id: 11004208\n# Query_time: 10.508030  Lock_time: 0.000034 Rows_sent: 0  Rows_examined: 4754675\nSET timestamp=1493371891;\ncall load_stats(1, '2017-04-28 00:00:00');",
                 "type": [
@@ -120,7 +118,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "apphost"
             }

--- a/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-debian-5-7-19.log-expected.json
+++ b/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-debian-5-7-19.log-expected.json
@@ -10,7 +10,7 @@
                     "database"
                 ],
                 "duration": 100000,
-                "ingested": "2024-06-18T05:50:01.533305927Z",
+                "ingested": "2024-12-10T06:12:49.437521496Z",
                 "kind": "event",
                 "original": "# User@Host: root[root] @  [172.17.0.11]  Id:     5\n# Query_time: 0.000100  Lock_time: 0.000033 Rows_sent: 101  Rows_examined: 101\nSET timestamp=1524768632;\nSELECT intcol1,charcol1 FROM t1;",
                 "type": [
@@ -35,7 +35,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "root"
             }

--- a/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-ubuntu-5-5-53.log-expected.json
+++ b/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-ubuntu-5-5-53.log-expected.json
@@ -12,7 +12,7 @@
                     "database"
                 ],
                 "duration": 153000,
-                "ingested": "2024-06-18T05:50:01.624195995Z",
+                "ingested": "2024-12-10T06:12:49.920462162Z",
                 "kind": "event",
                 "original": "# User@Host: debian-sys-maint[debian-sys-maint] @ localhost []\n# Query_time: 0.000153  Lock_time: 0.000061 Rows_sent: 1  Rows_examined: 5\nSET timestamp=1481294279;\nSELECT count(*) FROM mysql.user WHERE user='root' and password='';",
                 "type": [
@@ -36,7 +36,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "debian-sys-maint"
             }
@@ -51,7 +50,7 @@
                     "database"
                 ],
                 "duration": 2456000,
-                "ingested": "2024-06-18T05:50:01.624198886Z",
+                "ingested": "2024-12-10T06:12:49.920465291Z",
                 "kind": "event",
                 "original": "# User@Host: debian-sys-maint[debian-sys-maint] @ localhost []\n# Query_time: 0.002456  Lock_time: 0.000095 Rows_sent: 31  Rows_examined: 81\nSET timestamp=1481294279;\nselect concat('select count(*) into @discard from `',\n                    TABLE_SCHEMA, '`.`', TABLE_NAME, '`')\n      from information_schema.TABLES where ENGINE='MyISAM';",
                 "type": [
@@ -75,7 +74,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "debian-sys-maint"
             }
@@ -90,7 +88,7 @@
                     "database"
                 ],
                 "duration": 6278000,
-                "ingested": "2024-06-18T05:50:01.624201723Z",
+                "ingested": "2024-12-10T06:12:49.920468061Z",
                 "kind": "event",
                 "original": "# User@Host: debian-sys-maint[debian-sys-maint] @ localhost []\n# Query_time: 0.006278  Lock_time: 0.000153 Rows_sent: 0  Rows_examined: 808\nSET timestamp=1481294279;\nselect count(*) into @discard from `information_schema`.`COLUMNS`;",
                 "type": [
@@ -114,7 +112,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "debian-sys-maint"
             }
@@ -129,7 +126,7 @@
                     "database"
                 ],
                 "duration": 262000,
-                "ingested": "2024-06-18T05:50:01.624204468Z",
+                "ingested": "2024-12-10T06:12:49.920470837Z",
                 "kind": "event",
                 "original": "# User@Host: debian-sys-maint[debian-sys-maint] @ localhost []\n# Query_time: 0.000262  Lock_time: 0.000204 Rows_sent: 0  Rows_examined: 0\nSET timestamp=1481294279;\nselect count(*) into @discard from `information_schema`.`EVENTS`;",
                 "type": [
@@ -153,7 +150,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "debian-sys-maint"
             }
@@ -168,7 +164,7 @@
                     "database"
                 ],
                 "duration": 323000,
-                "ingested": "2024-06-18T05:50:01.624207248Z",
+                "ingested": "2024-12-10T06:12:49.920473615Z",
                 "kind": "event",
                 "original": "# User@Host: debian-sys-maint[debian-sys-maint] @ localhost []\n# Query_time: 0.000323  Lock_time: 0.000241 Rows_sent: 0  Rows_examined: 0\nSET timestamp=1481294279;\nselect count(*) into @discard from `information_schema`.`PARAMETERS`;",
                 "type": [
@@ -192,7 +188,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "debian-sys-maint"
             }
@@ -207,7 +202,7 @@
                     "database"
                 ],
                 "duration": 7084000,
-                "ingested": "2024-06-18T05:50:01.624210380Z",
+                "ingested": "2024-12-10T06:12:49.920476372Z",
                 "kind": "event",
                 "original": "# User@Host: debian-sys-maint[debian-sys-maint] @ localhost []\n# Query_time: 0.007084  Lock_time: 0.000148 Rows_sent: 0  Rows_examined: 81\nSET timestamp=1481294279;\nselect count(*) into @discard from `information_schema`.`PARTITIONS`;",
                 "type": [
@@ -231,7 +226,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "debian-sys-maint"
             }
@@ -246,7 +240,7 @@
                     "database"
                 ],
                 "duration": 277000,
-                "ingested": "2024-06-18T05:50:01.624213122Z",
+                "ingested": "2024-12-10T06:12:49.920479113Z",
                 "kind": "event",
                 "original": "# User@Host: debian-sys-maint[debian-sys-maint] @ localhost []\n# Query_time: 0.000277  Lock_time: 0.000135 Rows_sent: 0  Rows_examined: 23\nSET timestamp=1481294279;\nselect count(*) into @discard from `information_schema`.`PLUGINS`;",
                 "type": [
@@ -270,7 +264,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "debian-sys-maint"
             }
@@ -285,7 +278,7 @@
                     "database"
                 ],
                 "duration": 254000,
-                "ingested": "2024-06-18T05:50:01.624216369Z",
+                "ingested": "2024-12-10T06:12:49.920481866Z",
                 "kind": "event",
                 "original": "# User@Host: debian-sys-maint[debian-sys-maint] @ localhost []\n# Query_time: 0.000254  Lock_time: 0.000159 Rows_sent: 0  Rows_examined: 1\nSET timestamp=1481294279;\nselect count(*) into @discard from `information_schema`.`PROCESSLIST`;",
                 "type": [
@@ -309,7 +302,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "debian-sys-maint"
             }
@@ -324,7 +316,7 @@
                     "database"
                 ],
                 "duration": 297000,
-                "ingested": "2024-06-18T05:50:01.624219114Z",
+                "ingested": "2024-12-10T06:12:49.920484615Z",
                 "kind": "event",
                 "original": "# User@Host: debian-sys-maint[debian-sys-maint] @ localhost []\n# Query_time: 0.000297  Lock_time: 0.000229 Rows_sent: 0  Rows_examined: 0\nSET timestamp=1481294279;\nselect count(*) into @discard from `information_schema`.`ROUTINES`;",
                 "type": [
@@ -348,7 +340,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "debian-sys-maint"
             }
@@ -363,7 +354,7 @@
                     "database"
                 ],
                 "duration": 1676000,
-                "ingested": "2024-06-18T05:50:01.624222214Z",
+                "ingested": "2024-12-10T06:12:49.920487622Z",
                 "kind": "event",
                 "original": "# User@Host: debian-sys-maint[debian-sys-maint] @ localhost []\n# Query_time: 0.001676  Lock_time: 0.000156 Rows_sent: 0  Rows_examined: 0\nSET timestamp=1481294279;\nselect count(*) into @discard from `information_schema`.`TRIGGERS`;",
                 "type": [
@@ -387,7 +378,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "debian-sys-maint"
             }
@@ -402,7 +392,7 @@
                     "database"
                 ],
                 "duration": 8782000,
-                "ingested": "2024-06-18T05:50:01.624224947Z",
+                "ingested": "2024-12-10T06:12:49.920490349Z",
                 "kind": "event",
                 "original": "# User@Host: debian-sys-maint[debian-sys-maint] @ localhost []\n# Query_time: 0.008782  Lock_time: 0.001187 Rows_sent: 0  Rows_examined: 0\nSET timestamp=1481294279;\nselect count(*) into @discard from `information_schema`.`VIEWS`;",
                 "type": [
@@ -426,7 +416,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "debian-sys-maint"
             }
@@ -442,7 +431,7 @@
                     "database"
                 ],
                 "duration": 2000268000,
-                "ingested": "2024-06-18T05:50:01.624230471Z",
+                "ingested": "2024-12-10T06:12:49.920495838Z",
                 "kind": "event",
                 "original": "# User@Host: root[root] @ localhost []\n# Query_time: 2.000268  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 0\nSET timestamp=1481294342;\nselect sleep(2);",
                 "type": [
@@ -466,7 +455,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "root"
             }
@@ -482,7 +470,7 @@
                     "database"
                 ],
                 "duration": 138000,
-                "ingested": "2024-06-18T05:50:01.624236043Z",
+                "ingested": "2024-12-10T06:12:49.920501469Z",
                 "kind": "event",
                 "original": "# User@Host: root[root] @ localhost []\n# Query_time: 0.000138  Lock_time: 0.000056 Rows_sent: 0  Rows_examined: 0\nuse mysql;\nSET timestamp=1481294363;\nselect * from general_log;",
                 "type": [
@@ -507,7 +495,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "root"
             }
@@ -523,7 +510,7 @@
                     "database"
                 ],
                 "duration": 159000,
-                "ingested": "2024-06-18T05:50:01.624241500Z",
+                "ingested": "2024-12-10T06:12:49.920506967Z",
                 "kind": "event",
                 "original": "# User@Host: root[root] @ localhost []\n# Query_time: 0.000159  Lock_time: 0.000059 Rows_sent: 5  Rows_examined: 5\nSET timestamp=1481294380;\nselect * from user;",
                 "type": [
@@ -547,7 +534,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "root"
             }

--- a/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-ubuntu-8-0-15.log-expected.json
+++ b/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-ubuntu-8-0-15.log-expected.json
@@ -12,7 +12,7 @@
                     "database"
                 ],
                 "duration": 2475469000,
-                "ingested": "2024-06-18T05:50:01.819784889Z",
+                "ingested": "2024-12-10T06:12:50.510255757Z",
                 "kind": "event",
                 "original": "# User@Host: root[root] @ localhost []  Id:    14\n# Query_time: 2.475469  Lock_time: 0.000287 Rows_sent: 10  Rows_examined: 3145718\nuse employees;\nSET timestamp=1553436105;\nSELECT last_name, MAX(salary) AS salary FROM employees INNER JOIN salaries ON employees.emp_no = salaries.emp_no GROUP BY last_name ORDER BY salary DESC LIMIT 10;",
                 "type": [
@@ -38,7 +38,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "root"
             }
@@ -55,7 +54,7 @@
                 ],
                 "duration": 2631844000,
                 "end": "2019-03-24T14:04:53.713951Z",
-                "ingested": "2024-06-18T05:50:01.819797468Z",
+                "ingested": "2024-12-10T06:12:50.510329001Z",
                 "kind": "event",
                 "original": "# User@Host: root[root] @ localhost []  Id:    16\n# Query_time: 2.631844  Lock_time: 0.000145 Rows_sent: 10  Rows_examined: 3145718 Thread_id: 16 Errno: 0 Killed: 0 Bytes_received: 0 Bytes_sent: 312 Read_first: 1 Read_last: 0 Read_key: 3144072 Read_next: 2844047 Read_prev: 0 Read_rnd: 10 Read_rnd_next: 301663 Sort_merge_passes: 0 Sort_range_count: 0 Sort_rows: 10 Sort_scan_count: 1 Created_tmp_disk_tables: 0 Created_tmp_tables: 1 Start: 2019-03-24T14:04:51.082107Z End: 2019-03-24T14:04:53.713951Z\nuse employees;\nSET timestamp=1553436291;\nSELECT last_name, MAX(salary) AS salary FROM employees\n    INNER JOIN salaries ON employees.emp_no = salaries.emp_no\n    GROUP BY last_name\n    ORDER BY salary DESC\n    LIMIT 10;",
                 "start": "2019-03-24T14:04:51.082107Z",
@@ -99,7 +98,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "root"
             }

--- a/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-percona-ubuntu-5-7-19-innodb.log-expected.json
+++ b/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-percona-ubuntu-5-7-19-innodb.log-expected.json
@@ -11,7 +11,7 @@
                     "database"
                 ],
                 "duration": 50365000,
-                "ingested": "2024-06-18T05:50:01.924068482Z",
+                "ingested": "2024-12-10T06:12:51.022264422Z",
                 "kind": "event",
                 "original": "# User@Host: exporter[exporter] @ localhost []  Id: 14367293\n# Schema:   Last_errno: 1370  Killed: 0\n# Query_time: 0.050365  Lock_time: 0.010733  Rows_sent: 16  Rows_examined: 3146  Rows_affected: 0\n# Bytes_sent: 1362  Tmp_tables: 376  Tmp_disk_tables: 71  Tmp_table_sizes: 606208\n# QC_Hit: No  Full_scan: Yes  Full_join: Yes  Tmp_table: Yes  Tmp_table_on_disk: Yes\n# Filesort: No  Filesort_on_disk: No  Merge_passes: 0\n# No InnoDB statistics available for this query\n# Log_slow_rate_type: query  Log_slow_rate_limit: 100\nSET timestamp=1548052563;\nSELECT t.table_schema, t.table_name, column_name, `auto_increment`,\n                  pow(2, case data_type\n                    when 'tinyint'   then 7\n                    when 'smallint'  then 15\n                    when 'mediumint' then 23\n                    when 'int'       then 31\n                    when 'bigint'    then 63\n                    end+(column_type like '% unsigned'))-1 as max_int\n                  FROM information_schema.tables t\n                  JOIN information_schema.columns c\n                    ON BINARY t.table_schema = c.table_schema AND BINARY t.table_name = c.table_name\n                  WHERE c.extra = 'auto_increment' AND t.auto_increment IS NOT NULL;",
                 "type": [
@@ -53,7 +53,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "exporter"
             }
@@ -69,7 +68,7 @@
                     "database"
                 ],
                 "duration": 153883488000,
-                "ingested": "2024-06-18T05:50:01.924075120Z",
+                "ingested": "2024-12-10T06:12:51.022286375Z",
                 "kind": "event",
                 "original": "# User@Host: test[test] @  [192.168.123.123]  Id: 14370752\n# Schema: test  Last_errno: 3170  Killed: 0\n# Query_time: 153.883481  Lock_time: 0.024022  Rows_sent: 0  Rows_examined: 120309968  Rows_affected: 19198\n# Bytes_sent: 62  Tmp_tables: 0  Tmp_disk_tables: 0  Tmp_table_sizes: 0\n# InnoDB_trx_id: 69BB9C7F9\n# QC_Hit: No  Full_scan: No  Full_join: No  Tmp_table: No  Tmp_table_on_disk: No\n# Filesort: No  Filesort_on_disk: No  Merge_passes: 0\n#   InnoDB_IO_r_ops: 9744  InnoDB_IO_r_bytes: 79822848  InnoDB_IO_r_wait: 0.883446\n#   InnoDB_rec_lock_wait: 0.003038  InnoDB_queue_wait: 0.000000\n#   InnoDB_pages_distinct: 64872\n# Log_slow_rate_type: query  Log_slow_rate_limit: 100\nSET timestamp=1548062136;\nUPDATE test    SET test.state = 'NOT_RELEVANT', modified = now()  WHERE test.id IN (26328833, 390, 149386, 152268, 160997, 165304, 168524, 184105, 193022, 194533, 194862, 196469, 196487, 246398, 256594, 260566, 261862, 262342, 263701, 264166, 264607, 267671, 274879, 276704, 280964, 284366, 289323, 289843, 290004, 298999, 301213, 303494, 307920, 311905, 316311, 318404, 330846, 340751, 341433, 357191, 369184, 376876, 378360, 378492, 379470, 382131, 384077, 388368, 396815, 396881, 398272, 398950, 399589, 401299, 408787, 411293, 419109, 425953, 427659, 433183, 437030, 438332, 438386, 447037, 454231, 455257, 455344, 456385, 460420, 460425, 461252, 462338, 462531, 462684, 463104, 463395, 471073, 480069, 480078, 482399, 485205, 487971, 497191, 500261, 501855, 517585, 519310, 519654, 522575, 538425, 543560, 562315, 573934, 583466, 583490, 583502, 597605, 600875, 601546, 603879, 604467, 604619, 757786, 797285, 799155, 802905, 806268, 806798, 811974, 819684, 822629, 826406, 837733, 840128, 840131, 840251, 840277, 840302, 842966, 844294, 844300, 847837, 852503, 854272, 854299, 862983, 881405, 881461, 881467, 881560, 881908, 882435, 882453, 882651, 882711, 882811, 888265, 888286, 914091, 916288, 916316, 917708, 918238, 918887, 919222, 926607, 976977, 977010, 977067, 977131, 977185, 988249, 988276, 988336, 988360, 988504, 990994);",
                 "type": [
@@ -127,7 +126,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "test"
             }

--- a/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-percona-ubuntu-5-7-19.log-expected.json
+++ b/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-percona-ubuntu-5-7-19.log-expected.json
@@ -11,7 +11,7 @@
                     "database"
                 ],
                 "duration": 10569000,
-                "ingested": "2024-06-18T05:50:02.033543375Z",
+                "ingested": "2024-12-10T06:12:51.505408409Z",
                 "kind": "event",
                 "original": "# User@Host: check[check] @ localhost []  Id: 1098148226\n# Schema:   Last_errno: 0  Killed: 0\n# Query_time: 0.010569  Lock_time: 0.000067  Rows_sent: 1  Rows_examined: 928  Rows_affected: 0\n# Bytes_sent: 180  Tmp_tables: 1  Tmp_disk_tables: 0  Tmp_table_sizes: 0\n# QC_Hit: No  Full_scan: Yes  Full_join: No  Tmp_table: Yes  Tmp_table_on_disk: No\n# Filesort: No  Filesort_on_disk: No  Merge_passes: 0\n# No InnoDB statistics available for this query\n# Log_slow_rate_type: query  Log_slow_rate_limit: 100\nSET timestamp=1542349556;\nSHOW GLOBAL STATUS LIKE 'wsrep_local_state';",
                 "type": [
@@ -53,7 +53,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "check"
             }
@@ -69,7 +68,7 @@
                     "database"
                 ],
                 "duration": 36112000,
-                "ingested": "2024-06-18T05:50:02.033557437Z",
+                "ingested": "2024-12-10T06:12:51.505414162Z",
                 "kind": "event",
                 "original": "# User@Host: select[select] @  [192.168.123.123]  Id: 1101779094\n# Schema: database  Last_errno: 0  Killed: 0\n# Query_time: 0.036112  Lock_time: 0.000165  Rows_sent: 1  Rows_examined: 1  Rows_affected: 0\n# Bytes_sent: 529  Tmp_tables: 0  Tmp_disk_tables: 0  Tmp_table_sizes: 0\n# QC_Hit: No  Full_scan: No  Full_join: No  Tmp_table: No  Tmp_table_on_disk: No\n# Filesort: No  Filesort_on_disk: No  Merge_passes: 0\n#   InnoDB_IO_r_ops: 0  InnoDB_IO_r_bytes: 0  InnoDB_IO_r_wait: 0.000000\n#   InnoDB_rec_lock_wait: 0.000000  InnoDB_queue_wait: 0.000000\n#   InnoDB_pages_distinct: 3\n# Log_slow_rate_type: query  Log_slow_rate_limit: 100\nSET timestamp=1542373379;\nselect config.id as id, config.active as active from config where config.id='123456';",
                 "type": [
@@ -126,7 +125,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "select"
             }
@@ -142,7 +140,7 @@
                     "database"
                 ],
                 "duration": 23385000,
-                "ingested": "2024-06-18T05:50:02.033563225Z",
+                "ingested": "2024-12-10T06:12:51.505421108Z",
                 "kind": "event",
                 "original": "# User@Host: exporter[exporter] @ localhost []  Id: 14366748\n# Schema:   Last_errno: 0  Killed: 0\n# Query_time: 0.023385  Lock_time: 0.000039  Rows_sent: 390  Rows_examined: 390  Rows_affected: 0\n# Bytes_sent: 20195  Tmp_tables: 0  Tmp_disk_tables: 0  Tmp_table_sizes: 0\n# QC_Hit: No  Full_scan: Yes  Full_join: No  Tmp_table: No  Tmp_table_on_disk: No\n# Filesort: No  Filesort_on_disk: No  Merge_passes: 0\n# No InnoDB statistics available for this query\n# Log_slow_rate_type: query  Log_slow_rate_limit: 100\nSET timestamp=1548052390;\nSELECT EVENT_NAME, COUNT_STAR, SUM_TIMER_WAIT\n          FROM performance_schema.events_waits_summary_global_by_event_name;",
                 "type": [
@@ -184,7 +182,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "exporter"
             }
@@ -200,7 +197,7 @@
                     "database"
                 ],
                 "duration": 10278000,
-                "ingested": "2024-06-18T05:50:02.033568745Z",
+                "ingested": "2024-12-10T06:12:51.505425837Z",
                 "kind": "event",
                 "original": "# User@Host: test[test] @  [192.168.123.123]  Id: 14349788\n# Schema: test  Last_errno: 0  Killed: 0\n# Query_time: 0.010278  Lock_time: 0.000000  Rows_sent: 0  Rows_examined: 0  Rows_affected: 0\n# Bytes_sent: 11  Tmp_tables: 0  Tmp_disk_tables: 0  Tmp_table_sizes: 0\n# InnoDB_trx_id: 69B884E82\n# QC_Hit: No  Full_scan: No  Full_join: No  Tmp_table: No  Tmp_table_on_disk: No\n# Filesort: No  Filesort_on_disk: No  Merge_passes: 0\n# No InnoDB statistics available for this query\n# Log_slow_rate_type: query  Log_slow_rate_limit: 100\nSET timestamp=1548052470;\ncommit;",
                 "type": [
@@ -246,7 +243,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "test"
             }
@@ -262,7 +258,7 @@
                     "database"
                 ],
                 "duration": 14315000,
-                "ingested": "2024-06-18T05:50:02.033574289Z",
+                "ingested": "2024-12-10T06:12:51.505430538Z",
                 "kind": "event",
                 "original": "# User@Host: exporter[exporter] @ localhost []  Id: 14367106\n# Schema:   Last_errno: 1370  Killed: 0\n# Query_time: 0.014315  Lock_time: 0.000095  Rows_sent: 101  Rows_examined: 101  Rows_affected: 0\n# Bytes_sent: 7131  Tmp_tables: 111  Tmp_disk_tables: 24  Tmp_table_sizes: 114688\n# QC_Hit: No  Full_scan: Yes  Full_join: No  Tmp_table: Yes  Tmp_table_on_disk: Yes\n# Filesort: No  Filesort_on_disk: No  Merge_passes: 0\n# No InnoDB statistics available for this query\n# Log_slow_rate_type: query  Log_slow_rate_limit: 100\nSET timestamp=1548052533;\nSELECT\n                    TABLE_SCHEMA,\n                    TABLE_NAME,\n                    TABLE_TYPE,\n                    ifnull(ENGINE, 'NONE') as ENGINE,\n                    ifnull(VERSION, '0') as VERSION,\n                    ifnull(ROW_FORMAT, 'NONE') as ROW_FORMAT,\n                    ifnull(TABLE_ROWS, '0') as TABLE_ROWS,\n                    ifnull(DATA_LENGTH, '0') as DATA_LENGTH,\n                    ifnull(INDEX_LENGTH, '0') as INDEX_LENGTH,\n                    ifnull(DATA_FREE, '0') as DATA_FREE,\n                    ifnull(CREATE_OPTIONS, 'NONE') as CREATE_OPTIONS\n                  FROM information_schema.tables\n                  WHERE TABLE_SCHEMA = 'sys';",
                 "type": [
@@ -304,7 +300,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "exporter"
             }
@@ -320,7 +315,7 @@
                     "database"
                 ],
                 "duration": 50365000,
-                "ingested": "2024-06-18T05:50:02.033580519Z",
+                "ingested": "2024-12-10T06:12:51.505435389Z",
                 "kind": "event",
                 "original": "# User@Host: exporter[exporter] @ localhost []  Id: 14367293\n# Schema:   Last_errno: 1370  Killed: 0\n# Query_time: 0.050365  Lock_time: 0.010733  Rows_sent: 16  Rows_examined: 3146  Rows_affected: 0\n# Bytes_sent: 1362  Tmp_tables: 376  Tmp_disk_tables: 71  Tmp_table_sizes: 606208\n# QC_Hit: No  Full_scan: Yes  Full_join: Yes  Tmp_table: Yes  Tmp_table_on_disk: Yes\n# Filesort: No  Filesort_on_disk: No  Merge_passes: 0\n# No InnoDB statistics available for this query\n# Log_slow_rate_type: query  Log_slow_rate_limit: 100\nSET timestamp=1548052563;\nSELECT t.table_schema, t.table_name, column_name, `auto_increment`,\n                  pow(2, case data_type\n                    when 'tinyint'   then 7\n                    when 'smallint'  then 15\n                    when 'mediumint' then 23\n                    when 'int'       then 31\n                    when 'bigint'    then 63\n                    end+(column_type like '% unsigned'))-1 as max_int\n                  FROM information_schema.tables t\n                  JOIN information_schema.columns c\n                    ON BINARY t.table_schema = c.table_schema AND BINARY t.table_name = c.table_name\n                  WHERE c.extra = 'auto_increment' AND t.auto_increment IS NOT NULL;",
                 "type": [
@@ -362,7 +357,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "exporter"
             }
@@ -378,7 +372,7 @@
                     "database"
                 ],
                 "duration": 32463768000,
-                "ingested": "2024-06-18T05:50:02.033586012Z",
+                "ingested": "2024-12-10T06:12:51.505440096Z",
                 "kind": "event",
                 "original": "# User@Host: test[test] @  [192.168.123.123]  Id: 14360213\n# Schema: test  Last_errno: 0  Killed: 0\n# Query_time: 32.463767  Lock_time: 0.000084  Rows_sent: 267  Rows_examined: 267  Rows_affected: 0\n# Bytes_sent: 43805  Tmp_tables: 0  Tmp_disk_tables: 0  Tmp_table_sizes: 0\n# QC_Hit: No  Full_scan: No  Full_join: No  Tmp_table: No  Tmp_table_on_disk: No\n# Filesort: No  Filesort_on_disk: No  Merge_passes: 0\n#   InnoDB_IO_r_ops: 2  InnoDB_IO_r_bytes: 16384  InnoDB_IO_r_wait: 0.000213\n#   InnoDB_rec_lock_wait: 0.000000  InnoDB_queue_wait: 0.000000\n#   InnoDB_pages_distinct: 64832\n# Log_slow_rate_type: query  Log_slow_rate_limit: 100\nSET timestamp=1548052600;\nselect test.id as id, test.modified as mo, test.product as pr from test where (test.state in ('NOT_RELEVANT')) and test.last<='2019-01-21 06:36:08.432' and test.modified<='2019-01-07 06:36:08.432' limit 100000;",
                 "type": [
@@ -435,7 +429,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "test"
             }
@@ -451,7 +444,7 @@
                     "database"
                 ],
                 "duration": 153883488000,
-                "ingested": "2024-06-18T05:50:02.033591548Z",
+                "ingested": "2024-12-10T06:12:51.505444815Z",
                 "kind": "event",
                 "original": "# User@Host: test[test] @  [192.168.123.123]  Id: 14370752\n# Schema: test  Last_errno: 3170  Killed: 0\n# Query_time: 153.883481  Lock_time: 0.024022  Rows_sent: 0  Rows_examined: 120309968  Rows_affected: 19198\n# Bytes_sent: 62  Tmp_tables: 0  Tmp_disk_tables: 0  Tmp_table_sizes: 0\n# InnoDB_trx_id: 69BB9C7F9\n# QC_Hit: No  Full_scan: No  Full_join: No  Tmp_table: No  Tmp_table_on_disk: No\n# Filesort: No  Filesort_on_disk: No  Merge_passes: 0\n#   InnoDB_IO_r_ops: 9744  InnoDB_IO_r_bytes: 79822848  InnoDB_IO_r_wait: 0.883446\n#   InnoDB_rec_lock_wait: 0.003038  InnoDB_queue_wait: 0.000000\n#   InnoDB_pages_distinct: 64872\n# Log_slow_rate_type: query  Log_slow_rate_limit: 100\nSET timestamp=1548062136;\nUPDATE test    SET test.state = 'NOT_RELEVANT', modified = now()  WHERE test.id IN (26328833, 390, 149386, 152268, 160997, 165304, 168524, 184105, 193022, 194533, 194862, 196469, 196487, 246398, 256594, 260566, 261862, 262342, 263701, 264166, 264607, 267671, 274879, 276704, 280964, 284366, 289323, 289843, 290004, 298999, 301213, 303494, 307920, 311905, 316311, 318404, 330846, 340751, 341433, 357191, 369184, 376876, 378360, 378492, 379470, 382131, 384077, 388368, 396815, 396881, 398272, 398950, 399589, 401299, 408787, 411293, 419109, 425953, 427659, 433183, 437030, 438332, 438386, 447037, 454231, 455257, 455344, 456385, 460420, 460425, 461252, 462338, 462531, 462684, 463104, 463395, 471073, 480069, 480078, 482399, 485205, 487971, 497191, 500261, 501855, 517585, 519310, 519654, 522575, 538425, 543560, 562315, 573934, 583466, 583490, 583502, 597605, 600875, 601546, 603879, 604467, 604619, 757786, 797285, 799155, 802905, 806268, 806798, 811974, 819684, 822629, 826406, 837733, 840128, 840131, 840251, 840277, 840302, 842966, 844294, 844300, 847837, 852503, 854272, 854299, 862983, 881405, 881461, 881467, 881560, 881908, 882435, 882453, 882651, 882711, 882811, 888265, 888286, 914091, 916288, 916316, 917708, 918238, 918887, 919222, 926607, 976977, 977010, 977067, 977131, 977185, 988249, 988276, 988336, 988360, 988504, 990994);",
                 "type": [
@@ -509,7 +502,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "test"
             }

--- a/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-percona-ubuntu-8-0-15.log-expected.json
+++ b/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-percona-ubuntu-8-0-15.log-expected.json
@@ -12,7 +12,7 @@
                     "database"
                 ],
                 "duration": 2746607000,
-                "ingested": "2024-06-18T05:50:02.200346545Z",
+                "ingested": "2024-12-10T06:12:52.024496320Z",
                 "kind": "event",
                 "original": "# User@Host: root[root] @ localhost []  Id:   182\n# Schema: employees  Last_errno: 0  Killed: 0\n# Query_time: 2.746607  Lock_time: 0.000138  Rows_sent: 10  Rows_examined: 3145718  Rows_affected: 0\n# Bytes_sent: 312\nuse employees;\nSET timestamp=1553444561;\nSELECT last_name, MAX(salary) AS salary FROM employees     INNER JOIN salaries ON employees.emp_no = salaries.emp_no     GROUP BY last_name     ORDER BY salary DESC     LIMIT 10;\n/usr/sbin/mysqld, Version: 8.0.15-5 (Percona Server (GPL), Release '5', Revision 'f8a9e99'). started with:\nTcp port: 0  Unix socket: /var/run/mysqld/mysqld.sock\nTime                 Id Command    Argument",
                 "type": [
@@ -42,7 +42,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "root"
             }
@@ -58,7 +57,7 @@
                     "database"
                 ],
                 "duration": 3133066000,
-                "ingested": "2024-06-18T05:50:02.200355102Z",
+                "ingested": "2024-12-10T06:12:52.024501058Z",
                 "kind": "event",
                 "original": "# User@Host: root[root] @ localhost []  Id:     8\n# Schema: employees  Last_errno: 0  Killed: 0\n# Query_time: 3.133066  Lock_time: 0.000190  Rows_sent: 10  Rows_examined: 3145718  Rows_affected: 0\n# Bytes_sent: 312  Tmp_tables: 1  Tmp_disk_tables: 0  Tmp_table_sizes: 0\n# InnoDB_trx_id: 0\n# Full_scan: Yes  Full_join: No  Tmp_table: Yes  Tmp_table_on_disk: No\n# Filesort: Yes  Filesort_on_disk: No  Merge_passes: 0\n#   InnoDB_IO_r_ops: 5491  InnoDB_IO_r_bytes: 89964544  InnoDB_IO_r_wait: 0.003183\n#   InnoDB_rec_lock_wait: 0.000000  InnoDB_queue_wait: 0.000000\n#   InnoDB_pages_distinct: 6122\nuse employees;\nSET timestamp=1553444761;\nSELECT last_name, MAX(salary) AS salary FROM employees\n    INNER JOIN salaries ON employees.emp_no = salaries.emp_no\n    GROUP BY last_name\n    ORDER BY salary DESC\n    LIMIT 10;",
                 "type": [
@@ -113,7 +112,6 @@
             "tags": [
                 "preserve_original_event"
             ],
-            "temp": {},
             "user": {
                 "name": "root"
             }

--- a/packages/mysql/data_stream/slowlog/elasticsearch/ingest_pipeline/default.json
+++ b/packages/mysql/data_stream/slowlog/elasticsearch/ingest_pipeline/default.json
@@ -96,7 +96,7 @@
     },
     {
       "remove": {
-        "field": "temp.duration",
+        "field": "temp",
         "ignore_missing": true
       }
     },

--- a/packages/mysql/data_stream/slowlog/sample_event.json
+++ b/packages/mysql/data_stream/slowlog/sample_event.json
@@ -1,0 +1,97 @@
+{
+    "@timestamp": "2024-12-09T08:24:26.000Z",
+    "agent": {
+        "ephemeral_id": "fe3b9527-f8f9-4748-b550-bf9cb7154f2e",
+        "id": "21e163da-3324-4f31-be38-fb745d92b8c7",
+        "name": "elastic-agent-23600",
+        "type": "filebeat",
+        "version": "8.17.0"
+    },
+    "data_stream": {
+        "dataset": "mysql.slowlog",
+        "namespace": "41434",
+        "type": "logs"
+    },
+    "ecs": {
+        "version": "8.5.1"
+    },
+    "elastic_agent": {
+        "id": "21e163da-3324-4f31-be38-fb745d92b8c7",
+        "snapshot": true,
+        "version": "8.17.0"
+    },
+    "event": {
+        "agent_id_status": "verified",
+        "category": [
+            "database"
+        ],
+        "dataset": "mysql.slowlog",
+        "duration": 259000,
+        "ingested": "2024-12-09T08:24:47Z",
+        "kind": "event",
+        "timezone": "+00:00",
+        "type": [
+            "info"
+        ]
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": true,
+        "hostname": "elastic-agent-23600",
+        "ip": [
+            "192.168.253.2",
+            "192.168.241.7"
+        ],
+        "mac": [
+            "02-42-C0-A8-F1-07",
+            "02-42-C0-A8-FD-02"
+        ],
+        "name": "elastic-agent-23600",
+        "os": {
+            "family": "",
+            "kernel": "3.10.0-1160.92.1.el7.x86_64",
+            "name": "Wolfi",
+            "platform": "wolfi",
+            "type": "linux",
+            "version": "20230201"
+        }
+    },
+    "input": {
+        "type": "log"
+    },
+    "log": {
+        "file": {
+            "path": "/tmp/service_logs/mysql/8019a2ba561a-slow.log"
+        },
+        "flags": [
+            "multiline"
+        ],
+        "offset": 510
+    },
+    "mysql": {
+        "slowlog": {
+            "bytes_sent": 115,
+            "current_user": "root",
+            "killed": "0",
+            "last_errno": "0",
+            "lock_time": {
+                "sec": 0
+            },
+            "query": "select @@version_comment limit 1;",
+            "rows_affected": 0,
+            "rows_examined": 1,
+            "rows_sent": 1
+        },
+        "thread_id": 8
+    },
+    "source": {
+        "domain": "localhost"
+    },
+    "tags": [
+        "mysql-slowlog"
+    ],
+    "temp": {},
+    "user": {
+        "name": "root"
+    }
+}

--- a/packages/mysql/data_stream/slowlog/sample_event.json
+++ b/packages/mysql/data_stream/slowlog/sample_event.json
@@ -1,24 +1,24 @@
 {
-    "@timestamp": "2024-12-09T08:24:26.000Z",
+    "@timestamp": "2024-12-10T05:35:20.000Z",
     "agent": {
-        "ephemeral_id": "fe3b9527-f8f9-4748-b550-bf9cb7154f2e",
-        "id": "21e163da-3324-4f31-be38-fb745d92b8c7",
-        "name": "elastic-agent-23600",
+        "ephemeral_id": "b970821e-9579-4a3b-96db-0a751cb724de",
+        "id": "15b0faf9-c42a-4f8b-81f3-827a45988d1c",
+        "name": "elastic-agent-31305",
         "type": "filebeat",
-        "version": "8.17.0"
+        "version": "8.15.0"
     },
     "data_stream": {
         "dataset": "mysql.slowlog",
-        "namespace": "41434",
+        "namespace": "17576",
         "type": "logs"
     },
     "ecs": {
         "version": "8.5.1"
     },
     "elastic_agent": {
-        "id": "21e163da-3324-4f31-be38-fb745d92b8c7",
-        "snapshot": true,
-        "version": "8.17.0"
+        "id": "15b0faf9-c42a-4f8b-81f3-827a45988d1c",
+        "snapshot": false,
+        "version": "8.15.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -26,8 +26,8 @@
             "database"
         ],
         "dataset": "mysql.slowlog",
-        "duration": 259000,
-        "ingested": "2024-12-09T08:24:47Z",
+        "duration": 232000,
+        "ingested": "2024-12-10T05:35:37Z",
         "kind": "event",
         "timezone": "+00:00",
         "type": [
@@ -37,23 +37,25 @@
     "host": {
         "architecture": "x86_64",
         "containerized": true,
-        "hostname": "elastic-agent-23600",
+        "hostname": "elastic-agent-31305",
+        "id": "5c3f9f83eeec4f92817d995fce90f92f",
         "ip": [
-            "192.168.253.2",
-            "192.168.241.7"
+            "192.168.242.2",
+            "192.168.255.6"
         ],
         "mac": [
-            "02-42-C0-A8-F1-07",
-            "02-42-C0-A8-FD-02"
+            "02-42-C0-A8-F2-02",
+            "02-42-C0-A8-FF-06"
         ],
-        "name": "elastic-agent-23600",
+        "name": "elastic-agent-31305",
         "os": {
-            "family": "",
+            "codename": "focal",
+            "family": "debian",
             "kernel": "3.10.0-1160.92.1.el7.x86_64",
-            "name": "Wolfi",
-            "platform": "wolfi",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
             "type": "linux",
-            "version": "20230201"
+            "version": "20.04.6 LTS (Focal Fossa)"
         }
     },
     "input": {
@@ -61,7 +63,7 @@
     },
     "log": {
         "file": {
-            "path": "/tmp/service_logs/mysql/8019a2ba561a-slow.log"
+            "path": "/tmp/service_logs/mysql/51910f9b766e-slow.log"
         },
         "flags": [
             "multiline"
@@ -90,7 +92,6 @@
     "tags": [
         "mysql-slowlog"
     ],
-    "temp": {},
     "user": {
         "name": "root"
     }

--- a/packages/mysql/docs/README.md
+++ b/packages/mysql/docs/README.md
@@ -69,6 +69,89 @@ For MySQL, MariaDB and Percona the query to check replica status varies dependin
 
 The `error` dataset collects the MySQL error logs.
 
+An example event for `error` looks as following:
+
+```json
+{
+    "@timestamp": "2024-12-09T06:18:16.552Z",
+    "agent": {
+        "ephemeral_id": "c74f8326-f9c7-4c1f-9dd6-5cd5efe550eb",
+        "id": "4c979ea6-18d4-4c0b-92ed-d363d23d90b1",
+        "name": "elastic-agent-73203",
+        "type": "filebeat",
+        "version": "8.17.0"
+    },
+    "data_stream": {
+        "dataset": "mysql.error",
+        "namespace": "79664",
+        "type": "logs"
+    },
+    "ecs": {
+        "version": "8.11.0"
+    },
+    "elastic_agent": {
+        "id": "4c979ea6-18d4-4c0b-92ed-d363d23d90b1",
+        "snapshot": true,
+        "version": "8.17.0"
+    },
+    "event": {
+        "agent_id_status": "verified",
+        "category": [
+            "database"
+        ],
+        "code": "MY-011068",
+        "created": "2024-12-09T06:18:37.565Z",
+        "dataset": "mysql.error",
+        "ingested": "2024-12-09T06:18:40Z",
+        "kind": "event",
+        "provider": "Server",
+        "timezone": "+00:00",
+        "type": [
+            "info"
+        ]
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": true,
+        "hostname": "elastic-agent-73203",
+        "ip": [
+            "192.168.255.2",
+            "192.168.247.4"
+        ],
+        "mac": [
+            "02-42-C0-A8-F7-04",
+            "02-42-C0-A8-FF-02"
+        ],
+        "name": "elastic-agent-73203",
+        "os": {
+            "family": "",
+            "kernel": "3.10.0-1160.92.1.el7.x86_64",
+            "name": "Wolfi",
+            "platform": "wolfi",
+            "type": "linux",
+            "version": "20230201"
+        }
+    },
+    "input": {
+        "type": "log"
+    },
+    "log": {
+        "file": {
+            "path": "/tmp/service_logs/mysql/05cec82c0c63-error.log"
+        },
+        "level": "Warning",
+        "offset": 0
+    },
+    "message": "[MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.",
+    "mysql": {
+        "thread_id": 0
+    },
+    "tags": [
+        "mysql-error"
+    ]
+}
+```
+
 **ECS Field Reference**
 
 Please refer to the following [document](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) for detailed information on ECS fields.
@@ -96,6 +179,108 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 ### Slow Log
 
 The `slowlog` dataset collects the MySQL slow logs.
+
+An example event for `slowlog` looks as following:
+
+```json
+{
+    "@timestamp": "2024-12-09T08:24:26.000Z",
+    "agent": {
+        "ephemeral_id": "fe3b9527-f8f9-4748-b550-bf9cb7154f2e",
+        "id": "21e163da-3324-4f31-be38-fb745d92b8c7",
+        "name": "elastic-agent-23600",
+        "type": "filebeat",
+        "version": "8.17.0"
+    },
+    "data_stream": {
+        "dataset": "mysql.slowlog",
+        "namespace": "41434",
+        "type": "logs"
+    },
+    "ecs": {
+        "version": "8.5.1"
+    },
+    "elastic_agent": {
+        "id": "21e163da-3324-4f31-be38-fb745d92b8c7",
+        "snapshot": true,
+        "version": "8.17.0"
+    },
+    "event": {
+        "agent_id_status": "verified",
+        "category": [
+            "database"
+        ],
+        "dataset": "mysql.slowlog",
+        "duration": 259000,
+        "ingested": "2024-12-09T08:24:47Z",
+        "kind": "event",
+        "timezone": "+00:00",
+        "type": [
+            "info"
+        ]
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": true,
+        "hostname": "elastic-agent-23600",
+        "ip": [
+            "192.168.253.2",
+            "192.168.241.7"
+        ],
+        "mac": [
+            "02-42-C0-A8-F1-07",
+            "02-42-C0-A8-FD-02"
+        ],
+        "name": "elastic-agent-23600",
+        "os": {
+            "family": "",
+            "kernel": "3.10.0-1160.92.1.el7.x86_64",
+            "name": "Wolfi",
+            "platform": "wolfi",
+            "type": "linux",
+            "version": "20230201"
+        }
+    },
+    "input": {
+        "type": "log"
+    },
+    "log": {
+        "file": {
+            "path": "/tmp/service_logs/mysql/8019a2ba561a-slow.log"
+        },
+        "flags": [
+            "multiline"
+        ],
+        "offset": 510
+    },
+    "mysql": {
+        "slowlog": {
+            "bytes_sent": 115,
+            "current_user": "root",
+            "killed": "0",
+            "last_errno": "0",
+            "lock_time": {
+                "sec": 0
+            },
+            "query": "select @@version_comment limit 1;",
+            "rows_affected": 0,
+            "rows_examined": 1,
+            "rows_sent": 1
+        },
+        "thread_id": 8
+    },
+    "source": {
+        "domain": "localhost"
+    },
+    "tags": [
+        "mysql-slowlog"
+    ],
+    "temp": {},
+    "user": {
+        "name": "root"
+    }
+}
+```
 
 **ECS Field Reference**
 

--- a/packages/mysql/docs/README.md
+++ b/packages/mysql/docs/README.md
@@ -184,26 +184,26 @@ An example event for `slowlog` looks as following:
 
 ```json
 {
-    "@timestamp": "2024-12-09T08:24:26.000Z",
+    "@timestamp": "2024-12-10T05:35:20.000Z",
     "agent": {
-        "ephemeral_id": "fe3b9527-f8f9-4748-b550-bf9cb7154f2e",
-        "id": "21e163da-3324-4f31-be38-fb745d92b8c7",
-        "name": "elastic-agent-23600",
+        "ephemeral_id": "b970821e-9579-4a3b-96db-0a751cb724de",
+        "id": "15b0faf9-c42a-4f8b-81f3-827a45988d1c",
+        "name": "elastic-agent-31305",
         "type": "filebeat",
-        "version": "8.17.0"
+        "version": "8.15.0"
     },
     "data_stream": {
         "dataset": "mysql.slowlog",
-        "namespace": "41434",
+        "namespace": "17576",
         "type": "logs"
     },
     "ecs": {
         "version": "8.5.1"
     },
     "elastic_agent": {
-        "id": "21e163da-3324-4f31-be38-fb745d92b8c7",
-        "snapshot": true,
-        "version": "8.17.0"
+        "id": "15b0faf9-c42a-4f8b-81f3-827a45988d1c",
+        "snapshot": false,
+        "version": "8.15.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -211,8 +211,8 @@ An example event for `slowlog` looks as following:
             "database"
         ],
         "dataset": "mysql.slowlog",
-        "duration": 259000,
-        "ingested": "2024-12-09T08:24:47Z",
+        "duration": 232000,
+        "ingested": "2024-12-10T05:35:37Z",
         "kind": "event",
         "timezone": "+00:00",
         "type": [
@@ -222,23 +222,25 @@ An example event for `slowlog` looks as following:
     "host": {
         "architecture": "x86_64",
         "containerized": true,
-        "hostname": "elastic-agent-23600",
+        "hostname": "elastic-agent-31305",
+        "id": "5c3f9f83eeec4f92817d995fce90f92f",
         "ip": [
-            "192.168.253.2",
-            "192.168.241.7"
+            "192.168.242.2",
+            "192.168.255.6"
         ],
         "mac": [
-            "02-42-C0-A8-F1-07",
-            "02-42-C0-A8-FD-02"
+            "02-42-C0-A8-F2-02",
+            "02-42-C0-A8-FF-06"
         ],
-        "name": "elastic-agent-23600",
+        "name": "elastic-agent-31305",
         "os": {
-            "family": "",
+            "codename": "focal",
+            "family": "debian",
             "kernel": "3.10.0-1160.92.1.el7.x86_64",
-            "name": "Wolfi",
-            "platform": "wolfi",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
             "type": "linux",
-            "version": "20230201"
+            "version": "20.04.6 LTS (Focal Fossa)"
         }
     },
     "input": {
@@ -246,7 +248,7 @@ An example event for `slowlog` looks as following:
     },
     "log": {
         "file": {
-            "path": "/tmp/service_logs/mysql/8019a2ba561a-slow.log"
+            "path": "/tmp/service_logs/mysql/51910f9b766e-slow.log"
         },
         "flags": [
             "multiline"
@@ -275,7 +277,6 @@ An example event for `slowlog` looks as following:
     "tags": [
         "mysql-slowlog"
     ],
-    "temp": {},
     "user": {
         "name": "root"
     }

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -9,7 +9,7 @@ categories:
   - observability
 conditions:
   kibana:
-    version: "^8.17.0-SNAPSHOT"
+    version: "^8.15.0"
   elastic:
     subscription: basic
 screenshots:

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: mysql
 title: MySQL
-version: "1.25.1"
+version: "1.25.2"
 description: Collect logs and metrics from MySQL servers with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - observability
 conditions:
   kibana:
-    version: "^8.15.0"
+    version: "^8.17.0-SNAPSHOT"
   elastic:
     subscription: basic
 screenshots:


### PR DESCRIPTION
## Proposed commit message

Fix optional chaining in the replica_status data stream pipeline

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #11847

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->

![image](https://github.com/user-attachments/assets/0ee13350-4539-4bc7-81b5-081c7f0cbbd0)
