### PR TITLE
#12065 - 3/4/5 Added Port access role, Policies and Port events

### DIFF
--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -838,27 +838,27 @@ Note: Descriptions have not been filled out
 | <vrf_name> / <vrfname> | aruba.vrf.name          |
 
 #### [Policies events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/POLICY.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.policy.application  |             |      | network.application          |
-| aruba.policy.name         |             |      |                              |
+| Docs Field     | Schema Mapping               |
+|----------------|------------------------------|
+| <application>  | aruba.policy.application     |
+| <policy_name>  | aruba.policy.name            |
 
 #### [Port access roles events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ROLE.htm)
-| Field                         | Description | Type | Common                       |
-|-------------------------------|-------------|------|------------------------------|
-| aruba.port.cprole_error_string|             |      | error.message                |
-| aruba.port.role_name          |             |      | aruba.role                   |
+| Docs Field            | Schema Mapping               |
+|-----------------------|------------------------------|
+| <cprole_error_string> | event.reason                 |
+| <role_name>           | aruba.role                   |
 
 #### [Port events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PORT.htm)
-| Field                | Description | Type | Common                       |
-|----------------------|-------------|------|------------------------------|
-| aruba.port.error     |             |      | error.message                |
-| aruba.port.interface |             |      | observer.ingress.interface.name |
-| aruba.port.ip_address|             |      | destination.ip               |
-| aruba.port.mtu       |             |      | aruba.mtu                    |
-| aruba.port.policy    |             |      |                              |
-| aruba.port.status    |             |      | aruba.status                 |
-| aruba.port.vlan      |             |      | network.vlan.id              |
+| Docs Field   | Schema Mapping               |
+|--------------|------------------------------|
+| <error>      | event.reason                 |
+| <interface>  | aruba.interface.id           |
+| <ip_address> | client.ip                    |
+| <mtu>        | aruba.mtu                    |
+| <policy>     | aruba.policy.port            |
+| <status>     | aruba.status                 |
+| <vlan>       | network.vlan.id              |
 
 #### [Port security events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PORT-SECURITY.htm)
 | Field                | Description | Type | Common                       |

--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -856,7 +856,7 @@ Note: Descriptions have not been filled out
 | <interface>  | aruba.interface.id           |
 | <ip_address> | client.ip                    |
 | <mtu>        | aruba.mtu                    |
-| <policy>     | aruba.policy.port            |
+| <policy>     | aruba.policy.name            |
 | <status>     | aruba.status                 |
 | <vlan>       | network.vlan.id              |
 

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
@@ -34,6 +34,13 @@
 2024-07-31T15:40:10.904876-05:00 8360-Primaire intfd[808]: Event|408|LOG_WARN|INTF|1/1|Interface 1/1/29 is down because MACsec and PFC features are mutually exclusive.
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-led[1234]: Event|501|LOG_INFO|LED|-|There are 5 LED types in subsystem A
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-led[1234]: Event|502|LOG_INFO|LED|-|There are 10 LED configs in subsystem B
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-netlink[1234]: Event|601|LOG_ERR|Port|-|Netlink socket creation failed error: No buffer space available
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-netlink[1234]: Event|602|LOG_ERR|Port|-|Netlink socket bind failed error: Address already in use
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-netlink[1234]: Event|603|LOG_ERR|Port|-|Netlink failed to set mtu 1500 for interface eth0
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-netlink[1234]: Event|604|LOG_ERR|Port|-|Netlink failed to bring up the interface eth0
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-netlink[1234]: Event|605|LOG_ERR|Port|-|Unknown internal vlan policy policy1
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-netlink[1234]: Event|606|LOG_ERR|Port|-|Error allocating internal vlan for port vlan10
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-netlink[1234]: Event|607|LOG_ERR|Port|-|Overlapping networks observed for 192.168.1.1
 2024-06-18T12:45:38.182641-05:00 8360-Primaire loopback[1234]: Event|901|LOG_INFO|LOOPBACK|-|Loopback Interface eth0, created
 2024-06-18T12:46:38.182641-05:00 8360-Primaire loopback[1234]: Event|902|LOG_INFO|LOOPBACK|-|Loopback Interface eth0, deleted
 2024-06-18T12:47:38.182641-05:00 8360-Primaire loopback[1234]: Event|903|LOG_INFO|LOOPBACK|-|Loopback Interface eth0, configured administratively up
