### PR TITLE
#12065-6/7 PORT_ACCESS, Port Security and Port Statistics Event additions

### DIFF
--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -884,7 +884,7 @@ Note: Descriptions have not been filled out
 | <old_limit>   | aruba.port_access.old_limit  |
 | <old_mode>    | aruba.port_access.old_mode   |
 | <old_name>    | aruba.port_access.old_name   |
-| <policy_name> | aruba.port_access.policy_name|
+| <policy_name> | aruba.policy.name            |
 | <port>        | aruba.port                   |
 | <vlan_id>     | network.vlan.id              |
 

--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -864,7 +864,7 @@ Note: Descriptions have not been filled out
 | Docs Field   | Schema Mapping       |
 |--------------|----------------------|
 | <if_name>    | aruba.interface.name |
-| <mac_addr>   | server.mac           |
+| <mac_addr>   | client.mac           |
 | <port>       | aruba.port           |
 
 #### [Port Statistics events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/COUNTERS.htm)

--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -868,9 +868,9 @@ Note: Descriptions have not been filled out
 | <port>       | aruba.port           |
 
 #### [Port Statistics events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/COUNTERS.htm)
-| Field                | Description | Type | Common                       |
-|----------------------|-------------|------|------------------------------|
-| <name>      |             |      | server.port                  |
+| Docs Field | Schema Mapping       |
+|------------|----------------------|
+| <name>     | aruba.port           |
 
 #### [PORT_ACCESS events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PORT_ACCESS.htm)
 | Docs Field    | Schema Mapping               |

--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -861,29 +861,33 @@ Note: Descriptions have not been filled out
 | aruba.port.vlan      |             |      | network.vlan.id              |
 
 #### [Port security events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PORT-SECURITY.htm)
-| Field                | Description | Type | Common                       |
-|----------------------|-------------|------|------------------------------|
-| aruba.port.if_name   |             |      | observer.ingress.interface.name |
-| aruba.port.mac_addr  |             |      | server.mac                   |
-| aruba.port.port      |             |      | server.port                  |
+| Docs Field   | Schema Mapping       |
+|--------------|----------------------|
+| <if_name>    | aruba.interface.name |
+| <mac_addr>   | server.mac           |
+| <port>       | aruba.port           |
 
 #### [Port Statistics events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/COUNTERS.htm)
 | Field                | Description | Type | Common                       |
 |----------------------|-------------|------|------------------------------|
-| aruba.port.name      |             |      | server.port                  |
+| <name>      |             |      | server.port                  |
 
 #### [PORT_ACCESS events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PORT_ACCESS.htm)
-| Field                   | Description | Type | Common                       |
-|-------------------------|-------------|------|------------------------------|
-| aruba.port.limit        |             |      | aruba.limit.threshold                  |
-| aruba.port.mac_address  |             |      | client.mac                   |
-| aruba.port.mode         |             |      |                              |
-| aruba.port.name         |             |      | server.port                  |
-| aruba.port.old_limit    |             |      |                              |
-| aruba.port.old_mode     |             |      |                              |
-| aruba.port.old_name     |             |      |                              |
-| aruba.port.policy_name  |             |      |                              |
-| aruba.port.port         |             |      | server.port                  |
+| Docs Field    | Schema Mapping               |
+|---------------|------------------------------|
+| <limit>       | aruba.limit.threshold        |
+| <mac_address> | client.mac                   |
+| <mode>        | aruba.port_access.mode       |
+| <new_limit>   | aruba.limit.threshold        |
+| <new_name>    | aruba.port_access.name       |
+| <new_mode>    | aruba.port_access.mode       |
+| <old_limit>   | aruba.port_access.old_limit  |
+| <old_mode>    | aruba.port_access.old_mode   |
+| <old_name>    | aruba.port_access.old_name   |
+| <policy_name> | aruba.port_access.policy_name|
+| <port>        | aruba.port                   |
+| <vlan_id>     | network.vlan.id              |
+
 
 #### [Power events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/POWER.htm)
 | Field                   | Description | Type | Common                       |

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
@@ -547,6 +547,7 @@
                 "hardware": {
                     "device": "6000RCSE4802"
                 },
