### PR TITLE
Fix broken links in the security packages

### DIFF
--- a/packages/qnap_nas/_dev/build/docs/README.md
+++ b/packages/qnap_nas/_dev/build/docs/README.md
@@ -1,6 +1,6 @@
 # QNAP NAS
 
-The QNAP NAS integration collects Event and Access logs from [QNAP NAS](https://docs.qnap.com/nas-outdated/4.1/SMB/en/index.html?system_logs.htm) devices.
+The QNAP NAS integration collects Event and Access logs from [QNAP NAS](https://www.qnap.com/en/) devices.
 
 ## Log
 

--- a/packages/qnap_nas/docs/README.md
+++ b/packages/qnap_nas/docs/README.md
@@ -1,6 +1,6 @@
 # QNAP NAS
 
-The QNAP NAS integration collects Event and Access logs from [QNAP NAS](https://docs.qnap.com/nas-outdated/4.1/SMB/en/index.html?system_logs.htm) devices.
+The QNAP NAS integration collects Event and Access logs from [QNAP NAS](https://www.qnap.com/en/) devices.
 
 ## Log
 

--- a/packages/sophos/_dev/build/docs/README.md
+++ b/packages/sophos/_dev/build/docs/README.md
@@ -7,7 +7,7 @@ Currently, it accepts logs in syslog format or from a file for the following dev
 - `utm` dataset: supports [Unified Threat Management](https://www.sophos.com/en-us/support/documentation/sophos-utm) (formerly known as Astaro Security Gateway) logs.
 - `xg` dataset: supports [Sophos XG SFOS logs](https://docs.sophos.com/nsg/sophos-firewall/17.5/Help/en-us/webhelp/onlinehelp/nsg/sfos/concepts/Logs.html).
 
-To configure a remote syslog destination, please reference the [SophosXG/SFOS Documentation](https://community.sophos.com/kb/en-us/123184).
+To configure a remote syslog destination, please reference the [SophosXG/SFOS Documentation](https://support.sophos.com/support/s/?language=en_US#t=AllTab&sort=relevancy).
 
 The syslog format chosen should be `Default`.
 

--- a/packages/sophos/docs/README.md
+++ b/packages/sophos/docs/README.md
@@ -7,7 +7,7 @@ Currently, it accepts logs in syslog format or from a file for the following dev
 - `utm` dataset: supports [Unified Threat Management](https://www.sophos.com/en-us/support/documentation/sophos-utm) (formerly known as Astaro Security Gateway) logs.
 - `xg` dataset: supports [Sophos XG SFOS logs](https://docs.sophos.com/nsg/sophos-firewall/17.5/Help/en-us/webhelp/onlinehelp/nsg/sfos/concepts/Logs.html).
 
-To configure a remote syslog destination, please reference the [SophosXG/SFOS Documentation](https://community.sophos.com/kb/en-us/123184).
+To configure a remote syslog destination, please reference the [SophosXG/SFOS Documentation](https://support.sophos.com/support/s/?language=en_US#t=AllTab&sort=relevancy).
 
 The syslog format chosen should be `Default`.
 

--- a/packages/suricata/_dev/build/docs/README.md
+++ b/packages/suricata/_dev/build/docs/README.md
@@ -1,6 +1,6 @@
 # Suricata Integration
 
-This integration is for [Suricata](https://suricata-ids.org/). It reads the EVE
+This integration is for [Suricata](https://suricata.io/). It reads the EVE
 JSON output file. The EVE output writes alerts, anomalies, metadata, file info
 and protocol specific records as JSON.
 

--- a/packages/suricata/docs/README.md
+++ b/packages/suricata/docs/README.md
@@ -1,6 +1,6 @@
 # Suricata Integration
 
-This integration is for [Suricata](https://suricata-ids.org/). It reads the EVE
+This integration is for [Suricata](https://suricata.io/). It reads the EVE
 JSON output file. The EVE output writes alerts, anomalies, metadata, file info
 and protocol specific records as JSON.
 


### PR DESCRIPTION
This PR fixes the following broken links:

/packages/qnap_nas @elastic/sec-deployment-and-devices
https://docs.qnap.com/nas-outdated/4.1/SMB/en/index.html?system_logs.htm
=> https://www.qnap.com/en/

/packages/sophos @elastic/sec-deployment-and-devices
https://community.sophos.com/kb/en-us/123184
=> https://support.sophos.com/support/s/?language=en_US#t=AllTab&sort=relevancy

/packages/suricata @elastic/sec-deployment-and-devices
https://suricata-ids.org/
=> https://suricata.io/

Relates to https://github.com/elastic/integration-docs/issues/585