### PR TITLE
packages/salesforce: Fix processor syntax issue when adding new ones

### DIFF
--- a/packages/salesforce/changelog.yml
+++ b/packages/salesforce/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Remove indentation from processors to avoid syntax error when adding new processors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12097
 - version: "1.0.0"
   changes:
     - description: GA release of the Salesforce integration.

--- a/packages/salesforce/changelog.yml
+++ b/packages/salesforce/changelog.yml
@@ -2,7 +2,7 @@
 - version: "1.0.1"
   changes:
     - description: Remove indentation from processors to avoid syntax error when adding new processors.
-      type: enhancement
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/12097
 - version: "1.0.0"
   changes:

--- a/packages/salesforce/data_stream/apex/agent/stream/salesforce.yml.hbs
+++ b/packages/salesforce/data_stream/apex/agent/stream/salesforce.yml.hbs
@@ -43,10 +43,10 @@ publisher_pipeline.disable_host: true
 {{/contains}}
 
 processors:
-  - add_fields:
-      target: salesforce
-      fields:
-        instance_url: {{instance_url}}
+- add_fields:
+    target: salesforce
+    fields:
+      instance_url: {{instance_url}}
 {{#if processors}}
 {{processors}}
 {{/if}}

--- a/packages/salesforce/manifest.yml
+++ b/packages/salesforce/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: salesforce
 title: Salesforce
-version: "1.0.0"
+version: "1.0.1"
 description: |
   Collect logs from Salesforce instances using the Elastic Agent. This integration enables monitoring and analysis of various Salesforce logs, including Login, Logout, Setup Audit Trail, and Apex execution logs. Gain insights into user activity, security events, and application performance.
 type: integration


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Remove indentation from processors to avoid syntax error when adding new processors. This changed is required so that when processors are added from the UI they are at the same level (indentation) as the already added processors i.e., making it syntactically correct when formatted. Only `apex` is affected, for other datasets, it is in expected form.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

Tested by adding `- add_fields: { fields: { my_id: "12345" } }` from the UI in processors.
