### PR TITLE
Fix broken links in the nginx_ingress_controller package

### DIFF
--- a/packages/nginx_ingress_controller/_dev/build/docs/README.md
+++ b/packages/nginx_ingress_controller/_dev/build/docs/README.md
@@ -6,7 +6,7 @@ instances. It can parse access and error logs created by the ingress.
 ## Compatibility
 
 The integration was tested with the Nginx Ingress Controller v0.30.0 and v0.40.2. The log format is described
-[here](https://github.com/kubernetes/ingress-nginx/blob/nginx-0.30.0/docs/user-guide/nginx-configuration/log-format.md).
+[here](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/log-format.md).
 
 ## Logs
 

--- a/packages/nginx_ingress_controller/docs/README.md
+++ b/packages/nginx_ingress_controller/docs/README.md
@@ -6,7 +6,7 @@ instances. It can parse access and error logs created by the ingress.
 ## Compatibility
 
 The integration was tested with the Nginx Ingress Controller v0.30.0 and v0.40.2. The log format is described
-[here](https://github.com/kubernetes/ingress-nginx/blob/nginx-0.30.0/docs/user-guide/nginx-configuration/log-format.md).
+[here](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/log-format.md).
 
 ## Logs
 


### PR DESCRIPTION
This PR fixes the following broken link:

/packages/nginx_ingress_controller @elastic/obs-cloudnative-monitoring
https://github.com/kubernetes/ingress-nginx/blob/nginx-0.30.0/docs/user-guide/nginx-configuration/log-format.md
=>https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/log-format.md

Relates to https://github.com/elastic/integration-docs/issues/585