### PR TITLE
#12065-10 Adding Power over Ethernet events

### DIFF
--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -909,7 +909,6 @@ Note: Descriptions have not been filled out
 | <assigned_class>   | aruba.poe.assigned_class     |
 | <assigned_class_A> | aruba.poe.assigned_class_a   |
 | <assigned_class_B> | aruba.poe.assigned_class_b   |
-| <available>        | aruba.poe.available          |
 | <cntrl_name>       | aruba.poe.cntrl_name         |
 | <duration>         | aruba.poe.cntrl_name         |
 | <fault_type>       | aruba.poe.fault_type         |

--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -910,7 +910,7 @@ Note: Descriptions have not been filled out
 | <assigned_class_A> | aruba.poe.assigned_class_a   |
 | <assigned_class_B> | aruba.poe.assigned_class_b   |
 | <cntrl_name>       | aruba.poe.cntrl_name         |
-| <duration>         | aruba.poe.cntrl_name         |
+| <duration>         | aruba.poe.duration           |
 | <fault_type>       | aruba.poe.fault_type         |
 | <interface_name>   | aruba.interface.name         |
 | <threshold_limit>  | aruba.limit.threshold        |

--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -904,24 +904,29 @@ Note: Descriptions have not been filled out
 | <warnings>  | aruba.count            |
 
 #### [Power over Ethernet events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/POE.htm)
-| Field                       | Description | Type | Common                       |
-|-----------------------------|-------------|------|------------------------------|
-| aruba.power.assign_class    |             |      |                              |
-| aruba.power.assign_class_a  |             |      |                              |
-| aruba.power.assign_class_b  |             |      |                              |
-| aruba.power.available       |             |      |                              |
-| aruba.power.drawn           |             |      |                              |
-| aruba.power.fault_type      |             |      | error.type                   |
-| aruba.power.interface_name  |             |      |                              |
-| aruba.power.limit           |             |      | aruba.limit.threshold                  |
-| aruba.power.pair            |             |      |                              |
-| aruba.power.paira_class     |             |      |                              |
-| aruba.power.pairb_class     |             |      |                              |
-| aruba.power.pd_class        |             |      |                              |
-| aruba.power.pd_type         |             |      |                              |
-| aruba.power.req_class       |             |      |                              |
-| aruba.power.req_class_a     |             |      |                              |
-| aruba.power.req_class_b     |             |      |                              |
+| Docs Field         | Schema Mapping               |
+|--------------------|------------------------------|
+| <assigned_class>   | aruba.poe.assigned_class     |
+| <assigned_class_A> | aruba.poe.assigned_class_a   |
+| <assigned_class_B> | aruba.poe.assigned_class_b   |
+| <available>        | aruba.poe.available          |
+| <cntrl_name>       | aruba.poe.cntrl_name         |
+| <duration>         | aruba.poe.cntrl_name         |
+| <fault_type>       | error.type                   |
+| <interface_name>   | aruba.interface.name         |
+| <threshold_limit>  | aruba.limit.threshold        |
+| <pair>             | aruba.poe.pair               |
+| <paira_class>      | aruba.poe.paira_class        |
+| <pairb_class>      | aruba.poe.pairb_class        |
+| <pd_class>         | aruba.poe.pd_class           |
+| <pd_type>          | aruba.poe.pd_type            |
+| <power>            | aruba.power.value            |
+| <power_available>  | aruba.power.available        |
+| <power_drawn>      | aruba.power.value            |
+| <req_class>        | aruba.poe.req_class          |
+| <req_class_a>      | aruba.poe.req_class_a        |
+| <req_class_b>      | aruba.poe.req_class_b        |
+| <subsys_name>      | aruba.poe.subsys_name        |
 
 #### [Proxy ARP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PROXY-ARP.htm)
 | Field                | Description | Type | Common                       |

--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -912,7 +912,7 @@ Note: Descriptions have not been filled out
 | <available>        | aruba.poe.available          |
 | <cntrl_name>       | aruba.poe.cntrl_name         |
 | <duration>         | aruba.poe.cntrl_name         |
