### PR TITLE
Workaround issue with missing dynamic mapping in tines package

### DIFF
--- a/packages/tines/changelog.yml
+++ b/packages/tines/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.1"
+  changes:
+    - description: Workaround missing dynamic template for options field
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1234
 - version: "1.13.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` set to "pipeline_error".

--- a/packages/tines/data_stream/audit_logs/fields/fields.yml
+++ b/packages/tines/data_stream/audit_logs/fields/fields.yml
@@ -142,10 +142,6 @@
                   type: keyword
                 - name: oauthUrl
                   type: keyword
-                - name: options
-                  type: object
-                  object_type: keyword
-                  object_type_mapping_type: "*"
                 - name: options.createFormEmptyState
                   type: boolean
                 - name: readAccess
@@ -165,6 +161,8 @@
                 - name: teamId
                   type: long
                 - name: value
+                  type: keyword
+                - name: "*"
                   type: keyword
         - name: request_ip
           type: keyword

--- a/packages/tines/docs/README.md
+++ b/packages/tines/docs/README.md
@@ -76,6 +76,7 @@ All fields ingested to this data stream are stored under `tines.audit_log` as ea
 | tines.audit_log.inputs.actionIds |  | long |
 | tines.audit_log.inputs.diagramNoteIds |  | long |
 | tines.audit_log.inputs.fieldId |  | long |
+| tines.audit_log.inputs.inputs.\* |  | keyword |
 | tines.audit_log.inputs.inputs.actionId |  | long |
 | tines.audit_log.inputs.inputs.actionIds |  | long |
 | tines.audit_log.inputs.inputs.actions.actionId |  | long |
@@ -125,7 +126,6 @@ All fields ingested to this data stream are stored under `tines.audit_log` as ea
 | tines.audit_log.inputs.inputs.oauthScope |  | keyword |
 | tines.audit_log.inputs.inputs.oauthTokenUrl |  | keyword |
 | tines.audit_log.inputs.inputs.oauthUrl |  | keyword |
-| tines.audit_log.inputs.inputs.options |  | object |
 | tines.audit_log.inputs.inputs.options.createFormEmptyState |  | boolean |
 | tines.audit_log.inputs.inputs.readAccess |  | keyword |
 | tines.audit_log.inputs.inputs.required |  | boolean |

--- a/packages/tines/manifest.yml
+++ b/packages/tines/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: tines
 title: "Tines"
-version: "1.13.0"
+version: "1.13.1"
 description: "Tines Logs & Time Saved Reports"
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

No dynamic mapping was being generated for `tines.audit_log.inputs.inputs.options.*`, and this package uses the `tines.audit_log.inputs.inputs.options` field directly, without having any mapping for it or its sub-properties.

The workaround ensures that there is a mapping for `tines.audit_log.inputs.inputs.*` that serves for `tines.audit_log.inputs.inputs.options` as well as for its subobjects.

The configured dynamic mapping was not being generated due to some issue in Fleet that we are investigating.

We detected this issue while refactoring field mappings tests in elastic-package, more about this in https://github.com/elastic/elastic-package/pull/2214#issuecomment-2536692641.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

- Install the package.
- Check that `logs-tines.audit_logs@package` component template includes a dynamic mapping for these fields.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Issue found while testing https://github.com/elastic/elastic-package/pull/2214.