### PR TITLE
Include `user_agent.version` in dynamic_fields (pipeline tests)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,6 +8,7 @@ env:
   YQ_VERSION: 'v4.35.2'
   JQ_VERSION: '1.7'
   GH_CLI_VERSION: "2.29.0"
+  STACK_VERSION: 8.18.0-SNAPSHOT
 
   # Agent images used in pipeline steps
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,6 @@ env:
   YQ_VERSION: 'v4.35.2'
   JQ_VERSION: '1.7'
   GH_CLI_VERSION: "2.29.0"
-  STACK_VERSION: 8.18.0-SNAPSHOT
 
   # Agent images used in pipeline steps
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"

--- a/packages/apache/data_stream/access/_dev/test/pipeline/test-common-config.yml
+++ b/packages/apache/data_stream/access/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,6 @@
 dynamic_fields:
   event.ingested: ".*"
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   "@timestamp": "2020-04-28T11:07:58.223Z"
   tags:

--- a/packages/apache/data_stream/access/_dev/test/pipeline/test-common-config.yml
+++ b/packages/apache/data_stream/access/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,8 @@
 dynamic_fields:
   event.ingested: ".*"
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   "@timestamp": "2020-04-28T11:07:58.223Z"

--- a/packages/apache/data_stream/access/_dev/test/pipeline/test-common-config.yml
+++ b/packages/apache/data_stream/access/_dev/test/pipeline/test-common-config.yml
@@ -1,6 +1,6 @@
 dynamic_fields:
   event.ingested: ".*"
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-common-config.yml
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-common-config.yml
@@ -1,6 +1,6 @@
 dynamic_fields:
   "event.ingested": ".*"
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-common-config.yml
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-common-config.yml
@@ -1,2 +1,3 @@
 dynamic_fields:
   "event.ingested": ".*"
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-common-config.yml
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,6 @@
 dynamic_fields:
   "event.ingested": ".*"
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/aws/data_stream/cloudtrail/_dev/test/pipeline/test-common-config.yml
+++ b/packages/aws/data_stream/cloudtrail/_dev/test/pipeline/test-common-config.yml
@@ -1,4 +1,7 @@
 dynamic_fields:
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   # Simulate @timestamp value from Filebeat.

--- a/packages/aws/data_stream/cloudtrail/_dev/test/pipeline/test-common-config.yml
+++ b/packages/aws/data_stream/cloudtrail/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,6 @@
 fields:
   # Simulate @timestamp value from Filebeat.
   '@timestamp': '2021-11-11T01:02:03.123456789Z'
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
   tags:
     - preserve_original_event

--- a/packages/aws/data_stream/cloudtrail/_dev/test/pipeline/test-common-config.yml
+++ b/packages/aws/data_stream/cloudtrail/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/aws/data_stream/cloudtrail/_dev/test/pipeline/test-common-config.yml
+++ b/packages/aws/data_stream/cloudtrail/_dev/test/pipeline/test-common-config.yml
@@ -1,6 +1,7 @@
+dynamic_fields:
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   # Simulate @timestamp value from Filebeat.
   '@timestamp': '2021-11-11T01:02:03.123456789Z'
-  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
   tags:
     - preserve_original_event

--- a/packages/barracuda/data_stream/waf/_dev/test/pipeline/test-access.log-config.yml
+++ b/packages/barracuda/data_stream/waf/_dev/test/pipeline/test-access.log-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
+  "user_agent.version": '^(\d+\.\d+(\.|\..*)?|\d+)$'
 fields:
   tags:
     - preserve_original_event

--- a/packages/barracuda/data_stream/waf/_dev/test/pipeline/test-access.log-config.yml
+++ b/packages/barracuda/data_stream/waf/_dev/test/pipeline/test-access.log-config.yml
@@ -1,4 +1,7 @@
 dynamic_fields:
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^(\d+\.\d+(\.|\..*)?|\d+)$'
 fields:
   tags:

--- a/packages/barracuda/data_stream/waf/_dev/test/pipeline/test-access.log-config.yml
+++ b/packages/barracuda/data_stream/waf/_dev/test/pipeline/test-access.log-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^(\d+\.\d+(\.|\..*)?|\d+)$'

--- a/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,5 @@
+dynamic_fields:
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   tags:
     - forwarded

