### PR TITLE
#12065-1/2 Adding PIM events

### DIFF
--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -119,7 +119,7 @@ Note: Descriptions have not been filled out
 | <remote-addr>     | destination.address       |
 | <remote_as>       | destination.as.number     |
 | <src_ipaddr>      | source.ip                 |
-| <threshold_limit> | aruba.bgp.threshold_limit |
+| <threshold_limit> | aruba.limit.threshold     |
 | <vrf-name>        | aruba.vrf.name            |
 
 #### [Bluetooth Management events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/BLUETOOTH_MGMT.htm)
@@ -306,7 +306,7 @@ Note: Descriptions have not been filled out
 | <num_of_failure>         | aruba.error.count            |
 | <failure_type>           | error.type                   |
 | <compare_mode>           | aruba.fan.compare_mode       |
-| <num_of_failure_limit>   | aruba.limit                  |
+| <num_of_failure_limit>   | aruba.limit.threshold        |
 | <seconds>                | aruba.time.seconds           |
 | <reason>                 | event.reason                 |
 | <function>               | aruba.fan.function           |
@@ -371,7 +371,7 @@ Note: Descriptions have not been filled out
 | <socket>     | aruba.hardware.socket    |
 | <status>     | aruba.status             |
 | <test_name>  | aruba.hardware.test_name |
-| <threshold>  | aruba.limit              |
+| <threshold>  | aruba.limit.threshold    |
 | <type>       | aruba.hardware.type      |
 
 #### [Hardware Switch controller sync events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/HSC-SYNCD.htm)
@@ -425,7 +425,7 @@ Note: Descriptions have not been filled out
 | Field                              | Description | Type | Common                       |
 |------------------------------------|-------------|------|------------------------------|
 | aruba.lockdown.interface           |             |      | observer.ingress.interface.name |
-| aruba.lockdown.max_supported_limit |             |      | aruba.limit                  |
+| aruba.lockdown.max_supported_limit |             |      | aruba.limit.threshold           |
 
 #### [IP tunnels events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IP_TUNNEL.htm)
 | Doc Fields   | Schema Mapping            |
@@ -653,7 +653,7 @@ Note: Descriptions have not been filled out
 #### [Multicast Traffic Manager events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MTM.htm)
 | Docs Field | Schema Mapping |
 |------------|----------------|
-| <limit>    | aruba.limit    |
+| <limit>    | aruba.limit.threshold    |
 
 #### [Multiple spanning tree protocol events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MSTP.htm)
 | Docs Field          | Schema Mapping               |
@@ -682,7 +682,7 @@ Note: Descriptions have not been filled out
 |------------|--------------------|
 | <port>     | aruba.port         |
 | <vlan>     | network.vlan.id    |
-| <vlan_max> | aruba.limit        |
+| <vlan_max> | aruba.limit.threshold |
 
 #### [NAE Agents events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/NAE_ALERT.htm)
 | Docs Field | Schema Mapping      |
@@ -788,42 +788,54 @@ Note: Descriptions have not been filled out
 | <stats_id>       | aruba.ospf.stats_id                 |
 
 #### [Password Reset events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PASSWD_RESET.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
+| Docs Field               | Schema Mapping               |
+|--------------------------|------------------------------|
 
 #### [PIM events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PIM.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.pim.callerid        |             |      |                              |
-| aruba.pim.dip             |             |      |                              |
-| aruba.pim.ebsr_ip         |             |      | server.ip                    |
-| aruba.pim.err             |             |      | error.message                |
-| aruba.pim.error           |             |      | error.message                |
-| aruba.pim.error_value     |             |      | error.code                   |
-| aruba.pim.event           |             |      | event.code                   |
-| aruba.pim.fd              |             |      |                              |
-| aruba.pim.flowtype        |             |      |                              |
-| aruba.pim.group           |             |      |                              |
-| aruba.pim.ifname          |             |      | observer.ingress.interface.name |
-| aruba.pim.interfaceName   |             |      | observer.ingress.interface.name |
-| aruba.pim.ip_address      |             |      | server.ip                    |
-| aruba.pim.ip_version      |             |      |                              |
-| aruba.pim.isl_status      |             |      | aruba.status                 |
-| aruba.pim.neighbor_ip     |             |      | client.ip                    |
-| aruba.pim.pkt             |             |      | network.packets              |
-| aruba.pim.pkt_type        |             |      |                              |
-| aruba.pim.port            |             |      | server.port                  |
-| aruba.pim.priority        |             |      | aruba.priority               |
-| aruba.pim.reason          |             |      | event.reason                 |
-| aruba.pim.sip             |             |      | source.ip                    |
-| aruba.pim.source          |             |      |                              |
-| aruba.pim.srcport         |             |      | source.port                  |
-| aruba.pim.srcvid          |             |      | network.vlan.id              |
-| aruba.pim.state           |             |      | aruba.status                 |
-| aruba.pim.status          |             |      | aruba.status                 |
-| aruba.pim.totalvid        |             |      |                              |
-| aruba.pim.type            |             |      |                              |
-| aruba.pim.vrf_name        |             |      | aruba.vrf.name               |
+| Docs Field        | Schema Mapping               |
+|-------------------|------------------------------|
+| <callerid>        | aruba.pim.callerid           |
+| <dip0>            | aruba.pim.dip0               |
+| <dip1>            | aruba.pim.dip1               |
+| <dip2>            | aruba.pim.dip2               |
+| <dip3>            | aruba.pim.dip3               |
+| <ebsr_ip>         | aruba.pim.ebsr_ip            |
+| <err>             | aruba.error.description      |
+| <error>           | event.reason                 |
+| <error_value>     | aruba.pim.error_value        |
+| <event>           | aruba.pim.event              |
+| <fd>              | aruba.pim.fd                 |
+| <flowtype>        | aruba.pim.flowtype           |
+| <group>           | group.name                   |
+| <ifname>          | aruba.interface.name         |
+| <InterfaceName>   | aruba.interface.name         |
+| <ip_address>      | server.ip                    |
+| <ip_version>      | aruba.pim.ip_version         |
+| <isl_status>      | aruba.status                 |
+| <limit>           | aruba.limit.threshold        |
+| <mode>            | aruba.limit.mode             |
+| <neighbor_ip>     | client.ip                    |
+| <pim_version>     | package.version              |
+| <pkt>             | network.packets              |
+| <pkt_type>        | aruba.pim.pkt_type           |
+| <port>            | aruba.port                   |
+| <priority>        | aruba.priority               |
+| <qsize>           | aruba.pim.qsize              |
+| <reason>          | event.reason                 |
+| <sip0>            | aruba.pim.sip0               |
+| <sip1>            | aruba.pim.sip1               |
+| <sip2>            | aruba.pim.sip2               |
+| <sip3>            | aruba.pim.sip3               |
+| <source>          | source.ip                    |
+| <srcport>         | aruba.port                   |
+| <srcvid>          | network.vlan.id              |
+| <state>           | aruba.state                  |
+| <status>          | aruba.status                 |
+| <totalvid>        | aruba.pim.totalvid           |
+| <type>            | aruba.pim.type               |
+| <val>             | aruba.limit.read_value       |
+| <value>           | aruba.pim.error_value        |
+| <vrf_name> / <vrfname> | aruba.vrf.name          |
 
 #### [Policies events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/POLICY.htm)
 | Field                     | Description | Type | Common                       |
@@ -863,7 +875,7 @@ Note: Descriptions have not been filled out
 #### [PORT_ACCESS events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PORT_ACCESS.htm)
 | Field                   | Description | Type | Common                       |
 |-------------------------|-------------|------|------------------------------|