-| <fault_type>       | error.type                   |
+| <fault_type>       | aruba.poe.fault_type         |
 | <interface_name>   | aruba.interface.name         |
 | <threshold_limit>  | aruba.limit.threshold        |
 | <pair>             | aruba.poe.pair               |

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
@@ -492,6 +492,46 @@
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7804|LOG_INFO|ExternalStorage|-|Share myShare is dismounted
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7805|LOG_ERR|ExternalStorage|-|Share myShare mount is aborted
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7806|LOG_INFO|ExternalStorage|-|USB device connected.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7901|LOG_INFO|POWERETHERNET|-|Detected powered device on interface eth0. Type:Type1, Class:Class2
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7902|LOG_INFO|POWERETHERNET|-|Powered device power delivery on interface eth1
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7903|LOG_WARN|POWERETHERNET|-|Powered device power denied on interface eth2
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7904|LOG_WARN|POWERETHERNET|-|Powered device fault on interface eth3. Fault type Overload
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7905|LOG_INFO|POWERETHERNET|-|Powered device disconnected on interface eth4
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7906|LOG_INFO|POWERETHERNET|-|PoE disabled on interface eth5
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7907|LOG_INFO|POWERETHERNET|-|Powered device mps absent on interface eth6
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7908|LOG_INFO|POWERETHERNET|-|Detected dual signature powered device on interface eth7. Type:Type2, ClassA:Class3, ClassB:Class4
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7909|LOG_INFO|POWERETHERNET|-|Dual signature powered device power delivery on interface eth8
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7910|LOG_WARN|POWERETHERNET|-|Dual signature powered device fault on interface eth9 pair A. Fault type Overload
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7911|LOG_INFO|POWERETHERNET|-|Dual signature powered device mps absent on interface eth0
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7912|LOG_INFO|POWERETHERNET|-|Powered device FET bad fault recovered on interface eth1
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7913|LOG_INFO|POWERETHERNET|-|Powered device FET bad fault recovery failed on interface eth2
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7914|LOG_INFO|POWERETHERNET|-|Powered device got class demoted on interface eth3. Requested_class 3 Assigned_class 2
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7915|LOG_INFO|POWERETHERNET|-|Dual signature powered device got class demoted on interface eth4. Requested_classA 3 Requested_classB 4 Assigned_classA 2 Assigned_classB 3
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7916|LOG_INFO|POWERETHERNET|-|Powered device pre std detect enabled on interface eth5
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7917|LOG_INFO|POWERETHERNET|-|PoE usage exceeded threshold limit of 80W
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7918|LOG_INFO|POWERETHERNET|-|PoE controller Controller1 got into fault
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7919|LOG_INFO|POWERETHERNET|-|PoE controller Controller2 got reset
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7920|LOG_INFO|POWERETHERNET|-|Powered device got class promoted on interface eth0.Requested_class 3 Assigned_class 4
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7921|LOG_INFO|POWERETHERNET|-|Dual signature powered device got class promoted on interface eth1.Requested_classA 3 Requested_classB 4 Assigned_classA 2 Assigned_classB 3
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7922|LOG_INFO|POWERETHERNET|-|Powered device is drawing power more than its class on interface eth2, type:Type1 class:Class2 power:30W is exceeding the max average power of the PD class. Check the PD max power draw, cabling type and length to improve interoperability
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7923|LOG_INFO|POWERETHERNET|-|Powered device UVLO fault on interface eth3, will attempt to recover itself by toggling power
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7924|LOG_INFO|POWERETHERNET|-|Powered device FET BAD fault on interface eth4
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7925|LOG_INFO|POWERETHERNET|-|Dual signature powered device is drawing power more than its class on interface eth5, type:Type2 classA:Class3 classB:Class4 power:60W
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7926|LOG_INFO|POWERETHERNET|-|PoE usage is below threshold of 30W
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7927|LOG_WARN|POWERETHERNET|-|Total power drawn: 100W by powered device is exceeding the total available PoE power:90W. Check the PD max power draw, cabling type and length to avoid system crowbar.
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7928|LOG_WARN|POWERETHERNET|-|Powered device invalid signature indication on interface eth6.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7929|LOG_INFO|POWERETHERNET|-|PoE hardware access daemon exiting
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7930|LOG_INFO|POWERETHERNET|-|POE proto daemon exiting
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7931|LOG_INFO|POWERETHERNET|-|Always-on PoE detected a powered device on interface eth0 and delivered power
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7932|LOG_INFO|POWERETHERNET|-|Powered device disconnected on interface eth1 due to LLDP dot3 disable
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7933|LOG_INFO|POWERETHERNET|-|Subsystem subsystem1 came up with quick PoE
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7934|LOG_INFO|POWERETHERNET|-|Quick PoE detected a powered device on interface eth2 and delivered power
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7935|LOG_WARN|POWERETHERNET|-|Powered device denied on interface eth3 of line module with Quick PoE enabled. Remove device to avoid crowbar on reboot.
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7936|LOG_WARN|POWERETHERNET|-|Powered device demoted on interface eth4 of line module with Quick PoE enabled. Remove device to avoid crowbar on reboot.
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7937|LOG_WARN|POWERETHERNET|-|PoE disable ignored on interface eth5 because Quick PoE is enabled
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7938|LOG_WARN|POWERETHERNET|-|PoE assigned class configuration is ignored on interface eth6 because Quick PoE is enabled
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7939|LOG_INFO|POWERETHERNET|-|Powered device requested power down on interface eth0 5 minutes
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7940|LOG_INFO|POWERETHERNET|-|Powered device disconnected on interface eth1 due to pd-class-override config change
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|8001|LOG_INFO|AMM|-|Bluetooth has been enabled
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|8003|LOG_INFO|AMM|-|Bluetooth adapter inserted
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|8004|LOG_INFO|AMM|-|Bluetooth device connected: ab:cd:ef:12:34:56

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -18737,6 +18737,1495 @@
             ]
         },
         {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                },