--- a/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -1,4 +1,7 @@
 dynamic_fields:
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   tags:

--- a/packages/forcepoint_web/data_stream/logs/_dev/test/pipeline/test-common-config.yml
+++ b/packages/forcepoint_web/data_stream/logs/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/forcepoint_web/data_stream/logs/_dev/test/pipeline/test-common-config.yml
+++ b/packages/forcepoint_web/data_stream/logs/_dev/test/pipeline/test-common-config.yml
@@ -1,4 +1,7 @@
 dynamic_fields:
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   tags:

--- a/packages/forcepoint_web/data_stream/logs/_dev/test/pipeline/test-common-config.yml
+++ b/packages/forcepoint_web/data_stream/logs/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,5 @@
+dynamic_fields:
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   tags:
     - preserve_original_event

--- a/packages/forgerock/data_stream/am_access/_dev/test/pipeline/test-common-config.yml
+++ b/packages/forgerock/data_stream/am_access/_dev/test/pipeline/test-common-config.yml
@@ -1,2 +1,4 @@
+dynamic_fields:
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 numeric_keyword_fields:
   - "forgerock.response.detail.active"

--- a/packages/forgerock/data_stream/am_access/_dev/test/pipeline/test-common-config.yml
+++ b/packages/forgerock/data_stream/am_access/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/forgerock/data_stream/am_access/_dev/test/pipeline/test-common-config.yml
+++ b/packages/forgerock/data_stream/am_access/_dev/test/pipeline/test-common-config.yml
@@ -1,4 +1,7 @@
 dynamic_fields:
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 numeric_keyword_fields:
   - "forgerock.response.detail.active"

--- a/packages/fortinet_fortiproxy/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/fortinet_fortiproxy/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/fortinet_fortiproxy/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/fortinet_fortiproxy/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,3 @@
 dynamic_fields:
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
-fields:
-  tags:
-    - preserve_original_event
+

--- a/packages/fortinet_fortiproxy/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/fortinet_fortiproxy/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,6 @@
 dynamic_fields:
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 

--- a/packages/gcp/data_stream/audit/_dev/test/pipeline/test-common-config.yml
+++ b/packages/gcp/data_stream/audit/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/gcp/data_stream/audit/_dev/test/pipeline/test-common-config.yml
+++ b/packages/gcp/data_stream/audit/_dev/test/pipeline/test-common-config.yml
@@ -1,4 +1,7 @@
 dynamic_fields:
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   tags:

--- a/packages/gcp/data_stream/audit/_dev/test/pipeline/test-common-config.yml
+++ b/packages/gcp/data_stream/audit/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,5 @@
+dynamic_fields:
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   tags:
     - preserve_original_event

--- a/packages/github/data_stream/audit/_dev/test/pipeline/test-common-config.yml
+++ b/packages/github/data_stream/audit/_dev/test/pipeline/test-common-config.yml
@@ -3,4 +3,7 @@ fields:
     - preserve_original_event
 dynamic_fields:
   "event.ingested": "^.*$"
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/github/data_stream/audit/_dev/test/pipeline/test-common-config.yml
+++ b/packages/github/data_stream/audit/_dev/test/pipeline/test-common-config.yml
@@ -3,3 +3,4 @@ fields:
     - preserve_original_event
 dynamic_fields:
   "event.ingested": "^.*$"
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/github/data_stream/audit/_dev/test/pipeline/test-common-config.yml
+++ b/packages/github/data_stream/audit/_dev/test/pipeline/test-common-config.yml
@@ -3,7 +3,7 @@ fields:
     - preserve_original_event
 dynamic_fields:
   "event.ingested": "^.*$"
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/iis/data_stream/access/_dev/test/pipeline/test-common-config.yml
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
+  "user_agent.version": '^(\d+\.\d+(\.|\..*)?|\d+)$'
 fields:
   tags:
     - preserve_original_event

--- a/packages/iis/data_stream/access/_dev/test/pipeline/test-common-config.yml
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,5 @@
+dynamic_fields:
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   tags:
     - preserve_original_event

--- a/packages/iis/data_stream/access/_dev/test/pipeline/test-common-config.yml
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/test-common-config.yml
@@ -1,4 +1,7 @@
 dynamic_fields:
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^(\d+\.\d+(\.|\..*)?|\d+)$'
 fields:
   tags:

