### PR TITLE
Fix handling of lists in 'Set ECS categorization fields' scripts

### DIFF
--- a/packages/authentik/changelog.yml
+++ b/packages/authentik/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Defensively copy list parameters in 'Set ECS categorization fields' script.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12161
 - version: "1.2.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/authentik/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/authentik/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -133,7 +133,7 @@ processors:
           return;
         }
         params.get(ctx.authentik.event.action).forEach((k, v) -> {
-          ctx.event[k] = v
+          ctx.event[k] = v;
         });
   - set:
       field: observer.vendor

--- a/packages/authentik/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/authentik/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -133,7 +133,11 @@ processors:
           return;
         }
         params.get(ctx.authentik.event.action).forEach((k, v) -> {
-          ctx.event[k] = v;
+          if (v instanceof List) {
+            ctx.event[k] = new ArrayList(v);
+          } else {
+            ctx.event[k] = v;
+          }
         });
   - set:
       field: observer.vendor

--- a/packages/authentik/manifest.yml
+++ b/packages/authentik/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: authentik
 title: authentik
-version: 1.2.0
+version: 1.2.1
 description: Collect logs from authentik with Elastic Agent.
 type: integration
 categories:

--- a/packages/proofpoint_on_demand/changelog.yml
+++ b/packages/proofpoint_on_demand/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Defensively copy list parameters in 'Set ECS categorization fields' script.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12161
 - version: "1.3.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/proofpoint_on_demand/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/proofpoint_on_demand/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -90,7 +90,11 @@ processors:
           return;
         }
         params.get(ctx.json.audit.action.toLowerCase()).forEach((k, v) -> {
-          ctx.event[k] = v;
+          if (v instanceof List) {
+            ctx.event[k] = new ArrayList(v);
+          } else {
+            ctx.event[k] = v;
+          }
         });
   - set:
       field: observer.vendor

--- a/packages/proofpoint_on_demand/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/proofpoint_on_demand/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -90,7 +90,7 @@ processors:
           return;
         }
         params.get(ctx.json.audit.action.toLowerCase()).forEach((k, v) -> {
-          ctx.event[k] = v
+          ctx.event[k] = v;
         });
   - set:
       field: observer.vendor

--- a/packages/proofpoint_on_demand/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/proofpoint_on_demand/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -89,8 +89,7 @@ processors:
         if (ctx.json?.audit?.action == null || params.get(ctx.json.audit.action.toLowerCase()) == null) {
           return;
         }
-        def hm = new HashMap(params.get(ctx.json.audit.action.toLowerCase()));
-        hm.forEach((k, v) -> {
+        params.get(ctx.json.audit.action.toLowerCase()).forEach((k, v) -> {
           ctx.event[k] = v
         });
   - set:

--- a/packages/proofpoint_on_demand/manifest.yml
+++ b/packages/proofpoint_on_demand/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.4
 name: proofpoint_on_demand
 title: Proofpoint On Demand
-version: 1.3.0
+version: 1.3.1
 description: Collect logs from Proofpoint On Demand with Elastic Agent.
 type: integration
 categories:

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.63.1"
+  changes:
+    - description: Defensively copy list parameters in 'Set ECS categorization fields' script.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12161
 - version: "1.63.0"
   changes:
     - description: |

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
@@ -838,7 +838,11 @@ processors:
           return;
         }
         params.get(ctx.event.code).forEach((k, v) -> {
-          ctx.event[k] = v;
+          if (v instanceof List) {
+            ctx.event[k] = new ArrayList(v);
+          } else {
+            ctx.event[k] = v;
+          }
         });
   - script:
       lang: painless

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
@@ -837,8 +837,7 @@ processors:
         if (ctx.event?.code == null || params.get(ctx.event.code) == null) {
           return;
         }
-        def hm = new HashMap(params.get(ctx.event.code));
-        hm.forEach((k, v) -> ctx.event[k] = v);
+        params.get(ctx.event.code).forEach((k, v) -> ctx.event[k] = v);
   - script:
       lang: painless
       ignore_failure: false

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
@@ -837,7 +837,9 @@ processors:
         if (ctx.event?.code == null || params.get(ctx.event.code) == null) {
           return;
         }
-        params.get(ctx.event.code).forEach((k, v) -> ctx.event[k] = v);
+        params.get(ctx.event.code).forEach((k, v) -> {
+          ctx.event[k] = v
+        });
   - script:
       lang: painless
       ignore_failure: false

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
@@ -838,7 +838,7 @@ processors:
           return;
         }
         params.get(ctx.event.code).forEach((k, v) -> {
-          ctx.event[k] = v
+          ctx.event[k] = v;
         });
   - script:
       lang: painless

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: system
 title: System
-version: "1.63.0"
+version: "1.63.1"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:

--- a/packages/watchguard_firebox/changelog.yml
+++ b/packages/watchguard_firebox/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.3"
+  changes:
+    - description: Defensively copy list parameters in 'Set ECS categorization fields' script.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12161
 - version: "1.0.2"
   changes:
     - description: Improve key/value splitting in traffic logs.

