### PR TITLE
Update link in the Rapid7 Threat Command Integration

### DIFF
--- a/packages/ti_rapid7_threat_command/_dev/build/docs/README.md
+++ b/packages/ti_rapid7_threat_command/_dev/build/docs/README.md
@@ -52,7 +52,7 @@ The minimum **kibana.version** required is **8.12.0**.
 
 Check the prerequisites for [Transforms](https://www.elastic.co/guide/en/elasticsearch/reference/current/transform-setup.html#transform-setup).
 
-Check the prerequisites for [Actions and Connectors](https://www.elastic.co/guide/en/kibana/current/create-connector-api.html#_prerequisites_16).
+Check the prerequisites for [Actions and Connectors](https://www.elastic.co/guide/en/kibana/current/action-types.html).
 
 ## Setup
 

--- a/packages/ti_rapid7_threat_command/changelog.yml
+++ b/packages/ti_rapid7_threat_command/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.1"
+  changes:
+    - description: Update link in the Rapid7 Threat Command Integration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12135
 - version: "2.2.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/ti_rapid7_threat_command/docs/README.md
+++ b/packages/ti_rapid7_threat_command/docs/README.md
@@ -52,7 +52,7 @@ The minimum **kibana.version** required is **8.12.0**.
 
 Check the prerequisites for [Transforms](https://www.elastic.co/guide/en/elasticsearch/reference/current/transform-setup.html#transform-setup).
 
-Check the prerequisites for [Actions and Connectors](https://www.elastic.co/guide/en/kibana/current/create-connector-api.html#_prerequisites_16).
+Check the prerequisites for [Actions and Connectors](https://www.elastic.co/guide/en/kibana/current/action-types.html).
 
 ## Setup
 

--- a/packages/ti_rapid7_threat_command/manifest.yml
+++ b/packages/ti_rapid7_threat_command/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: ti_rapid7_threat_command
 title: Rapid7 Threat Command
-version: "2.2.0"
+version: "2.2.1"
 description: Collect threat intelligence from Threat Command API with Elastic Agent.
 type: integration
 categories: ["security", "threat_intel"]


### PR DESCRIPTION
This PR updates the following AsciiDoc redirect https://www.elastic.co/guide/en/kibana/current/create-connector-api.html#_prerequisites_16 to point to the new page https://www.elastic.co/guide/en/kibana/current/action-types.html