--- a/packages/iis/data_stream/access/_dev/test/pipeline/test-common-config.yml
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^(\d+\.\d+(\.|\..*)?|\d+)$'

--- a/packages/imperva_cloud_waf/data_stream/event/_dev/test/pipeline/test-common-config.yml
+++ b/packages/imperva_cloud_waf/data_stream/event/_dev/test/pipeline/test-common-config.yml
@@ -6,4 +6,7 @@ dynamic_fields:
   # This can be removed after ES 8.14 is the minimum version.
   # Relates: https://github.com/elastic/elasticsearch/pull/105689
   url.extension: '^.*$'
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/imperva_cloud_waf/data_stream/event/_dev/test/pipeline/test-common-config.yml
+++ b/packages/imperva_cloud_waf/data_stream/event/_dev/test/pipeline/test-common-config.yml
@@ -6,3 +6,4 @@ dynamic_fields:
   # This can be removed after ES 8.14 is the minimum version.
   # Relates: https://github.com/elastic/elasticsearch/pull/105689
   url.extension: '^.*$'
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/imperva_cloud_waf/data_stream/event/_dev/test/pipeline/test-common-config.yml
+++ b/packages/imperva_cloud_waf/data_stream/event/_dev/test/pipeline/test-common-config.yml
@@ -6,7 +6,7 @@ dynamic_fields:
   # This can be removed after ES 8.14 is the minimum version.
   # Relates: https://github.com/elastic/elasticsearch/pull/105689
   url.extension: '^.*$'
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/modsecurity/data_stream/auditlog/_dev/test/pipeline/test-common-config.yml
+++ b/packages/modsecurity/data_stream/auditlog/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/modsecurity/data_stream/auditlog/_dev/test/pipeline/test-common-config.yml
+++ b/packages/modsecurity/data_stream/auditlog/_dev/test/pipeline/test-common-config.yml
@@ -1,4 +1,7 @@
 dynamic_fields:
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   tags:

--- a/packages/modsecurity/data_stream/auditlog/_dev/test/pipeline/test-common-config.yml
+++ b/packages/modsecurity/data_stream/auditlog/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,5 @@
+dynamic_fields:
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   tags:
     - preserve_original_event

--- a/packages/netskope/data_stream/events/_dev/test/pipeline/test-common-config.yml
+++ b/packages/netskope/data_stream/events/_dev/test/pipeline/test-common-config.yml
@@ -5,7 +5,7 @@ dynamic_fields:
   # This can be removed after ES 8.14 is the minimum version.
   # Relates: https://github.com/elastic/elasticsearch/pull/105689
   netskope.events.url.extension: '^.*$'
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/netskope/data_stream/events/_dev/test/pipeline/test-common-config.yml
+++ b/packages/netskope/data_stream/events/_dev/test/pipeline/test-common-config.yml
@@ -5,4 +5,7 @@ dynamic_fields:
   # This can be removed after ES 8.14 is the minimum version.
   # Relates: https://github.com/elastic/elasticsearch/pull/105689
   netskope.events.url.extension: '^.*$'
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/netskope/data_stream/events/_dev/test/pipeline/test-common-config.yml
+++ b/packages/netskope/data_stream/events/_dev/test/pipeline/test-common-config.yml
@@ -5,3 +5,4 @@ dynamic_fields:
   # This can be removed after ES 8.14 is the minimum version.
   # Relates: https://github.com/elastic/elasticsearch/pull/105689
   netskope.events.url.extension: '^.*$'
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/nginx/data_stream/access/_dev/test/pipeline/test-common-config.yml
+++ b/packages/nginx/data_stream/access/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,8 @@
 dynamic_fields:
   "event.ingested": ".*"
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 multiline:
   first_line_pattern: "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}"

--- a/packages/nginx/data_stream/access/_dev/test/pipeline/test-common-config.yml
+++ b/packages/nginx/data_stream/access/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,6 @@
 dynamic_fields:
   "event.ingested": ".*"
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 multiline:
   first_line_pattern: "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}"
 fields:

