### PR TITLE
Fix aws logs duplicated keys in agent template

### DIFF
--- a/packages/aws_logs/changelog.yml
+++ b/packages/aws_logs/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Fix dupplicated keys buffer_size, fips_enabled, in agent template.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/11891
+      link: https://github.com/elastic/integrations/pull/12100
 - version: "1.5.1"
   changes:
     - description: Add required permissions for Custom AWS Logs.

--- a/packages/aws_logs/changelog.yml
+++ b/packages/aws_logs/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.5.2
+  changes:
+    - description: Fix dupplicated keys buffer_size, fips_enabled, in agent template.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11891
 - version: "1.5.1"
   changes:
     - description: Add required permissions for Custom AWS Logs.
@@ -20,7 +25,7 @@
       link: https://github.com/elastic/integrations/pull/11681
 - version: "1.4.0"
   changes:
-    - description: Update file_selectors field to be able to receive multiline configuration 
+    - description: Update file_selectors field to be able to receive multiline configuration
       type: enhancement
       link: https://github.com/elastic/integrations/pull/10789
 - version: "1.3.1"

--- a/packages/aws_logs/data_stream/generic/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws_logs/data_stream/generic/agent/stream/aws-s3.yml.hbs
@@ -65,9 +65,7 @@ encoding: {{ encoding }}
 {{#if expand_event_list_from_field }}
 expand_event_list_from_field: {{ expand_event_list_from_field }}
 {{/if}}
-{{#if buffer_size }}
-buffer_size: {{ buffer_size }}
-{{/if}}
+
 {{#if fips_enabled }}
 fips_enabled: {{ fips_enabled }}
 {{/if}}
@@ -127,9 +125,6 @@ session_token: {{session_token}}
 {{/if}}
 {{#if role_arn}}
 role_arn: {{role_arn}}
-{{/if}}
-{{#if fips_enabled}}
-fips_enabled: {{fips_enabled}}
 {{/if}}
 {{#if proxy_url }}
 proxy_url: {{proxy_url}}

--- a/packages/aws_logs/manifest.yml
+++ b/packages/aws_logs/manifest.yml
@@ -3,7 +3,7 @@ name: aws_logs
 title: Custom AWS Logs
 description: Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.
 type: integration
-version: "1.5.1"
+version: "1.5.2"
 categories:
   - observability
   - custom


### PR DESCRIPTION
Resolve https://github.com/elastic/integrations/issues/12099

Fix duplicated keys in agent template, that was crashing the Fleet UI 

Tested after the fix and it work as expected:

<img width="1501" alt="Screenshot 2024-12-13 at 10 07 21 AM" src="https://github.com/user-attachments/assets/551d1a35-f5d6-4b6b-906e-f63b3bae8e07" />
