### PR TITLE
ti_custom: Add docs about retrieving ISAC feeds

### DIFF
--- a/packages/ti_custom/_dev/build/docs/README.md
+++ b/packages/ti_custom/_dev/build/docs/README.md
@@ -60,7 +60,7 @@ To configure the integration to pull threat intelligence from an ISAC feed, foll
     - Authentication Credentials: Username, password, API Key, or client certificate, as required by the ISAC.
 
 3. Set up the integration:
-    - The server URL and collection name should be used to build the URL as follows: `https://{server_url}/{api-root}/collections/{name}/objects/`
+    - The server URL and collection name should be used to build the URL as follows: `https://{base_url}/{api-root}/collections/{name}/objects/`
     - Provide the username/password, API Key or upload a client certificate, depending on the ISAC’s requirements.
     - Set how often the integration should pull updates (e.g. every hour). You can also set the time range to search for indicators when the agent runs for the first time with the Initial Interval.
 

--- a/packages/ti_custom/_dev/build/docs/README.md
+++ b/packages/ti_custom/_dev/build/docs/README.md
@@ -46,6 +46,26 @@ However, for APIs that don't follow a specific communication protocol. The corre
 
 By default the integration only supports STIX 2.1 indicators. This means that to process IOCs in other formats, the `Restrict STIX 2.1 format` option must be disabled, and a custom pipeline added to map the indicators correctly.
 
+### Collecting Threat Intelligence from ISAC Feeds
+
+The Custom Threat Intelligence integration allows you to connect to and pull threat indicators from any server supporting the TAXII protocol. This makes this integration the perfect fit for retrieving structured threat intelligence from Information Sharing and Analysis Centers (ISACs), such as MS-ISAC, FS-ISAC, H-ISAC, and others. These ISACs provide STIX-formatted threat data through TAXII servers.
+
+To configure the integration to pull threat intelligence from an ISAC feed, follow these steps:
+
+1. Ensure ISAC Membership: Confirm that you are a member of the desired ISAC (e.g., MS-ISAC, FS-ISAC) and have access to its TAXII server credentials. Some ISACs require registration and approval before providing TAXII feed access.
+
+2. Obtain the following information from your ISAC:
+    - Server URL: The endpoint for the ISAC’s TAXII server (e.g. https://example-isac.org/taxii/).
+    - Collection Name: The specific collection containing the threat intelligence you want to retrieve.
+    - Authentication Credentials: Username, password, API Key, or client certificate, as required by the ISAC.
+
+3. Set up the integration:
+    - The server URL and collection name should be used to build the URL as follows: `https://{server_url}/{api-root}/collections/{name}/objects/`
+    - Provide the username/password, API Key or upload a client certificate, depending on the ISAC’s requirements.
+    - Set how often the integration should pull updates (e.g. every hour). You can also set the time range to search for indicators when the agent runs for the first time with the Initial Interval.
+
+Once the integration is running and pulling data, it automatically maps threat indicator fields from STIX to ECS. Verify that the imported indicators (e.g. IPs, domains, hashes) align with your detection rules.
+
 ### Expiration of Indicators of Compromise (IOCs)
 
 The Custom Threat Intelligence integration supports IOC expiration. The ingested IOCs expire after certain duration. Based on the [STIX 2.1 reference](https://docs.oasis-open.org/cti/stix/v2.1/os/stix-v2.1-os.html), the following options are available to determine the expiration of indicators:

--- a/packages/ti_custom/changelog.yml
+++ b/packages/ti_custom/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.0"
+  changes:
+    - description: Improve documentation on how to proceed with ISAC feeds.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12098
 - version: "0.4.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` set to "pipeline_error".

--- a/packages/ti_custom/docs/README.md
+++ b/packages/ti_custom/docs/README.md
@@ -60,7 +60,7 @@ To configure the integration to pull threat intelligence from an ISAC feed, foll
     - Authentication Credentials: Username, password, API Key, or client certificate, as required by the ISAC.
 
 3. Set up the integration:
-    - The server URL and collection name should be used to build the URL as follows: `https://{server_url}/{api-root}/collections/{name}/objects/`
+    - The server URL and collection name should be used to build the URL as follows: `https://{base_url}/{api-root}/collections/{name}/objects/`
     - Provide the username/password, API Key or upload a client certificate, depending on the ISAC’s requirements.
     - Set how often the integration should pull updates (e.g. every hour). You can also set the time range to search for indicators when the agent runs for the first time with the Initial Interval.
 

--- a/packages/ti_custom/docs/README.md
+++ b/packages/ti_custom/docs/README.md
@@ -46,6 +46,26 @@ However, for APIs that don't follow a specific communication protocol. The corre
 
 By default the integration only supports STIX 2.1 indicators. This means that to process IOCs in other formats, the `Restrict STIX 2.1 format` option must be disabled, and a custom pipeline added to map the indicators correctly.
 
+### Collecting Threat Intelligence from ISAC Feeds
+
+The Custom Threat Intelligence integration allows you to connect to and pull threat indicators from any server supporting the TAXII protocol. This makes this integration the perfect fit for retrieving structured threat intelligence from Information Sharing and Analysis Centers (ISACs), such as MS-ISAC, FS-ISAC, H-ISAC, and others. These ISACs provide STIX-formatted threat data through TAXII servers.
+
+To configure the integration to pull threat intelligence from an ISAC feed, follow these steps:
+
+1. Ensure ISAC Membership: Confirm that you are a member of the desired ISAC (e.g., MS-ISAC, FS-ISAC) and have access to its TAXII server credentials. Some ISACs require registration and approval before providing TAXII feed access.
+
+2. Obtain the following information from your ISAC:
+    - Server URL: The endpoint for the ISAC’s TAXII server (e.g. https://example-isac.org/taxii/).
+    - Collection Name: The specific collection containing the threat intelligence you want to retrieve.
+    - Authentication Credentials: Username, password, API Key, or client certificate, as required by the ISAC.
+
+3. Set up the integration:
+    - The server URL and collection name should be used to build the URL as follows: `https://{server_url}/{api-root}/collections/{name}/objects/`
+    - Provide the username/password, API Key or upload a client certificate, depending on the ISAC’s requirements.
+    - Set how often the integration should pull updates (e.g. every hour). You can also set the time range to search for indicators when the agent runs for the first time with the Initial Interval.
+
+Once the integration is running and pulling data, it automatically maps threat indicator fields from STIX to ECS. Verify that the imported indicators (e.g. IPs, domains, hashes) align with your detection rules.
+
 ### Expiration of Indicators of Compromise (IOCs)
 
 The Custom Threat Intelligence integration supports IOC expiration. The ingested IOCs expire after certain duration. Based on the [STIX 2.1 reference](https://docs.oasis-open.org/cti/stix/v2.1/os/stix-v2.1-os.html), the following options are available to determine the expiration of indicators:

--- a/packages/ti_custom/manifest.yml
+++ b/packages/ti_custom/manifest.yml
@@ -3,7 +3,7 @@ name: ti_custom
 title: Custom Threat Intelligence
 description: Ingest threat intelligence data in STIX 2.1 format with Elastic Agent
 type: integration
-version: 0.4.0
+version: 0.5.0
 categories:
   - custom
   - security


### PR DESCRIPTION
## Proposed commit message

See title.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Related to https://github.com/elastic/enhancements/issues/22961

## Screenshots

<img width="1251" alt="image" src="https://github.com/user-attachments/assets/5dc57076-4c7a-4cd0-aa0c-17fcac888de5" />