@@ -307,7 +314,7 @@
 2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-ospfv3[1234]: Event|4905|LOG_INFO|OSPFv3|-|Interface fe80::1 on eth0(0.0.0.0) changed from DOWN to UP, input: 1
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5101|LOG_ERR|PIM|-|Failed to send HELLO packet on Interface eth0
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5101|LOG_ERR|PIM|-|Throttled 2 Messages
- 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5102|LOG_INFO|PIM|-|PIM interface eth0 is configured with IP 192.168.1.1
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5102|LOG_INFO|PIM|-|PIM interface eth0 is configured with IP 192.168.1.1
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5103|LOG_ERR|PIM|-|Packet dropped from 192.168.1.2 on interface eth0 error checksum_error
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5103|LOG_ERR|PIM|-|Throttled 100 Messages
 2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5104|LOG_ERR|PIM|-|Received packet from router 192.168.1.3, unkwn pkt type 5
@@ -323,7 +330,7 @@
 2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5110|LOG_ERR|PIM|-|Multicast socket creation failed with Fd: 5 on Port: 1234. Error description: permission_denied
 2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5111|LOG_ERR|PIM|-|OVSDB operation failed with timeout_error
 2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5111|LOG_ERR|PIM|-|Throttled 100 Messages
- 2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5112|LOG_INFO|PIM|-|New Elected BSR for VRF default is 192.168.1.9 with priority 5
+2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5112|LOG_INFO|PIM|-|New Elected BSR for VRF default is 192.168.1.9 with priority 5
 2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5113|LOG_INFO|PIM|-|Elected BSR removed on VRF default
 2024-06-18T12:58:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5114|LOG_INFO|PIM|-|Candidate BSR 192.168.1.10 with priority 10 is active on interface eth0
 2024-06-18T12:59:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5115|LOG_INFO|PIM|-|PIM Neighbor 192.168.1.11 is up on interface eth0
@@ -546,6 +553,10 @@
 2024-06-19T13:54:24.900661-05:00 8360-Primaire hpe-restd[1956]: Event|9207|LOG_INFO|DCBx|-|PFC TLV status active on interface eth1
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-restd[1956]: Event|9208|LOG_INFO|DCBx|-|PFC TLV status inactive on interface eth1
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-restd[1956]: Event|9209|LOG_WARN|DCBx|-|PFC TLV status priority mismatch on interface eth1
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-clearpass[1234]: Event|9301|LOG_ERR|PORTACCESS|-|Failed to apply ClearPass role - role_not_found
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-clearpass[1234]: Event|9302|LOG_ERR|PORTACCESS|-|Failed to create the role - admin_role, maximum limit reached
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-clearpass[1234]: Event|9302|LOG_ERR|PORTACCESS|-|Falied to create the role - admin_role, maximum limit reached
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-clearpass[1234]: Event|9302|LOG_ERR|PORTACCESS|-|Throttled 100 Messages
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-evpn[1234]: Event|9501|LOG_INFO|EVPN|-|EVPN EVI: evi created
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-evpn[1234]: Event|9502|LOG_INFO|EVPN|-|EVPN EVI: evi deleted
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-evpn[1234]: Event|9503|LOG_INFO|EVPN|-|EVPN RD: rd updated for EVI: evi
@@ -589,6 +600,7 @@
 2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|9807|LOG_INFO|IP|-|IPV6_SOURCE_LOCKDOWN is disabled on interface eth1
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|10002|LOG_INFO|AMM|-|mock_acl_name on 1/1/25 (route-in): 10 mock ace string
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|10003|LOG_ERR|AMM|-|ACL mock_acl_type mock_acl_name failed to apply on mock_application
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-policy[1234]: Event|10101|LOG_ERR|POLICY|-|Policy security_policy failed to apply on firewall_application
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|10401|LOG_INFO|AMM|-|ARP inspection mock_status on vlan vpn-Internet.
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|10402|LOG_ERR|AMM|-|ARP inspection mock_status on port 1/1/25.
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-l3encap[1234]: Event|10601|LOG_WARN|L3ENCAP|-|L3 resources critical for neighbor and route forwarding are low. Used: 80, Available: 20

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -1387,6 +1387,258 @@
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",
             "aruba": {
                 "component": {
+                    "category": "Port"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "601",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-netlink[1234]: Event|601|LOG_ERR|Port|-|Netlink socket creation failed error: No buffer space available",
+                "reason": "error: No buffer space available"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-netlink",
+                    "procid": "1234"
+                }
+            },
+            "message": "Netlink socket creation failed error: No buffer space available",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Port"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "602",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-netlink[1234]: Event|602|LOG_ERR|Port|-|Netlink socket bind failed error: Address already in use",
+                "reason": "error: Address already in use"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-netlink",
+                    "procid": "1234"
+                }
+            },
+            "message": "Netlink socket bind failed error: Address already in use",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Port"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "mtu": "1500"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "603",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-netlink[1234]: Event|603|LOG_ERR|Port|-|Netlink failed to set mtu 1500 for interface eth0"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-netlink",
+                    "procid": "1234"
+                }
+            },
+            "message": "Netlink failed to set mtu 1500 for interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Port"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "status": "up"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "604",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-netlink[1234]: Event|604|LOG_ERR|Port|-|Netlink failed to bring up the interface eth0"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-netlink",
+                    "procid": "1234"
+                }
+            },
+            "message": "Netlink failed to bring up the interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Port"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "policy": {
+                    "port": "policy1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "605",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-netlink[1234]: Event|605|LOG_ERR|Port|-|Unknown internal vlan policy policy1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-netlink",
+                    "procid": "1234"
+                }
+            },
+            "message": "Unknown internal vlan policy policy1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Port"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "606",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-netlink[1234]: Event|606|LOG_ERR|Port|-|Error allocating internal vlan for port vlan10"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-netlink",
+                    "procid": "1234"
+                }
+            },
+            "message": "Error allocating internal vlan for port vlan10",
+            "network": {
+                "vlan": {
+                    "id": "vlan10"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Port"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "607",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-netlink[1234]: Event|607|LOG_ERR|Port|-|Overlapping networks observed for 192.168.1.1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-netlink",
+                    "procid": "1234"
+                }
+            },
+            "message": "Overlapping networks observed for 192.168.1.1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
                     "category": "LOOPBACK"
                 },
                 "event_type": "Event",