-| aruba.port.limit        |             |      | aruba.limit                  |
+| aruba.port.limit        |             |      | aruba.limit.threshold                  |
 | aruba.port.mac_address  |             |      | client.mac                   |
 | aruba.port.mode         |             |      |                              |
 | aruba.port.name         |             |      | server.port                  |
@@ -897,7 +909,7 @@ Note: Descriptions have not been filled out
 | aruba.power.drawn           |             |      |                              |
 | aruba.power.fault_type      |             |      | error.type                   |
 | aruba.power.interface_name  |             |      |                              |
-| aruba.power.limit           |             |      | aruba.limit                  |
+| aruba.power.limit           |             |      | aruba.limit.threshold                  |
 | aruba.power.pair            |             |      |                              |
 | aruba.power.paira_class     |             |      |                              |
 | aruba.power.pairb_class     |             |      |                              |
@@ -1076,7 +1088,7 @@ Note: Descriptions have not been filled out
 | aruba.supportability.signal          |             |      | process.exit_code            |
 | aruba.supportability.state           |             |      | service.state                |
 | aruba.supportability.supported_files_name |        |      |                              |
-| aruba.supportability.threshold       |             |      | aruba.limit                  |
+| aruba.supportability.threshold       |             |      | aruba.limit.threshold                  |
 | aruba.supportability.timestamp       |             |      | process.end                  |
 | aruba.supportability.type            |             |      | file.type                    |
 | aruba.supportability.vrf             |             |      | aruba.vrf.id                 |

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
@@ -305,11 +305,47 @@
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-ospfv3[1234]: Event|4903|LOG_INFO|OSPFv3|-|OSPF3 designated routers field entry added: group_id=1 fp_id=2 stat_id=3
 2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-ospfv3[1234]: Event|4904|LOG_INFO|OSPFv3|-|AdjChg: Nbr 192.168.1.1 on interface fe80::1 on eth0(0.0.0.0): INIT -> FULL
 2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-ospfv3[1234]: Event|4905|LOG_INFO|OSPFv3|-|Interface fe80::1 on eth0(0.0.0.0) changed from DOWN to UP, input: 1
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5101|LOG_ERR|PIM|-|Failed to send HELLO packet on Interface eth0
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5101|LOG_ERR|PIM|-|Throttled 2 Messages
+ 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5102|LOG_INFO|PIM|-|PIM interface eth0 is configured with IP 192.168.1.1
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5103|LOG_ERR|PIM|-|Packet dropped from 192.168.1.2 on interface eth0 error checksum_error
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5103|LOG_ERR|PIM|-|Throttled 100 Messages
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5104|LOG_ERR|PIM|-|Received packet from router 192.168.1.3, unkwn pkt type 5
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5104|LOG_ERR|PIM|-|Throttled 100 Messages
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5105|LOG_ERR|PIM|-|Failed to add flow 10.0.0.1, 192.168.1.4 (active 1 10 20 unicast 100)
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5106|LOG_ERR|PIM|-|Failed to remove flow g 10.0.0.1, s 192, 168.1.6 (inactive 2 30 unicast 200)
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5106|LOG_ERR|PIM|-|Failed to remove flow 10.0.0.1, 192.168.1.6 (inactive 2 30 unicast 200)
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5107|LOG_WARN|PIM|-|Failed to add a mroute for s=192.168.1.7, g=224.0.0.1 on interface eth0 as the configured mroute limits are reached
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5107|LOG_WARN|PIM|-|Throttled 100 Messages
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5108|LOG_WARN|PIM|-|Failed to add a mroute for s=192.168.1.8, g=224.0.0.2 on interface eth0 as the configured sources per group limit is reached
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5108|LOG_WARN|PIM|-|Throttled 100 Messages
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5109|LOG_INFO|PIM|-|This router is elected as the IPv4 DR for interface eth0
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5110|LOG_ERR|PIM|-|Multicast socket creation failed with Fd: 5 on Port: 1234. Error description: permission_denied
+2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5111|LOG_ERR|PIM|-|OVSDB operation failed with timeout_error
+2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5111|LOG_ERR|PIM|-|Throttled 100 Messages
+ 2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5112|LOG_INFO|PIM|-|New Elected BSR for VRF default is 192.168.1.9 with priority 5
+2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5113|LOG_INFO|PIM|-|Elected BSR removed on VRF default
+2024-06-18T12:58:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5114|LOG_INFO|PIM|-|Candidate BSR 192.168.1.10 with priority 10 is active on interface eth0
+2024-06-18T12:59:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5115|LOG_INFO|PIM|-|PIM Neighbor 192.168.1.11 is up on interface eth0
+2024-06-18T13:00:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5116|LOG_WARN|PIM|-|100000 packet is discarded on interface eth0. Reason: checksum_error
+2024-06-18T13:00:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5116|LOG_WARN|PIM|-|Throttled 100 Messages
+2024-06-18T13:01:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5117|LOG_INFO|PIM|-|Forwarding state has changed to up on IPv4 enabled interface eth0
+2024-06-18T13:02:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5118|LOG_INFO|PIM|-|PIMv2 sparse mode is enabled on interface eth0
+2024-06-18T13:03:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5119|LOG_INFO|PIM|-|Router PIMv2 is sparse mode on VRF default
+2024-06-18T13:04:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5120|LOG_INFO|PIM|-|Candidate RP 192.168.1.12 is added on VRF default
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5121|LOG_INFO|PIM|-|Software Packet Queue 80% threshold value 100 reached. Queue size: 80
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5122|LOG_INFO|PIM|-|This router is elected as the IPv4 VSX DR for interface eth0
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5123|LOG_INFO|PIM|-|VSX ISL Status changed to up
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5124|LOG_INFO|PIM|-|Candidate RP 192.168.1.1 is configured on interface eth0
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5125|LOG_INFO|PIM|-|BFD Session created for neighbor 192.168.1.2 on interface eth0
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5126|LOG_INFO|PIM|-|BFD Session deleted for neighbor 192.168.1.2 on interface eth0
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5601|LOG_INFO|HTTPSSERVER|-|User admin has enabled read-only for REST mode
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5602|LOG_INFO|HTTPSSERVER|-|User admin has enabled HTTPS Server on VRF default
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5603|LOG_INFO|HTTPSSERVER|-|User admin closed all HTTPS sessions
 2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5604|LOG_INFO|HTTPSSERVER|-|User admin changed the HTTPS Server max user sessions amount to 10
 2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5605|LOG_INFO|HTTPSSERVER|-|User admin changed the HTTPS Server idle timeout to 300
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-password[1234]: Event|5901|LOG_INFO|PASSRESET|-|Password reset succeeded for admin user.
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-password[1234]: Event|5902|LOG_ERR|PASSRESET|-|Password reset failed for admin user.
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-nae[1234]: Event|6002|LOG_INFO|NAE|-|NAE agent nae_agent_1 stopped to collect samples from http://example.com.
 2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-nae[1234]: Event|6003|LOG_ERR|NAE|-|NAE agent nae_agent_1 with URI http://example.com has error and cannot collect samples.
 2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-nae[1234]: Event|6006|LOG_ERR|NAE|-|NAE agent nae_agent_1 with condition condition_1 has error and is not watched.

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -562,7 +562,9 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "limit": 2,
+                "limit": {
+                    "threshold": "2"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -607,7 +609,9 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "limit": 2,
+                "limit": {
+                    "threshold": "2"
+                },
                 "sequence": "1/1",
                 "time": {
                     "seconds": 60
@@ -970,7 +974,9 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "limit": 2,
+                "limit": {
+                    "threshold": "2"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -7783,15 +7789,15 @@
         {
             "@timestamp": "2024-06-19T14:22:07.025548-05:00",
             "aruba": {
-                "bgp": {
-                    "threshold_limit": 10
-                },
                 "component": {
                     "category": "AMM"
                 },
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "limit": {
+                    "threshold": "10"
                 },
                 "sequence": "1/1",
                 "vrf": {
@@ -8274,7 +8280,9 @@
                     "device": "8360-Primaire",
                     "socket": "mock_socket"
                 },
-                "limit": 1,
+                "limit": {
+                    "threshold": "1"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -8312,7 +8320,9 @@
                     "channel": "mock_channel",
                     "device": "8360-Primaire"
                 },
-                "limit": 1,
+                "limit": {
+                    "threshold": "1"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -8351,7 +8361,9 @@
                     "offlined": 3,
                     "page": "mock_page"
                 },
-                "limit": 1,
+                "limit": {
+                    "threshold": "1"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -8455,7 +8467,9 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "limit": 50
+                "limit": {
+                    "threshold": "50"
+                }
             },
             "ecs": {
                 "version": "8.11.0"
@@ -10909,7 +10923,9 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "limit": 100
+                "limit": {
+                    "threshold": "100"
+                }
             },
             "ecs": {
                 "version": "8.11.0"
@@ -11723,6 +11739,1358 @@
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",
             "aruba": {
                 "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                },
+                "pim": {
+                    "pkt_type": "HELLO"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5101",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5101|LOG_ERR|PIM|-|Failed to send HELLO packet on Interface eth0"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to send HELLO packet on Interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "throttle_count": 2
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5101",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5101|LOG_ERR|PIM|-|Throttled 2 Messages"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Throttled 2 Messages",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5102",
+                "original": " 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5102|LOG_INFO|PIM|-|PIM interface eth0 is configured with IP 192.168.1.1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "PIM interface eth0 is configured with IP 192.168.1.1",
+            "server": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                },
+                "pim": {
+                    "error_value": "checksum_error"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5103",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5103|LOG_ERR|PIM|-|Packet dropped from 192.168.1.2 on interface eth0 error checksum_error",
+                "reason": "error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Packet dropped from 192.168.1.2 on interface eth0 error checksum_error",
+            "server": {
+                "ip": "192.168.1.2"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "throttle_count": 100
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5103",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5103|LOG_ERR|PIM|-|Throttled 100 Messages"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Throttled 100 Messages",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "pim": {
+                    "pkt_type": "5"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5104",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5104|LOG_ERR|PIM|-|Received packet from router 192.168.1.3, unkwn pkt type 5"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Received packet from router 192.168.1.3, unkwn pkt type 5",
+            "server": {
+                "ip": "192.168.1.3"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "throttle_count": 100
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5104",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5104|LOG_ERR|PIM|-|Throttled 100 Messages"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Throttled 100 Messages",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "pim": {
+                    "callerid": "100",
+                    "dip0": "10",
+                    "dip1": "0",
+                    "dip2": "0",
+                    "dip3": "1",
+                    "flowtype": "unicast",
+                    "sip0": "192",
+                    "sip1": "168",
+                    "sip2": "1",
+                    "sip3": "4",
+                    "totalvid": 20
+                },
+                "port": "1",
+                "status": "active"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5105",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5105|LOG_ERR|PIM|-|Failed to add flow 10.0.0.1, 192.168.1.4 (active 1 10 20 unicast 100)"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to add flow 10.0.0.1, 192.168.1.4 (active 1 10 20 unicast 100)",
+            "network": {
+                "vlan": {
+                    "id": "10"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "pim": {
+                    "callerid": "200",
+                    "dip0": "10",
+                    "dip1": "0",
+                    "dip2": "0",
+                    "dip3": "1",
+                    "flowtype": "unicast",
+                    "sip0": "192",
+                    "sip1": "168",
+                    "sip2": "1",
+                    "sip3": "6"
+                },
+                "port": "2",
+                "status": "inactive"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5106",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5106|LOG_ERR|PIM|-|Failed to remove flow g 10.0.0.1, s 192, 168.1.6 (inactive 2 30 unicast 200)"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to remove flow g 10.0.0.1, s 192, 168.1.6 (inactive 2 30 unicast 200)",
+            "network": {
+                "vlan": {
+                    "id": "30"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "pim": {
+                    "callerid": "200",
+                    "dip0": "10",
+                    "dip1": "0",
+                    "dip2": "0",
+                    "dip3": "1",
+                    "flowtype": "unicast",
+                    "sip0": "192",
+                    "sip1": "168",
+                    "sip2": "1",
+                    "sip3": "6"
+                },
+                "port": "2",
+                "status": "inactive"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5106",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5106|LOG_ERR|PIM|-|Failed to remove flow 10.0.0.1, 192.168.1.6 (inactive 2 30 unicast 200)"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to remove flow 10.0.0.1, 192.168.1.6 (inactive 2 30 unicast 200)",
+            "network": {
+                "vlan": {
+                    "id": "30"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5107",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5107|LOG_WARN|PIM|-|Failed to add a mroute for s=192.168.1.7, g=224.0.0.1 on interface eth0 as the configured mroute limits are reached"
+            },
+            "group": {
+                "name": "224.0.0.1"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to add a mroute for s=192.168.1.7, g=224.0.0.1 on interface eth0 as the configured mroute limits are reached",
+            "source": {
+                "ip": "192.168.1.7"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "throttle_count": 100
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5107",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5107|LOG_WARN|PIM|-|Throttled 100 Messages"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Throttled 100 Messages",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5108",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5108|LOG_WARN|PIM|-|Failed to add a mroute for s=192.168.1.8, g=224.0.0.2 on interface eth0 as the configured sources per group limit is reached"
+            },
+            "group": {
+                "name": "224.0.0.2"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to add a mroute for s=192.168.1.8, g=224.0.0.2 on interface eth0 as the configured sources per group limit is reached",
+            "source": {
+                "ip": "192.168.1.8"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "throttle_count": 100
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5108",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5108|LOG_WARN|PIM|-|Throttled 100 Messages"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Throttled 100 Messages",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                },
+                "pim": {
+                    "ip_version": "IPv4"
+                },
+                "state": "DR"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5109",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5109|LOG_INFO|PIM|-|This router is elected as the IPv4 DR for interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "This router is elected as the IPv4 DR for interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "error": {
+                    "description": "permission_denied"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "pim": {
+                    "fd": "5",
+                    "type": "Multicast"
+                },
+                "port": "1234"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5110",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5110|LOG_ERR|PIM|-|Multicast socket creation failed with Fd: 5 on Port: 1234. Error description: permission_denied",
+                "reason": "socket creation"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Multicast socket creation failed with Fd: 5 on Port: 1234. Error description: permission_denied",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5111",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5111|LOG_ERR|PIM|-|OVSDB operation failed with timeout_error",
+                "reason": "timeout_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "OVSDB operation failed with timeout_error",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "throttle_count": 100
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5111",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5111|LOG_ERR|PIM|-|Throttled 100 Messages"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Throttled 100 Messages",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:56:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "pim": {
+                    "ebsr_ip": "192.168.1.9"
+                },
+                "priority": "5",
+                "vrf": {
+                    "name": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5112",
+                "original": " 2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5112|LOG_INFO|PIM|-|New Elected BSR for VRF default is 192.168.1.9 with priority 5"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "New Elected BSR for VRF default is 192.168.1.9 with priority 5",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:57:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vrf": {
+                    "name": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5113",
+                "original": "2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5113|LOG_INFO|PIM|-|Elected BSR removed on VRF default"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Elected BSR removed on VRF default",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:58:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                },
+                "priority": "10",
+                "status": "active"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5114",
+                "original": "2024-06-18T12:58:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5114|LOG_INFO|PIM|-|Candidate BSR 192.168.1.10 with priority 10 is active on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Candidate BSR 192.168.1.10 with priority 10 is active on interface eth0",
+            "server": {
+                "ip": "192.168.1.10"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:59:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                },
+                "pim": {
+                    "event": "up"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.11"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5115",
+                "original": "2024-06-18T12:59:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5115|LOG_INFO|PIM|-|PIM Neighbor 192.168.1.11 is up on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "PIM Neighbor 192.168.1.11 is up on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:00:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5116",
+                "original": "2024-06-18T13:00:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5116|LOG_WARN|PIM|-|100000 packet is discarded on interface eth0. Reason: checksum_error",
+                "reason": "checksum_error"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "100000 packet is discarded on interface eth0. Reason: checksum_error",
+            "network": {
+                "packets": 100000
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:00:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "throttle_count": 100
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5116",
+                "original": "2024-06-18T13:00:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5116|LOG_WARN|PIM|-|Throttled 100 Messages"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Throttled 100 Messages",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:01:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                },
+                "pim": {
+                    "ip_version": "IPv4"
+                },
+                "state": "up"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5117",
+                "original": "2024-06-18T13:01:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5117|LOG_INFO|PIM|-|Forwarding state has changed to up on IPv4 enabled interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Forwarding state has changed to up on IPv4 enabled interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:02:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                },
+                "pim": {
+                    "mode": "sparse"
+                },
+                "status": "enabled"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5118",
+                "original": "2024-06-18T13:02:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5118|LOG_INFO|PIM|-|PIMv2 sparse mode is enabled on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "PIMv2 sparse mode is enabled on interface eth0",
+            "package": {
+                "version": "PIMv2"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:03:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "pim": {
+                    "mode": "sparse mode"
+                },
+                "vrf": {
+                    "name": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5119",
+                "original": "2024-06-18T13:03:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5119|LOG_INFO|PIM|-|Router PIMv2 is sparse mode on VRF default"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Router PIMv2 is sparse mode on VRF default",
+            "package": {
+                "version": "PIMv2"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:04:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "pim": {
+                    "event": "added"
+                },
+                "vrf": {
+                    "name": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5120",
+                "original": "2024-06-18T13:04:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5120|LOG_INFO|PIM|-|Candidate RP 192.168.1.12 is added on VRF default"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Candidate RP 192.168.1.12 is added on VRF default",
+            "server": {
+                "ip": "192.168.1.12"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "limit": {
+                    "read_value": 100,
+                    "threshold": "80%"
+                },
+                "pim": {
+                    "qsize": 80
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5121",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5121|LOG_INFO|PIM|-|Software Packet Queue 80% threshold value 100 reached. Queue size: 80"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Software Packet Queue 80% threshold value 100 reached. Queue size: 80",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                },
+                "pim": {
+                    "ip_version": "IPv4"
+                },
+                "state": "DR"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5122",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5122|LOG_INFO|PIM|-|This router is elected as the IPv4 VSX DR for interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "This router is elected as the IPv4 VSX DR for interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "status": "up"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5123",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5123|LOG_INFO|PIM|-|VSX ISL Status changed to up"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX ISL Status changed to up",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5124",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5124|LOG_INFO|PIM|-|Candidate RP 192.168.1.1 is configured on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "Candidate RP 192.168.1.1 is configured on interface eth0",
+            "server": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5125",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5125|LOG_INFO|PIM|-|BFD Session created for neighbor 192.168.1.2 on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "BFD Session created for neighbor 192.168.1.2 on interface eth0",
+            "server": {
+                "ip": "192.168.1.2"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PIM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5126",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5126|LOG_INFO|PIM|-|BFD Session deleted for neighbor 192.168.1.2 on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-pim",
+                    "procid": "1234"
+                }
+            },
+            "message": "BFD Session deleted for neighbor 192.168.1.2 on interface eth0",
+            "server": {
+                "ip": "192.168.1.2"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
                     "category": "HTTPSSERVER"
                 },
                 "event_type": "Event",
@@ -11916,6 +13284,72 @@
                     "name": "admin"
                 }
             },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PASSRESET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5901",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-password[1234]: Event|5901|LOG_INFO|PASSRESET|-|Password reset succeeded for admin user."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-password",
+                    "procid": "1234"
+                }
+            },
+            "message": "Password reset succeeded for admin user.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PASSRESET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5902",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-password[1234]: Event|5902|LOG_ERR|PASSRESET|-|Password reset failed for admin user."
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-password",
+                    "procid": "1234"
+                }
+            },
+            "message": "Password reset failed for admin user.",
             "tags": [
                 "preserve_original_event"
             ]
@@ -20853,7 +22287,9 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "limit": 1000
+                "limit": {
+                    "threshold": "1000"
+                }
             },
             "ecs": {
                 "version": "8.11.0"
@@ -20887,7 +22323,9 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "limit": 1000
+                "limit": {
+                    "threshold": "1000"
+                }
             },
             "ecs": {
                 "version": "8.11.0"
@@ -20921,7 +22359,9 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "limit": 1000
+                "limit": {
+                    "threshold": "1000"
+                }
             },
             "ecs": {
                 "version": "8.11.0"

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -118,14 +118,14 @@ processors:
       description: "Log error when system shutdown is initiated due to critical fan faults"
       if: "ctx.event?.code == '209'"
       patterns:
-        - "^Shutting down system now because %{NUMBER:aruba.error.count:long} %{DATA:error.type} %{DATA:aruba.fan.compare_mode} limit of %{NUMBER:aruba.limit:long}"
+        - "^Shutting down system now because %{NUMBER:aruba.error.count:long} %{DATA:error.type} %{DATA:aruba.fan.compare_mode} limit of %{NUMBER:aruba.limit.threshold}"
   - grok:
       field: message
       tag: fan_event_211
       description: "Log error when the number of failures exceed the allowable limit"
       if: "ctx.event?.code == '211'"
       patterns:
-        - "^Shutting down system in %{NUMBER:aruba.time.seconds:long} seconds because %{NUMBER:aruba.error.count:long} %{DATA:error.type} %{DATA:aruba.fan.compare_mode} limit of %{NUMBER:aruba.limit:long}"
+        - "^Shutting down system in %{NUMBER:aruba.time.seconds:long} seconds because %{NUMBER:aruba.error.count:long} %{DATA:error.type} %{DATA:aruba.fan.compare_mode} limit of %{GREEDYDATA:aruba.limit.threshold}"
   - grok:
       field: message
       tag: fan_event_213
@@ -206,7 +206,7 @@ processors:
       description: "Log error when number of faulty/supported fans does not meet the allowable limit"
       if: "ctx.event?.code == '222'"
       patterns:
-        - "^%{NUMBER:aruba.error.count:long} %{DATA:error.type} %{DATA:aruba.fan.compare_mode} limit of %{NUMBER:aruba.limit:long}"
+        - "^%{NUMBER:aruba.error.count:long} %{DATA:error.type} %{DATA:aruba.fan.compare_mode} limit of %{GREEDYDATA:aruba.limit.threshold}"
   - dissect:
       field: message
       tag: fan_event_223
@@ -832,7 +832,7 @@ processors:
       field: "message"
       description: "Trap when the rib size reaches the threshold value."
       patterns:
-        - "^The BGP RIB has reached the threshold limit of %{DATA:aruba.bgp.threshold_limit:long} for VRF %{DATA:aruba.vrf.name}': yes"
+        - "^The BGP RIB has reached the threshold limit of %{DATA:aruba.limit.threshold} for VRF %{DATA:aruba.vrf.name}': yes"
   - grok:
       if: "ctx.event.code == '2920'"
       tag: bgp_event_2920
@@ -890,7 +890,7 @@ processors:
         - "^Module %{DATA:aruba.hardware.channel} %{3011_3012_3013_COMMON}"
         - "^Page %{DATA:aruba.hardware.page} %{3011_3012_3013_COMMON}"
       pattern_definitions:
-        3011_3012_3013_COMMON: "correctable memory error count %{NUMBER:aruba.hardware.cecount:long} exceeded threshold %{NUMBER:aruba.limit:long}(?:%{3011_3012_3013_OPTIONAL})?"
+        3011_3012_3013_COMMON: "correctable memory error count %{NUMBER:aruba.hardware.cecount:long} exceeded threshold %{NUMBER:aruba.limit.threshold}(?:%{3011_3012_3013_OPTIONAL})?"
         3011_3012_3013_OPTIONAL: " and %{NUMBER:aruba.hardware.offlined:long}"
 
     # MVRP events (310x)
@@ -902,7 +902,7 @@ processors:
       if: "['3101','3102','3103','3104','3105'].contains(ctx.event?.code)"
       patterns:
         - "^MVRP (en|dis)abled on port %{GREEDYDATA:aruba.port}"
-        - "^MVRP failed to create VLAN %{DATA:network.vlan.id}. Maximum VLANs %{NUMBER:aruba.limit:long} already created"
+        - "^MVRP failed to create VLAN %{DATA:network.vlan.id}. Maximum VLANs %{DATA:aruba.limit.threshold} already created"
         - "^MVRP statistics have been cleared for (%{3104_PATTERN}|%{3105_PATTERN})"
       pattern_definitions:
         3104_PATTERN: "port %{GREEDYDATA:aruba.port}"
@@ -965,7 +965,7 @@ processors:
       tag: multicast_traffic_mgr_event_4001
       description: "Event raised when the maximum number of multicast L3 Bridge Control Forwarding entries is reached"
       if: "ctx.event?.code == '4001'"
-      pattern: "The Multicast L3 Bridge Control Forwarding entries limit was reached: %{aruba.limit}"
+      pattern: "The Multicast L3 Bridge Control Forwarding entries limit was reached: %{aruba.limit.threshold}"
 
     # Management events (430x)
     # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MGMT.htm
@@ -1056,6 +1056,178 @@ processors:
       pattern_definitions:
         INTERFACE_AREA: "(I|i)nterface %{DATA:aruba.ospf.link_local} on %{DATA:aruba.interface.id}\\(%{DATA:aruba.ospf.area}\\)"
         STATE_CHANGE: "%{DATA:aruba.ospf.old_state} (->|to) %{GREEDYDATA:aruba.state}"
+
+  # PIM events (51xx)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PIM.htm
+
+  - grok:
+      if: "ctx.event?.code == '5101'"
+      field: message
+      tag: pim_event_5101
+      description: "Send error packet"
+      patterns:
+        - "^Failed to send %{DATA:aruba.pim.pkt_type} packet on Interface %{GREEDYDATA:aruba.interface.name}"
+        - "^Throttled %{NUMBER:aruba.throttle_count:long} Messages"
+  - dissect:
+      if: "ctx.event?.code == '5102'"
+      field: message
+      tag: pim_event_5102
+      description: "Pim IP config"
+      pattern: "PIM interface %{aruba.interface.name} is configured with IP %{server.ip}"
+  - grok:
+      if: "ctx.event?.code == '5103'"
+      field: message
+      tag: pim_event_5103
+      description: "Packet dropped"
+      patterns: 
+        - "^Packet dropped from %{IP:server.ip} on interface %{DATA:aruba.interface.name} %{DATA:event.reason} %{GREEDYDATA:aruba.pim.error_value}"
+        - "^Throttled %{NUMBER:aruba.throttle_count:long} Messages"
+  - grok:
+      if: "ctx.event?.code == '5104'"
+      field: message
+      tag: pim_event_5104
+      description: "Received packet from router"
+      patterns: 
+        - "^Received packet from router %{IP:server.ip}, unkwn pkt type %{GREEDYDATA:aruba.pim.pkt_type}"
+        - "^Throttled %{NUMBER:aruba.throttle_count:long} Messages"
+  - grok:
+      if: "ctx.event?.code == '5105'"
+      field: message
+      tag: pim_event_5105
+      description: "Failed to add flow"
+      patterns: 
+        - "^Failed to add flow %{IP_BIT:aruba.pim.dip0}.%{IP_BIT:aruba.pim.dip1}.%{IP_BIT:aruba.pim.dip2}.%{IP_BIT:aruba.pim.dip3}, %{IP_BIT:aruba.pim.sip0}.%{IP_BIT:aruba.pim.sip1}.%{IP_BIT:aruba.pim.sip2}.%{IP_BIT:aruba.pim.sip3} \\(%{DATA:aruba.status} %{DATA:aruba.port} %{DATA:network.vlan.id} %{NUMBER:aruba.pim.totalvid:long} %{DATA:aruba.pim.flowtype} %{DATA:aruba.pim.callerid}\\)"
+      pattern_definitions:
+        IP_BIT: "(?:[0-1]?[0-9]{1,2}|2[0-4][0-9]|25[0-5])"
+  - grok:
+      if: "ctx.event?.code == '5106'"
+      field: message
+      tag: pim_event_5106
+      description: "Failed to remove flow for Hardware"
+      patterns:
+        - "^Failed to remove flow g %{IP_BIT:aruba.pim.dip0}.%{IP_BIT:aruba.pim.dip1}.%{IP_BIT:aruba.pim.dip2}.%{IP_BIT:aruba.pim.dip3}, s %{IP_BIT:aruba.pim.sip0}, %{IP_BIT:aruba.pim.sip1}.%{IP_BIT:aruba.pim.sip2}.%{DATA:aruba.pim.sip3} \\(%{DATA:aruba.status} %{DATA:aruba.port} %{DATA:network.vlan.id} %{DATA:aruba.pim.flowtype} %{DATA:aruba.pim.callerid}\\)"
+        # Added another pattern in case the documentation is incorrect, aligned this pattern with the 5105 pattern
+        - "^Failed to remove flow %{IP_BIT:aruba.pim.dip0}.%{IP_BIT:aruba.pim.dip1}.%{IP_BIT:aruba.pim.dip2}.%{IP_BIT:aruba.pim.dip3}, %{IP_BIT:aruba.pim.sip0}.%{IP_BIT:aruba.pim.sip1}.%{IP_BIT:aruba.pim.sip2}.%{IP_BIT:aruba.pim.sip3} \\(%{DATA:aruba.status} %{DATA:aruba.port} %{DATA:network.vlan.id} %{DATA:aruba.pim.flowtype} %{DATA:aruba.pim.callerid}\\)"
+      pattern_definitions:
+        IP_BIT: "(?:[0-1]?[0-9]{1,2}|2[0-4][0-9]|25[0-5])"
+  - grok:
+      if: "['5107', '5108'].contains(ctx.event?.code)"
+      field: message
+      tag: pim_event_5107_5108
+      description: "Failed to program mroute as the limits are reached | sources per group limit is reached"
+      patterns: 
+        - "^Failed to add a mroute for s=%{IP:source.ip}, g=%{DATA:group.name} on interface %{DATA:aruba.interface.name} "
+        - "^Throttled %{NUMBER:aruba.throttle_count:long} Messages"
+  - dissect:
+      if: "ctx.event?.code == '5109'"
+      field: message
+      tag: pim_event_5109
+      description: "PIM DR election log"
+      pattern: "This router is elected as the %{aruba.pim.ip_version} %{aruba.state} for interface %{aruba.interface.name}"
+  - dissect:
+      if: "ctx.event?.code == '5110'"
+      field: message
+      tag: pim_event_5110
+      description: "Multicast socket creation error"
+      pattern: "%{aruba.pim.type} %{event.reason} failed with Fd: %{aruba.pim.fd} on Port: %{aruba.port}. Error description: %{aruba.error.description}"
+  - grok:
+      if: "ctx.event?.code == '5111'"
+      field: message
+      tag: pim_event_5111
+      description: "DB Operation failed"
+      patterns: 
+        - "OVSDB operation failed with %{GREEDYDATA:event.reason}"
+        - "^Throttled %{NUMBER:aruba.throttle_count:long} Messages"
+  - dissect:
+      if: "ctx.event?.code == '5112'"
+      field: message
+      tag: pim_event_5112
+      description: "Elected BSR"
+      pattern: "New Elected BSR for VRF %{aruba.vrf.name} is %{aruba.pim.ebsr_ip} with priority %{aruba.priority}"
+  - dissect:
+      if: "ctx.event?.code == '5113'"
+      field: message
+      tag: pim_event_5113
+      description: "Elected BSR removed"
+      pattern: "Elected BSR removed on VRF %{aruba.vrf.name}"
+  - dissect:
+      if: "ctx.event?.code == '5114'"
+      field: message
+      tag: pim_event_5114
+      description: "Configured candidate BSR"
+      pattern: "Candidate BSR %{server.ip} with priority %{aruba.priority} is %{aruba.status} on interface %{aruba.interface.name}"
+  - dissect:
+      if: "ctx.event?.code == '5115'"
+      field: message
+      tag: pim_event_5115
+      description: "Neighbor status"
+      pattern: "PIM Neighbor %{client.ip} is %{aruba.pim.event} on interface %{aruba.interface.name}"
+  - grok:
+      if: "ctx.event?.code == '5116'"
+      field: message
+      tag: pim_event_5116
+      description: "Packet drop"
+      patterns: 
+        - "^%{NUMBER:network.packets:long} packet is discarded on interface %{DATA:aruba.interface.name}. Reason: %{GREEDYDATA:event.reason}"
+        - "^Throttled %{NUMBER:aruba.throttle_count:long} Messages"
+  - dissect:
+      if: "ctx.event?.code == '5117'"
+      field: message
+      tag: pim_event_5117
+      description: "Interface operational status"
+      pattern: "Forwarding state has changed to %{aruba.state} on %{aruba.pim.ip_version} enabled interface %{aruba.interface.name}"
+  - dissect:
+      if: "ctx.event?.code == '5118'"
+      field: message
+      tag: pim_event_5118
+      description: "Interface PIM mode"
+      pattern: "%{package.version} %{aruba.pim.mode} mode is %{aruba.status} on interface %{aruba.interface.name}"
+  - dissect:
+      if: "ctx.event?.code == '5119'"
+      field: message
+      tag: pim_event_5119
+      description: "Router pim configuration status"
+      pattern: "Router %{package.version} is %{aruba.pim.mode} on VRF %{aruba.vrf.name}"
+  - dissect:
+      if: "ctx.event?.code == '5120'"
+      field: message
+      tag: pim_event_5120
+      description: "Learnt or removed candidate RP"
+      pattern: "Candidate RP %{server.ip} is %{aruba.pim.event} on VRF %{aruba.vrf.name}"
+  - grok:
+      if: "ctx.event?.code == '5121'"
+      field: message
+      tag: pim_event_5121
+      description: "Software Packet Queue reaches threshold"
+      patterns: 
+        - "^Software Packet Queue %{DATA:aruba.limit.threshold} threshold value %{NUMBER:aruba.limit.read_value:long} reached. Queue size: %{NUMBER:aruba.pim.qsize:long}"
+  - dissect:
+      if: "ctx.event?.code == '5122'"
+      field: message
+      tag: pim_event_5122
+      description: "PIM VSX DR Election log"
+      pattern: "This router is elected as the %{aruba.pim.ip_version} VSX %{aruba.state} for interface %{aruba.interface.name}"
+  - dissect:
+      if: "ctx.event?.code == '5123'"
+      field: message
+      tag: pim_event_5123
+      description: "VSX ISL Status update log"
+      pattern: "VSX ISL Status changed to %{aruba.status}"
+  - grok:
+      if: "ctx.event?.code == '5124'"
+      field: message
+      tag: pim_event_5124
+      description: "Configured candidate RP"
+      patterns: 
+        - "^Candidate RP %{IP:server.ip} is configured on interface %{GREEDYDATA:aruba.interface.name}"
+  - grok:
+      field: message
+      tag: pim_event_5125_5126
+      if: "['5125','5126'].contains(ctx.event?.code)"
+      description: "BFD Session created or deleted"
+      patterns:
+        - "^BFD Session (created|deleted) for neighbor %{IP:server.ip} on interface %{GREEDYDATA:aruba.interface.name}"
+
 
   # HTTPS Server events (560x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/HTTPS_SERVER.htm
@@ -1168,7 +1340,7 @@ processors:
       description: "Duplicate IP detected from ARP reply | Duplicate IPv6 address detected from Neighbour advertisement | Duplicate IP detected from ARP request"
       patterns:
         - "^Duplicate (IPv4|IPv6) address %{IP:client.ip} is detected on port %{DATA:aruba.port} with a MAC address of %{MAC:client.mac}"
-        - "^Throttled %{NUMBER:aruba.throttle_count:long} Messages" 
+        - "^Throttled %{NUMBER:aruba.throttle_count:long} Messages"
   
   # Credential Manager events (65xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CREDMGR.htm
@@ -2009,8 +2181,8 @@ processors:
       field: "message"
       description: "This log event informs the user that IP_SOURCE_LOCKDOWN resource utilization has reached 80 percent of the supported limits"
       patterns:
-        - "^IP_SOURCE_LOCKDOWN resource utilization has (reached|reduced)( below)? 80 percent of the supported limit of %{NUMBER:aruba.limit:long} on the system"
-        - "^IP_SOURCE_LOCKDOWN resource utilization has exceeded maximum supported limit of %{NUMBER:aruba.limit:long} on the system. IP source-lockdown functionality will not work for new entries"
+        - "^IP_SOURCE_LOCKDOWN resource utilization has (reached|reduced)( below)? 80 percent of the supported limit of %{DATA:aruba.limit.threshold} on the system"
+        - "^IP_SOURCE_LOCKDOWN resource utilization has exceeded maximum supported limit of %{DATA:aruba.limit.threshold} on the system. IP source-lockdown functionality will not work for new entries"
         - "^(IPV4_SOURCE_LOCKDOWN|IPV6_SOURCE_LOCKDOWN) is (enabled|disabled) on interface %{GREEDYDATA:aruba.interface.id}"
 
   # ACLs events (100xx)
@@ -2262,13 +2434,8 @@ processors:
 
   # Convert due to dissect processing
   # - aruba.slot
-  # - aruba.limit
   - convert:
       field: aruba.slot
-      type: long
-      ignore_missing: true
-  - convert:
-      field: aruba.limit
       type: long
       ignore_missing: true
 

--- a/packages/hpe_aruba_cx/data_stream/log/fields/ecs.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/ecs.yml
@@ -21,6 +21,8 @@
 - external: ecs
   name: error.code
 - external: ecs
+  name: error.message
+- external: ecs
   name: error.type
 - external: ecs
   name: event.action

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -101,9 +101,6 @@
         - name: pg_name
           type: keyword
           description: ""
-        - name: threshold_limit
-          type: long
-          description: ""
         - name: vtep_ip
           type: ip
           description: ""
@@ -241,6 +238,9 @@
       fields:
         - name: count
           type: long
+          description: ""
+        - name: description
+          type: keyword
           description: ""
     - name: event_type
       type: keyword
@@ -522,8 +522,15 @@
       type: long
       description: ""
     - name: limit
-      type: long
+      type: group
       description: ""
+      fields:
+        - name: threshold
+          type: keyword
+          description: ""
+        - name: read_value
+          type: long
+          description: ""
     - name: lldp
       type: group
       fields:
@@ -750,6 +757,69 @@
           type: keyword
           description: ""
         - name: stats_id
+          type: keyword
+          description: ""
+    - name: pim
+      type: group
+      fields:
+        - name: callerid
+          type: keyword
+          description: ""
+        - name: dip0
+          type: keyword
+          description: ""
+        - name: dip1
+          type: keyword
+          description: ""
+        - name: dip2
+          type: keyword
+          description: ""
+        - name: dip3
+          type: keyword
+          description: ""
+        - name: ebsr_ip
+          type: ip
+          description: ""
+        - name: error_value
+          type: keyword
+          description: ""
+        - name: event
+          type: keyword
+          description: ""
+        - name: fd
+          type: keyword
+          description: ""
+        - name: flowtype
+          type: keyword
+          description: ""
+        - name: ip_version
+          type: keyword
+          description: ""
+        - name: mode
+          type: keyword
+          description: ""
+        - name: pkt_type
+          type: keyword
+          description: ""
+        - name: qsize
+          type: long
+          description: ""
+        - name: sip0
+          type: keyword
+          description: ""
+        - name: sip1
+          type: keyword
+          description: ""
+        - name: sip2
+          type: keyword
+          description: ""
+        - name: sip3
+          type: keyword
+          description: ""
+        - name: totalvid
+          type: long
+          description: ""
+        - name: type
           type: keyword
           description: ""
     - name: port

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -119,7 +119,7 @@ Note: Descriptions have not been filled out
 | <remote-addr>     | destination.address       |
 | <remote_as>       | destination.as.number     |
 | <src_ipaddr>      | source.ip                 |
-| <threshold_limit> | aruba.bgp.threshold_limit |
+| <threshold_limit> | aruba.limit.threshold     |
 | <vrf-name>        | aruba.vrf.name            |
 
 #### [Bluetooth Management events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/BLUETOOTH_MGMT.htm)
@@ -306,7 +306,7 @@ Note: Descriptions have not been filled out
 | <num_of_failure>         | aruba.error.count            |
 | <failure_type>           | error.type                   |
 | <compare_mode>           | aruba.fan.compare_mode       |
-| <num_of_failure_limit>   | aruba.limit                  |
+| <num_of_failure_limit>   | aruba.limit.threshold        |
 | <seconds>                | aruba.time.seconds           |
 | <reason>                 | event.reason                 |
 | <function>               | aruba.fan.function           |
@@ -371,7 +371,7 @@ Note: Descriptions have not been filled out
 | <socket>     | aruba.hardware.socket    |
 | <status>     | aruba.status             |
 | <test_name>  | aruba.hardware.test_name |
-| <threshold>  | aruba.limit              |
+| <threshold>  | aruba.limit.threshold    |
 | <type>       | aruba.hardware.type      |
 
 #### [Hardware Switch controller sync events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/HSC-SYNCD.htm)
@@ -425,7 +425,7 @@ Note: Descriptions have not been filled out
 | Field                              | Description | Type | Common                       |
 |------------------------------------|-------------|------|------------------------------|
 | aruba.lockdown.interface           |             |      | observer.ingress.interface.name |
-| aruba.lockdown.max_supported_limit |             |      | aruba.limit                  |
+| aruba.lockdown.max_supported_limit |             |      | aruba.limit.threshold           |
 
 #### [IP tunnels events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IP_TUNNEL.htm)
 | Doc Fields   | Schema Mapping            |
@@ -653,7 +653,7 @@ Note: Descriptions have not been filled out
 #### [Multicast Traffic Manager events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MTM.htm)
 | Docs Field | Schema Mapping |
 |------------|----------------|
-| <limit>    | aruba.limit    |
+| <limit>    | aruba.limit.threshold    |
 
 #### [Multiple spanning tree protocol events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MSTP.htm)
 | Docs Field          | Schema Mapping               |
@@ -682,7 +682,7 @@ Note: Descriptions have not been filled out
 |------------|--------------------|
 | <port>     | aruba.port         |
 | <vlan>     | network.vlan.id    |
-| <vlan_max> | aruba.limit        |
+| <vlan_max> | aruba.limit.threshold |
 
 #### [NAE Agents events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/NAE_ALERT.htm)
 | Docs Field | Schema Mapping      |
@@ -788,42 +788,54 @@ Note: Descriptions have not been filled out
 | <stats_id>       | aruba.ospf.stats_id                 |
 
 #### [Password Reset events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PASSWD_RESET.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
+| Docs Field               | Schema Mapping               |
+|--------------------------|------------------------------|
 
 #### [PIM events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PIM.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.pim.callerid        |             |      |                              |
-| aruba.pim.dip             |             |      |                              |
-| aruba.pim.ebsr_ip         |             |      | server.ip                    |
-| aruba.pim.err             |             |      | error.message                |
-| aruba.pim.error           |             |      | error.message                |
-| aruba.pim.error_value     |             |      | error.code                   |
-| aruba.pim.event           |             |      | event.code                   |
-| aruba.pim.fd              |             |      |                              |
-| aruba.pim.flowtype        |             |      |                              |
-| aruba.pim.group           |             |      |                              |
-| aruba.pim.ifname          |             |      | observer.ingress.interface.name |
-| aruba.pim.interfaceName   |             |      | observer.ingress.interface.name |
-| aruba.pim.ip_address      |             |      | server.ip                    |
-| aruba.pim.ip_version      |             |      |                              |
-| aruba.pim.isl_status      |             |      | aruba.status                 |
-| aruba.pim.neighbor_ip     |             |      | client.ip                    |
-| aruba.pim.pkt             |             |      | network.packets              |
-| aruba.pim.pkt_type        |             |      |                              |
-| aruba.pim.port            |             |      | server.port                  |
-| aruba.pim.priority        |             |      | aruba.priority               |
-| aruba.pim.reason          |             |      | event.reason                 |
-| aruba.pim.sip             |             |      | source.ip                    |
-| aruba.pim.source          |             |      |                              |
-| aruba.pim.srcport         |             |      | source.port                  |
-| aruba.pim.srcvid          |             |      | network.vlan.id              |
-| aruba.pim.state           |             |      | aruba.status                 |
-| aruba.pim.status          |             |      | aruba.status                 |
-| aruba.pim.totalvid        |             |      |                              |
-| aruba.pim.type            |             |      |                              |
-| aruba.pim.vrf_name        |             |      | aruba.vrf.name               |
+| Docs Field        | Schema Mapping               |
+|-------------------|------------------------------|
+| <callerid>        | aruba.pim.callerid           |
+| <dip0>            | aruba.pim.dip0               |
+| <dip1>            | aruba.pim.dip1               |
+| <dip2>            | aruba.pim.dip2               |
+| <dip3>            | aruba.pim.dip3               |
+| <ebsr_ip>         | aruba.pim.ebsr_ip            |
+| <err>             | aruba.error.description      |
+| <error>           | event.reason                 |
+| <error_value>     | aruba.pim.error_value        |
+| <event>           | aruba.pim.event              |
+| <fd>              | aruba.pim.fd                 |
+| <flowtype>        | aruba.pim.flowtype           |
+| <group>           | group.name                   |
+| <ifname>          | aruba.interface.name         |
+| <InterfaceName>   | aruba.interface.name         |
+| <ip_address>      | server.ip                    |
+| <ip_version>      | aruba.pim.ip_version         |
+| <isl_status>      | aruba.status                 |
+| <limit>           | aruba.limit.threshold        |
+| <mode>            | aruba.limit.mode             |
+| <neighbor_ip>     | client.ip                    |
+| <pim_version>     | package.version              |
+| <pkt>             | network.packets              |
+| <pkt_type>        | aruba.pim.pkt_type           |
+| <port>            | aruba.port                   |
+| <priority>        | aruba.priority               |
+| <qsize>           | aruba.pim.qsize              |
+| <reason>          | event.reason                 |
+| <sip0>            | aruba.pim.sip0               |
+| <sip1>            | aruba.pim.sip1               |
+| <sip2>            | aruba.pim.sip2               |
+| <sip3>            | aruba.pim.sip3               |
+| <source>          | source.ip                    |
+| <srcport>         | aruba.port                   |
+| <srcvid>          | network.vlan.id              |
+| <state>           | aruba.state                  |
+| <status>          | aruba.status                 |
+| <totalvid>        | aruba.pim.totalvid           |
+| <type>            | aruba.pim.type               |
+| <val>             | aruba.limit.read_value       |
+| <value>           | aruba.pim.error_value        |
+| <vrf_name> / <vrfname> | aruba.vrf.name          |
 
 #### [Policies events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/POLICY.htm)
 | Field                     | Description | Type | Common                       |
@@ -863,7 +875,7 @@ Note: Descriptions have not been filled out
 #### [PORT_ACCESS events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PORT_ACCESS.htm)
 | Field                   | Description | Type | Common                       |
 |-------------------------|-------------|------|------------------------------|
-| aruba.port.limit        |             |      | aruba.limit                  |
+| aruba.port.limit        |             |      | aruba.limit.threshold                  |
 | aruba.port.mac_address  |             |      | client.mac                   |
 | aruba.port.mode         |             |      |                              |
 | aruba.port.name         |             |      | server.port                  |
@@ -897,7 +909,7 @@ Note: Descriptions have not been filled out
 | aruba.power.drawn           |             |      |                              |
 | aruba.power.fault_type      |             |      | error.type                   |
 | aruba.power.interface_name  |             |      |                              |
-| aruba.power.limit           |             |      | aruba.limit                  |
+| aruba.power.limit           |             |      | aruba.limit.threshold                  |
 | aruba.power.pair            |             |      |                              |
 | aruba.power.paira_class     |             |      |                              |
 | aruba.power.pairb_class     |             |      |                              |
@@ -1076,7 +1088,7 @@ Note: Descriptions have not been filled out
 | aruba.supportability.signal          |             |      | process.exit_code            |
 | aruba.supportability.state           |             |      | service.state                |
 | aruba.supportability.supported_files_name |        |      |                              |
-| aruba.supportability.threshold       |             |      | aruba.limit                  |
+| aruba.supportability.threshold       |             |      | aruba.limit.threshold                  |
 | aruba.supportability.timestamp       |             |      | process.end                  |
 | aruba.supportability.type            |             |      | file.type                    |
 | aruba.supportability.vrf             |             |      | aruba.vrf.id                 |
@@ -1324,7 +1336,6 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.bgp.error_subcode |  | keyword |
 | aruba.bgp.id |  | keyword |
 | aruba.bgp.pg_name |  | keyword |
-| aruba.bgp.threshold_limit |  | long |
 | aruba.bgp.vtep_ip |  | ip |
 | aruba.cfm.id | Maintenance Endpoint ID | keyword |
 | aruba.cfm.interface | Interface name on which CFM event occurred | keyword |
@@ -1358,6 +1369,7 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.erps.port_name |  | keyword |
 | aruba.erps.ring_id |  | keyword |
 | aruba.error.count |  | long |
+| aruba.error.description |  | keyword |
 | aruba.event_type |  | keyword |
 | aruba.evpn.rd |  | keyword |
 | aruba.evpn.rt |  | keyword |
@@ -1440,7 +1452,8 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.lag.mode |  | keyword |
 | aruba.lag.psc |  | keyword |
 | aruba.len |  | long |
-| aruba.limit |  | long |
+| aruba.limit.read_value |  | long |
+| aruba.limit.threshold |  | keyword |
 | aruba.lldp.ninterface |  | keyword |
 | aruba.lldp.npvid |  | long |
 | aruba.lldp.pvid |  | long |
@@ -1504,6 +1517,26 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.ospf.old_state |  | keyword |
 | aruba.ospf.router_id |  | keyword |
 | aruba.ospf.stats_id |  | keyword |
+| aruba.pim.callerid |  | keyword |
+| aruba.pim.dip0 |  | keyword |
+| aruba.pim.dip1 |  | keyword |
+| aruba.pim.dip2 |  | keyword |
+| aruba.pim.dip3 |  | keyword |
+| aruba.pim.ebsr_ip |  | ip |
+| aruba.pim.error_value |  | keyword |
+| aruba.pim.event |  | keyword |
+| aruba.pim.fd |  | keyword |
+| aruba.pim.flowtype |  | keyword |
+| aruba.pim.ip_version |  | keyword |
+| aruba.pim.mode |  | keyword |
+| aruba.pim.pkt_type |  | keyword |
+| aruba.pim.qsize |  | long |
+| aruba.pim.sip0 |  | keyword |
+| aruba.pim.sip1 |  | keyword |
+| aruba.pim.sip2 |  | keyword |
+| aruba.pim.sip3 |  | keyword |
+| aruba.pim.totalvid |  | long |
+| aruba.pim.type |  | keyword |
 | aruba.port |  | keyword |
 | aruba.prefix |  | keyword |
 | aruba.priority |  | keyword |
@@ -1550,6 +1583,7 @@ The `log` dataset collects the HPE Aruba CX logs.
 | destination.mac | MAC address of the destination. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | error.code | Error code describing the error. | keyword |
+| error.message | Error message. | match_only_text |
 | error.type | The type of the error, for example the class name of the exception. | keyword |
 | event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
 | event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |


### PR DESCRIPTION
Ticket:
Support the first 70-80 event types for the Aruba integration
https://github.com/elastic/integrations/issues/12065

Change Log:
- refactored the `aruba.limit` to `aruba.limit.threshold` and `aruba.limit.read_value`
- added support for PIM events, docs, generated logs

Note: There is nothing to do for Password Reset events, so I refactored the docs

Test Cases:
- validate that the pipeline test pass
- validated that the expected file parses the proper fields for the different message type


