### PR TITLE
#12118-3/4 Rapid per VLAN Spanning Tree Protocol and QoS events

### DIFF
--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -946,34 +946,34 @@ Note: Descriptions have not been filled out
 | <val>              | error.code           |
 
 #### [Quality of Service events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/QOS.htm)
-| Field                       | Description | Type | Common                       |
-|-----------------------------|-------------|------|------------------------------|
-| aruba.qos.error             |             |      | error.message                |
-| aruba.qos.error_string      |             |      | error.message                |
+| Docs Field       | Schema Mapping       |
+|------------------|----------------------|
+| <error>          | event.reason         |
+| <error_string>   | event.reason         |
 
 #### [Rapid per VLAN Spanning Tree Protocol events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/RPVST.htm)
-| Field                            | Description | Type | Common                       |
-|----------------------------------|-------------|------|------------------------------|
-| aruba.vlan.current_virtual_ports |             |      |                              |
-| aruba.vlan.interface             |             |      | observer.ingress.interface.name |
-| aruba.vlan.mac                   |             |      | client.mac                   |
-| aruba.vlan.Maximum_Virtual_Ports |             |      |                              |
-| aruba.vlan.new_mac               |             |      | client.mac                   |
-| aruba.vlan.new_mode              |             |      |                              |
-| aruba.vlan.new_port              |             |      | server.port                  |
-| aruba.vlan.new_priority          |             |      | aruba.priority               |
-| aruba.vlan.npvid                 |             |      |                              |
-| aruba.vlan.old_mac               |             |      |                              |
-| aruba.vlan.old_mode              |             |      |                              |
-| aruba.vlan.old_port              |             |      |                              |
-| aruba.vlan.old_priority          |             |      |                              |
-| aruba.vlan.port                  |             |      | server.port                  |
-| aruba.vlan.pkt_type              |             |      | event.type                   |
-| aruba.vlan.priority_mac          |             |      | client.mac                   |
-| aruba.vlan.proto                 |             |      |                              |
-| aruba.vlan.pvid                  |             |      |                              |
-| aruba.vlan.rpvst_instance        |             |      |                              |
-| aruba.vlan.vlan                  |             |      | network.vlan.id              |
+| Docs Field              | Schema Mapping               |
+|-------------------------|------------------------------|
+| <Current_Virtual_Ports> | aruba.limit.read_value       |
+| <interface>             | aruba.interface.id           |
+| <mac>                   | client.mac                   |
+| <Maximum_Virtual_Ports> | aruba.limit.threshold        |
+| <new_mac>               | client.mac                   |
+| <new_mode>              | aruba.rpvst.new_mode         |
+| <new_port>              | aruba.port                   |
+| <new_priority>          | aruba.priority               |
+| <npvid>                 | aruba.rpvst.npvid            |
+| <old_mac>               | aruba.rpvst.old_mac          |
+| <old_mode>              | aruba.rpvst.old_mode         |
+| <old_port>              | aruba.rpvst.old_port         |
+| <old_priority>          | aruba.rpvst.old_priority     |
+| <port>                  | aruba.port                   |
+| <pkt_type>              | aruba.rpvst.pkt_type         |
+| <priority_mac>          | client.mac                   |
+| <proto>                 | aruba.rpvst.proto            |
+| <pvid>                  | aruba.rpvst.pvid             |
+| <instance>              | aruba.instance.id            |
+| <vlan>                  | network.vlan.id              |
 
 #### [RBAC events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/RBACD.htm)
 | Field                 | Description | Type | Common            |

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
@@ -334,6 +334,20 @@
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-ospfv3[1234]: Event|4903|LOG_INFO|OSPFv3|-|OSPF3 designated routers field entry added: group_id=1 fp_id=2 stat_id=3
 2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-ospfv3[1234]: Event|4904|LOG_INFO|OSPFv3|-|AdjChg: Nbr 192.168.1.1 on interface fe80::1 on eth0(0.0.0.0): INIT -> FULL
 2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-ospfv3[1234]: Event|4905|LOG_INFO|OSPFv3|-|Interface fe80::1 on eth0(0.0.0.0) changed from DOWN to UP, input: 1
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5001|LOG_INFO|RPVST|-|RPVST Enabled
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5002|LOG_INFO|RPVST|-|RPVST Disabled
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5003|LOG_INFO|RPVST|-|RPVST - Root changed from 32768: 00:1A:2B:3C:4D:5E to 4096: 00:1A:2B:3C:4D:5E on VLAN 10.
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5004|LOG_WARN|RPVST|-|Port 1/1/1 disabled - BPDU received on protected port on VLAN 10.
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5005|LOG_INFO|RPVST|-|RPVST starved for BPDUs on port 1/1/2 from 00:1A:2B:3C:4D:5E on VLAN 20.
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5006|LOG_INFO|RPVST|-|Topology change received on port 1/1/3 from source: 00:11:22:33:44:88 on VLAN 30.
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5007|LOG_INFO|RPVST|-|Topology change generated on port 1/1/4 on VLAN 40.
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5008|LOG_WARN|RPVST|-|Port 1/1/5 blocked on RPVST instance 1
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5009|LOG_WARN|RPVST|-|Port 1/1/6 unblocked on RPVST instance 1
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5010|LOG_INFO|RPVST|-|Root port changed from port1 to port2 on VLAN 10.
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5011|LOG_INFO|RPVST|-|PVID mismatch detected on eth0 with pvid = 100, Neighbor pvid = 200
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5011|LOG_INFO|RPVST|-|Throttled 2 Messages
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5012|LOG_INFO|RPVST|-|spanning tree mode changed from RSTP to MSTP, it will trigger the reconvergence.
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5013|LOG_INFO|RPVST|-|Current Virtual Ports 150 exceeds the max supported limit 100
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5101|LOG_ERR|PIM|-|Failed to send HELLO packet on Interface eth0
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5101|LOG_ERR|PIM|-|Throttled 2 Messages
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5102|LOG_INFO|PIM|-|PIM interface eth0 is configured with IP 192.168.1.1
@@ -373,6 +387,8 @@
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5603|LOG_INFO|HTTPSSERVER|-|User admin closed all HTTPS sessions
 2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5604|LOG_INFO|HTTPSSERVER|-|User admin changed the HTTPS Server max user sessions amount to 10
 2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5605|LOG_INFO|HTTPSSERVER|-|User admin changed the HTTPS Server idle timeout to 300
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-qos[1234]: Event|5701|LOG_INFO|QOS|-|QoS failed to retrieve default information. Error: timeout_error
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-qos[1234]: Event|5702|LOG_ERR|QOS|-|QoS error: configuration_error
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-qos[1234]: Event|5801|LOG_ERR|QOSASIC|-|QoS failed initial initialization for slot 1. Error: initialization_error
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-qos[1234]: Event|5802|LOG_ERR|QOSASIC|-|QoS failed final initialization on new slot 2 for peer slot 1
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-qos[1234]: Event|5803|LOG_ERR|QOSASIC|-|QoS error after card removal from slot 3

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -12792,6 +12792,548 @@
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",
             "aruba": {
                 "component": {
+                    "category": "RPVST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5001",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5001|LOG_INFO|RPVST|-|RPVST Enabled"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rpvst",
+                    "procid": "1234"
+                }
+            },
+            "message": "RPVST Enabled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "RPVST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5002",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5002|LOG_INFO|RPVST|-|RPVST Disabled"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rpvst",
+                    "procid": "1234"
+                }
+            },
+            "message": "RPVST Disabled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "RPVST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "priority": "4096",
+                "rpvst": {
+                    "old_mac": "00-1A-2B-3C-4D-5E",
+                    "old_priority": "32768"
+                }
+            },
+            "client": {
+                "mac": "00-1A-2B-3C-4D-5E"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5003",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5003|LOG_INFO|RPVST|-|RPVST - Root changed from 32768: 00:1A:2B:3C:4D:5E to 4096: 00:1A:2B:3C:4D:5E on VLAN 10."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rpvst",
+                    "procid": "1234"
+                }
+            },
+            "message": "RPVST - Root changed from 32768: 00:1A:2B:3C:4D:5E to 4096: 00:1A:2B:3C:4D:5E on VLAN 10.",
+            "network": {
+                "vlan": {
+                    "id": "10"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "RPVST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5004",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5004|LOG_WARN|RPVST|-|Port 1/1/1 disabled - BPDU received on protected port on VLAN 10."
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-rpvst",
+                    "procid": "1234"
+                }
+            },
+            "message": "Port 1/1/1 disabled - BPDU received on protected port on VLAN 10.",
+            "network": {
+                "vlan": {
+                    "id": "10"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "RPVST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/2",
+                "rpvst": {
+                    "pkt_type": "BPDUs",
+                    "proto": "RPVST"
+                }
+            },
+            "client": {
+                "mac": "00-1A-2B-3C-4D-5E"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5005",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5005|LOG_INFO|RPVST|-|RPVST starved for BPDUs on port 1/1/2 from 00:1A:2B:3C:4D:5E on VLAN 20."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rpvst",
+                    "procid": "1234"
+                }
+            },
+            "message": "RPVST starved for BPDUs on port 1/1/2 from 00:1A:2B:3C:4D:5E on VLAN 20.",
+            "network": {
+                "vlan": {
+                    "id": "20"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "RPVST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/3"
+            },
+            "client": {
+                "mac": "00-11-22-33-44-88"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5006",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5006|LOG_INFO|RPVST|-|Topology change received on port 1/1/3 from source: 00:11:22:33:44:88 on VLAN 30."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rpvst",
+                    "procid": "1234"
+                }
+            },
+            "message": "Topology change received on port 1/1/3 from source: 00:11:22:33:44:88 on VLAN 30.",
+            "network": {
+                "vlan": {
+                    "id": ""
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "RPVST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/4"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5007",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5007|LOG_INFO|RPVST|-|Topology change generated on port 1/1/4 on VLAN 40."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rpvst",
+                    "procid": "1234"
+                }
+            },
+            "message": "Topology change generated on port 1/1/4 on VLAN 40.",
+            "network": {
+                "vlan": {
+                    "id": ""
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "RPVST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "instance 1"
+                },
+                "port": "1/1/5"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5008",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5008|LOG_WARN|RPVST|-|Port 1/1/5 blocked on RPVST instance 1"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-rpvst",
+                    "procid": "1234"
+                }
+            },
+            "message": "Port 1/1/5 blocked on RPVST instance 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "RPVST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "instance 1"
+                },
+                "port": "1/1/6"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5009",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5009|LOG_WARN|RPVST|-|Port 1/1/6 unblocked on RPVST instance 1"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-rpvst",
+                    "procid": "1234"
+                }
+            },
+            "message": "Port 1/1/6 unblocked on RPVST instance 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "RPVST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "port2",
+                "rpvst": {
+                    "old_port": "port1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5010",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5010|LOG_INFO|RPVST|-|Root port changed from port1 to port2 on VLAN 10."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rpvst",
+                    "procid": "1234"
+                }
+            },
+            "message": "Root port changed from port1 to port2 on VLAN 10.",
+            "network": {
+                "vlan": {
+                    "id": "10"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "RPVST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "rpvst": {
+                    "npvid": "200",
+                    "pvid": "100"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5011",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5011|LOG_INFO|RPVST|-|PVID mismatch detected on eth0 with pvid = 100, Neighbor pvid = 200"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rpvst",
+                    "procid": "1234"
+                }
+            },
+            "message": "PVID mismatch detected on eth0 with pvid = 100, Neighbor pvid = 200",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "RPVST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "throttle_count": 2
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5011",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5011|LOG_INFO|RPVST|-|Throttled 2 Messages"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rpvst",
+                    "procid": "1234"
+                }
+            },
+            "message": "Throttled 2 Messages",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "RPVST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rpvst": {
+                    "new_mode": "MSTP",
+                    "old_mode": "RSTP"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5012",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5012|LOG_INFO|RPVST|-|spanning tree mode changed from RSTP to MSTP, it will trigger the reconvergence."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rpvst",
+                    "procid": "1234"
+                }
+            },
+            "message": "spanning tree mode changed from RSTP to MSTP, it will trigger the reconvergence.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "RPVST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "limit": {
+                    "read_value": 150,
+                    "threshold": "100"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5013",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-rpvst[1234]: Event|5013|LOG_INFO|RPVST|-|Current Virtual Ports 150 exceeds the max supported limit 100"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rpvst",
+                    "procid": "1234"
+                }
+            },
+            "message": "Current Virtual Ports 150 exceeds the max supported limit 100",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
                     "category": "PIM"
                 },
                 "event_type": "Event",