@@ -11830,7 +12082,7 @@
                     "network"
                 ],
                 "code": "5102",
-                "original": " 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5102|LOG_INFO|PIM|-|PIM interface eth0 is configured with IP 192.168.1.1"
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5102|LOG_INFO|PIM|-|PIM interface eth0 is configured with IP 192.168.1.1"
             },
             "log": {
                 "level": "LOG_INFO",
@@ -12482,7 +12734,7 @@
                     "network"
                 ],
                 "code": "5112",
-                "original": " 2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5112|LOG_INFO|PIM|-|New Elected BSR for VRF default is 192.168.1.9 with priority 5"
+                "original": "2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5112|LOG_INFO|PIM|-|New Elected BSR for VRF default is 192.168.1.9 with priority 5"
             },
             "log": {
                 "level": "LOG_INFO",
@@ -20843,6 +21095,142 @@
             ]
         },
         {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PORTACCESS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9301",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-clearpass[1234]: Event|9301|LOG_ERR|PORTACCESS|-|Failed to apply ClearPass role - role_not_found",
+                "reason": "role_not_found"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-clearpass",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to apply ClearPass role - role_not_found",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PORTACCESS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "role": "admin_role"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9302",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-clearpass[1234]: Event|9302|LOG_ERR|PORTACCESS|-|Failed to create the role - admin_role, maximum limit reached"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-clearpass",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to create the role - admin_role, maximum limit reached",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PORTACCESS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "role": "admin_role"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9302",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-clearpass[1234]: Event|9302|LOG_ERR|PORTACCESS|-|Falied to create the role - admin_role, maximum limit reached"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-clearpass",
+                    "procid": "1234"
+                }
+            },
+            "message": "Falied to create the role - admin_role, maximum limit reached",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PORTACCESS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "throttle_count": 100
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9302",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-clearpass[1234]: Event|9302|LOG_ERR|PORTACCESS|-|Throttled 100 Messages"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-clearpass",
+                    "procid": "1234"
+                }
+            },
+            "message": "Throttled 100 Messages",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-06-19T13:53:38.182641-05:00",
             "aruba": {
                 "component": {
@@ -22605,6 +22993,43 @@
                 }
             },
             "message": "ACL mock_acl_type mock_acl_name failed to apply on mock_application",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POLICY"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "policy": {
