### PR TITLE
[Cloud Security] Changed CSPM agentless identification tags

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -11,14 +11,15 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "1.12.0-preview02"
+- description: Changed the agentless tags to be a list
+    type: enhancement
+    link: https://github.com/elastic/integrations/pull/12066
 - version: "1.12.0-preview01"
   changes:
     - description: Add cloud connectors support
       type: enhancement
       link: https://github.com/elastic/integrations/pull/11663
-    - description: Changed the agentless tags to be a list
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/12066
 - version: "1.11.0"
   changes:
     - description: Promote integration

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -12,9 +12,9 @@
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
 - version: "1.12.0-preview02"
-- description: Changed the agentless tags to be a list
-    type: enhancement
-    link: https://github.com/elastic/integrations/pull/12066
+    - description: Changed the agentless tags to be a list
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12066
 - version: "1.12.0-preview01"
   changes:
     - description: Add cloud connectors support

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -16,6 +16,9 @@
     - description: Add cloud connectors support
       type: enhancement
       link: https://github.com/elastic/integrations/pull/11663
+    - description: Changed the agentless tags to be a list
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12066
 - version: "1.11.0"
   changes:
     - description: Promote integration

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -12,6 +12,7 @@
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
 - version: "1.12.0-preview02"
+  changes:
     - description: Changed the agentless tags to be a list
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12066

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.3
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.12.0-preview01"
+version: "1.12.0-preview02"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -107,7 +107,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        organization: elastic
+        organization: security
         division: engineering
         team: cloud-security-posture
     inputs:


### PR DESCRIPTION


## Proposed commit message

Changed the agentless identification tags for CSPM integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

When saving the CSPM integration using an agentless agent, the request should include the following labels

```
org: security
division: engineering
team: cloud-security-posture
```

## Related issues
- Closes https://github.com/elastic/security-team/issues/11401