+                "poe": {
+                    "pd_class": "Class2",
+                    "pd_type": "Type1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7901",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7901|LOG_INFO|POWERETHERNET|-|Detected powered device on interface eth0. Type:Type1, Class:Class2"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Detected powered device on interface eth0. Type:Type1, Class:Class2",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7902",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7902|LOG_INFO|POWERETHERNET|-|Powered device power delivery on interface eth1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Powered device power delivery on interface eth1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth2"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7903",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7903|LOG_WARN|POWERETHERNET|-|Powered device power denied on interface eth2"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Powered device power denied on interface eth2",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth3"
+                },
+                "poe": {
+                    "fault_type": "Overload"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7904",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7904|LOG_WARN|POWERETHERNET|-|Powered device fault on interface eth3. Fault type Overload"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Powered device fault on interface eth3. Fault type Overload",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7905",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7905|LOG_INFO|POWERETHERNET|-|Powered device disconnected on interface eth4"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Powered device disconnected on interface eth4",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth5"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7906",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7906|LOG_INFO|POWERETHERNET|-|PoE disabled on interface eth5"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "PoE disabled on interface eth5",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth6"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7907",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7907|LOG_INFO|POWERETHERNET|-|Powered device mps absent on interface eth6"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Powered device mps absent on interface eth6",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth7"
+                },
+                "poe": {
+                    "paira_class": "Class3",
+                    "pairb_class": "Class4",
+                    "pd_type": "Type2"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7908",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7908|LOG_INFO|POWERETHERNET|-|Detected dual signature powered device on interface eth7. Type:Type2, ClassA:Class3, ClassB:Class4"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Detected dual signature powered device on interface eth7. Type:Type2, ClassA:Class3, ClassB:Class4",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth8"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7909",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7909|LOG_INFO|POWERETHERNET|-|Dual signature powered device power delivery on interface eth8"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Dual signature powered device power delivery on interface eth8",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth9"
+                },
+                "poe": {
+                    "fault_type": "Overload",
+                    "pair": "A"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7910",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7910|LOG_WARN|POWERETHERNET|-|Dual signature powered device fault on interface eth9 pair A. Fault type Overload"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Dual signature powered device fault on interface eth9 pair A. Fault type Overload",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7911",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7911|LOG_INFO|POWERETHERNET|-|Dual signature powered device mps absent on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Dual signature powered device mps absent on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7912",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7912|LOG_INFO|POWERETHERNET|-|Powered device FET bad fault recovered on interface eth1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Powered device FET bad fault recovered on interface eth1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth2"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7913",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7913|LOG_INFO|POWERETHERNET|-|Powered device FET bad fault recovery failed on interface eth2"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Powered device FET bad fault recovery failed on interface eth2",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth3"
+                },
+                "poe": {
+                    "assigned_class": "2",
+                    "req_class": "3"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7914",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7914|LOG_INFO|POWERETHERNET|-|Powered device got class demoted on interface eth3. Requested_class 3 Assigned_class 2"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Powered device got class demoted on interface eth3. Requested_class 3 Assigned_class 2",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth4"
+                },
+                "poe": {
+                    "assigned_class_a": "2",
+                    "assigned_class_b": "3",
+                    "req_class_a": "3",
+                    "req_class_b": "4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7915",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7915|LOG_INFO|POWERETHERNET|-|Dual signature powered device got class demoted on interface eth4. Requested_classA 3 Requested_classB 4 Assigned_classA 2 Assigned_classB 3"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Dual signature powered device got class demoted on interface eth4. Requested_classA 3 Requested_classB 4 Assigned_classA 2 Assigned_classB 3",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth5"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7916",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7916|LOG_INFO|POWERETHERNET|-|Powered device pre std detect enabled on interface eth5"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Powered device pre std detect enabled on interface eth5",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "limit": {
+                    "threshold": "80W"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7917",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7917|LOG_INFO|POWERETHERNET|-|PoE usage exceeded threshold limit of 80W"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "PoE usage exceeded threshold limit of 80W",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "poe": {
+                    "cntrl_name": "Controller1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7918",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7918|LOG_INFO|POWERETHERNET|-|PoE controller Controller1 got into fault"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "PoE controller Controller1 got into fault",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "poe": {
+                    "cntrl_name": "Controller2"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7919",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7919|LOG_INFO|POWERETHERNET|-|PoE controller Controller2 got reset"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "PoE controller Controller2 got reset",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                },
+                "poe": {
+                    "assigned_class": "4",
+                    "req_class": "3"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7920",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7920|LOG_INFO|POWERETHERNET|-|Powered device got class promoted on interface eth0.Requested_class 3 Assigned_class 4"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Powered device got class promoted on interface eth0.Requested_class 3 Assigned_class 4",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth1"
+                },
+                "poe": {
+                    "assigned_class_a": "2",
+                    "assigned_class_b": "3",
+                    "req_class_a": "3",
+                    "req_class_b": "4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7921",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7921|LOG_INFO|POWERETHERNET|-|Dual signature powered device got class promoted on interface eth1.Requested_classA 3 Requested_classB 4 Assigned_classA 2 Assigned_classB 3"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Dual signature powered device got class promoted on interface eth1.Requested_classA 3 Requested_classB 4 Assigned_classA 2 Assigned_classB 3",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth2"
+                },
+                "poe": {
+                    "pd_class": "Class2",
+                    "pd_type": "Type1"
+                },
+                "power": {
+                    "value": "30W"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7922",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7922|LOG_INFO|POWERETHERNET|-|Powered device is drawing power more than its class on interface eth2, type:Type1 class:Class2 power:30W is exceeding the max average power of the PD class. Check the PD max power draw, cabling type and length to improve interoperability"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Powered device is drawing power more than its class on interface eth2, type:Type1 class:Class2 power:30W is exceeding the max average power of the PD class. Check the PD max power draw, cabling type and length to improve interoperability",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth3,"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7923",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7923|LOG_INFO|POWERETHERNET|-|Powered device UVLO fault on interface eth3, will attempt to recover itself by toggling power"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Powered device UVLO fault on interface eth3, will attempt to recover itself by toggling power",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7924",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7924|LOG_INFO|POWERETHERNET|-|Powered device FET BAD fault on interface eth4"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Powered device FET BAD fault on interface eth4",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth5"
+                },
+                "poe": {
+                    "paira_class": "Class3",
+                    "pairb_class": "Class4",
+                    "pd_type": "Type2"
+                },
+                "power": {
+                    "value": "60W"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7925",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7925|LOG_INFO|POWERETHERNET|-|Dual signature powered device is drawing power more than its class on interface eth5, type:Type2 classA:Class3 classB:Class4 power:60W"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Dual signature powered device is drawing power more than its class on interface eth5, type:Type2 classA:Class3 classB:Class4 power:60W",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "limit": {
+                    "threshold": "30W"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7926",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7926|LOG_INFO|POWERETHERNET|-|PoE usage is below threshold of 30W"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "PoE usage is below threshold of 30W",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "power": {
+                    "available": "90",
+                    "value": "100"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7927",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7927|LOG_WARN|POWERETHERNET|-|Total power drawn: 100W by powered device is exceeding the total available PoE power:90W. Check the PD max power draw, cabling type and length to avoid system crowbar."
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Total power drawn: 100W by powered device is exceeding the total available PoE power:90W. Check the PD max power draw, cabling type and length to avoid system crowbar.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth6"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7928",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7928|LOG_WARN|POWERETHERNET|-|Powered device invalid signature indication on interface eth6."
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Powered device invalid signature indication on interface eth6.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7929",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7929|LOG_INFO|POWERETHERNET|-|PoE hardware access daemon exiting"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "PoE hardware access daemon exiting",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7930",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7930|LOG_INFO|POWERETHERNET|-|POE proto daemon exiting"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "POE proto daemon exiting",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7931",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7931|LOG_INFO|POWERETHERNET|-|Always-on PoE detected a powered device on interface eth0 and delivered power"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Always-on PoE detected a powered device on interface eth0 and delivered power",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7932",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7932|LOG_INFO|POWERETHERNET|-|Powered device disconnected on interface eth1 due to LLDP dot3 disable"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Powered device disconnected on interface eth1 due to LLDP dot3 disable",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "poe": {
+                    "subsys_name": "subsystem1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7933",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7933|LOG_INFO|POWERETHERNET|-|Subsystem subsystem1 came up with quick PoE"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Subsystem subsystem1 came up with quick PoE",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth2"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7934",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7934|LOG_INFO|POWERETHERNET|-|Quick PoE detected a powered device on interface eth2 and delivered power"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Quick PoE detected a powered device on interface eth2 and delivered power",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth3"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7935",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7935|LOG_WARN|POWERETHERNET|-|Powered device denied on interface eth3 of line module with Quick PoE enabled. Remove device to avoid crowbar on reboot."
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Powered device denied on interface eth3 of line module with Quick PoE enabled. Remove device to avoid crowbar on reboot.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7936",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7936|LOG_WARN|POWERETHERNET|-|Powered device demoted on interface eth4 of line module with Quick PoE enabled. Remove device to avoid crowbar on reboot."
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Powered device demoted on interface eth4 of line module with Quick PoE enabled. Remove device to avoid crowbar on reboot.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth5"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7937",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7937|LOG_WARN|POWERETHERNET|-|PoE disable ignored on interface eth5 because Quick PoE is enabled"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "PoE disable ignored on interface eth5 because Quick PoE is enabled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth6"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7938",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7938|LOG_WARN|POWERETHERNET|-|PoE assigned class configuration is ignored on interface eth6 because Quick PoE is enabled"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "PoE assigned class configuration is ignored on interface eth6 because Quick PoE is enabled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                },
+                "poe": {
+                    "duration": "5 minutes"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7939",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7939|LOG_INFO|POWERETHERNET|-|Powered device requested power down on interface eth0 5 minutes"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Powered device requested power down on interface eth0 5 minutes",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "POWERETHERNET"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7940",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-poe[1234]: Event|7940|LOG_INFO|POWERETHERNET|-|Powered device disconnected on interface eth1 due to pd-class-override config change"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-poe",
+                    "procid": "1234"
+                }
+            },
+            "message": "Powered device disconnected on interface eth1 due to pd-class-override config change",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-06-12T14:00:38.324517-05:00",
             "aruba": {
                 "component": {

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1762,6 +1762,120 @@ processors:
       if: "ctx.event?.code == '7806'"
       pattern: "USB device %{aruba.status}."
 
+  # Power over Ethernet events (79xx)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/POE.htm
+  - dissect:
+      if: "ctx.event?.code == '7901'"
+      tag: poe_event_7901
+      field: "message"
+      description: "Detected powered device on interface. Type, Class."
+      pattern: "Detected powered device on interface %{aruba.interface.name}. Type:%{aruba.poe.pd_type}, Class:%{aruba.poe.pd_class}"
+  - grok:
+      if: "['7902','7903','7905','7906','7907','7909','7911','7912','7913','7916','7924'].contains(ctx.event?.code)"
+      tag: poe_event_7902_7903_7905_7906_7907_7909_7911_7912_7913_7916_7924
+      field: "message"
+      patterns:
+        - "interface %{GREEDYDATA:aruba.interface.name}"
+  - dissect:
+      if: "ctx.event?.code == '7904'"
+      tag: poe_event_7904
+      field: "message"
+      description: "Powered device fault on interface. Fault type."
+      pattern: "Powered device fault on interface %{aruba.interface.name}. Fault type %{aruba.poe.fault_type}"
+  - dissect:
+      if: "ctx.event?.code == '7908'"
+      tag: poe_event_7908
+      field: "message"
+      description: "Detected dual signature powered device on interface. Type, ClassA, ClassB"
+      pattern: "Detected dual signature powered device on interface %{aruba.interface.name}. Type:%{aruba.poe.pd_type}, ClassA:%{aruba.poe.paira_class}, ClassB:%{aruba.poe.pairb_class}"
+  - dissect:
+      if: "ctx.event?.code == '7910'"
+      tag: poe_event_7910
+      field: "message"
+      description: "Dual signature powered device fault on interface. Fault type."
+      pattern: "Dual signature powered device fault on interface %{aruba.interface.name} pair %{aruba.poe.pair}. Fault type %{aruba.poe.fault_type}"
+  - dissect:
+      if: "ctx.event?.code == '7914'"
+      tag: poe_event_7914
+      field: "message"
+      description: "Powered device got class demoted on interface"
+      pattern: "Powered device got class demoted on interface %{aruba.interface.name}. Requested_class %{aruba.poe.req_class} Assigned_class %{aruba.poe.assigned_class}"
+  - dissect:
+      if: "ctx.event?.code == '7915'"
+      tag: poe_event_7915
+      field: "message"
+      description: "Dual signature powered device got class demoted on interface"
+      pattern: "Dual signature powered device got class demoted on interface %{aruba.interface.name}. Requested_classA %{aruba.poe.req_class_a} Requested_classB %{aruba.poe.req_class_b} Assigned_classA %{aruba.poe.assigned_class_a} Assigned_classB %{aruba.poe.assigned_class_b}"
+  - grok:
+      if: "['7917', '7926'].contains(ctx.event?.code)"
+      tag: poe_event_7917_7926
+      field: "message"
+      description: "PoE usage exceeded threshold limit | PoE usage is below threshold"
+      patterns: 
+        - "^PoE usage (exceeded|is below) threshold( limit)? of %{GREEDYDATA:aruba.limit.threshold}"
+  - grok:
+      if: "['7918', '7919'].contains(ctx.event?.code)"
+      tag: poe_event_7918_7919
+      field: "message"
+      description: "PoE controller got into fault | reset"
+      patterns:
+        - "^PoE controller %{DATA:aruba.poe.cntrl_name} got"
+  - dissect:
+      if: "ctx.event?.code == '7920'"
+      tag: poe_event_7920
+      field: "message"
+      description: "Powered device got class promoted"
+      pattern: "Powered device got class promoted on interface %{aruba.interface.name}.Requested_class %{aruba.poe.req_class} Assigned_class %{aruba.poe.assigned_class}"
+  - dissect:
+      if: "ctx.event?.code == '7921'"
+      tag: poe_event_7921
+      field: "message"
+      description: "Dual signature powered device got class promoted"
+      pattern: "Dual signature powered device got class promoted on interface %{aruba.interface.name}.Requested_classA %{aruba.poe.req_class_a} Requested_classB %{aruba.poe.req_class_b} Assigned_classA %{aruba.poe.assigned_class_a} Assigned_classB %{aruba.poe.assigned_class_b}"
+  - dissect:
+      if: "ctx.event?.code == '7922'"
+      tag: poe_event_7922
+      field: "message"
+      description: "Powered device is drawing power more than its class"
+      pattern: "Powered device is drawing power more than its class on interface %{aruba.interface.name}, type:%{aruba.poe.pd_type} class:%{aruba.poe.pd_class} power:%{aruba.power.value} is exceeding the max average power of the PD class. Check the PD max power draw, cabling type and length to improve interoperability"
+  - grok:
+      if: "['7923','7931','7932','7934','7935','7936','7937','7938','7940'].contains(ctx.event?.code)"
+      tag: poe_event_7923_7931_7932_7934_7935_7936_7937_7938_7940
+      field: "message"
+      patterns:
+        - "interface %{DATA:aruba.interface.name} "
+  - dissect:
+      if: "ctx.event?.code == '7925'"
+      tag: poe_event_7925
+      field: "message"
+      description: "Dual signature powered device is drawing power more than its class"
+      pattern: "Dual signature powered device is drawing power more than its class on interface %{aruba.interface.name}, type:%{aruba.poe.pd_type} classA:%{aruba.poe.paira_class} classB:%{aruba.poe.pairb_class} power:%{aruba.power.value}"
+  - dissect:
+      if: "ctx.event?.code == '7927'"
+      tag: poe_event_7927
+      field: "message"
+      description: "PoE drawn power is more than available PoE power"
+      pattern: "Total power drawn: %{aruba.power.value}W by powered device is exceeding the total available PoE power:%{aruba.power.available}W. Check the PD max power draw, cabling type and length to avoid system crowbar."
+  - dissect:
+      if: "ctx.event?.code == '7928'"
+      tag: poe_event_7928
+      field: "message"
+      description: "Powered device invalid signature indication"
+      pattern: "Powered device invalid signature indication on interface %{aruba.interface.name}."
+  - dissect:
+      if: "ctx.event?.code == '7933'"
+      tag: poe_event_7933
+      field: "message"
+      description: "Subsystem came up with quick PoE"
+      pattern: "Subsystem %{aruba.poe.subsys_name} came up with quick PoE"
+  - dissect:
+      if: "ctx.event?.code == '7939'"
+      tag: poe_event_7939
+      field: "message"
+      description: "Powered device requested power down on interface."
+      pattern: "Powered device requested power down on interface %{aruba.interface.name} %{aruba.poe.duration}"
+        
+
   # Bluetooth Management events (80xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/BLUETOOTH_MGMT.htm
   - grok:

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -834,7 +834,57 @@
     - name: port
       type: keyword
       description: ""
-
+    - name: poe
+      type: group
+      fields:
+        - name: assigned_class
+          type: keyword
+          description: ""
+        - name: assigned_class_a
+          type: keyword
+          description: ""
+        - name: assigned_class_b
+          type: keyword
+          description: ""
+        - name: available
+          type: keyword
+          description: ""
+        - name: cntrl_name
+          type: keyword
+          description: ""
+        - name: duration
+          type: keyword
+          description: ""
+        - name: fault_type
+          type: keyword
+          description: ""
+        - name: pair
+          type: keyword
+          description: ""
+        - name: paira_class
+          type: keyword
+          description: ""
+        - name: pairb_class
+          type: keyword
+          description: ""
+        - name: pd_class
+          type: keyword
+          description: ""
+        - name: pd_type
+          type: keyword
+          description: ""
+        - name: req_class
+          type: keyword
+          description: "" 
+        - name: req_class_a
+          type: keyword
+          description: ""
+        - name: req_class_b
+          type: keyword
+          description: "" 
+        - name: subsys_name
+          type: keyword
+          description: ""
     - name: port_access
       type: group
       fields:
@@ -856,6 +906,9 @@
     - name: power
       type: group
       fields:
+        - name: available
+          type: keyword
+          description: ""
         - name: fanidx
           type: long
           description: ""
@@ -872,6 +925,9 @@
           type: keyword
           description: ""
         - name: type
+          type: keyword
+          description: ""
+        - name: value
           type: keyword
           description: ""
     - name: prefix

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -909,7 +909,6 @@ Note: Descriptions have not been filled out
 | <assigned_class>   | aruba.poe.assigned_class     |
 | <assigned_class_A> | aruba.poe.assigned_class_a   |
 | <assigned_class_B> | aruba.poe.assigned_class_b   |
-| <available>        | aruba.poe.available          |
 | <cntrl_name>       | aruba.poe.cntrl_name         |
 | <duration>         | aruba.poe.cntrl_name         |
 | <fault_type>       | aruba.poe.fault_type         |

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -910,7 +910,7 @@ Note: Descriptions have not been filled out
 | <assigned_class_A> | aruba.poe.assigned_class_a   |
 | <assigned_class_B> | aruba.poe.assigned_class_b   |
 | <cntrl_name>       | aruba.poe.cntrl_name         |
-| <duration>         | aruba.poe.cntrl_name         |
+| <duration>         | aruba.poe.duration           |
 | <fault_type>       | aruba.poe.fault_type         |
 | <interface_name>   | aruba.interface.name         |
 | <threshold_limit>  | aruba.limit.threshold        |

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -904,24 +904,29 @@ Note: Descriptions have not been filled out
 | <warnings>  | aruba.count            |
 
 #### [Power over Ethernet events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/POE.htm)
-| Field                       | Description | Type | Common                       |
-|-----------------------------|-------------|------|------------------------------|
-| aruba.power.assign_class    |             |      |                              |
-| aruba.power.assign_class_a  |             |      |                              |
-| aruba.power.assign_class_b  |             |      |                              |
-| aruba.power.available       |             |      |                              |
-| aruba.power.drawn           |             |      |                              |
-| aruba.power.fault_type      |             |      | error.type                   |
-| aruba.power.interface_name  |             |      |                              |
-| aruba.power.limit           |             |      | aruba.limit.threshold                  |
-| aruba.power.pair            |             |      |                              |
-| aruba.power.paira_class     |             |      |                              |
-| aruba.power.pairb_class     |             |      |                              |
-| aruba.power.pd_class        |             |      |                              |
-| aruba.power.pd_type         |             |      |                              |
-| aruba.power.req_class       |             |      |                              |
-| aruba.power.req_class_a     |             |      |                              |
-| aruba.power.req_class_b     |             |      |                              |
+| Docs Field         | Schema Mapping               |
+|--------------------|------------------------------|
+| <assigned_class>   | aruba.poe.assigned_class     |
+| <assigned_class_A> | aruba.poe.assigned_class_a   |
+| <assigned_class_B> | aruba.poe.assigned_class_b   |
+| <available>        | aruba.poe.available          |
+| <cntrl_name>       | aruba.poe.cntrl_name         |
+| <duration>         | aruba.poe.cntrl_name         |
+| <fault_type>       | error.type                   |
+| <interface_name>   | aruba.interface.name         |
+| <threshold_limit>  | aruba.limit.threshold        |
+| <pair>             | aruba.poe.pair               |
+| <paira_class>      | aruba.poe.paira_class        |
+| <pairb_class>      | aruba.poe.pairb_class        |
+| <pd_class>         | aruba.poe.pd_class           |
+| <pd_type>          | aruba.poe.pd_type            |
+| <power>            | aruba.power.value            |
+| <power_available>  | aruba.power.available        |
+| <power_drawn>      | aruba.power.value            |
+| <req_class>        | aruba.poe.req_class          |
+| <req_class_a>      | aruba.poe.req_class_a        |
+| <req_class_b>      | aruba.poe.req_class_b        |
+| <subsys_name>      | aruba.poe.subsys_name        |
 
 #### [Proxy ARP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PROXY-ARP.htm)
 | Field                | Description | Type | Common                       |
@@ -1541,6 +1546,22 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.pim.sip3 |  | keyword |
 | aruba.pim.totalvid |  | long |
 | aruba.pim.type |  | keyword |
+| aruba.poe.assigned_class |  | keyword |
+| aruba.poe.assigned_class_a |  | keyword |
+| aruba.poe.assigned_class_b |  | keyword |
+| aruba.poe.available |  | keyword |
+| aruba.poe.cntrl_name |  | keyword |
+| aruba.poe.duration |  | keyword |
+| aruba.poe.fault_type |  | keyword |
+| aruba.poe.pair |  | keyword |
+| aruba.poe.paira_class |  | keyword |
+| aruba.poe.pairb_class |  | keyword |
+| aruba.poe.pd_class |  | keyword |
+| aruba.poe.pd_type |  | keyword |
+| aruba.poe.req_class |  | keyword |
+| aruba.poe.req_class_a |  | keyword |
+| aruba.poe.req_class_b |  | keyword |
+| aruba.poe.subsys_name |  | keyword |
 | aruba.policy.application |  | keyword |
 | aruba.policy.name |  | keyword |
 | aruba.port |  | keyword |
@@ -1549,12 +1570,14 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.port_access.old_limit |  | keyword |
 | aruba.port_access.old_mode |  | keyword |
 | aruba.port_access.old_name |  | keyword |
+| aruba.power.available |  | keyword |
 | aruba.power.fanidx |  | long |
 | aruba.power.name |  | keyword |
 | aruba.power.redund |  | keyword |
 | aruba.power.sensorid |  | keyword |
 | aruba.power.support |  | keyword |
 | aruba.power.type |  | keyword |
+| aruba.power.value |  | keyword |
 | aruba.prefix |  | keyword |
 | aruba.priority |  | keyword |
 | aruba.role |  | keyword |

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -912,7 +912,7 @@ Note: Descriptions have not been filled out
 | <available>        | aruba.poe.available          |
 | <cntrl_name>       | aruba.poe.cntrl_name         |
 | <duration>         | aruba.poe.cntrl_name         |
-| <fault_type>       | error.type                   |
+| <fault_type>       | aruba.poe.fault_type         |
 | <interface_name>   | aruba.interface.name         |
 | <threshold_limit>  | aruba.limit.threshold        |
 | <pair>             | aruba.poe.pair               |


### PR DESCRIPTION
Ticket:
Support the first 70-80 event types for the Aruba integration
https://github.com/elastic/integrations/issues/12065

Change Log:
- Power over Ethernet events (79xx)

Test Cases:

- validate that the pipeline test pass
- validated that the expected file parses the proper fields for the different message type