### PR TITLE
[M365 Defender] change connection_string to secret

### DIFF
--- a/packages/m365_defender/changelog.yml
+++ b/packages/m365_defender/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.18.0"
+- version: "2.17.1"
   changes:
     - description: Change connection_string to be a secret
       type: bugfix

--- a/packages/m365_defender/changelog.yml
+++ b/packages/m365_defender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.18.0"
+  changes:
+    - description: Change connection_string to be a secret
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12112
 - version: "2.17.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/m365_defender/data_stream/event/manifest.yml
+++ b/packages/m365_defender/data_stream/event/manifest.yml
@@ -24,11 +24,12 @@ streams:
         description: >-
           We recommend using a dedicated consumer group for the azure input. Reusing consumer groups among non-related consumers can cause unexpected behavior and possibly lost events.
       - name: connection_string
-        type: text
+        type: password
         title: Connection String
         multi: false
         required: true
         show_user: true
+        secret: true
         description: >-
           The connection string required to communicate with Event Hubs. See [Get an Event Hubs connection string](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string) to learn more.
       - name: storage_account

--- a/packages/m365_defender/manifest.yml
+++ b/packages/m365_defender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: m365_defender
 title: Microsoft M365 Defender
-version: "2.17.0"
+version: "2.18.0"
 description: Collect logs from Microsoft M365 Defender with Elastic Agent.
 categories:
   - "security"

--- a/packages/m365_defender/manifest.yml
+++ b/packages/m365_defender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: m365_defender
 title: Microsoft M365 Defender
-version: "2.18.0"
+version: "2.17.1"
 description: Collect logs from Microsoft M365 Defender with Elastic Agent.
 categories:
   - "security"


### PR DESCRIPTION
Change property connection_string to be a secret like in the other integrations like https://github.com/elastic/integrations/blob/main/packages/azure/manifest.yml