--- a/packages/nginx/data_stream/access/_dev/test/pipeline/test-common-config.yml
+++ b/packages/nginx/data_stream/access/_dev/test/pipeline/test-common-config.yml
@@ -1,6 +1,6 @@
 dynamic_fields:
   "event.ingested": ".*"
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/nginx_ingress_controller/data_stream/access/_dev/test/pipeline/test-ingest-raw.log-config.yml
+++ b/packages/nginx_ingress_controller/data_stream/access/_dev/test/pipeline/test-ingest-raw.log-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/nginx_ingress_controller/data_stream/access/_dev/test/pipeline/test-ingest-raw.log-config.yml
+++ b/packages/nginx_ingress_controller/data_stream/access/_dev/test/pipeline/test-ingest-raw.log-config.yml
@@ -1,4 +1,7 @@
 dynamic_fields:
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 multiline:
   first_line_pattern: "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}"

--- a/packages/nginx_ingress_controller/data_stream/access/_dev/test/pipeline/test-ingest-raw.log-config.yml
+++ b/packages/nginx_ingress_controller/data_stream/access/_dev/test/pipeline/test-ingest-raw.log-config.yml
@@ -1,3 +1,5 @@
+dynamic_fields:
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 multiline:
   first_line_pattern: "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}"
 fields:

--- a/packages/o365/data_stream/audit/_dev/test/pipeline/test-common-config.yml
+++ b/packages/o365/data_stream/audit/_dev/test/pipeline/test-common-config.yml
@@ -1,4 +1,7 @@
 dynamic_fields:
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   "@timestamp": "2020-04-28T11:07:58.223Z"

--- a/packages/o365/data_stream/audit/_dev/test/pipeline/test-common-config.yml
+++ b/packages/o365/data_stream/audit/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,5 @@
+dynamic_fields:
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   "@timestamp": "2020-04-28T11:07:58.223Z"
   "_conf":

--- a/packages/o365/data_stream/audit/_dev/test/pipeline/test-common-config.yml
+++ b/packages/o365/data_stream/audit/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-events.log-config.yml
+++ b/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-events.log-config.yml
@@ -1,4 +1,7 @@
 dynamic_fields:
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   "@timestamp": "2020-04-28T11:07:58.223Z"

--- a/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-events.log-config.yml
+++ b/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-events.log-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-events.log-config.yml
+++ b/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-events.log-config.yml
@@ -1,3 +1,5 @@
+dynamic_fields:
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   "@timestamp": "2020-04-28T11:07:58.223Z"
   tags:

--- a/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-no-flattened-events.log-config.yml
+++ b/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-no-flattened-events.log-config.yml
@@ -1,4 +1,7 @@
 dynamic_fields:
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   "@timestamp": "2020-04-28T11:07:58.223Z"

--- a/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-no-flattened-events.log-config.yml
+++ b/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-no-flattened-events.log-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-no-flattened-events.log-config.yml
+++ b/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-no-flattened-events.log-config.yml
@@ -1,3 +1,5 @@
+dynamic_fields:
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   "@timestamp": "2020-04-28T11:07:58.223Z"
   tags:

--- a/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-yes-flattened-events.log-config.yml
+++ b/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-yes-flattened-events.log-config.yml
@@ -1,4 +1,7 @@
 dynamic_fields:
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   "@timestamp": "2020-04-28T11:07:58.223Z"

--- a/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-yes-flattened-events.log-config.yml
+++ b/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-yes-flattened-events.log-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-yes-flattened-events.log-config.yml
+++ b/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-yes-flattened-events.log-config.yml
@@ -1,3 +1,5 @@
+dynamic_fields:
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   "@timestamp": "2020-04-28T11:07:58.223Z"
   tags:

--- a/packages/proofpoint_tap/data_stream/clicks_permitted/_dev/test/pipeline/test-common-config.yml
+++ b/packages/proofpoint_tap/data_stream/clicks_permitted/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/proofpoint_tap/data_stream/clicks_permitted/_dev/test/pipeline/test-common-config.yml
+++ b/packages/proofpoint_tap/data_stream/clicks_permitted/_dev/test/pipeline/test-common-config.yml
@@ -1,4 +1,7 @@
 dynamic_fields:
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   tags:

--- a/packages/proofpoint_tap/data_stream/clicks_permitted/_dev/test/pipeline/test-common-config.yml
+++ b/packages/proofpoint_tap/data_stream/clicks_permitted/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,5 @@
+dynamic_fields:
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   tags:
     - preserve_original_event