+                "port": "1/1/18",
                 "sequence": "1/1"
             },
             "ecs": {
@@ -582,6 +583,7 @@
                 "hardware": {
                     "device": "6000RCSE4802"
                 },
+                "port": "1/1/18",
                 "sequence": "1/1"
             },
             "ecs": {

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
@@ -392,6 +392,10 @@
 2024-06-20T15:52:07.025548-05:00 8360-Primaire credmgrd[456]: Event|6507|LOG_ERR|CREDMGR|-|Failed to write SSH authorized keys for user myUser
 2024-06-20T15:52:07.025548-05:00 8360-Primaire credmgrd[456]: Event|6508|LOG_INFO|CREDMGR|-|SSH authorized keys deleted for user myUser
 2024-06-20T15:52:07.025548-05:00 8360-Primaire credmgrd[456]: Event|6509|LOG_ERR|CREDMGR|-|User myUser has configured an invalid SSH authorized key with key identifier myKeyIdentifier
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-portstats[1234]: Event|6601|LOG_ERR|PORTSTATS|-|Failed to create layer 3 IPv4 RX statistic for port:eth0
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-portstats[1234]: Event|6602|LOG_ERR|PORTSTATS|-|Failed to create layer 3 IPv6 RX statistic for port:eth1
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-portstats[1234]: Event|6603|LOG_ERR|PORTSTATS|-|Failed to create layer 3 IPv4 TX statistic for port:eth2
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-portstats[1234]: Event|6604|LOG_ERR|PORTSTATS|-|Failed to create layer 3 IPv6 TX statistic for port:eth3
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-mirroring[1234]: Event|6701|LOG_ERR|Mirroring|-|Failed to create mirror session 1
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-mirroring[1234]: Event|6702|LOG_INFO|Mirroring|-|Mirror session 1 created
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-mirroring[1234]: Event|6703|LOG_ERR|Mirroring|-|Failed to delete mirror session 1
@@ -546,6 +550,8 @@
 2024-06-19T13:54:24.900661-05:00 8360-Primaire hpe-restd[1956]: Event|9207|LOG_INFO|DCBx|-|PFC TLV status active on interface eth1
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-restd[1956]: Event|9208|LOG_INFO|DCBx|-|PFC TLV status inactive on interface eth1
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-restd[1956]: Event|9209|LOG_WARN|DCBx|-|PFC TLV status priority mismatch on interface eth1
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-portsecurity[1234]: Event|9401|LOG_INFO|PORTSEC|-|Client limit exceeded on port eth0, caused by an unauthorized client 00:1A:2B:3C:4D:5E
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-portsecurity[1234]: Event|9402|LOG_INFO|PORTSEC|-|Port security sticky client move violation triggered on port eth1 for client with MAC address 00:1A:2B:3C:4D:5E
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-evpn[1234]: Event|9501|LOG_INFO|EVPN|-|EVPN EVI: evi created
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-evpn[1234]: Event|9502|LOG_INFO|EVPN|-|EVPN EVI: evi deleted
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-evpn[1234]: Event|9503|LOG_INFO|EVPN|-|EVPN RD: rd updated for EVI: evi
@@ -591,6 +597,12 @@
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|10003|LOG_ERR|AMM|-|ACL mock_acl_type mock_acl_name failed to apply on mock_application
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|10401|LOG_INFO|AMM|-|ARP inspection mock_status on vlan vpn-Internet.
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|10402|LOG_ERR|AMM|-|ARP inspection mock_status on port 1/1/25.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-portaccess[1234]: Event|10501|LOG_INFO|PORT_ACCESS|-|Client 00:1A:2B:3C:4D:5E was logged-off administratively through command-line interface
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-portaccess[1234]: Event|10504|LOG_INFO|PORT_ACCESS|-|Clients were logged-off on the port eth0 due to a change in authentication mode from WPA2 to WPA3
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-portaccess[1234]: Event|10505|LOG_INFO|PORT_ACCESS|-|Clients were logged-off on the port eth0 due to a change in client limit from 10 to 20
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-portaccess[1234]: Event|10506|LOG_INFO|PORT_ACCESS|-|The name associated with VLAN 100 changed from old_vlan to new_vlan
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-portaccess[1234]: Event|10507|LOG_INFO|PORT_ACCESS|-|Clients using policy guest_policy were logged-off due to a configuration change in the policy
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-portaccess[1234]: Event|10508|LOG_ERR|PORT_ACCESS|-|VLAN conflict detected on port eth0
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-l3encap[1234]: Event|10601|LOG_WARN|L3ENCAP|-|L3 resources critical for neighbor and route forwarding are low. Used: 80, Available: 20
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-l3encap[1234]: Event|10602|LOG_INFO|L3ENCAP|-|L3 resources critical for neighbor and route forwarding are at safe levels. Used: 50, Available: 50
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-l3encap[1234]: Event|10603|LOG_ERR|L3ENCAP|-|Out of L3 resources critical for neighbor and route forwarding. Used: 100, Available: 0

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -15034,6 +15034,142 @@
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",
             "aruba": {
                 "component": {
+                    "category": "PORTSTATS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "6601",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-portstats[1234]: Event|6601|LOG_ERR|PORTSTATS|-|Failed to create layer 3 IPv4 RX statistic for port:eth0"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-portstats",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to create layer 3 IPv4 RX statistic for port:eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PORTSTATS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "6602",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-portstats[1234]: Event|6602|LOG_ERR|PORTSTATS|-|Failed to create layer 3 IPv6 RX statistic for port:eth1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-portstats",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to create layer 3 IPv6 RX statistic for port:eth1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PORTSTATS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth2"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "6603",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-portstats[1234]: Event|6603|LOG_ERR|PORTSTATS|-|Failed to create layer 3 IPv4 TX statistic for port:eth2"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-portstats",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to create layer 3 IPv4 TX statistic for port:eth2",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PORTSTATS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth3"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "6604",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-portstats[1234]: Event|6604|LOG_ERR|PORTSTATS|-|Failed to create layer 3 IPv6 TX statistic for port:eth3"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-portstats",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to create layer 3 IPv6 TX statistic for port:eth3",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
                     "category": "Mirroring"
                 },
                 "event_type": "Event",
@@ -20843,6 +20979,82 @@
             ]
         },
         {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PORTSEC"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9401",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-portsecurity[1234]: Event|9401|LOG_INFO|PORTSEC|-|Client limit exceeded on port eth0, caused by an unauthorized client 00:1A:2B:3C:4D:5E"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-portsecurity",
+                    "procid": "1234"
+                }
+            },
+            "message": "Client limit exceeded on port eth0, caused by an unauthorized client 00:1A:2B:3C:4D:5E",
+            "server": {
+                "mac": "00-1A-2B-3C-4D-5E"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PORTSEC"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9402",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-portsecurity[1234]: Event|9402|LOG_INFO|PORTSEC|-|Port security sticky client move violation triggered on port eth1 for client with MAC address 00:1A:2B:3C:4D:5E"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-portsecurity",
+                    "procid": "1234"
+                }
+            },
+            "message": "Port security sticky client move violation triggered on port eth1 for client with MAC address 00:1A:2B:3C:4D:5E",
+            "server": {
+                "mac": "00-1A-2B-3C-4D-5E"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-06-19T13:53:38.182641-05:00",
             "aruba": {
                 "component": {
@@ -22679,6 +22891,232 @@
                 }
             },
             "message": "ARP inspection mock_status on port 1/1/25.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PORT_ACCESS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "mac": "00-1A-2B-3C-4D-5E"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "10501",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-portaccess[1234]: Event|10501|LOG_INFO|PORT_ACCESS|-|Client 00:1A:2B:3C:4D:5E was logged-off administratively through command-line interface"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-portaccess",
+                    "procid": "1234"
+                }
+            },
+            "message": "Client 00:1A:2B:3C:4D:5E was logged-off administratively through command-line interface",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PORT_ACCESS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0",
+                "port_access": {
+                    "mode": "WPA3",
+                    "old_mode": "WPA2"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "10504",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-portaccess[1234]: Event|10504|LOG_INFO|PORT_ACCESS|-|Clients were logged-off on the port eth0 due to a change in authentication mode from WPA2 to WPA3"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-portaccess",
+                    "procid": "1234"
+                }
+            },
+            "message": "Clients were logged-off on the port eth0 due to a change in authentication mode from WPA2 to WPA3",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PORT_ACCESS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "limit": {
+                    "threshold": "20"
+                },
+                "port": "eth0",
+                "port_access": {
+                    "old_limit": "10"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "10505",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-portaccess[1234]: Event|10505|LOG_INFO|PORT_ACCESS|-|Clients were logged-off on the port eth0 due to a change in client limit from 10 to 20"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-portaccess",
+                    "procid": "1234"
+                }
+            },
+            "message": "Clients were logged-off on the port eth0 due to a change in client limit from 10 to 20",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PORT_ACCESS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port_access": {
+                    "name": "new_vlan",
+                    "old_name": "old_vlan"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "10506",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-portaccess[1234]: Event|10506|LOG_INFO|PORT_ACCESS|-|The name associated with VLAN 100 changed from old_vlan to new_vlan"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-portaccess",
+                    "procid": "1234"
+                }
+            },
+            "message": "The name associated with VLAN 100 changed from old_vlan to new_vlan",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PORT_ACCESS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port_access": {
+                    "policy_name": "guest_policy"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "10507",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-portaccess[1234]: Event|10507|LOG_INFO|PORT_ACCESS|-|Clients using policy guest_policy were logged-off due to a configuration change in the policy"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-portaccess",
+                    "procid": "1234"
+                }
+            },
+            "message": "Clients using policy guest_policy were logged-off due to a configuration change in the policy",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "PORT_ACCESS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "10508",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-portaccess[1234]: Event|10508|LOG_ERR|PORT_ACCESS|-|VLAN conflict detected on port eth0"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-portaccess",
+                    "procid": "1234"
+                }
+            },
+            "message": "VLAN conflict detected on port eth0",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -21380,6 +21380,9 @@
                     "name": "eth0"
                 }
             },
