### PR TITLE
journald: add missing source.ip and host.ip ECS fields

### DIFF
--- a/packages/journald/changelog.yml
+++ b/packages/journald/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.1"
+  changes:
+    - description: Add missing source.ip and host.ip ECS fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12166
 - version: "1.1.0"
   changes:
     - description: Upgrade journald to ECS 8.10.

--- a/packages/journald/docs/README.md
+++ b/packages/journald/docs/README.md
@@ -144,6 +144,7 @@ An example event looks as follows:
 | event.code | Identification code for this event, if one exists. Some event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID. | keyword |
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
+| host.ip | Host ip address. | ip |
 | input.type |  | keyword |
 | journald.audit.login_uid | The login UID of the process the journal entry originates from, as maintained by the kernel audit subsystem. | long |
 | journald.audit.session | The session of the process the journal entry originates from, as maintained by the kernel audit subsystem. | keyword |
@@ -189,6 +190,7 @@ An example event looks as follows:
 | process.command_line.text | Multi-field of `process.command_line`. | match_only_text |
 | process.pid | Process id. | long |
 | process.thread.capabilities.effective | This is the set of capabilities used by the kernel to perform permission checks for the thread. | keyword |
+| source.ip | IP address of the source. | ip |
 | systemd.cgroup | The control group path in the systemd hierarchy. | keyword |
 | systemd.invocation_id | The invocation ID for the runtime cycle of the unit the message was generated in, as available to processes of the unit in $INVOCATION_ID. | keyword |
 | systemd.owner_uid | The owner UID of the systemd user unit or systemd session (if any) of the process the journal entry originates from. | long |

--- a/packages/journald/fields/ecs.yml
+++ b/packages/journald/fields/ecs.yml
@@ -8,6 +8,8 @@
   external: ecs
 - name: host.id
   external: ecs
+- name: host.ip
+  external: ecs
 - name: log.syslog.facility.code
   external: ecs
 - name: log.syslog.priority
@@ -31,6 +33,8 @@
 - name: process.command_line
   external: ecs
 - name: process.pid
+  external: ecs
+- name: source.ip
   external: ecs
 - name: tags
   external: ecs

--- a/packages/journald/manifest.yml
+++ b/packages/journald/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.6.0
 name: journald
 title: "Custom Journald logs"
-version: 1.1.0
+version: 1.1.1
 description: Collect logs from journald with Elastic Agent.
 type: input
 categories:


### PR DESCRIPTION
## Proposed commit message

This commit adds the missing ECS mappings for `source.ip` and `host.ip`. Since these fields were not mapped, they defaulted to keyword in logs from journald, causing conflicts in the data view.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## How to test

Maybe there is a faster way, but what I did is the following:

- Deploy a 8.12.1 cloud stack
- Enroll an agent
- Install the journald integration in the agent policy
- In Discover, visualize the `host.ip` field, it shows as conflict (keyword, ip)
- Package the integration and deploy to the existing cluster: `elastic-package install --zip ./integrations/build/packages/journald-1.1.1.zip -v`
- Update the integration in the agent policy
- In the new index after the rollover, confirm that mappings are correct (host.ip and source.ip are shown as `ip`)
- Delete the old conflicting index
- Check new data in Kibana, `source.ip` and `host.ip` are shown as `ip` and no conflict is reported.

## Related issues

- Fixes https://github.com/elastic/integrations/issues/9690

## Screenshots