--- a/packages/slack/data_stream/audit/_dev/test/pipeline/test-common-config.yml
+++ b/packages/slack/data_stream/audit/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/slack/data_stream/audit/_dev/test/pipeline/test-common-config.yml
+++ b/packages/slack/data_stream/audit/_dev/test/pipeline/test-common-config.yml
@@ -1,4 +1,7 @@
 dynamic_fields:
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   tags:

--- a/packages/slack/data_stream/audit/_dev/test/pipeline/test-common-config.yml
+++ b/packages/slack/data_stream/audit/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,5 @@
+dynamic_fields:
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   tags:
     - preserve_original_event

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-common-config.yml
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-common-config.yml
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-common-config.yml
@@ -1,6 +1,5 @@
 dynamic_fields:
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
-dynamic_fields:
   "network.community_id": ".*"
 fields:
   tags:

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-common-config.yml
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-common-config.yml
@@ -1,4 +1,7 @@
 dynamic_fields:
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
   "network.community_id": ".*"
 fields:

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-common-config.yml
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-common-config.yml
@@ -1,4 +1,6 @@
 dynamic_fields:
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
+dynamic_fields:
   "network.community_id": ".*"
 fields:
   tags:

--- a/packages/suricata/data_stream/eve/_dev/test/pipeline/test-common-config.yml
+++ b/packages/suricata/data_stream/eve/_dev/test/pipeline/test-common-config.yml
@@ -1,6 +1,6 @@
 dynamic_fields:
   "event.ingested": ".*"
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/suricata/data_stream/eve/_dev/test/pipeline/test-common-config.yml
+++ b/packages/suricata/data_stream/eve/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,8 @@
 dynamic_fields:
   "event.ingested": ".*"
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   "@timestamp": "2020-04-28T11:07:58.223Z"

--- a/packages/suricata/data_stream/eve/_dev/test/pipeline/test-common-config.yml
+++ b/packages/suricata/data_stream/eve/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,6 @@
 dynamic_fields:
   "event.ingested": ".*"
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   "@timestamp": "2020-04-28T11:07:58.223Z"
   tags:

--- a/packages/trend_micro_vision_one/data_stream/detection/_dev/test/pipeline/test-common-config.yml
+++ b/packages/trend_micro_vision_one/data_stream/detection/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  # This can be removed after ES 8.16.2 is the latest minimum version
+  # This can be removed after ES 8.16.2 is set as the minimum version supported in the manifest.
   # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
   # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'

--- a/packages/trend_micro_vision_one/data_stream/detection/_dev/test/pipeline/test-common-config.yml
+++ b/packages/trend_micro_vision_one/data_stream/detection/_dev/test/pipeline/test-common-config.yml
@@ -1,4 +1,7 @@
 dynamic_fields:
+  # This can be removed after ES 8.16.2 is the latest minimum version
+  # Once removed, it requires to update pipeline tests to remove the trailing dot where required.
+  # Relates:  https://github.com/elastic/elasticsearch/pull/117213
   "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   tags:

--- a/packages/trend_micro_vision_one/data_stream/detection/_dev/test/pipeline/test-common-config.yml
+++ b/packages/trend_micro_vision_one/data_stream/detection/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,5 @@
+dynamic_fields:
+  "user_agent.version": '^\d+\.\d+(\.|\..*)?$'
 fields:
   tags:
     - preserve_original_event


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Include a new dynamic field for `user_agent.version` in order to accept versions with a trailing dot.

Related issue: https://github.com/elastic/elasticsearch/issues/116950

This regex needs to accept values like these ones (examples from apache and iis package):
- 15.0.a2
- 50.0.
- 50.0
- 7.79.1
- 54.0.2840.98
- 2016

Builds failing:
- 8.18.0-SNAPSHOT https://buildkite.com/elastic/integrations/builds/19186
- 9.0.0-SNAPSHOT https://buildkite.com/elastic/integrations/builds/19187

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

- [x] Test with 8.18.0-SNAPSHOT https://buildkite.com/elastic/integrations/builds/19224
- [x] Test with stack version defined as constraint https://buildkite.com/elastic/integrations/builds/19284

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Relates https://github.com/elastic/elasticsearch/issues/116950
- Closes https://github.com/elastic/integrations/issues/12036