+            "client": {
+                "mac": "00-1A-2B-3C-4D-5E"
+            },
             "ecs": {
                 "version": "8.11.0"
             },
@@ -21398,9 +21401,6 @@
                 }
             },
             "message": "Client limit exceeded on port eth0, caused by an unauthorized client 00:1A:2B:3C:4D:5E",
-            "server": {
-                "mac": "00-1A-2B-3C-4D-5E"
-            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -21416,6 +21416,9 @@
                     "device": "8360-Primaire"
                 },
                 "port": "eth1"
+            },
+            "client": {
+                "mac": "00-1A-2B-3C-4D-5E"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -21435,9 +21438,6 @@
                 }
             },
             "message": "Port security sticky client move violation triggered on port eth1 for client with MAC address 00:1A:2B:3C:4D:5E",
-            "server": {
-                "mac": "00-1A-2B-3C-4D-5E"
-            },
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -2142,8 +2142,8 @@ processors:
       if: "['9401','9402'].contains(ctx.event?.code)"
       description: "Log event when an intruder is detected on the port | sticky mac is moved to other port"
       patterns:
-        - "^Client limit exceeded on port %{DATA:aruba.interface.name}, caused by an unauthorized client %{MAC:server.mac}"
-        - "^Port security sticky client move violation triggered on port %{DATA:aruba.port} for client with MAC address %{MAC:server.mac}"
+        - "^Client limit exceeded on port %{DATA:aruba.interface.name}, caused by an unauthorized client %{MAC:client.mac}"
+        - "^Port security sticky client move violation triggered on port %{DATA:aruba.port} for client with MAC address %{MAC:client.mac}"
 
   # EVPN Events (95xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/EVPN.htm

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1375,6 +1375,16 @@ processors:
       description: "Logs a message when SSH authorized key fails validation check"
       pattern: "User %{user.name} has configured an invalid SSH authorized key with key identifier %{user.id}"
 