+                    "application": "firewall_application",
+                    "name": "security_policy"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "10101",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-policy[1234]: Event|10101|LOG_ERR|POLICY|-|Policy security_policy failed to apply on firewall_application"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-policy",
+                    "procid": "1234"
+                }
+            },
+            "message": "Policy security_policy failed to apply on firewall_application",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -1536,7 +1536,7 @@
                     "device": "8360-Primaire"
                 },
                 "policy": {
-                    "port": "policy1"
+                    "name": "policy1"
                 }
             },
             "ecs": {

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -286,7 +286,7 @@ processors:
       tag: port_event_605
       description: "Unknown internal vlan policy"
       if: "ctx.event?.code == '605'"
-      pattern: "Unknown internal vlan policy %{aruba.policy.port}"
+      pattern: "Unknown internal vlan policy %{aruba.policy.name}"
   - dissect:
       field: message
       tag: port_event_606
@@ -2112,7 +2112,7 @@ processors:
         - "^PFC TLV status priority mismatch on interface %{DATA:aruba.dcbx.intf_name}$"
 
   # Port access roles events (930x)
-  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DCBX.htm
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ROLE.htm
   - grok:
       field: message
       tag: port_access_event_9301_9302

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -265,6 +265,41 @@ processors:
       patterns:
         - "^There are %{NUMBER:aruba.count:long} LED (types|configs) in subsystem %{GREEDYDATA:aruba.subsystem}"
 
+    # Port events (60x)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LED.htm
+  - grok:
+      field: message
+      tag: port_event_601_602
+      description: "Log when netlink socket [creation|bind] failed"
+      if: "['601','602'].contains(ctx.event?.code)"
+      patterns:
+        - "^Netlink socket (creation|bind) failed %{GREEDYDATA:event.reason}"
+  - grok:
+      field: message
+      tag: port_event_603_604
+      description: "Log when netlink failed to set mtu for interface | failed to change the interface status"
+      if: "['603','604'].contains(ctx.event?.code)"
+      patterns:
+        - "^Netlink failed to (set mtu %{DATA:aruba.mtu} for|bring %{DATA:aruba.status} the) interface %{GREEDYDATA:aruba.interface.id}"
+  - dissect:
+      field: message
+      tag: port_event_605
+      description: "Unknown internal vlan policy"
+      if: "ctx.event?.code == '605'"
+      pattern: "Unknown internal vlan policy %{aruba.policy.port}"
+  - dissect:
+      field: message
+      tag: port_event_606
+      description: "Log when allocation failed for internal vlan for port"
+      if: "ctx.event?.code == '606'"
+      pattern: "Error allocating internal vlan for port %{network.vlan.id}"
+  - dissect:
+      field: message
+      tag: port_event_607
+      description: "Log when a duplicate address is received on a port"
+      if: "ctx.event?.code == '607'"
+      pattern: "Overlapping networks observed for %{client.ip}"
+
     # Loopback events (90x)
     # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LOOPBACK.htm
   - grok:
@@ -2076,6 +2111,19 @@ processors:
       patterns:
         - "^PFC TLV status priority mismatch on interface %{DATA:aruba.dcbx.intf_name}$"
 
+  # Port access roles events (930x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DCBX.htm
+  - grok:
+      field: message
+      tag: port_access_event_9301_9302
+      if: "['9301','9302'].contains(ctx.event?.code)"
+      description: "Logs an event if there are errors when applying a ClearPass role | maximum limit is reached while creating a Port Access Role"
+      patterns:
+        - "^Failed to apply ClearPass role - %{GREEDYDATA:event.reason}"
+        # There is a spelling error in the documentation removing the matching for "Failed"
+        - "to create the role - %{DATA:aruba.role}, maximum limit reached"
+        - "^Throttled %{NUMBER:aruba.throttle_count:long} Messages"
+
   # EVPN Events (95xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/EVPN.htm
   - grok:
@@ -2200,6 +2248,15 @@ processors:
       field: "message"
       description: "ACL application failure"
       pattern: "ACL %{aruba.acl.type} %{aruba.acl.name} failed to apply on %{aruba.acl.application}"
+
+  # Policies events (1010x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/POLICY.htm
+  - dissect:
+      if: "ctx.event?.code == '10101'"
+      tag: policies_event_10101
+      field: "message"
+      description: "Policy application failure"
+      pattern: "Policy %{aruba.policy.name} failed to apply on %{aruba.policy.application}"
 
   # ARP security events (104xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ARP-SECURITY.htm

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -822,6 +822,18 @@
         - name: type
           type: keyword
           description: ""
+    - name: policy
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: ""
+        - name: application
+          type: keyword
+          description: ""
+        - name: port
+          type: keyword
+          description: ""
     - name: port
       type: keyword
       description: ""

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -831,9 +831,6 @@
         - name: application
           type: keyword
           description: ""
-        - name: port
-          type: keyword
-          description: ""
     - name: port
       type: keyword
       description: ""

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -856,7 +856,7 @@ Note: Descriptions have not been filled out
 | <interface>  | aruba.interface.id           |
 | <ip_address> | client.ip                    |
 | <mtu>        | aruba.mtu                    |
-| <policy>     | aruba.policy.port            |
+| <policy>     | aruba.policy.name            |
 | <status>     | aruba.status                 |
 | <vlan>       | network.vlan.id              |
 
@@ -1539,7 +1539,6 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.pim.type |  | keyword |
 | aruba.policy.application |  | keyword |
 | aruba.policy.name |  | keyword |
-| aruba.policy.port |  | keyword |
 | aruba.port |  | keyword |
 | aruba.prefix |  | keyword |
 | aruba.priority |  | keyword |

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -838,27 +838,27 @@ Note: Descriptions have not been filled out
 | <vrf_name> / <vrfname> | aruba.vrf.name          |
 
 #### [Policies events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/POLICY.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.policy.application  |             |      | network.application          |
-| aruba.policy.name         |             |      |                              |
+| Docs Field     | Schema Mapping               |
+|----------------|------------------------------|
+| <application>  | aruba.policy.application     |
+| <policy_name>  | aruba.policy.name            |
 
 #### [Port access roles events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ROLE.htm)
-| Field                         | Description | Type | Common                       |
-|-------------------------------|-------------|------|------------------------------|
-| aruba.port.cprole_error_string|             |      | error.message                |
-| aruba.port.role_name          |             |      | aruba.role                   |
+| Docs Field            | Schema Mapping               |
+|-----------------------|------------------------------|
+| <cprole_error_string> | event.reason                 |
+| <role_name>           | aruba.role                   |
 
 #### [Port events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PORT.htm)
-| Field                | Description | Type | Common                       |
-|----------------------|-------------|------|------------------------------|
-| aruba.port.error     |             |      | error.message                |
-| aruba.port.interface |             |      | observer.ingress.interface.name |
-| aruba.port.ip_address|             |      | destination.ip               |
-| aruba.port.mtu       |             |      | aruba.mtu                    |
-| aruba.port.policy    |             |      |                              |
-| aruba.port.status    |             |      | aruba.status                 |
-| aruba.port.vlan      |             |      | network.vlan.id              |
+| Docs Field   | Schema Mapping               |
+|--------------|------------------------------|
+| <error>      | event.reason                 |
+| <interface>  | aruba.interface.id           |
+| <ip_address> | client.ip                    |
+| <mtu>        | aruba.mtu                    |
+| <policy>     | aruba.policy.port            |
+| <status>     | aruba.status                 |
+| <vlan>       | network.vlan.id              |
 
 #### [Port security events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PORT-SECURITY.htm)
 | Field                | Description | Type | Common                       |
@@ -1537,6 +1537,9 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.pim.sip3 |  | keyword |
 | aruba.pim.totalvid |  | long |
 | aruba.pim.type |  | keyword |
+| aruba.policy.application |  | keyword |
+| aruba.policy.name |  | keyword |
+| aruba.policy.port |  | keyword |
 | aruba.port |  | keyword |
 | aruba.prefix |  | keyword |
 | aruba.priority |  | keyword |


### PR DESCRIPTION
Ticket:
Support the first 70-80 event types for the Aruba integration
https://github.com/elastic/integrations/issues/12065

Change Log:
Added Port events (60x)
Added Port access roles events (930x)
Policies events (1010x)

Test Cases:
validate that the pipeline test pass
validated that the expected file parses the proper fields for the different message type