@@ -14337,6 +14879,74 @@
                     "name": "admin"
                 }
             },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "QOS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5701",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-qos[1234]: Event|5701|LOG_INFO|QOS|-|QoS failed to retrieve default information. Error: timeout_error",
+                "reason": "timeout_error"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-qos",
+                    "procid": "1234"
+                }
+            },
+            "message": "QoS failed to retrieve default information. Error: timeout_error",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "QOS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5702",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-qos[1234]: Event|5702|LOG_ERR|QOS|-|QoS error: configuration_error",
+                "reason": "configuration_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-qos",
+                    "procid": "1234"
+                }
+            },
+            "message": "QoS error: configuration_error",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1161,9 +1161,71 @@ processors:
         INTERFACE_AREA: "(I|i)nterface %{DATA:aruba.ospf.link_local} on %{DATA:aruba.interface.id}\\(%{DATA:aruba.ospf.area}\\)"
         STATE_CHANGE: "%{DATA:aruba.ospf.old_state} (->|to) %{GREEDYDATA:aruba.state}"
 
+  # Rapid per VLAN Spanning Tree Protocol events (500x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/RPVST.htm
+  - dissect:
+      if: "ctx.event?.code == '5003'"
+      tag: rpvst_event_5003
+      field: "message"
+      description: "This log event indicates that RPVST root on a VLAN has changed"
+      pattern: "RPVST - Root changed from %{aruba.rpvst.old_priority}: %{aruba.rpvst.old_mac} to %{aruba.priority}: %{client.mac} on VLAN %{network.vlan.id}."
+  - dissect:
+      if: "ctx.event?.code == '5004'"
+      tag: rpvst_event_5004
+      field: "message"
+      description: "This log event informs the user BPDU received on protected port"
+      pattern: "Port %{aruba.port} disabled - BPDU received on protected port on VLAN %{network.vlan.id}."
+  - dissect:
+      if: "ctx.event?.code == '5005'"
+      tag: rpvst_event_5005
+      field: "message"
+      description: "This log event informs the user that the Rx is starved in paticular port"
+      pattern: "%{aruba.rpvst.proto} starved for %{aruba.rpvst.pkt_type} on port %{aruba.port} from %{client.mac} on VLAN %{network.vlan.id}."
+  - grok:
+      if: "['5006','5007'].contains(ctx.event?.code)"
+      tag: rpvst_event_5006_5007
+      field: "message"
+      description: "This log event informs the user that the RPVST topology change is [received|generated]"
+      patterns:
+        - "^Topology change (received|generated) on port %{DATA:aruba.port}( from source: %{MAC:client.mac})? on VLAN %{DATA:network.vlan.id}."
+  - grok:
+      if: "['5008','5009'].contains(ctx.event?.code)"
+      tag: rpvst_event_5008_5009
+      field: "message"
+      description: "This log event informs the user that the port is [unblocked|blocked] on the instance"
+      patterns:
+        - "^Port %{DATA:aruba.port} (unblocked|blocked) on RPVST %{GREEDYDATA:aruba.instance.id}"
+  - dissect:
+      if: "ctx.event?.code == '5010'"
+      tag: rpvst_event_5010
+      field: "message"
+      description: "This log event informs the user that the root port is changed"
+      pattern: "Root port changed from %{aruba.rpvst.old_port} to %{aruba.port} on VLAN %{network.vlan.id}."
+  - grok:
+      if: "ctx.event?.code == '5011'"
+      tag: rpvst_event_5011
+      field: "message"
+      description: "Log event when the PVID mismatches between the switch and neighbor over an interface"
+      patterns:
+        - "^PVID mismatch detected on %{DATA:aruba.interface.id} with pvid = %{DATA:aruba.rpvst.pvid}, Neighbor pvid = %{GREEDYDATA:aruba.rpvst.npvid}"
+        - "^Throttled %{NUMBER:aruba.throttle_count:long} Messages"
+  - dissect:
+      if: "ctx.event?.code == '5012'"
+      tag: rpvst_event_5012
+      field: "message"
+      description: "This log event informs the user that the spanning tree mode is changed."
+      pattern: "spanning tree mode changed from %{aruba.rpvst.old_mode} to %{aruba.rpvst.new_mode}, it will trigger the reconvergence."
+  - grok:
+      if: "ctx.event?.code == '5013'"
+      tag: rpvst_event_5013
+      field: "message"
+      description: "Log event when the current virtual port count crosses the maximum allowed value"
+      patterns: 
+        - "^Current Virtual Ports %{NUMBER:aruba.limit.read_value:long} exceeds the max supported limit %{GREEDYDATA:aruba.limit.threshold}"
+
+
   # PIM events (51xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/PIM.htm
