### PR TITLE
 [CI] Update find_oldest_supported_version script

### DIFF
--- a/.buildkite/scripts/find_oldest_supported_version.py
+++ b/.buildkite/scripts/find_oldest_supported_version.py
@@ -2,19 +2,30 @@
 import argparse
 import requests
 import sys
-import yaml
 import unittest
+import yaml
 
-VERSION_URL = "https://artifacts-api.elastic.co/v1/versions?x-elastic-no-kpi=true"
+from requests.adapters import HTTPAdapter, Retry
+
+ARTIFACTS_URL = "https://artifacts-api.elastic.co"
+VERSION_URL = ARTIFACTS_URL + "/v1/versions?x-elastic-no-kpi=true"
 
 
 def fetch_version():
-    return requests.get(VERSION_URL).json()
+    # Retry forever on connection or 500 errors, assume the artifacts API
+    # will come back. If it doesn't come back we cannot continue executing
+    # jobs in any case.
+    retries = Retry(
+        total=None,
+        backoff_factor=0.5,
+        status_forcelist=[500, 502, 503, 504],
+    )
+    session = requests.Session()
+    session.mount(ARTIFACTS_URL, HTTPAdapter(max_retries=retries))
+    return session.get(VERSION_URL).json()
 
 
 def find_oldest_supported_version(kibana_version_condition: str) -> str:
-    # The logic of this function is copied from https://github.com/elastic/apm-pipeline-library/blob/main/vars/findOldestSupportedVersion.groovy
-
     if "||" in kibana_version_condition and kibana_version_condition.index("||") >= 0:
         return handle_or(kibana_version_condition)
 
@@ -42,33 +53,6 @@ def find_oldest_supported_version(kibana_version_condition: str) -> str:
     if not next_patch_exists and (snapshot_version in available_versions):
         return snapshot_version
 
-    # Use the version as is if it exists.
-    if version in available_versions:
-        return version
-
-    # Old minors may not be available in artifacts-api, if it is older
-    # than the others in the same major, return the version as is.
-    older = True
-    for available_version in available_versions:
-        available_parts = available_version.split(".")
-        if len(available_parts) < 2:
-            continue
-
-        available_major = available_parts[0]
-        available_minor = available_parts[1]
-        if major == available_major and minor > available_minor:
-            older = False
-            break
-    if older:
-        return version
-
-    # If no version has been found so far, try with the snapshot of the next version
-    # in the current major.
-    major_snapshot = f"{major}.x-SNAPSHOT"
-    if major_snapshot in available_aliases:
-        return major_snapshot
-
-    # Otherwise, return it, whatever this is.
     return version
 
 
@@ -157,19 +141,22 @@ class TestFindOldestSupportVersion(unittest.TestCase):
             "8.8.0",
             "8.8.1",
             "8.8.2",
-            "8.9.0",
             "8.9.1-SNAPSHOT",
             "8.9.1",
             "8.9.2-SNAPSHOT",
             "8.9.2",
+            "8.9.4",
             "8.10.0-SNAPSHOT",
             "8.10.0",
             "8.10.1-SNAPSHOT",
+            "8.10.1",
             "8.11.0-SNAPSHOT"
         ],
         "aliases": [
+            "7.x-SNAPSHOT",
             "7.17-SNAPSHOT",
             "7.17",
+            "8.x-SNAPSHOT",
             "8.7",
             "8.8",
             "8.9-SNAPSHOT",
@@ -212,6 +199,23 @@ class TestFindOldestSupportVersion(unittest.TestCase):
     def test_too_old_to_be_in_api(self):
         self.assertEqual(find_oldest_supported_version("7.16.0"), "7.16.0")
         self.assertEqual(find_oldest_supported_version("8.6.0"), "8.6.0")
+        self.assertEqual(find_oldest_supported_version("7.6.0"), "7.6.0")
+
+    def test_newer_major_or_minor_versions_not_shown_in_api(self):
+        # next minor from 7.x
+        self.assertEqual(find_oldest_supported_version("7.19.0"), "7.19.0")
+        # next minor from 8.x
+        self.assertEqual(find_oldest_supported_version("8.12.0"), "8.12.0")
+        # next patch from 8.8.x
+        self.assertEqual(find_oldest_supported_version("8.8.3"), "8.8.3")
+        # next major 9.0
+        self.assertEqual(find_oldest_supported_version("9.0.0"), "9.0.0")
+
+    def test_missing_older_versions_in_api_response(self):
+        # exists 8.9.1 and 8.8.x, but not 8.9.0
+        self.assertEqual(find_oldest_supported_version("8.9.0"), "8.9.0")
+        # exists 8.9.2 and 8.9.4, but not 8.9.3
+        self.assertEqual(find_oldest_supported_version("8.9.3"), "8.9.3")
 
     def test_or(self):
         self.assertEqual(find_oldest_supported_version("8.6.0||8.7.0"), "8.6.0")


### PR DESCRIPTION
## Proposed commit message

Update find_oldest_supported_version.py as in main branch to get the latest fixes to get the latest supported version of the stack.

- Before
```
 $ python3 .buildkite/scripts/find_oldest_supported_version.py --manifest-path packages/security_detection_engine/manifest.yml 
8.x-SNAPSHOT
```
- After
```
 $ python3 .buildkite/scripts/find_oldest_supported_version.py --manifest-path packages/security_detection_engine/manifest.yml 
8.14.0
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Relates https://github.com/elastic/integrations/pull/11265
- Relates https://github.com/elastic/integrations/pull/11227


