### PR TITLE
Fix broken links in Observability integrations packages

### DIFF
--- a/packages/azure_application_insights/_dev/build/docs/README.md
+++ b/packages/azure_application_insights/_dev/build/docs/README.md
@@ -1,6 +1,6 @@
 # Azure Application Insights Integration
 
-The [Application Insights](https://docs.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview) Integration allows users to retrieve application insights metrics from specified applications.  
+The Application Insights Integration allows users to retrieve application insights metrics from specified applications.  
 
 ### Integration level configuration options
 

--- a/packages/azure_application_insights/_dev/build/docs/README.md
+++ b/packages/azure_application_insights/_dev/build/docs/README.md
@@ -6,7 +6,7 @@ The [Application Insights](https://docs.microsoft.com/en-us/azure/azure-monitor/
 
 `Application ID`:: (_[]string_) ID of the application. This is Application ID from the API Access settings blade in the Azure portal.
 
-`Api Key`:: (_[]string_) The API key which will be generated. See [Azure Monitor Log Analytics API Overview](https://dev.applicationinsights.io/documentation/Authorization/API-key-and-App-ID) for more information.
+`Api Key`:: (_[]string_) The API key which will be generated. See [Azure Monitor Log Analytics API Overview](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/api/overview) for more information.
 
 
 The integration contains the following data streams:

--- a/packages/azure_application_insights/docs/README.md
+++ b/packages/azure_application_insights/docs/README.md
@@ -1,6 +1,6 @@
 # Azure Application Insights Integration
 
-The [Application Insights](https://docs.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview) Integration allows users to retrieve application insights metrics from specified applications.  
+The Application Insights Integration allows users to retrieve application insights metrics from specified applications.  
 
 ### Integration level configuration options
 

--- a/packages/azure_application_insights/docs/README.md
+++ b/packages/azure_application_insights/docs/README.md
@@ -6,7 +6,7 @@ The [Application Insights](https://docs.microsoft.com/en-us/azure/azure-monitor/
 
 `Application ID`:: (_[]string_) ID of the application. This is Application ID from the API Access settings blade in the Azure portal.
 
-`Api Key`:: (_[]string_) The API key which will be generated. See [Azure Monitor Log Analytics API Overview](https://dev.applicationinsights.io/documentation/Authorization/API-key-and-App-ID) for more information.
+`Api Key`:: (_[]string_) The API key which will be generated. See [Azure Monitor Log Analytics API Overview](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/api/overview) for more information.
 
 
 The integration contains the following data streams:

--- a/packages/azure_billing/_dev/build/docs/README.md
+++ b/packages/azure_billing/_dev/build/docs/README.md
@@ -20,7 +20,7 @@ Usage details metrics track actual expenses including details like subscription 
 To use this integration you will need:
 
 * **Azure App Registration**: You need to set up an Azure App Registration to allow the Agent to access the Azure APIs. The App Registration requires a role to access the billing information. The required role is different depending on the subscription, department, or billing account scope. Check the [Setup section](#setup) for more details.
-* **Elasticsearch and Kibana**: You need Elasticsearch to store and search your data and Kibana to visualize and manage it. You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, the [Native Azure Integration](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/elastic.elasticsearch?tab=Overview), or self-manage the Elastic Stack on your hardware.
+* **Elasticsearch and Kibana**: You need Elasticsearch to store and search your data and Kibana to visualize and manage it. You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, the [Native Azure Integration](https://azuremarketplace.microsoft.com/en/marketplace/apps/elastic.ec-azure-pp?tab=overview), or self-manage the Elastic Stack on your hardware.
 * **Payment method**: Azure Billing Metrics integration queries are charged based on the number of standard API calls. One integration makes two calls every 24 hours in the standard configuration.
 
 ## Setup

--- a/packages/azure_billing/docs/README.md
+++ b/packages/azure_billing/docs/README.md
@@ -20,7 +20,7 @@ Usage details metrics track actual expenses including details like subscription 
 To use this integration you will need:
 
 * **Azure App Registration**: You need to set up an Azure App Registration to allow the Agent to access the Azure APIs. The App Registration requires a role to access the billing information. The required role is different depending on the subscription, department, or billing account scope. Check the [Setup section](#setup) for more details.
-* **Elasticsearch and Kibana**: You need Elasticsearch to store and search your data and Kibana to visualize and manage it. You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, the [Native Azure Integration](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/elastic.elasticsearch?tab=Overview), or self-manage the Elastic Stack on your hardware.
+* **Elasticsearch and Kibana**: You need Elasticsearch to store and search your data and Kibana to visualize and manage it. You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, the [Native Azure Integration](https://azuremarketplace.microsoft.com/en/marketplace/apps/elastic.ec-azure-pp?tab=overview), or self-manage the Elastic Stack on your hardware.
 * **Payment method**: Azure Billing Metrics integration queries are charged based on the number of standard API calls. One integration makes two calls every 24 hours in the standard configuration.
 
 ## Setup

--- a/packages/azure_functions/_dev/build/docs/README.md
+++ b/packages/azure_functions/_dev/build/docs/README.md
@@ -91,7 +91,7 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 To use this integration you will need:
 
 * **Azure App Registration**: You need to set up an Azure App Registration to allow the Agent to access the Azure APIs. The App Registration requires the Monitoring Reader role to access to be able to collect metrics from Function Apps. See more details in the Setup section.
-* **Elasticsearch and Kibana**: You need Elasticsearch to store and search your data and Kibana to visualize and manage it. You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, the [Native Azure Integration](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/elastic.elasticsearch?tab=Overview), or self-manage the Elastic Stack on your hardware.
+* **Elasticsearch and Kibana**: You need Elasticsearch to store and search your data and Kibana to visualize and manage it. You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, the [Native Azure Integration](https://azuremarketplace.microsoft.com/en/marketplace/apps/elastic.ec-azure-pp?tab=overview), or self-manage the Elastic Stack on your hardware.
 
 #### Setup
 

--- a/packages/azure_functions/docs/README.md
+++ b/packages/azure_functions/docs/README.md
@@ -177,7 +177,7 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 To use this integration you will need:
 
 * **Azure App Registration**: You need to set up an Azure App Registration to allow the Agent to access the Azure APIs. The App Registration requires the Monitoring Reader role to access to be able to collect metrics from Function Apps. See more details in the Setup section.
-* **Elasticsearch and Kibana**: You need Elasticsearch to store and search your data and Kibana to visualize and manage it. You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, the [Native Azure Integration](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/elastic.elasticsearch?tab=Overview), or self-manage the Elastic Stack on your hardware.
+* **Elasticsearch and Kibana**: You need Elasticsearch to store and search your data and Kibana to visualize and manage it. You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, the [Native Azure Integration](https://azuremarketplace.microsoft.com/en/marketplace/apps/elastic.ec-azure-pp?tab=overview), or self-manage the Elastic Stack on your hardware.
 
 #### Setup
 

--- a/packages/azure_metrics/_dev/build/docs/README.md
+++ b/packages/azure_metrics/_dev/build/docs/README.md
@@ -58,7 +58,7 @@ Elastic Agent needs an App Registration to access Azure on your behalf to collec
 To use this integration you will need:
 
 * **Azure App Registration**: You need to set up an Azure App Registration to allow the Agent to access the Azure APIs. See more details in the [Setup section](#setup).
-* **Elasticsearch and Kibana**: You need Elasticsearch to store and search your data and Kibana to visualize and manage it. You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, the [Native Azure Integration](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/elastic.elasticsearch?tab=Overview), or self-manage the Elastic Stack on your hardware.
+* **Elasticsearch and Kibana**: You need Elasticsearch to store and search your data and Kibana to visualize and manage it. You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, the [Native Azure Integration](https://azuremarketplace.microsoft.com/en/marketplace/apps/elastic.ec-azure-pp?tab=overview), or self-manage the Elastic Stack on your hardware.
 
 ### Authentication and costs
 

--- a/packages/azure_metrics/docs/README.md
+++ b/packages/azure_metrics/docs/README.md
@@ -58,7 +58,7 @@ Elastic Agent needs an App Registration to access Azure on your behalf to collec
 To use this integration you will need:
 
 * **Azure App Registration**: You need to set up an Azure App Registration to allow the Agent to access the Azure APIs. See more details in the [Setup section](#setup).
-* **Elasticsearch and Kibana**: You need Elasticsearch to store and search your data and Kibana to visualize and manage it. You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, the [Native Azure Integration](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/elastic.elasticsearch?tab=Overview), or self-manage the Elastic Stack on your hardware.
+* **Elasticsearch and Kibana**: You need Elasticsearch to store and search your data and Kibana to visualize and manage it. You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, the [Native Azure Integration](https://azuremarketplace.microsoft.com/en/marketplace/apps/elastic.ec-azure-pp?tab=overview), or self-manage the Elastic Stack on your hardware.
 
 ### Authentication and costs
 

--- a/packages/citrix_adc/_dev/build/docs/README.md
+++ b/packages/citrix_adc/_dev/build/docs/README.md
@@ -77,7 +77,7 @@ For step-by-step instructions on how to set up an integration, see the [Getting 
 
 ### Steps for configuring Syslog format:
 
-The Citrix WAF GUI can be used to configure syslog servers and WAF message types to be sent to the syslog servers. Refer to [How to Send Application Firewall Messages to a Separate Syslog Server](https://support.citrix.com/article/CTX138973) and [How to Send NetScaler Application Firewall Logs to Syslog Server and NS.log](https://support.citrix.com/article/CTX211543) for details.
+The Citrix WAF GUI can be used to configure syslog servers and WAF message types to be sent to the syslog servers. Refer to [How to Send Application Firewall Messages to a Separate Syslog Server](https://support.citrix.com/article/CTX138973) and [How to Send NetScaler Application Firewall Logs to Syslog Server and NS.log](https://support.citrix.com/s/article/CTX138973-how-to-send-application-firewall-messages-to-a-separate-syslog-server?language=en_US) for details.
 
 ## Validation
 

--- a/packages/citrix_adc/_dev/build/docs/README.md
+++ b/packages/citrix_adc/_dev/build/docs/README.md
@@ -77,7 +77,7 @@ For step-by-step instructions on how to set up an integration, see the [Getting 
 
 ### Steps for configuring Syslog format:
 
-The Citrix WAF GUI can be used to configure syslog servers and WAF message types to be sent to the syslog servers. For more details on how to Send Application Firewall Messages to a Separate Syslog Server, or how to send NetScaler Application Firewall Logs to Syslog Server and NS.log, check the [Citrix support articles](https://support.citrix.com) and [NetScaler Web App Firewall documentation](https://docs.netscaler.com/en-us/citrix-adc/current-release/application-firewall/).
+The Citrix WAF GUI can be used to configure syslog servers and WAF message types to be sent to the syslog servers. Refer to [How to Send Application Firewall Messages to a Separate Syslog Server](https://support.citrix.com/s/article/CTX138973-how-to-send-application-firewall-messages-to-a-separate-syslog-server) and [How to Send NetScaler Application Firewall Logs to Syslog Server and NS.log](https://support.citrix.com/s/article/CTX483235-send-logs-to-external-syslog-server?language=en_US) for details.
 
 ## Validation
 

--- a/packages/citrix_adc/_dev/build/docs/README.md
+++ b/packages/citrix_adc/_dev/build/docs/README.md
@@ -77,7 +77,7 @@ For step-by-step instructions on how to set up an integration, see the [Getting 
 
 ### Steps for configuring Syslog format:
 
-The Citrix WAF GUI can be used to configure syslog servers and WAF message types to be sent to the syslog servers. Refer to [How to Send Application Firewall Messages to a Separate Syslog Server](https://support.citrix.com/article/CTX138973) and [How to Send NetScaler Application Firewall Logs to Syslog Server and NS.log](https://support.citrix.com/s/article/CTX138973-how-to-send-application-firewall-messages-to-a-separate-syslog-server?language=en_US) for details.
+The Citrix WAF GUI can be used to configure syslog servers and WAF message types to be sent to the syslog servers. For more details on how to Send Application Firewall Messages to a Separate Syslog Server, or how to send NetScaler Application Firewall Logs to Syslog Server and NS.log, check the [Citrix support articles](https://support.citrix.com) and [NetScaler Web App Firewall documentation](https://docs.netscaler.com/en-us/citrix-adc/current-release/application-firewall/).
 
 ## Validation
 

--- a/packages/citrix_adc/docs/README.md
+++ b/packages/citrix_adc/docs/README.md
@@ -77,7 +77,7 @@ For step-by-step instructions on how to set up an integration, see the [Getting 
 
 ### Steps for configuring Syslog format:
 
-The Citrix WAF GUI can be used to configure syslog servers and WAF message types to be sent to the syslog servers. Refer to [How to Send Application Firewall Messages to a Separate Syslog Server](https://support.citrix.com/article/CTX138973) and [How to Send NetScaler Application Firewall Logs to Syslog Server and NS.log](https://support.citrix.com/article/CTX211543) for details.
+The Citrix WAF GUI can be used to configure syslog servers and WAF message types to be sent to the syslog servers. Refer to [How to Send Application Firewall Messages to a Separate Syslog Server](https://support.citrix.com/article/CTX138973) and [How to Send NetScaler Application Firewall Logs to Syslog Server and NS.log](https://support.citrix.com/s/article/CTX138973-how-to-send-application-firewall-messages-to-a-separate-syslog-server?language=en_US) for details.
 
 ## Validation
 

--- a/packages/citrix_adc/docs/README.md
+++ b/packages/citrix_adc/docs/README.md
@@ -77,7 +77,7 @@ For step-by-step instructions on how to set up an integration, see the [Getting 
 
 ### Steps for configuring Syslog format:
 
-The Citrix WAF GUI can be used to configure syslog servers and WAF message types to be sent to the syslog servers. For more details on how to Send Application Firewall Messages to a Separate Syslog Server, or how to send NetScaler Application Firewall Logs to Syslog Server and NS.log, check the [Citrix support articles](https://support.citrix.com) and [NetScaler Web App Firewall documentation](https://docs.netscaler.com/en-us/citrix-adc/current-release/application-firewall/).
+The Citrix WAF GUI can be used to configure syslog servers and WAF message types to be sent to the syslog servers. Refer to [How to Send Application Firewall Messages to a Separate Syslog Server](https://support.citrix.com/s/article/CTX138973-how-to-send-application-firewall-messages-to-a-separate-syslog-server) and [How to Send NetScaler Application Firewall Logs to Syslog Server and NS.log](https://support.citrix.com/s/article/CTX483235-send-logs-to-external-syslog-server?language=en_US) for details.
 
 ## Validation
 

--- a/packages/citrix_adc/docs/README.md
+++ b/packages/citrix_adc/docs/README.md
@@ -77,7 +77,7 @@ For step-by-step instructions on how to set up an integration, see the [Getting 
 
 ### Steps for configuring Syslog format:
 
-The Citrix WAF GUI can be used to configure syslog servers and WAF message types to be sent to the syslog servers. Refer to [How to Send Application Firewall Messages to a Separate Syslog Server](https://support.citrix.com/article/CTX138973) and [How to Send NetScaler Application Firewall Logs to Syslog Server and NS.log](https://support.citrix.com/s/article/CTX138973-how-to-send-application-firewall-messages-to-a-separate-syslog-server?language=en_US) for details.
+The Citrix WAF GUI can be used to configure syslog servers and WAF message types to be sent to the syslog servers. For more details on how to Send Application Firewall Messages to a Separate Syslog Server, or how to send NetScaler Application Firewall Logs to Syslog Server and NS.log, check the [Citrix support articles](https://support.citrix.com) and [NetScaler Web App Firewall documentation](https://docs.netscaler.com/en-us/citrix-adc/current-release/application-firewall/).
 
 ## Validation
 

--- a/packages/citrix_waf/_dev/build/docs/README.md
+++ b/packages/citrix_waf/_dev/build/docs/README.md
@@ -26,7 +26,7 @@ It is recommended to configure the application firewall to enable CEF-formatted 
 
 #### Syslog
 
-The Citrix WAF GUI can be used to configure syslog servers and WAF message types to be sent to the syslog servers. Refer to [How to Send Application Firewall Messages to a Separate Syslog Server](https://support.citrix.com/article/CTX138973) and [How to Send NetScaler Application Firewall Logs to Syslog Server and NS.log](https://support.citrix.com/article/CTX211543) for details.
+The Citrix WAF GUI can be used to configure syslog servers and WAF message types to be sent to the syslog servers. For more details on how to Send Application Firewall Messages to a Separate Syslog Server, or how to send NetScaler Application Firewall Logs to Syslog Server and NS.log, check the [Citrix support articles](https://support.citrix.com) and [NetScaler Web App Firewall documentation](https://docs.netscaler.com/en-us/citrix-adc/current-release/application-firewall/).
 
 ### Configure the Citrix WAF integration
 

--- a/packages/citrix_waf/_dev/build/docs/README.md
+++ b/packages/citrix_waf/_dev/build/docs/README.md
@@ -26,7 +26,7 @@ It is recommended to configure the application firewall to enable CEF-formatted 
 
 #### Syslog
 
-The Citrix WAF GUI can be used to configure syslog servers and WAF message types to be sent to the syslog servers. For more details on how to Send Application Firewall Messages to a Separate Syslog Server, or how to send NetScaler Application Firewall Logs to Syslog Server and NS.log, check the [Citrix support articles](https://support.citrix.com) and [NetScaler Web App Firewall documentation](https://docs.netscaler.com/en-us/citrix-adc/current-release/application-firewall/).
+The Citrix WAF GUI can be used to configure syslog servers and WAF message types to be sent to the syslog servers. Refer to [How to Send Application Firewall Messages to a Separate Syslog Server](https://support.citrix.com/s/article/CTX138973-how-to-send-application-firewall-messages-to-a-separate-syslog-server) and [How to Send NetScaler Application Firewall Logs to Syslog Server and NS.log](https://support.citrix.com/s/article/CTX483235-send-logs-to-external-syslog-server?language=en_US) for details.
 
 ### Configure the Citrix WAF integration
 

--- a/packages/citrix_waf/docs/README.md
+++ b/packages/citrix_waf/docs/README.md
@@ -26,7 +26,7 @@ It is recommended to configure the application firewall to enable CEF-formatted 
 
 #### Syslog
 
-The Citrix WAF GUI can be used to configure syslog servers and WAF message types to be sent to the syslog servers. Refer to [How to Send Application Firewall Messages to a Separate Syslog Server](https://support.citrix.com/article/CTX138973) and [How to Send NetScaler Application Firewall Logs to Syslog Server and NS.log](https://support.citrix.com/article/CTX211543) for details.
+The Citrix WAF GUI can be used to configure syslog servers and WAF message types to be sent to the syslog servers. For more details on how to Send Application Firewall Messages to a Separate Syslog Server, or how to send NetScaler Application Firewall Logs to Syslog Server and NS.log, check the [Citrix support articles](https://support.citrix.com) and [NetScaler Web App Firewall documentation](https://docs.netscaler.com/en-us/citrix-adc/current-release/application-firewall/).
 
 ### Configure the Citrix WAF integration
 

--- a/packages/citrix_waf/docs/README.md
+++ b/packages/citrix_waf/docs/README.md
@@ -26,7 +26,7 @@ It is recommended to configure the application firewall to enable CEF-formatted 
 
 #### Syslog
 
-The Citrix WAF GUI can be used to configure syslog servers and WAF message types to be sent to the syslog servers. For more details on how to Send Application Firewall Messages to a Separate Syslog Server, or how to send NetScaler Application Firewall Logs to Syslog Server and NS.log, check the [Citrix support articles](https://support.citrix.com) and [NetScaler Web App Firewall documentation](https://docs.netscaler.com/en-us/citrix-adc/current-release/application-firewall/).
+The Citrix WAF GUI can be used to configure syslog servers and WAF message types to be sent to the syslog servers. Refer to [How to Send Application Firewall Messages to a Separate Syslog Server](https://support.citrix.com/s/article/CTX138973-how-to-send-application-firewall-messages-to-a-separate-syslog-server) and [How to Send NetScaler Application Firewall Logs to Syslog Server and NS.log](https://support.citrix.com/s/article/CTX483235-send-logs-to-external-syslog-server?language=en_US) for details.
 
 ### Configure the Citrix WAF integration
 

--- a/packages/jolokia_input/docs/README.md
+++ b/packages/jolokia_input/docs/README.md
@@ -1,6 +1,6 @@
 # Jolokia input
 
-This input package collects metrics from  [Jolokia agents](https://jolokia.org/reference/html/agents.html) running on a target JMX server or dedicated proxy server.
+This input package collects metrics from  [Jolokia agents](https://jolokia.org/agent.html) running on a target JMX server or dedicated proxy server.
 
 The metrics are collected by communicating with a Jolokia HTTP/REST endpoint that exposes the JMX metrics over HTTP/REST/JSON.
 

--- a/packages/nats/_dev/build/docs/README.md
+++ b/packages/nats/_dev/build/docs/README.md
@@ -1,7 +1,7 @@
 # NATS integration
 
 This integration is used to collect logs and metrics from [NATS servers](https://nats.io/).
-The integration collects metrics from [NATS monitoring server APIs](https://nats.io/documentation/managing_the_server/monitoring/).
+The integration collects metrics from [NATS monitoring server APIs](https://docs.nats.io/running-a-nats-service/configuration/monitoring).
 
 
 ## Compatibility

--- a/packages/nats/_dev/build/docs/README.md
+++ b/packages/nats/_dev/build/docs/README.md
@@ -1,7 +1,7 @@
 # NATS integration
 
 This integration is used to collect logs and metrics from [NATS servers](https://nats.io/).
-The integration collects metrics from [NATS monitoring server APIs](https://docs.nats.io/running-a-nats-service/configuration/monitoring).
+The integration collects metrics from [NATS monitoring server APIs](https://docs.nats.io/running-a-nats-service/nats_admin/monitoring).
 
 
 ## Compatibility

--- a/packages/nats/docs/README.md
+++ b/packages/nats/docs/README.md
@@ -1,7 +1,7 @@
 # NATS integration
 
 This integration is used to collect logs and metrics from [NATS servers](https://nats.io/).
-The integration collects metrics from [NATS monitoring server APIs](https://nats.io/documentation/managing_the_server/monitoring/).
+The integration collects metrics from [NATS monitoring server APIs](https://docs.nats.io/running-a-nats-service/configuration/monitoring).
 
 
 ## Compatibility

--- a/packages/nats/docs/README.md
+++ b/packages/nats/docs/README.md
@@ -1,7 +1,7 @@
 # NATS integration
 
 This integration is used to collect logs and metrics from [NATS servers](https://nats.io/).
-The integration collects metrics from [NATS monitoring server APIs](https://docs.nats.io/running-a-nats-service/configuration/monitoring).
+The integration collects metrics from [NATS monitoring server APIs](https://docs.nats.io/running-a-nats-service/nats_admin/monitoring).
 
 
 ## Compatibility

--- a/packages/oracle_weblogic/_dev/build/docs/README.md
+++ b/packages/oracle_weblogic/_dev/build/docs/README.md
@@ -22,7 +22,7 @@ In order to ingest data from Oracle WebLogic:
      -javaagent:/home/oracle/jolokia-jvm-1.6.0-agent.jar=port=8005,host=localhost
     ```
 
-    (Optional) User can run Jolokia on https by configuring following parameters.
+    (Optional) User can run Jolokia on https by configuring the following [parameters](https://jolokia.org/reference/html/manual/agents.html#agent-jvm-config).
 
     ```
      -javaagent:<path-to-jolokia-agent>=port=<port>,host=<hostname>,protocol=<http/https>,keystore=<path-to-keystore>,keystorePassword=<kestore-password>,keyStoreType=<keystore-type>

--- a/packages/oracle_weblogic/_dev/build/docs/README.md
+++ b/packages/oracle_weblogic/_dev/build/docs/README.md
@@ -22,7 +22,7 @@ In order to ingest data from Oracle WebLogic:
      -javaagent:/home/oracle/jolokia-jvm-1.6.0-agent.jar=port=8005,host=localhost
     ```
 
-    (Optional) User can run Jolokia on https by configuring following [parameters](https://jolokia.org/reference/html/agents.html#:~:text=Table%C2%A03.6.-,JVM%20agent%20configuration%20options,-Parameter).
+    (Optional) User can run Jolokia on https by configuring following parameters.
 
     ```
      -javaagent:<path-to-jolokia-agent>=port=<port>,host=<hostname>,protocol=<http/https>,keystore=<path-to-keystore>,keystorePassword=<kestore-password>,keyStoreType=<keystore-type>

--- a/packages/oracle_weblogic/docs/README.md
+++ b/packages/oracle_weblogic/docs/README.md
@@ -22,7 +22,7 @@ In order to ingest data from Oracle WebLogic:
      -javaagent:/home/oracle/jolokia-jvm-1.6.0-agent.jar=port=8005,host=localhost
     ```
 
-    (Optional) User can run Jolokia on https by configuring following parameters.
+    (Optional) User can run Jolokia on https by configuring the following [parameters](https://jolokia.org/reference/html/manual/agents.html#agent-jvm-config).
 
     ```
      -javaagent:<path-to-jolokia-agent>=port=<port>,host=<hostname>,protocol=<http/https>,keystore=<path-to-keystore>,keystorePassword=<kestore-password>,keyStoreType=<keystore-type>

--- a/packages/oracle_weblogic/docs/README.md
+++ b/packages/oracle_weblogic/docs/README.md
@@ -22,7 +22,7 @@ In order to ingest data from Oracle WebLogic:
      -javaagent:/home/oracle/jolokia-jvm-1.6.0-agent.jar=port=8005,host=localhost
     ```
 
-    (Optional) User can run Jolokia on https by configuring following [parameters](https://jolokia.org/reference/html/agents.html#:~:text=Table%C2%A03.6.-,JVM%20agent%20configuration%20options,-Parameter).
+    (Optional) User can run Jolokia on https by configuring following parameters.
 
     ```
      -javaagent:<path-to-jolokia-agent>=port=<port>,host=<hostname>,protocol=<http/https>,keystore=<path-to-keystore>,keystorePassword=<kestore-password>,keyStoreType=<keystore-type>


### PR DESCRIPTION
This PR fixes the following broken links:

/packages/azure_application_insights @elastic/obs-infraobs-integrations
https://dev.applicationinsights.io/documentation/Authorization/API-key-and-App-ID
=> https://learn.microsoft.com/en-us/azure/azure-monitor/logs/api/overview

azure_billing, azure_functions, azure_metrics @elastic/obs-infraobs-integrations
https://azuremarketplace.microsoft.com/en-us/marketplace/apps/elastic.elasticsearch?tab=Overview
=> https://azuremarketplace.microsoft.com/en/marketplace/apps/elastic.ec-azure-pp?tab=overview

/packages/citrix_adc @elastic/obs-infraobs-integrations
/packages/citrix_waf @elastic/sec-deployment-and-devices
https://support.citrix.com/article/CTX211543
=> https://support.citrix.com/s/article/CTX138973-how-to-send-application-firewall-messages-to-a-separate-syslog-server?language=en_US

/packages/jolokia_input @elastic/obs-infraobs-integrations
https://jolokia.org/reference/html/agents.html
=> https://jolokia.org/agent.html

/packages/nats @elastic/obs-infraobs-integrations
https://nats.io/documentation/managing_the_server/monitoring/
=> https://docs.nats.io/running-a-nats-service/configuration/monitoring

/packages/oracle_weblogic @elastic/obs-infraobs-integrations
https://jolokia.org/reference/html/agents.html#:~:text=Table%C2%A03.6.-,JVM%20agent%20configuration%20options,-Parameter
=> remove the link

## Related issue

https://github.com/elastic/integration-docs/issues/585