-
   - grok:
       if: "ctx.event?.code == '5101'"
       field: message
@@ -1348,6 +1410,16 @@ processors:
         5603_PATTERN: "closed all HTTPS sessions"
         5604_PATTERN: "changed the HTTPS Server max user sessions amount to %{NUMBER:aruba.server.sessions:long}"
         5605_PATTERN: "changed the HTTPS Server idle timeout to %{NUMBER:aruba.timeout:long}"
+
+  # Quality of Service events (570x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/QOS.htm
+  - grok:
+      if: "['5701','5702'].contains(ctx.event?.code)"
+      tag: qos_event_5701_5702
+      field: "message"
+      description: "QoS failed to retrieve default configuration | QoS error occurred"
+      patterns:
+        - "(E|e)rror: %{GREEDYDATA:event.reason}"
 
   # QoS ASIC Provider events (580x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/QOS_ASIC.htm
@@ -2761,7 +2833,15 @@ processors:
       pattern: "[:.]"
       replacement: "-"
       ignore_missing: true
-  
+  - uppercase:
+      field: aruba.rpvst.old_mac
+      ignore_missing: true
+  - gsub:
+      field: aruba.rpvst.old_mac
+      pattern: "[:.]"
+      replacement: "-"
+      ignore_missing: true
+
   # Make sure that host.ip and host.mac are arrays
   - set:
       field: host.ip

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -948,6 +948,36 @@
     - name: role
       type: keyword
       description: ""
