### PR TITLE
qualys_vmdr: Handle empty XML responses in Qualys asset_host_detection.

### DIFF
--- a/packages/qualys_vmdr/_dev/deploy/docker/files/config.yml
+++ b/packages/qualys_vmdr/_dev/deploy/docker/files/config.yml
@@ -4,7 +4,17 @@ rules:
     query_params:
       action: list
       truncation_limit: 1000
-      id_min: 5641289 # Pagination request.
+      id_min: 77777777 # Pagination request 2. Should returns 0 events.
+    responses:
+      - status_code: 200
+        body: |- # handling empty XML response
+
+  - path: /api/2.0/fo/asset/host/vm/detection/
+    methods: ['GET']
+    query_params:
+      action: list
+      truncation_limit: 1000
+      id_min: 5641289 # Pagination request 1.
     responses:
       - status_code: 200
         body: |-
@@ -112,6 +122,11 @@ rules:
                   </DETECTION_LIST>
                 </HOST>
               </HOST_LIST>
+              <WARNING>
+                <CODE>1980</CODE>
+                <TEXT>1000 record limit exceeded. Use URL to get next batch of results.</TEXT>
+                <URL><![CDATA[http://{{ env "SERVER_ADDRESS" }}/api/2.0/fo/asset/host/vm/detection/?action=list&truncation_limit=1000&id_min=77777777]]></URL>
+              </WARNING>
             </RESPONSE>
           </HOST_LIST_VM_DETECTION_OUTPUT>
   - path: /api/2.0/fo/asset/host/vm/detection/
@@ -230,7 +245,7 @@ rules:
                 <CODE>1980</CODE>
                 <TEXT>1000 record limit exceeded. Use URL to get next batch of results.</TEXT>
                 <URL><![CDATA[http://{{ env "SERVER_ADDRESS" }}/api/2.0/fo/asset/host/vm/detection/?action=list&truncation_limit=1000&id_min=5641289]]></URL>
-                </WARNING>
+              </WARNING>
             </RESPONSE>
           </HOST_LIST_VM_DETECTION_OUTPUT>
   - path: /api/2.0/fo/knowledge_base/vuln/

--- a/packages/qualys_vmdr/changelog.yml
+++ b/packages/qualys_vmdr/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Handle empty XML responses in Qualys asset_host_detection.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/12092
 - version: "5.6.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` set to "pipeline_error".

--- a/packages/qualys_vmdr/changelog.yml
+++ b/packages/qualys_vmdr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "5.6.1"
+  changes:
+    - description: Handle empty XML responses in Qualys asset_host_detection.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "5.6.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` set to "pipeline_error".

--- a/packages/qualys_vmdr/data_stream/asset_host_detection/agent/stream/input.yml.hbs
+++ b/packages/qualys_vmdr/data_stream/asset_host_detection/agent/stream/input.yml.hbs
@@ -43,50 +43,54 @@ program: |
     }).do_request().as(resp,
       resp.StatusCode == 200
       ?
-        resp.Body.as(xml, try(bytes(xml).decode_xml('qualys_api_2_0'), "decode_xml_error").as(body, 
-          !has(body.decode_xml_error) 
-          ?
-            (body.?doc.HOST_LIST_VM_DETECTION_OUTPUT.RESPONSE.HOST_LIST.HOST.hasValue() 
+        (has(resp.Body) && size(resp.Body) != 0 
+        ?
+          (resp.Body.as(xml, try(bytes(xml).decode_xml('qualys_api_2_0'), "decode_xml_error").as(body, 
+            !has(body.decode_xml_error) 
             ?
-              ({
-                "events": body.doc.HOST_LIST_VM_DETECTION_OUTPUT.RESPONSE.HOST_LIST.HOST.map(h,
-                  h.DETECTION_LIST.DETECTION.map(v, {
-                    "message": h.with({"DETECTION_LIST": v}).encode_json(),
-                  })
-                ).flatten(),
-                ?"pagination_url": body.?doc.HOST_LIST_VM_DETECTION_OUTPUT.RESPONSE.WARNING.URL,
-                "want_more": body.?doc.HOST_LIST_VM_DETECTION_OUTPUT.RESPONSE.WARNING.URL.hasValue(),
-              })
+              (body.?doc.HOST_LIST_VM_DETECTION_OUTPUT.RESPONSE.hasValue() 
+              ?
+                ({
+                  "events": body.?doc.HOST_LIST_VM_DETECTION_OUTPUT.RESPONSE.HOST_LIST.HOST.orValue([]).map(h,
+                    h.DETECTION_LIST.DETECTION.map(v, {
+                      "message": h.with({"DETECTION_LIST": v}).encode_json(),
+                    })
+                  ).flatten(),
+                  ?"pagination_url": body.?doc.HOST_LIST_VM_DETECTION_OUTPUT.RESPONSE.WARNING.URL,
+                  "want_more": body.?doc.HOST_LIST_VM_DETECTION_OUTPUT.RESPONSE.WARNING.URL.hasValue(),
+                })
+              :
+                {
+                  "events": {
+                    "error": {
+                      "message": "xsd and response mismatch:" + (
+                          string(resp.Body)
+                      ),
+                    },
+                  },
+                  "want_more": false,
+                }
+              )
             :
               {
                 "events": {
                   "error": {
-                    "message": "xsd and response mismatch:" + (
-                      size(resp.Body) != 0 ?
+                    "message": "decode_xml error:" + string(body.decode_xml_error) + ":" + (
                         string(resp.Body)
-                      :
-                        "XML response missing"
                     ),
                   },
                 },
                 "want_more": false,
               }
-            )
-          :
-            {
-              "events": {
-                "error": {
-                  "message": "decode_xml error:" + string(body.decode_xml_error) + ":" + (
-                    size(resp.Body) != 0 ?
-                      string(resp.Body)
-                    :
-                      "XML response missing"
-                  ),
-                },
-              },
-              "want_more": false,
-            }
-        ))
+          )))
+        :
+          // Qualys sends 200 success but with no response body. 
+          // Handling this case as okay.
+          {
+            "events": [],
+            "want_more": false,
+          }
+        )
       :
         {
           "events": {

--- a/packages/qualys_vmdr/manifest.yml
+++ b/packages/qualys_vmdr/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: qualys_vmdr
 title: Qualys VMDR
-version: "5.6.0"
+version: "5.6.1"
 description: Collect data from Qualys VMDR platform with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
Qualys can send empty XML response body with 200 success status. 
Handle this case as valid.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Run system tests for `asset_host_detection`:
`eval "$(elastic-package stack shellinit)" && elastic-package test system --generate  -v --defer-cleanup 30m --data-streams=asset_host_detection`
```
--- Test results for package: qualys_vmdr - START ---
╭─────────────┬──────────────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE     │ DATA STREAM          │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├─────────────┼──────────────────────┼───────────┼───────────┼────────┼───────────────┤
│ qualys_vmdr │ asset_host_detection │ system    │ default   │ PASS   │ 38.544323042s │
╰─────────────┴──────────────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: qualys_vmdr - END   ---
Done
```