--- a/packages/watchguard_firebox/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/watchguard_firebox/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -4620,6 +4620,8 @@ processors:
         params.get(ctx.watchguard_firebox.log.msg_id).forEach((k, v) -> {
           if (k.equals("log_type")) {
             ctx.watchguard_firebox.log[k] = v;
+          } else if (v instanceof List) {
+            ctx.event[k] = new ArrayList(v);
           } else {
             ctx.event[k] = v;
           }

--- a/packages/watchguard_firebox/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/watchguard_firebox/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -4621,7 +4621,7 @@ processors:
           if (k.equals("log_type")) {
             ctx.watchguard_firebox.log[k] = v;
           } else {
-            ctx.event[k] = v
+            ctx.event[k] = v;
           }
         });
   - set:

--- a/packages/watchguard_firebox/manifest.yml
+++ b/packages/watchguard_firebox/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.4
 name: watchguard_firebox
 title: WatchGuard Firebox
-version: 1.0.2
+version: 1.0.3
 description: Collect logs from WatchGuard Firebox with Elastic Agent.
 type: integration
 categories:

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.3"
+  changes:
+    - description: Defensively copy list parameters in 'Set ECS categorization fields' script.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12161
 - version: "2.3.2"
   changes:
     - description: Fix powerhsell context info value split.

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security.yml
@@ -760,8 +760,7 @@ processors:
         if (ctx.event?.code == null || params.get(ctx.event.code) == null) {
           return;
         }
-        def hm = new HashMap(params.get(ctx.event.code));
-        hm.forEach((k, v) -> ctx.event[k] = v);
+        params.get(ctx.event.code).forEach((k, v) -> ctx.event[k] = v);
   - script:
       lang: painless
       ignore_failure: false

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security.yml
@@ -761,7 +761,11 @@ processors:
           return;
         }
         params.get(ctx.event.code).forEach((k, v) -> {
-          ctx.event[k] = v;
+          if (v instanceof List) {
+            ctx.event[k] = new ArrayList(v);
+          } else {
+            ctx.event[k] = v;
+          }
         });
   - script:
       lang: painless

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security.yml
@@ -757,7 +757,7 @@ processors:
             - change
           action: directory-service-object-modified
       source: |-
-        if (ctx?.event?.code == null || params.get(ctx.event.code) == null) {
+        if (ctx.event?.code == null || params.get(ctx.event.code) == null) {
           return;
         }
         def hm = new HashMap(params.get(ctx.event.code));

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security.yml
@@ -760,7 +760,9 @@ processors:
         if (ctx.event?.code == null || params.get(ctx.event.code) == null) {
           return;
         }
-        params.get(ctx.event.code).forEach((k, v) -> ctx.event[k] = v);
+        params.get(ctx.event.code).forEach((k, v) -> {
+          ctx.event[k] = v
+        });
   - script:
       lang: painless
       ignore_failure: false

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security.yml
@@ -761,7 +761,7 @@ processors:
           return;
         }
         params.get(ctx.event.code).forEach((k, v) -> {
-          ctx.event[k] = v
+          ctx.event[k] = v;
         });
   - script:
       lang: painless

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 2.3.2
+version: 2.3.3
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:

--- a/packages/zscaler_zia/changelog.yml
+++ b/packages/zscaler_zia/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.6.1"
+  changes:
+    - description: Defensively copy list parameters in 'Set ECS categorization fields' script.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12161
 - version: "3.6.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/zscaler_zia/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zscaler_zia/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -288,7 +288,9 @@ processors:
         if (ctx.json?.category == null || params.get(ctx.json.category) == null) {
           return;
         }
-        params.get(ctx.json.category).forEach((k, v) -> ctx.event[k] = v);
+        params.get(ctx.json.category).forEach((k, v) -> {
+          ctx.event[k] = v
+        });
       on_failure:
         - append:
             field: error.message

--- a/packages/zscaler_zia/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zscaler_zia/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -288,8 +288,7 @@ processors:
         if (ctx.json?.category == null || params.get(ctx.json.category) == null) {
           return;
         }
-        def hm = new HashMap(params.get(ctx.json.category));
-        hm.forEach((k, v) -> ctx.event[k] = v);
+        params.get(ctx.json.category).forEach((k, v) -> ctx.event[k] = v);
       on_failure:
         - append:
             field: error.message

--- a/packages/zscaler_zia/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zscaler_zia/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -289,7 +289,7 @@ processors:
           return;
         }
         params.get(ctx.json.category).forEach((k, v) -> {
-          ctx.event[k] = v
+          ctx.event[k] = v;
         });
       on_failure:
         - append:

--- a/packages/zscaler_zia/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zscaler_zia/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -289,7 +289,11 @@ processors:
           return;
         }
         params.get(ctx.json.category).forEach((k, v) -> {
-          ctx.event[k] = v;
+          if (v instanceof List) {
+            ctx.event[k] = new ArrayList(v);
+          } else {
+            ctx.event[k] = v;
+          }
         });
       on_failure:
         - append:

--- a/packages/zscaler_zia/manifest.yml
+++ b/packages/zscaler_zia/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: zscaler_zia
 title: Zscaler Internet Access
-version: "3.6.0"
+version: "3.6.1"
 description: Collect logs from Zscaler Internet Access (ZIA) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Defensively copy list parameters in 'Set ECS categorization fields' scripts. See https://github.com/elastic/elasticsearch/issues/91977.