+    - name: rpvst
+      type: group
+      fields:
+        - name: new_mode
+          type: keyword
+          description: ""
+        - name: npvid
+          type: keyword
+          description: ""
+        - name: old_mac
+          type: keyword
+          description: ""
+        - name: old_mode
+          type: keyword
+          description: ""
+        - name: old_port
+          type: keyword
+          description: ""
+        - name: old_priority
+          type: keyword
+          description: ""
+        - name: pkt_type
+          type: keyword
+          description: ""
+        - name: proto
+          type: keyword
+          description: ""
+        - name: pvid
+          type: keyword
+          description: ""
     - name: sequence
       type: keyword
       description: ""

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -946,34 +946,34 @@ Note: Descriptions have not been filled out
 | <val>              | error.code           |
 
 #### [Quality of Service events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/QOS.htm)
-| Field                       | Description | Type | Common                       |
-|-----------------------------|-------------|------|------------------------------|
-| aruba.qos.error             |             |      | error.message                |
-| aruba.qos.error_string      |             |      | error.message                |
+| Docs Field       | Schema Mapping       |
+|------------------|----------------------|
+| <error>          | event.reason         |
+| <error_string>   | event.reason         |
 
 #### [Rapid per VLAN Spanning Tree Protocol events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/RPVST.htm)
