### PR TITLE
[azure_frontdoor] Add `storage_account_container` variables

### DIFF
--- a/packages/azure_frontdoor/changelog.yml
+++ b/packages/azure_frontdoor/changelog.yml
@@ -1,3 +1,9 @@
+# newer versions go on top
+- version: "2.1.2"
+  changes:
+    - description: Add `storage_account_container` variables.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12151
 - version: "2.1.1"
   changes:
     - description: Change connection_string to be a secret

--- a/packages/azure_frontdoor/data_stream/access/manifest.yml
+++ b/packages/azure_frontdoor/data_stream/access/manifest.yml
@@ -23,6 +23,14 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: storage_account_container
+        type: text
+        title: Storage Account Container
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          The storage account container where the integration stores the checkpoint data for the consumer group. It is an advanced option to use with extreme care. You MUST use a dedicated storage account container for each Azure log type (activity, sign-in, audit logs, and others). DO NOT REUSE the same container name for more than one Azure log type. See [Container Names](https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names) for details on naming rules from Microsoft. The integration generates a default container name if not specified.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/azure_frontdoor/data_stream/waf/agent/stream/azure-eventhub.yml.hbs
+++ b/packages/azure_frontdoor/data_stream/waf/agent/stream/azure-eventhub.yml.hbs
@@ -1,9 +1,15 @@
 {{#if connection_string}}
 connection_string: {{connection_string}}
 {{/if}}
+{{#if storage_account_container }}
+storage_account_container: {{storage_account_container}}
+{{else}}
+{{#if eventhub}}
+storage_account_container: frontdoor-waf-{{eventhub}}
+{{/if}}
+{{/if}}
 {{#if eventhub}}
 eventhub: {{eventhub}}
-storage_account_container: frontdoor-waf-{{eventhub}}
 {{/if}}
 {{#if consumer_group}}
 consumer_group: {{consumer_group}}

--- a/packages/azure_frontdoor/data_stream/waf/manifest.yml
+++ b/packages/azure_frontdoor/data_stream/waf/manifest.yml
@@ -23,6 +23,14 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: storage_account_container
+        type: text
+        title: Storage Account Container
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          The storage account container where the integration stores the checkpoint data for the consumer group. It is an advanced option to use with extreme care. You MUST use a dedicated storage account container for each Azure log type (activity, sign-in, audit logs, and others). DO NOT REUSE the same container name for more than one Azure log type. See [Container Names](https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names) for details on naming rules from Microsoft. The integration generates a default container name if not specified.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/azure_frontdoor/manifest.yml
+++ b/packages/azure_frontdoor/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: azure_frontdoor
 title: "Azure Frontdoor"
-version: "2.1.1"
+version: "2.1.2"
 description: "This Elastic integration collects logs from Azure Frontdoor."
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[azure_frontdoor] Add `storage_account_container` variables

Added to the manifests of both data streams.
Already used by the input config for the `access` data stream.
Usage added in the input config for the `waf` data stream.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 