+    # Port Statistics events (660x)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/COUNTERS.htm
+  - grok:
+      field: message
+      tag: port_stats_event_6601_6602_6603_6604
+      description: "Logs a message when the creation of a Layer 3 IPv4/IPv6 RX/TX counter fails"
+      if: "['6601','6602','6603','6604'].contains(ctx.event?.code)"
+      patterns:
+        - "^Failed to create layer 3 (IPv4|IPv6) (RX|TX) statistic for port:%{GREEDYDATA:aruba.port}"
+
     # Mirroring events (670x)
     # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MIRRORING.htm
   - grok:
@@ -2076,6 +2086,17 @@ processors:
       patterns:
         - "^PFC TLV status priority mismatch on interface %{DATA:aruba.dcbx.intf_name}$"
 
+  # Port security events (940x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PORT-SECURITY.htm
+  - grok:
+      field: message
+      tag: port_security_event_9401_9402
+      if: "['9401','9402'].contains(ctx.event?.code)"
+      description: "Log event when an intruder is detected on the port | sticky mac is moved to other port"
+      patterns:
+        - "^Client limit exceeded on port %{DATA:aruba.interface.name}, caused by an unauthorized client %{MAC:server.mac}"
+        - "^Port security sticky client move violation triggered on port %{DATA:aruba.port} for client with MAC address %{MAC:server.mac}"
+
   # EVPN Events (95xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/EVPN.htm
   - grok:
@@ -2211,6 +2232,45 @@ processors:
       patterns:
         - "^ARP inspection %{DATA:aruba.status} on vlan %{GREEDYDATA:network.vlan.id}."
         - "^ARP inspection %{DATA:aruba.status} on port %{GREEDYDATA:aruba.port}."
+
+  # PORT_ACCESS events (1050x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PORT_ACCESS.htm
+  - grok:
+      if: "['10501','10502','10503'].contains(ctx.event?.code)"
+      tag: port_access_event_10501_10502_10503
+      field: "message"
+      description: "Client was logged-off administratively through command-line interface | port is [unblocked|blocked] by port-access daemon"
+      patterns:
+        - "^Client %{MAC:client.mac} was logged-off administratively through command-line interface"
+        - "^Port %{DATA:aruba.port} is (blocked|unblocked) by port-access"
+  - grok:
+      if: "['10504','10505'].contains(ctx.event?.code)"
+      tag: port_access_event_10504_10505
+      field: "message"
+      description: "The authentication mode associated with the port is changed | The client limit associated with the port is changed"
+      patterns:
+        - "^Clients were logged-off on the port %{DATA:aruba.port} due to a change in (%{AUTH_MODE_CHANGE}|%{LIMIT_CHANGE})"
+      pattern_definitions:
+        AUTH_MODE_CHANGE: "authentication mode from %{DATA:aruba.port_access.old_mode} to %{GREEDYDATA:aruba.port_access.mode}"
+        LIMIT_CHANGE: "client limit from %{DATA:aruba.port_access.old_limit} to %{GREEDYDATA:aruba.limit.threshold}"
+  - dissect:
+      if: "ctx.event?.code == '10506'"
+      tag: port_access_event_10506
+      field: "message"
+      description: "The name associated with a VLAN in use by port-access daemon changed"
+      pattern: "The name associated with VLAN %{network.vlan.id} changed from %{aruba.port_access.old_name} to %{aruba.port_access.name}"
+  - dissect:
+      if: "ctx.event?.code == '10507'"
+      tag: port_access_event_10507
+      field: "message"
+      description: "The policy configuration is updated by the user"
+      pattern: "Clients using policy %{aruba.port_access.policy_name} were logged-off due to a configuration change in the policy"
+  - dissect:
+      if: "ctx.event?.code == '10508'"
+      tag: port_access_event_10508
+      field: "message"
+      description: "VLAN is configured as Trunk for some clients and access for others. This could potentially result in traffic loss"
+      pattern: "VLAN conflict detected on port %{aruba.port}"
 
   # L3 Encap capacity events (1060x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3_ENCAP.htm

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -825,6 +825,27 @@
     - name: port
       type: keyword
       description: ""
+    - name: port_access
+      type: group
+      fields:
+        - name: mode
+          type: keyword
+          description: ""
+        - name: name
+          type: keyword
+          description: ""
+        - name: old_limit
+          type: keyword
+          description: ""
+        - name: old_mode
+          type: keyword
+          description: ""
+        - name: old_name
+          type: keyword
+          description: ""
+        - name: policy_name
+          type: keyword
+          description: ""
     - name: prefix
       type: keyword
       description: ""

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -852,9 +852,6 @@
         - name: old_name
           type: keyword
           description: ""
-        - name: policy_name
-          type: keyword
-          description: ""
     - name: prefix
       type: keyword
       description: ""

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -1549,7 +1549,6 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.port_access.old_limit |  | keyword |
 | aruba.port_access.old_mode |  | keyword |
 | aruba.port_access.old_name |  | keyword |
-| aruba.port_access.policy_name |  | keyword |
 | aruba.prefix |  | keyword |
 | aruba.priority |  | keyword |
 | aruba.role |  | keyword |

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -861,29 +861,33 @@ Note: Descriptions have not been filled out
 | aruba.port.vlan      |             |      | network.vlan.id              |
 
 #### [Port security events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PORT-SECURITY.htm)