-| Field                            | Description | Type | Common                       |
-|----------------------------------|-------------|------|------------------------------|
-| aruba.vlan.current_virtual_ports |             |      |                              |
-| aruba.vlan.interface             |             |      | observer.ingress.interface.name |
-| aruba.vlan.mac                   |             |      | client.mac                   |
-| aruba.vlan.Maximum_Virtual_Ports |             |      |                              |
-| aruba.vlan.new_mac               |             |      | client.mac                   |
-| aruba.vlan.new_mode              |             |      |                              |
-| aruba.vlan.new_port              |             |      | server.port                  |
-| aruba.vlan.new_priority          |             |      | aruba.priority               |
-| aruba.vlan.npvid                 |             |      |                              |
-| aruba.vlan.old_mac               |             |      |                              |
-| aruba.vlan.old_mode              |             |      |                              |
-| aruba.vlan.old_port              |             |      |                              |
-| aruba.vlan.old_priority          |             |      |                              |
-| aruba.vlan.port                  |             |      | server.port                  |
-| aruba.vlan.pkt_type              |             |      | event.type                   |
-| aruba.vlan.priority_mac          |             |      | client.mac                   |
-| aruba.vlan.proto                 |             |      |                              |
-| aruba.vlan.pvid                  |             |      |                              |
-| aruba.vlan.rpvst_instance        |             |      |                              |
-| aruba.vlan.vlan                  |             |      | network.vlan.id              |
+| Docs Field              | Schema Mapping               |
+|-------------------------|------------------------------|
+| <Current_Virtual_Ports> | aruba.limit.read_value       |
+| <interface>             | aruba.interface.id           |
+| <mac>                   | client.mac                   |
+| <Maximum_Virtual_Ports> | aruba.limit.threshold        |
+| <new_mac>               | client.mac                   |
+| <new_mode>              | aruba.rpvst.new_mode         |
+| <new_port>              | aruba.port                   |
+| <new_priority>          | aruba.priority               |
+| <npvid>                 | aruba.rpvst.npvid            |
+| <old_mac>               | aruba.rpvst.old_mac          |
+| <old_mode>              | aruba.rpvst.old_mode         |
+| <old_port>              | aruba.rpvst.old_port         |
+| <old_priority>          | aruba.rpvst.old_priority     |
+| <port>                  | aruba.port                   |
+| <pkt_type>              | aruba.rpvst.pkt_type         |
+| <priority_mac>          | client.mac                   |
+| <proto>                 | aruba.rpvst.proto            |
+| <pvid>                  | aruba.rpvst.pvid             |
+| <instance>              | aruba.instance.id            |
+| <vlan>                  | network.vlan.id              |
 
 #### [RBAC events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/RBACD.htm)
 | Field                 | Description | Type | Common            |
@@ -1582,6 +1582,15 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.qos.new_slot |  | keyword |
 | aruba.qos.queue |  | keyword |
 | aruba.role |  | keyword |
+| aruba.rpvst.new_mode |  | keyword |
+| aruba.rpvst.npvid |  | keyword |
+| aruba.rpvst.old_mac |  | keyword |
+| aruba.rpvst.old_mode |  | keyword |
+| aruba.rpvst.old_port |  | keyword |
+| aruba.rpvst.old_priority |  | keyword |
+| aruba.rpvst.pkt_type |  | keyword |
+| aruba.rpvst.proto |  | keyword |
+| aruba.rpvst.pvid |  | keyword |
 | aruba.sequence |  | keyword |
 | aruba.server.mode |  | keyword |
 | aruba.server.sessions |  | long |


### PR DESCRIPTION
Parent Ticket:
https://github.com/elastic/integrations/issues/12118

Adding
- Rapid per VLAN Spanning Tree Protocol events (500x)
- Quality of Service events (570x) 
- Note: added generated logs, parsing logic and added post-process for aruba.rpvst.old_mac