### PR TITLE
[Arista NG Firewall] Correct Grok pattern due to change in Syslog message format.

### DIFF
--- a/packages/arista_ngfw/changelog.yml
+++ b/packages/arista_ngfw/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Correct Grok pattern due to change in Syslog message format.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12176
 - version: "1.2.0"
   changes:
     - description: "Allow @custom pipeline access to event.original without setting preserve_original_event."

--- a/packages/arista_ngfw/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/arista_ngfw/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -15,7 +15,7 @@ processors:
   - grok:
       field: event.original
       patterns:
-        - '<%{NONNEGINT:log.syslog.priority:int}>%{SYSLOGTIMESTAMP:_temp_.raw_date} %{WORD}  %{NOTSPACE}\:  %{GREEDYDATA:_temp_.full_message}'
+        - '<%{NONNEGINT:log.syslog.priority:int}>%{SYSLOGTIMESTAMP:_temp_.raw_date} %{WORD}  %{NOTSPACE}\:[\s]+%{GREEDYDATA:_temp_.full_message}'
   - script:
       description: Translate log.syslog.priority to log.syslog.severity.code and log.syslog.facility.code
       lang: painless

--- a/packages/arista_ngfw/manifest.yml
+++ b/packages/arista_ngfw/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: arista_ngfw
 title: "Arista NG Firewall"
-version: "1.2.0"
+version: "1.2.1"
 source:
   license: "Elastic-2.0"
 description: "Collect logs and metrics from Arista NG Firewall."


### PR DESCRIPTION
## Type of change
- Bug

## Proposed commit message
A recent update to Arista NG Firewall changed the Syslog message format slightly. Where there used to be two spaces preceding the message body, the new format only includes a single space. The updated Grok pattern accounts for both the old, double-spaced format and the new single-spaced format.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

- [x] Tested changes locally

## How to test this PR locally

Modified the `default` ingest pipeline with the proposed Grok pattern change, and the messages are now parsing again properly. 

## Related issues

- Closes #12175 