-| Field                | Description | Type | Common                       |
-|----------------------|-------------|------|------------------------------|
-| aruba.port.if_name   |             |      | observer.ingress.interface.name |
-| aruba.port.mac_addr  |             |      | server.mac                   |
-| aruba.port.port      |             |      | server.port                  |
+| Docs Field   | Schema Mapping       |
+|--------------|----------------------|
+| <if_name>    | aruba.interface.name |
+| <mac_addr>   | server.mac           |
+| <port>       | aruba.port           |
 
 #### [Port Statistics events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/COUNTERS.htm)
 | Field                | Description | Type | Common                       |
 |----------------------|-------------|------|------------------------------|
-| aruba.port.name      |             |      | server.port                  |
+| <name>      |             |      | server.port                  |
 
 #### [PORT_ACCESS events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PORT_ACCESS.htm)
-| Field                   | Description | Type | Common                       |
-|-------------------------|-------------|------|------------------------------|
-| aruba.port.limit        |             |      | aruba.limit.threshold                  |
-| aruba.port.mac_address  |             |      | client.mac                   |
-| aruba.port.mode         |             |      |                              |
-| aruba.port.name         |             |      | server.port                  |
-| aruba.port.old_limit    |             |      |                              |
-| aruba.port.old_mode     |             |      |                              |
-| aruba.port.old_name     |             |      |                              |
-| aruba.port.policy_name  |             |      |                              |
-| aruba.port.port         |             |      | server.port                  |
+| Docs Field    | Schema Mapping               |
+|---------------|------------------------------|
+| <limit>       | aruba.limit.threshold        |
+| <mac_address> | client.mac                   |
+| <mode>        | aruba.port_access.mode       |
+| <new_limit>   | aruba.limit.threshold        |
+| <new_name>    | aruba.port_access.name       |
+| <new_mode>    | aruba.port_access.mode       |
+| <old_limit>   | aruba.port_access.old_limit  |
+| <old_mode>    | aruba.port_access.old_mode   |
+| <old_name>    | aruba.port_access.old_name   |
+| <policy_name> | aruba.port_access.policy_name|
+| <port>        | aruba.port                   |
+| <vlan_id>     | network.vlan.id              |
+
 
 #### [Power events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/POWER.htm)
 | Field                   | Description | Type | Common                       |
@@ -1538,6 +1542,12 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.pim.totalvid |  | long |
 | aruba.pim.type |  | keyword |
 | aruba.port |  | keyword |
+| aruba.port_access.mode |  | keyword |
+| aruba.port_access.name |  | keyword |
+| aruba.port_access.old_limit |  | keyword |
+| aruba.port_access.old_mode |  | keyword |
+| aruba.port_access.old_name |  | keyword |
+| aruba.port_access.policy_name |  | keyword |
 | aruba.prefix |  | keyword |
 | aruba.priority |  | keyword |
 | aruba.role |  | keyword |

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -884,7 +884,7 @@ Note: Descriptions have not been filled out
 | <old_limit>   | aruba.port_access.old_limit  |
 | <old_mode>    | aruba.port_access.old_mode   |
 | <old_name>    | aruba.port_access.old_name   |
-| <policy_name> | aruba.port_access.policy_name|
+| <policy_name> | aruba.policy.name            |
 | <port>        | aruba.port                   |
 | <vlan_id>     | network.vlan.id              |
 

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -864,7 +864,7 @@ Note: Descriptions have not been filled out
 | Docs Field   | Schema Mapping       |
 |--------------|----------------------|
 | <if_name>    | aruba.interface.name |
-| <mac_addr>   | server.mac           |
+| <mac_addr>   | client.mac           |
 | <port>       | aruba.port           |
 
 #### [Port Statistics events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/COUNTERS.htm)

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -868,9 +868,9 @@ Note: Descriptions have not been filled out
 | <port>       | aruba.port           |
 
 #### [Port Statistics events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/COUNTERS.htm)
-| Field                | Description | Type | Common                       |
-|----------------------|-------------|------|------------------------------|
-| <name>      |             |      | server.port                  |
+| Docs Field | Schema Mapping       |
+|------------|----------------------|
+| <name>     | aruba.port           |
 
 #### [PORT_ACCESS events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PORT_ACCESS.htm)
 | Docs Field    | Schema Mapping               |


### PR DESCRIPTION
Ticket:
Support the first 70-80 event types for the Aruba integration
https://github.com/elastic/integrations/issues/12065

Change Log:
- PORT_ACCESS events (1050x)
- Port security events (940x)
- Port Statistics events (660x)

Test Cases:
validate that the pipeline test pass
validated that the expected file parses the proper fields for the different message type