### PR TITLE
#12118 8/9/10 Added 3 new events types (sFlow, Self Test and REST)

### DIFF
--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -992,67 +992,78 @@ Note: Descriptions have not been filled out
 |------------|------------------------------|
 | <uuid_str> | aruba.instance.id            |
 
-#### [REST events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/RESTD.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.rest.action         |             |      | event.action                 |
-| aruba.rest.activate_address |           |      | server.address               |
-| aruba.rest.added_user     |             |      |                              |
-| aruba.rest.added_user_role |            |      | aruba.role                   |
-| aruba.rest.agent_name     |             |      | agent.name                   |
-| aruba.rest.autztype       |             |      |                              |
-| aruba.rest.central_location |           |      | server.address               |
-| aruba.rest.reboot_command |             |      |                              |
-| aruba.rest.config_from_name |           |      |                              |
-| aruba.rest.config_to_name |             |      |                              |
-| aruba.rest.deleted_user   |             |      |                              |
-| aruba.rest.dns            |             |      |                              |
-| aruba.rest.dns_nameserver |             |      | dns.id                       |
-| aruba.rest.error          |             |      | error.message                |
-| aruba.rest.match          |             |      |                              |
-| aruba.rest.mode           |             |      |                              |
-| aruba.rest.resource       |             |      |                              |
-| aruba.rest.rest_operation |             |      |                              |
-| aruba.rest.script_name    |             |      |                              |
-| aruba.rest.sessionid      |             |      |                              |
-| aruba.rest.source_ip      |             |      | source.ip                    |
-| aruba.rest.subscriber     |             |      |                              |
-| aruba.rest.subscription   |             |      |                              |
-| aruba.rest.config_value   |             |      |                              |
-| aruba.rest.uri            |             |      | url.full                     |
-| aruba.rest.url            |             |      | url.full                     |
-| aruba.rest.user           |             |      | user.name                    |
-| aruba.rest.vrf            |             |      | aruba.vrf.id                 |
+#### [REST events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/RESTD.htm)
+| Docs Field           | Schema Mapping             |
+|----------------------|----------------------------|
+| `<action>`           | event.action               |
+| `<activate_address>` | aruba.rest.activate_address|
+| `<added_user>`       | aruba.rest.added_user      |
+| `<added_user_role>`  | aruba.role                 |
+| `<autztype>`         | aruba.rest.autztype        |
+| `<central_location>` | aruba.rest.central_location|
+| `<central_source>`   | aruba.rest.central_source  |
+| `<command>`          | aruba.rest.command         |
+| `<config_name>`      | aruba.rest.config_name     |
+| `<deleted_user>`     | aruba.rest.deleted_user    |
+| `<dns>`              | aruba.rest.ip              |
+| `<dns_nameserver>`   | aruba.rest.dns_nameserver  |
+| `<error>`            | event.reason               |
+| `<from_name>`        | aruba.rest.config_from_name|
+| `<identity>`         | aruba.rest.identity        |
+| `<ip_address>`       | client.ip                  |
+| `<match>`            | aruba.rest.match           |
+| `<mgmt_intf>`        | aruba.interface.id         |
+| `<mode>`             | aruba.rest.mode            |
+| `<name>`             | aruba.rest.name            |
+| `<resource>`         | aruba.rest.resource        |
+| `<rest_operation>`   | aruba.rest.operation       |
+| `<sessionid>`        | aruba.session.id           |
+| `<source_ip>`        | source.ip                  |
+| `<subscriber>`       | aruba.rest.subscriber      |
+| `<subscription>`     | aruba.rest.subscription    |
+| `<to_name>`          | aruba.rest.config_to_name  |
+| `<uri>`              | url.original               |
+| `<url>`              | url.original               |
+| `<user>`             | user.name                  |
+| `<vrf>`              | aruba.vrf.id               |
+| `<vrf_name>`         | aruba.vrf.name             |
+| `<value>`            | aruba.rest.type            |
 
-#### [Self Test events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/SELFTEST.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.self_test.error     |             |      | error.message                |
-| aruba.self_test.interface |             |      |                              |
-| aruba.self_test.slot      |             |      | aruba.slot                   |
-| aruba.self_test.stack     |             |      |                              |
-| aruba.self_test.subsystem |             |      | aruba.subsystem              |
+#### [Self Test events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SELFTEST.htm)
+| Docs Field   | Schema Mapping              |
+|--------------|-----------------------------|
+| `<interface>`| aruba.interface.id          |
+| `<slot>`     | aruba.slot                  |
+| `<stack>`    | aruba.self_test.stack       |
+| `<subsystem>`| aruba.subsystem             |
+| `<value>`    | event.reason                |
+
+#### [Self Test Monitor events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SelfTestMonitor.htm)
+| Docs Field   | Schema Mapping              |
+|--------------|-----------------------------|
 
 #### [sFlow events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/SFLOW.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.sflow.bridge        |             |      |                              |
-| aruba.sflow.chain         |             |      |                              |
-| aruba.sflow.desc          |             |      |                              |
-| aruba.sflow.dgramsize     |             |      |                              |
-| aruba.sflow.error         |             |      | error.message                |
-| aruba.sflow.file          |             |      | file.name                    |
-| aruba.sflow.hdrlen        |             |      | aruba.len                    |
-| aruba.sflow.ifIndex       |             |      | observer.ingress.interface.id|
-| aruba.sflow.intvl         |             |      |                              |
-| aruba.sflow.ip_address    |             |      | destination.ip               |
-| aruba.sflow.mode          |             |      |                              |
-| aruba.sflow.new_rate      |             |      |                              |
-| aruba.sflow.old_rate      |             |      |                              |
-| aruba.sflow.operation     |             |      | event.action                 |
-| aruba.sflow.port          |             |      | server.port                  |
-| aruba.sflow.port_name     |             |      | server.port                  |
-| aruba.sflow.unit          |             |      | aruba.unit                   |
+| Docs Field        | Schema Mapping                             |
+|-------------------|--------------------------------------------|
+| `<bridge>`        | aruba.sflow.bridge                         |
+| `<chain>`         | aruba.sflow.chain                          |
+| `<desc>`          | aruba.error.description                    |
+| `<dgramsize>`     | aruba.sflow.dgramsize                      |
+| `<error>`         | event.reason                               |
+| `<file>`          | file.name                                  |
+| `<hdrlen>`        | aruba.len                                  |
+| `<ifIndex>`       | aruba.interface.id                         |
+| `<interface>`     | aruba.interface.id                         |
+| `<intvl>`         | aruba.sflow.intvl                          |
+| `<ip_addr>`       | client.ip                                  |
+| `<ip_address>`    | client.ip                                  |
+| `<mode>`          | aruba.sflow.mode                           |
+| `<new_rate>`      | aruba.sflow.new_rate                       |
+| `<old_rate>`      | aruba.sflow.old_rate                       |
+| `<operation>`     | aruba.sflow.operation                      |
+| `<port>`          | aruba.port                                 |
+| `<port_name>`     | aruba.port                                 |
+| `<unit>`          | aruba.unit                                 |
 
 #### [SFTP Client events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/SFTP_CLIENT.htm)
 | Field                | Description | Type | Common                       |

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
@@ -400,6 +400,9 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "6000RCSE4802"
+                },
+                "rest": {
+                    "central_source": "activate"
                 }
             },
             "ecs": {
@@ -955,6 +958,9 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "6300-DIST-RDL"
+                },
+                "vrf": {
+                    "id": "default"
                 }
             },
             "ecs": {
@@ -975,6 +981,9 @@
                 }
             },
             "message": "Aruba Activate server https://www.elastic.co/security is reachable via VRF default.",
+            "server": {
+                "address": "https://www.elastic.co/security"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -1008,6 +1017,9 @@
                 }
             },
             "message": "Switch time is synced with Aruba Activate Server https://www.elastic.co/security.",
+            "server": {
+                "address": "https://www.elastic.co/security"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -1021,6 +1033,13 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "6300-DIST-RDL"
+                },
+                "rest": {
+                    "central_location": "",
+                    "central_source": "activate"
+                },
+                "vrf": {
+                    "id": ""
                 }
             },
             "ecs": {
@@ -4429,6 +4448,9 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "session": {
+                    "id": "-ZWxhc3RpYy5jby9kb2Nz"
                 }
             },
             "ecs": {
@@ -4451,7 +4473,10 @@
             "message": "Authentication failed for user satori in session -ZWxhc3RpYy5jby9kb2Nz",
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "user": {
+                "name": "satori"
+            }
         },
         {
             "@timestamp": "2024-08-01T15:15:46.388565-05:00",
@@ -4462,6 +4487,9 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "session": {
+                    "id": "ZWxhc3RpYy5jby9kb2Nz"
                 }
             },
             "ecs": {
@@ -4484,7 +4512,10 @@
             "message": "Authentication succeeded for user admin in session ZWxhc3RpYy5jby9kb2Nz",
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "user": {
+                "name": "admin"
+            }
         },
         {
             "@timestamp": "2024-06-19T13:55:45.705314-05:00",
@@ -4495,12 +4526,16 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "rest": {
+                    "resource": "RoleDefault"
                 }
             },
             "ecs": {
                 "version": "8.11.0"
             },
             "event": {
+                "action": "PUT",
                 "category": [
                     "network"
                 ],
@@ -4517,7 +4552,10 @@
             "message": "Authorization succeeded for user admin, for resource RoleDefault, with action PUT",
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "user": {
+                "name": "admin"
+            }
         },
         {
             "@timestamp": "2024-06-19T13:54:24.803858-05:00",
@@ -4528,12 +4566,16 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "rest": {
+                    "resource": "RoleDefault"
                 }
             },
             "ecs": {
                 "version": "8.11.0"
             },
             "event": {
+                "action": "POST",
                 "category": [
                     "network"
                 ],
@@ -4550,7 +4592,10 @@
             "message": "Authorization succeeded for user admin, for resource RoleDefault, with action POST",
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "user": {
+                "name": "admin"
+            }
         },
         {
             "@timestamp": "2024-06-19T13:53:38.174569-05:00",
@@ -4561,12 +4606,16 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "rest": {
+                    "resource": "RoleDefault"
                 }
             },
             "ecs": {
                 "version": "8.11.0"
             },
             "event": {
+                "action": "DELETE",
                 "category": [
                     "network"
                 ],
@@ -4583,7 +4632,10 @@
             "message": "Authorization succeeded for user admin, for resource RoleDefault, with action DELETE",
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "user": {
+                "name": "admin"
+            }
         },
         {
             "@timestamp": "2024-06-19T13:54:24.900661-05:00",
@@ -4616,7 +4668,10 @@
             "message": "admin created",
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "user": {
+                "name": "admin"
+            }
         },
         {
             "@timestamp": "2024-06-19T13:53:38.182641-05:00",
@@ -4649,7 +4704,13 @@
             "message": "admin deleted /users/user_name",
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "original": "/users/user_name"
+            },
+            "user": {
+                "name": "admin"
+            }
         },
         {
             "@timestamp": "2024-06-19T13:55:45.805480-05:00",
@@ -4682,7 +4743,13 @@
             "message": "admin modified /users/user_name",
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "original": "/users/user_name"
+            },
+            "user": {
+                "name": "admin"
+            }
         },
         {
             "@timestamp": "2024-08-01T15:15:46.437583-05:00",
@@ -4693,6 +4760,9 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "rest": {
+                    "subscriber": "subscriber_name"
                 }
             },
             "ecs": {
@@ -4715,7 +4785,10 @@
             "message": "User: admin added subscriber: subscriber_name.",
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "user": {
+                "name": "admin"
+            }
         },
         {
             "@timestamp": "2024-08-01T15:16:22.055165-05:00",
@@ -4726,6 +4799,10 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "rest": {
+                    "subscriber": "subscriber_name",
+                    "subscription": "subscription_name"
                 }
             },
             "ecs": {
@@ -4759,6 +4836,9 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "rest": {
+                    "name": "vlan_specific_mac_monitor"
                 }
             },
             "ecs": {
@@ -4781,7 +4861,10 @@
             "message": "NAE Script vlan_specific_mac_monitor has been created by user admin.",
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "user": {
+                "name": "admin"
+            }
         },
         {
             "@timestamp": "2023-11-10T10:56:21.357037-05:00",
@@ -4792,6 +4875,9 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "rest": {
+                    "name": "MAC_PAR_VLAN"
                 }
             },
             "ecs": {
@@ -4814,7 +4900,10 @@
             "message": "NAE Agent MAC_PAR_VLAN has been created by user admin.",
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "user": {
+                "name": "admin"
+            }
         },
         {
             "@timestamp": "2024-08-01T10:10:37.829267-05:00",
@@ -4825,6 +4914,9 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "vrf": {
+                    "id": "vpn-Internet"
                 }
             },
             "ecs": {
@@ -4845,6 +4937,9 @@
                 }
             },
             "message": "Aruba Activate server https://www.elastic.co/security is reachable via VRF vpn-Internet.",
+            "server": {
+                "address": "https://www.elastic.co/security"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -4878,6 +4973,9 @@
                 }
             },
             "message": "Aruba Activate server https://www.elastic.co/security is not reachable through any supported VRF.",
+            "server": {
+                "address": "https://www.elastic.co/security"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -4944,6 +5042,9 @@
                 }
             },
             "message": "Switch time is synced with Aruba Activate Server https://www.elastic.co/security.",
+            "server": {
+                "address": "https://www.elastic.co/security"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -4957,6 +5058,13 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "rest": {
+                    "central_location": "",
+                    "central_source": "activate"
+                },
+                "vrf": {
+                    "id": ""
                 }
             },
             "ecs": {
@@ -4990,6 +5098,9 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "rest": {
+                    "identity": "127.0.0.1"
                 }
             },
             "ecs": {
@@ -5012,7 +5123,10 @@
             "message": "User satori login from 127.0.0.1 for REST session has failed",
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "user": {
+                "name": "satori"
+            }
         },
         {
             "@timestamp": "2024-06-19T14:38:17.422545-05:00",
@@ -5023,6 +5137,9 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "rest": {
+                    "identity": "127.0.0.1"
                 }
             },
             "ecs": {
@@ -5045,7 +5162,10 @@
             "message": "User admin logged out of REST session from 127.0.0.1",
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "user": {
+                "name": "admin"
+            }
         },
         {
             "@timestamp": "2024-06-19T14:38:17.422469-05:00",
@@ -5056,6 +5176,9 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "rest": {
+                    "identity": "127.0.0.1"
                 }
             },
             "ecs": {
@@ -5078,7 +5201,13 @@
             "message": "WebUI session from 127.0.0.1 with User admin timed out due to idle timeout",
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "user": {
+                "name": "admin"
+            },
+            "user_agent": {
+                "name": "WebUI"
+            }
         },
         {
             "@timestamp": "2024-06-19T14:20:36.871390-05:00",

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
@@ -62,6 +62,38 @@
 2024-06-18T12:45:38.182641-05:00 8360-Primaire loopback[1234]: Event|901|LOG_INFO|LOOPBACK|-|Loopback Interface eth0, created
 2024-06-18T12:46:38.182641-05:00 8360-Primaire loopback[1234]: Event|902|LOG_INFO|LOOPBACK|-|Loopback Interface eth0, deleted
 2024-06-18T12:47:38.182641-05:00 8360-Primaire loopback[1234]: Event|903|LOG_INFO|LOOPBACK|-|Loopback Interface eth0, configured administratively up
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1001|LOG_ERR|sFlow|-|Failed to start host sFlow agent: connection_timeout
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1002|LOG_ERR|sFlow|-|Failed to read host sFlow configuration file /etc/sflow.conf: file_not_found
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1003|LOG_ERR|sFlow|-|Failed to apply sFlow configuration from bridge br0: invalid_configuration
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1004|LOG_ERR|sFlow|-|Failed to delete all iptable rules: permission_denied
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1005|LOG_ERR|sFlow|-|Failed to add INPUT iptable rules for eth0: rule_conflict
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1006|LOG_ERR|sFlow|-|sFlow initialization failed: initialization_error
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1007|LOG_ERR|sFlow|-|Invalid packet sent by ASIC in sFlow callback: packet_malformed
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1008|LOG_ERR|sFlow|-|Unable to get netdev for interface eth1
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1009|LOG_ERR|sFlow|-|Failed to create KNET filter as description is blank
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1010|LOG_ERR|sFlow|-|Failed to create KNET filter for: sFlow_filter
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1011|LOG_ERR|sFlow|-|The received sampled packet is null
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1012|LOG_ERR|sFlow|-|The sFlow agent is not initialized
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1013|LOG_ERR|sFlow|-|The sFlow sampler is not initialized
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1014|LOG_ERR|sFlow|-|Cannot enable/disable sFlow on an invalid port: eth0
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1015|LOG_ERR|sFlow|-|sFlow sampler is not available on port: eth1
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1016|LOG_ERR|sFlow|-|sFlow receiver is not available
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1017|LOG_ERR|sFlow|-|Failed to retrieve port configuration: timeout_error
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1018|LOG_ERR|sFlow|-|Failed to set sampling rate on port eth2: permission_denied
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1019|LOG_ERR|sFlow|-|Failed to get sampling rate on port eth3: not_supported
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1020|LOG_ERR|sFlow|-|Invalid agent interface IP address: 192.168.1.1
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1021|LOG_ERR|sFlow|-|Invalid collector IP address: 192.168.1.1
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1022|LOG_ERR|sFlow|-|Failed to get interface statistics for unit 1 port eth0: timeout_error
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1023|LOG_INFO|sFlow|-|sFlow agent created.
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1024|LOG_INFO|sFlow|-|sFlow agent deleted.
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1025|LOG_INFO|sFlow|-|Changed sFlow sampling rate from 1000 to 2000.
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1026|LOG_INFO|sFlow|-|Set sFlow agents header len to 128.
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1027|LOG_INFO|sFlow|-|Set sFlow agents IP to 192.168.1.1.
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1028|LOG_INFO|sFlow|-|Set max datagram size on sFlow agent to 1500.
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1029|LOG_INFO|sFlow|-|Add sFlow poller on eth0 with ifIndex 1 at interval 30.
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1030|LOG_INFO|sFlow|-|Remove sFlow poller on 1.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1031|LOG_INFO|sFlow|-|Set polling interval of 30 on sFlow agent.
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1032|LOG_INFO|sFlow|-|sFlow sampling mode set to random.
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1301|LOG_INFO|LACP|-|Dynamic LAG 1 created
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1302|LOG_INFO|LACP|-|Dynamic LAG 1 deleted
 2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-lacp[1234]: Event|1305|LOG_INFO|LACP|-|LACP system priority set to 100
@@ -336,6 +368,57 @@
 2024-06-20T14:04:38.324517-05:00 8360-Primaire hpe-firmware[1989034]: Event|4405|LOG_ERR|AMM|-|Firmware image signature not valid
 2024-06-20T14:05:38.324517-05:00 8360-Primaire hpe-firmware[1989034]: Event|4406|LOG_ERR|AMM|-|Firmware image is not compatible with hardware
 2024-06-20T14:06:38.324517-05:00 8360-Primaire hpe-firmware[1989034]: Event|4407|LOG_ERR|AMM|-|Firmware image is invalid
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-selftest[1234]: Event|4501|LOG_INFO|SELFTEST|-|Selftest has started on subsystem subsystem1
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-selftest[1234]: Event|4502|LOG_INFO|SELFTEST|-|Selftest has completed on subsystem subsystem1
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-selftest[1234]: Event|4503|LOG_ERR|SELFTEST|-|Selftest has failed on subsystem subsystem1 with error code 1234
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-selftest[1234]: Event|4504|LOG_ERR|SELFTEST|-|Selftest has failed on stack1/1/interface1 with error code 5678
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4603|LOG_ERR|REST|-|Conflict in authorization configuration. Existing config::URL(/old/url), type(old_type) New config::(/new/url), type(new_type)
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4604|LOG_INFO|REST|-|Session started for user admin, session 12345
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4605|LOG_INFO|REST|-|Session ended for user admin, session 12345
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4606|LOG_ERR|REST|-|Authorization failed for user admin, for resource /resource, with action read
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4608|LOG_INFO|REST|-|Authorization allowed for user admin, for resource /resource, with action read
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4609|LOG_INFO|REST|-|User admin added new_user with role admin
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4610|LOG_INFO|REST|-|User admin deleted old_user
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4611|LOG_INFO|REST|-|User admin successfully changed password
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4612|LOG_WARN|REST|-|User admin password change failed
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4613|LOG_INFO|REST|-|admin has written a new switch configuration to switch_config_1
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4614|LOG_INFO|REST|-|admin has copied switch configuration config_old to config_new
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4615|LOG_INFO|REST|-|admin has configured 8.8.8.8 DNS nameserver to 8.8.4.4
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4616|LOG_INFO|REST|-|admin has deleted all DNS nameservers
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4617|LOG_INFO|REST|-|admin created http://www.example.com
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4621|LOG_INFO|REST|-|User: admin removed subscriber: subscriber1.
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4623|LOG_INFO|REST|-|Subscriber: subscriber1 removed subscription: subscription1.
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4624|LOG_WARN|REST|-|Unable to add new subscriber. Max number of subscribers has been reached.
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4625|LOG_WARN|REST|-|Unable to add new subscription. Max number of subscriptions for subscriber1 has been reached.
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4627|LOG_INFO|REST|-|NAE Script script1 has been deleted by user admin.
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4629|LOG_INFO|REST|-|NAE Agent agent1 has been updated by user admin.
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4630|LOG_INFO|REST|-|NAE Agent agent1 has been deleted by user admin.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4631|LOG_ERR|REST|-|Error rebooting switch, reboot command: reboot, error received: timeout
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4632|LOG_INFO|REST|-|Connection to HPE Aruba Networking Central on location New York on VRF default with Source IP 192.168.1.1 has been successfully established.
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4633|LOG_INFO|REST|-|Connection to HPE Aruba Networking Central on location New York on VRF default and Source IP 192.168.1.1 has been closed by Aruba Central. Requesting new Aruba Central location from CLI/DHCP/Activate.
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4634|LOG_INFO|REST|-|Connection to HPE Aruba Networking Central on location New York on VRF default and Source IP 192.168.1.1 has been closed by Aruba Central. Trying to reconnect.
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4635|LOG_INFO|REST|-|Received HPE Aruba Networking Central location San Francisco on VRF default with Source IP 192.168.1.2
+2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4636|LOG_INFO|REST|-|Received new HPE Aruba Networking Central location. Closing existing connection with Aruba Central on location San Francisco on VRF default with Source IP 192.168.1.2.
+2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4637|LOG_ERR|REST|-|Internal error. Closing connection to Aruba Central on location San Francisco on VRF default with Source IP 192.168.1.2.
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4638|LOG_INFO|REST|-|Waiting for HPE Aruba Networking Central location from CLI/DHCP/Aruba Activate Server.
+2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4639|LOG_INFO|REST|-|Connecting to HPE Aruba Networking Central on location San Francisco on VRF default with Source IP 192.168.1.2.
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4640|LOG_ERR|REST|-|Failed to connect to HPE Aruba Networking Central on location San Francisco on VRF default with Source IP 192.168.1.2
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4641|LOG_INFO|REST|-|HPE Aruba Networking Central is disabled.
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4642|LOG_INFO|REST|-|HPE Aruba Networking Central is disabled. Closing connection to Aruba Central on location New York on VRF default with Source IP 192.168.1.1
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4643|LOG_INFO|REST|-|HPE Aruba Networking Central is enabled.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4652|LOG_WARN|REST|-|Central connected, any config change through rest POST operation may not be persistent. If central reapplies the config, change can be overwritten
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4653|LOG_INFO|REST|-|User admin has configured read-only for configuration lockout
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4654|LOG_INFO|REST|-|HPE Aruba Networking Central support mode is enabled for a vtysh session
+2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4649|LOG_ERR|REST|-|Unable to sync switch time with Aruba Activate Server 192.168.1.2 via VRF default.
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4650|LOG_INFO|REST|-|Unable to fetch HPE Aruba Networking Central location South Africa from DHCP via VRF default.
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4651|LOG_INFO|REST|-|HPE Aruba Networking Central location San Francisco successfully fetched from DHCP via VRF default
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4655|LOG_INFO|REST|-|User admin logged in from identity_1 through REST session
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4656|LOG_ERR|REST|-|User admin login from identity_1 for REST session has failed
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4657|LOG_INFO|REST|-|User admin logged out of REST session from identity_1
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4658|LOG_WARN|REST|-|REST session from identity_1 with User admin is rejected because maximum session limit is reached
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4660|LOG_INFO|REST|-|REST server is enabled on VRF default
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4661|LOG_INFO|REST|-|REST server is disabled on VRF default
+2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4662|LOG_INFO|REST|-|User satori login from 127.0.0.1 for REST session has failed since the user is trying to login through an interface which is not allowed. Allowed interfaces are: interface1
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4801|LOG_INFO|MACLEARN|-|MAC 00:1A:2B:3C:4D:5E moved from port eth0 to port eth1 on VLAN 10
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4802|LOG_INFO|MACLEARN|-|All dynamic MAC addresses on VLAN 10 were flushed
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4803|LOG_INFO|MACLEARN|-|All dynamic MAC addresses on port eth0 were flushed

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -2401,6 +2401,1134 @@
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",
             "aruba": {
                 "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sflow": {
+                    "operation": "start"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1001",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1001|LOG_ERR|sFlow|-|Failed to start host sFlow agent: connection_timeout",
+                "reason": "connection_timeout"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to start host sFlow agent: connection_timeout",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sflow": {
+                    "operation": "read"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1002",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1002|LOG_ERR|sFlow|-|Failed to read host sFlow configuration file /etc/sflow.conf: file_not_found",
+                "reason": "file_not_found"
+            },
+            "file": {
+                "name": "/etc/sflow.conf"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to read host sFlow configuration file /etc/sflow.conf: file_not_found",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sflow": {
+                    "bridge": "br0",
+                    "operation": "apply"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1003",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1003|LOG_ERR|sFlow|-|Failed to apply sFlow configuration from bridge br0: invalid_configuration",
+                "reason": "invalid_configuration"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to apply sFlow configuration from bridge br0: invalid_configuration",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1004",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1004|LOG_ERR|sFlow|-|Failed to delete all iptable rules: permission_denied",
+                "reason": "permission_denied"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to delete all iptable rules: permission_denied",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0",
+                "sflow": {
+                    "chain": "INPUT",
+                    "operation": "add"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1005",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1005|LOG_ERR|sFlow|-|Failed to add INPUT iptable rules for eth0: rule_conflict",
+                "reason": "rule_conflict"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to add INPUT iptable rules for eth0: rule_conflict",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1006",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1006|LOG_ERR|sFlow|-|sFlow initialization failed: initialization_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "sFlow initialization failed: initialization_error",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1007",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1007|LOG_ERR|sFlow|-|Invalid packet sent by ASIC in sFlow callback: packet_malformed"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Invalid packet sent by ASIC in sFlow callback: packet_malformed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1008",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1008|LOG_ERR|sFlow|-|Unable to get netdev for interface eth1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Unable to get netdev for interface eth1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1009",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1009|LOG_ERR|sFlow|-|Failed to create KNET filter as description is blank"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to create KNET filter as description is blank",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "error": {
+                    "description": "sFlow_filter"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1010",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1010|LOG_ERR|sFlow|-|Failed to create KNET filter for: sFlow_filter"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to create KNET filter for: sFlow_filter",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1011",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1011|LOG_ERR|sFlow|-|The received sampled packet is null"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "The received sampled packet is null",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1012",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1012|LOG_ERR|sFlow|-|The sFlow agent is not initialized"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "The sFlow agent is not initialized",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1013",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1013|LOG_ERR|sFlow|-|The sFlow sampler is not initialized"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "The sFlow sampler is not initialized",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1014",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1014|LOG_ERR|sFlow|-|Cannot enable/disable sFlow on an invalid port: eth0"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Cannot enable/disable sFlow on an invalid port: eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1015",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1015|LOG_ERR|sFlow|-|sFlow sampler is not available on port: eth1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "sFlow sampler is not available on port: eth1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1016",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1016|LOG_ERR|sFlow|-|sFlow receiver is not available"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "sFlow receiver is not available",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1017",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1017|LOG_ERR|sFlow|-|Failed to retrieve port configuration: timeout_error",
+                "reason": "timeout_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to retrieve port configuration: timeout_error",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth2"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1018",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1018|LOG_ERR|sFlow|-|Failed to set sampling rate on port eth2: permission_denied",
+                "reason": "permission_denied"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to set sampling rate on port eth2: permission_denied",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth3"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1019",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1019|LOG_ERR|sFlow|-|Failed to get sampling rate on port eth3: not_supported",
+                "reason": "not_supported"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to get sampling rate on port eth3: not_supported",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1020",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1020|LOG_ERR|sFlow|-|Invalid agent interface IP address: 192.168.1.1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Invalid agent interface IP address: 192.168.1.1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1021",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1021|LOG_ERR|sFlow|-|Invalid collector IP address: 192.168.1.1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Invalid collector IP address: 192.168.1.1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0",
+                "unit": "1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1022",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1022|LOG_ERR|sFlow|-|Failed to get interface statistics for unit 1 port eth0: timeout_error",
+                "reason": "timeout_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to get interface statistics for unit 1 port eth0: timeout_error",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1023",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1023|LOG_INFO|sFlow|-|sFlow agent created."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "sFlow agent created.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1024",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1024|LOG_INFO|sFlow|-|sFlow agent deleted."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "sFlow agent deleted.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sflow": {
+                    "new_rate": "2000",
+                    "old_rate": "1000"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1025",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1025|LOG_INFO|sFlow|-|Changed sFlow sampling rate from 1000 to 2000."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Changed sFlow sampling rate from 1000 to 2000.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "len": 128
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1026",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1026|LOG_INFO|sFlow|-|Set sFlow agents header len to 128."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Set sFlow agents header len to 128.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1027",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1027|LOG_INFO|sFlow|-|Set sFlow agents IP to 192.168.1.1."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Set sFlow agents IP to 192.168.1.1.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sflow": {
+                    "dgramsize": 1500
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1028",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1028|LOG_INFO|sFlow|-|Set max datagram size on sFlow agent to 1500."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Set max datagram size on sFlow agent to 1500.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "1"
+                },
+                "port": "eth0",
+                "sflow": {
+                    "intvl": "30"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1029",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1029|LOG_INFO|sFlow|-|Add sFlow poller on eth0 with ifIndex 1 at interval 30."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Add sFlow poller on eth0 with ifIndex 1 at interval 30.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": " 1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1030",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1030|LOG_INFO|sFlow|-|Remove sFlow poller on 1."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Remove sFlow poller on 1.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sflow": {
+                    "intvl": "30"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1031",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1031|LOG_INFO|sFlow|-|Set polling interval of 30 on sFlow agent."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "Set polling interval of 30 on sFlow agent.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "sFlow"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sflow": {
+                    "mode": "random"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1032",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-sflow[1234]: Event|1032|LOG_INFO|sFlow|-|sFlow sampling mode set to random."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-sflow",
+                    "procid": "1234"
+                }
+            },
+            "message": "sFlow sampling mode set to random.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
                     "category": "LACP"
                 },
                 "event_type": "Event",
@@ -12808,6 +13936,1958 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SELFTEST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "subsystem": "subsystem1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4501",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-selftest[1234]: Event|4501|LOG_INFO|SELFTEST|-|Selftest has started on subsystem subsystem1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-selftest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Selftest has started on subsystem subsystem1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SELFTEST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "subsystem": "subsystem1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4502",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-selftest[1234]: Event|4502|LOG_INFO|SELFTEST|-|Selftest has completed on subsystem subsystem1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-selftest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Selftest has completed on subsystem subsystem1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SELFTEST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "subsystem": "subsystem1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4503",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-selftest[1234]: Event|4503|LOG_ERR|SELFTEST|-|Selftest has failed on subsystem subsystem1 with error code 1234",
+                "reason": "1234"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-selftest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Selftest has failed on subsystem subsystem1 with error code 1234",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SELFTEST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "interface1"
+                },
+                "self_test": {
+                    "stack": "stack1"
+                },
+                "slot": 1
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4504",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-selftest[1234]: Event|4504|LOG_ERR|SELFTEST|-|Selftest has failed on stack1/1/interface1 with error code 5678",
+                "reason": "5678"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-selftest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Selftest has failed on stack1/1/interface1 with error code 5678",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "autztype": "new_type",
+                    "match": "/old/url",
+                    "type": "old_type"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4603",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4603|LOG_ERR|REST|-|Conflict in authorization configuration. Existing config::URL(/old/url), type(old_type) New config::(/new/url), type(new_type)"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Conflict in authorization configuration. Existing config::URL(/old/url), type(old_type) New config::(/new/url), type(new_type)",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "original": "/new/url"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4604",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4604|LOG_INFO|REST|-|Session started for user admin, session 12345"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Session started for user admin, session 12345",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4605",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4605|LOG_INFO|REST|-|Session ended for user admin, session 12345"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Session ended for user admin, session 12345",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "resource": "/resource"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "read",
+                "category": [
+                    "network"
+                ],
+                "code": "4606",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4606|LOG_ERR|REST|-|Authorization failed for user admin, for resource /resource, with action read"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Authorization failed for user admin, for resource /resource, with action read",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "resource": "/resource"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "read",
+                "category": [
+                    "network"
+                ],
+                "code": "4608",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4608|LOG_INFO|REST|-|Authorization allowed for user admin, for resource /resource, with action read"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Authorization allowed for user admin, for resource /resource, with action read",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "added_user": "new_user"
+                },
+                "role": "admin"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4609",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4609|LOG_INFO|REST|-|User admin added new_user with role admin"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "User admin added new_user with role admin",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "deleted_user": "old_user"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4610",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4610|LOG_INFO|REST|-|User admin deleted old_user"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "User admin deleted old_user",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4611",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4611|LOG_INFO|REST|-|User admin successfully changed password"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "User admin successfully changed password",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4612",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4612|LOG_WARN|REST|-|User admin password change failed"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "User admin password change failed",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "config_name": "switch_config_1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4613",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4613|LOG_INFO|REST|-|admin has written a new switch configuration to switch_config_1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "admin has written a new switch configuration to switch_config_1",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "config_from_name": "config_old",
+                    "config_to_name": "config_new"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4614",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4614|LOG_INFO|REST|-|admin has copied switch configuration config_old to config_new"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "admin has copied switch configuration config_old to config_new",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "dns": "8.8.4.4",
+                    "dns_nameserver": "8.8.8.8"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4615",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4615|LOG_INFO|REST|-|admin has configured 8.8.8.8 DNS nameserver to 8.8.4.4"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "admin has configured 8.8.8.8 DNS nameserver to 8.8.4.4",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4616",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4616|LOG_INFO|REST|-|admin has deleted all DNS nameservers"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "admin has deleted all DNS nameservers",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4617",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4617|LOG_INFO|REST|-|admin created http://www.example.com"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "admin created http://www.example.com",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "original": "http://www.example.com"
+            },
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "subscriber": "subscriber1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4621",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4621|LOG_INFO|REST|-|User: admin removed subscriber: subscriber1."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "User: admin removed subscriber: subscriber1.",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "subscriber": "subscriber1",
+                    "subscription": "subscription1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4623",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4623|LOG_INFO|REST|-|Subscriber: subscriber1 removed subscription: subscription1."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Subscriber: subscriber1 removed subscription: subscription1.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4624",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4624|LOG_WARN|REST|-|Unable to add new subscriber. Max number of subscribers has been reached."
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Unable to add new subscriber. Max number of subscribers has been reached.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "subscriber": "subscriber1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4625",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4625|LOG_WARN|REST|-|Unable to add new subscription. Max number of subscriptions for subscriber1 has been reached."
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Unable to add new subscription. Max number of subscriptions for subscriber1 has been reached.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "name": "script1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4627",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4627|LOG_INFO|REST|-|NAE Script script1 has been deleted by user admin."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "NAE Script script1 has been deleted by user admin.",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "name": "agent1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4629",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4629|LOG_INFO|REST|-|NAE Agent agent1 has been updated by user admin."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "NAE Agent agent1 has been updated by user admin.",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "name": "agent1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4630",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4630|LOG_INFO|REST|-|NAE Agent agent1 has been deleted by user admin."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "NAE Agent agent1 has been deleted by user admin.",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "command": "reboot"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4631",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4631|LOG_ERR|REST|-|Error rebooting switch, reboot command: reboot, error received: timeout",
+                "reason": "timeout"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Error rebooting switch, reboot command: reboot, error received: timeout",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "central_location": "New York"
+                },
+                "vrf": {
+                    "id": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4632",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4632|LOG_INFO|REST|-|Connection to HPE Aruba Networking Central on location New York on VRF default with Source IP 192.168.1.1 has been successfully established."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Connection to HPE Aruba Networking Central on location New York on VRF default with Source IP 192.168.1.1 has been successfully established.",
+            "source": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "central_location": "New York"
+                },
+                "vrf": {
+                    "id": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4633",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4633|LOG_INFO|REST|-|Connection to HPE Aruba Networking Central on location New York on VRF default and Source IP 192.168.1.1 has been closed by Aruba Central. Requesting new Aruba Central location from CLI/DHCP/Activate."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Connection to HPE Aruba Networking Central on location New York on VRF default and Source IP 192.168.1.1 has been closed by Aruba Central. Requesting new Aruba Central location from CLI/DHCP/Activate.",
+            "source": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "central_location": "New York"
+                },
+                "vrf": {
+                    "id": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4634",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4634|LOG_INFO|REST|-|Connection to HPE Aruba Networking Central on location New York on VRF default and Source IP 192.168.1.1 has been closed by Aruba Central. Trying to reconnect."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Connection to HPE Aruba Networking Central on location New York on VRF default and Source IP 192.168.1.1 has been closed by Aruba Central. Trying to reconnect.",
+            "source": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "central_location": "San Francisco"
+                },
+                "vrf": {
+                    "id": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4635",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4635|LOG_INFO|REST|-|Received HPE Aruba Networking Central location San Francisco on VRF default with Source IP 192.168.1.2"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Received HPE Aruba Networking Central location San Francisco on VRF default with Source IP 192.168.1.2",
+            "source": {
+                "ip": "192.168.1.2"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "central_location": "San Francisco"
+                },
+                "vrf": {
+                    "id": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4636",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4636|LOG_INFO|REST|-|Received new HPE Aruba Networking Central location. Closing existing connection with Aruba Central on location San Francisco on VRF default with Source IP 192.168.1.2."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Received new HPE Aruba Networking Central location. Closing existing connection with Aruba Central on location San Francisco on VRF default with Source IP 192.168.1.2.",
+            "source": {
+                "ip": "192.168.1.2"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "central_location": "San Francisco"
+                },
+                "vrf": {
+                    "id": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4637",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4637|LOG_ERR|REST|-|Internal error. Closing connection to Aruba Central on location San Francisco on VRF default with Source IP 192.168.1.2."
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Internal error. Closing connection to Aruba Central on location San Francisco on VRF default with Source IP 192.168.1.2.",
+            "source": {
+                "ip": "192.168.1.2"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4638",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4638|LOG_INFO|REST|-|Waiting for HPE Aruba Networking Central location from CLI/DHCP/Aruba Activate Server."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Waiting for HPE Aruba Networking Central location from CLI/DHCP/Aruba Activate Server.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "central_location": "San Francisco"
+                },
+                "vrf": {
+                    "id": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4639",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4639|LOG_INFO|REST|-|Connecting to HPE Aruba Networking Central on location San Francisco on VRF default with Source IP 192.168.1.2."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Connecting to HPE Aruba Networking Central on location San Francisco on VRF default with Source IP 192.168.1.2.",
+            "source": {
+                "ip": "192.168.1.2"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "central_location": "San Francisco"
+                },
+                "vrf": {
+                    "id": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4640",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4640|LOG_ERR|REST|-|Failed to connect to HPE Aruba Networking Central on location San Francisco on VRF default with Source IP 192.168.1.2"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to connect to HPE Aruba Networking Central on location San Francisco on VRF default with Source IP 192.168.1.2",
+            "source": {
+                "ip": "192.168.1.2"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4641",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4641|LOG_INFO|REST|-|HPE Aruba Networking Central is disabled."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "HPE Aruba Networking Central is disabled.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "central_location": "New York"
+                },
+                "vrf": {
+                    "id": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4642",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4642|LOG_INFO|REST|-|HPE Aruba Networking Central is disabled. Closing connection to Aruba Central on location New York on VRF default with Source IP 192.168.1.1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "HPE Aruba Networking Central is disabled. Closing connection to Aruba Central on location New York on VRF default with Source IP 192.168.1.1",
+            "source": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4643",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4643|LOG_INFO|REST|-|HPE Aruba Networking Central is enabled."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "HPE Aruba Networking Central is enabled.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "operation": "POST"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4652",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4652|LOG_WARN|REST|-|Central connected, any config change through rest POST operation may not be persistent. If central reapplies the config, change can be overwritten"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Central connected, any config change through rest POST operation may not be persistent. If central reapplies the config, change can be overwritten",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "mode": "read-only"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4653",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4653|LOG_INFO|REST|-|User admin has configured read-only for configuration lockout"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "User admin has configured read-only for configuration lockout",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "mode": "enabled"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4654",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4654|LOG_INFO|REST|-|HPE Aruba Networking Central support mode is enabled for a vtysh session"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "HPE Aruba Networking Central support mode is enabled for a vtysh session",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vrf": {
+                    "id": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4649",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4649|LOG_ERR|REST|-|Unable to sync switch time with Aruba Activate Server 192.168.1.2 via VRF default."
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Unable to sync switch time with Aruba Activate Server 192.168.1.2 via VRF default.",
+            "server": {
+                "address": "192.168.1.2"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "central_location": "South Africa",
+                    "central_source": "DHCP"
+                },
+                "vrf": {
+                    "id": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4650",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4650|LOG_INFO|REST|-|Unable to fetch HPE Aruba Networking Central location South Africa from DHCP via VRF default."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "Unable to fetch HPE Aruba Networking Central location South Africa from DHCP via VRF default.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "central_location": "San Francisco",
+                    "central_source": "DHCP"
+                },
+                "vrf": {
+                    "id": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4651",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4651|LOG_INFO|REST|-|HPE Aruba Networking Central location San Francisco successfully fetched from DHCP via VRF default"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "HPE Aruba Networking Central location San Francisco successfully fetched from DHCP via VRF default",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "identity": "identity_1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4655",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4655|LOG_INFO|REST|-|User admin logged in from identity_1 through REST session"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "User admin logged in from identity_1 through REST session",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "identity": "identity_1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4656",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4656|LOG_ERR|REST|-|User admin login from identity_1 for REST session has failed"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "User admin login from identity_1 for REST session has failed",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "identity": "identity_1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4657",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4657|LOG_INFO|REST|-|User admin logged out of REST session from identity_1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "User admin logged out of REST session from identity_1",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "rest": {
+                    "identity": "identity_1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4658",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4658|LOG_WARN|REST|-|REST session from identity_1 with User admin is rejected because maximum session limit is reached"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "REST session from identity_1 with User admin is rejected because maximum session limit is reached",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vrf": {
+                    "name": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4660",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4660|LOG_INFO|REST|-|REST server is enabled on VRF default"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "REST server is enabled on VRF default",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vrf": {
+                    "name": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4661",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4661|LOG_INFO|REST|-|REST server is disabled on VRF default"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "REST server is disabled on VRF default",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "REST"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "interface1"
+                }
+            },
+            "client": {
+                "ip": "127.0.0.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4662",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire hpe-rest[1234]: Event|4662|LOG_INFO|REST|-|User satori login from 127.0.0.1 for REST session has failed since the user is trying to login through an interface which is not allowed. Allowed interfaces are: interface1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-rest",
+                    "procid": "1234"
+                }
+            },
+            "message": "User satori login from 127.0.0.1 for REST session has failed since the user is trying to login through an interface which is not allowed. Allowed interfaces are: interface1",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "satori"
+            }
         },
         {
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -368,6 +368,120 @@ processors:
       patterns:
         - "^Loopback Interface %{DATA:aruba.interface.id}, (created|deleted|configured administratively %{GREEDYDATA:aruba.interface.state})"
 
+    # sFlow events (10xx)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SFLOW.htm
+  - grok:
+      field: message
+      tag: sflow_event_1001_1002_1003
+      description: "Log a failure when trying to start/stop/restart host sFlow daemon | read/write to host sFlow configuration file | trying to configure sFlow on SIM OVS"
+      if: "['1001','1002','1003'].contains(ctx.event?.code)"
+      patterns:
+        - "^Failed to %{DATA:aruba.sflow.operation} host sFlow (agent|configuration file %{DATA:file.name}): %{GREEDYDATA:event.reason}"
+        - "^Failed to %{DATA:aruba.sflow.operation} sFlow configuration from bridge %{DATA:aruba.sflow.bridge}: %{GREEDYDATA:event.reason}"
+  - dissect:
+      field: message
+      tag: sflow_event_1005
+      description: "Log a failure when trying to add/delete an iptable rule for sFlow."
+      if: "ctx.event?.code == '1005'"
+      pattern: "Failed to %{aruba.sflow.operation} %{aruba.sflow.chain} iptable rules for %{aruba.port}: %{event.reason}"
+  - dissect:
+      field: message
+      tag: sflow_event_1008
+      description: "Logs an error if an interface does not have a netdev class."
+      if: "ctx.event?.code == '1008'"
+      pattern: "Unable to get netdev for interface %{aruba.interface.id}"
+  - dissect:
+      field: message
+      tag: sflow_event_1010
+      description: "Logs an error if sFlow KNET filter creation fails."
+      if: "ctx.event?.code == '1010'"
+      pattern: "Failed to create KNET filter for: %{aruba.error.description}"
+  - grok:
+      field: message
+      tag: sflow_event_1014_1015
+      description: "Logs an error if sFlow is enabled/disabled on an invalid port | if sFlow sampler is missing on a port"
+      if: "['1014','1015'].contains(ctx.event?.code)"
+      patterns:
+        - "port: %{GREEDYDATA:aruba.port}"
+  - grok:
+      field: message
+      tag: sflow_event_1004_1017
+      description: "Log a failure when trying to delete all iptable rules added for sFlow | if port configuration is not available"
+      if: "['1004','1017'].contains(ctx.event?.code)"
+      patterns:
+        - ": %{GREEDYDATA:event.reason}"
+  - grok:
+      field: message
+      tag: sflow_event_1018_1019
+      description: "Logs an error if (getting|setting) a sampling rate on a port fails."
+      if: "['1018','1019'].contains(ctx.event?.code)"
+      patterns:
+        - "^Failed to (get|set) sampling rate on port %{DATA:aruba.port}: %{GREEDYDATA:event.reason}"
+  - grok:
+      field: message
+      tag: sflow_event_1020_1021
+      description: "Logs an error in case of invalid agent interface IP address configuration | invalid collector IP address configuration."
+      if: "['1020','1021'].contains(ctx.event?.code)"
+      patterns:
+        - "IP address: %{IP:client.ip}"
+  - dissect:
+      field: message
+      tag: sflow_event_1022
+      description: "Logs an error if unable to retrieve interface statistics."
+      if: "ctx.event?.code == '1022'"
+      pattern: "Failed to get interface statistics for unit %{aruba.unit} port %{aruba.port}: %{event.reason}"
+  - dissect:
+      field: message
+      tag: sflow_event_1025
+      description: "Logs a change in sFlow sampling rate."
+      if: "ctx.event?.code == '1025'"
+      pattern: "Changed sFlow sampling rate from %{aruba.sflow.old_rate} to %{aruba.sflow.new_rate}."
+  - grok:
+      field: message
+      tag: sflow_event_1026
+      description: "Logs sFlow agents header length event."
+      if: "ctx.event?.code == '1026'"
+      patterns: 
+        - "Set sFlow agents header len to %{NUMBER:aruba.len:long}."
+  - grok:
+      field: message
+      tag: sflow_event_1027
+      description: "Logs sFlow agents header length event."
+      if: "ctx.event?.code == '1027'"
+      patterns: 
+        - "^Set sFlow agents IP to %{IP:client.ip}."
+  - grok:
+      field: message
+      tag: sflow_event_1028
+      description: "Log setting max datagram size on sFlow agent."
+      if: "ctx.event?.code == '1028'"
+      patterns: 
+        - "^Set max datagram size on sFlow agent to %{NUMBER:aruba.sflow.dgramsize:long}."
+  - dissect:
+      field: message
+      tag: sflow_event_1029
+      description: "Add sFlow poller on a port"
+      if: "ctx.event?.code == '1029'"
+      pattern: "Add sFlow poller on %{aruba.port} with ifIndex %{aruba.interface.id} at interval %{aruba.sflow.intvl}."
+  - dissect:
+      field: message
+      tag: sflow_event_1030
+      description: "Delete sFlow poller on a port."
+      if: "ctx.event?.code == '1030'"
+      pattern: "Remove sFlow poller on%{aruba.interface.id}."
+  - dissect:
+      field: message
+      tag: sflow_event_1031
+      description: "Set polling interval for sFlow agent."
+      if: "ctx.event?.code == '1031'"
+      pattern: "Set polling interval of %{aruba.sflow.intvl} on sFlow agent."
+  - dissect:
+      field: message
+      tag: sflow_event_1032
+      description: "Logs change in sFlow mode."
+      if: "ctx.event?.code == '1032'"
+      pattern: "sFlow sampling mode set to %{aruba.sflow.mode}."
+
     # LACP events (13xx)
     # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LACP.htm
   - grok:
@@ -1166,6 +1280,183 @@ processors:
       description: "Indicates that a switch firmware update failed from a remote or local source"
       patterns:
         - "^User %{DATA:user.name}: %{DATA:aruba.firmware.image_profile} image update failed via %{DATA:aruba.firmware.dnld_type}( from %{HOSTNAME:source.address})?$"
+
+  # Self Test events (450x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SELFTEST.htm
+  - grok:
+      if: "['4501','4502'].contains(ctx.event?.code)"
+      tag: self_test_event_4501_4502
+      field: "message"
+      description: "logs the [started|completion] of selftest on a particular subsystem"
+      patterns:
+        - "^Selftest has (started|completed) on subsystem %{GREEDYDATA:aruba.subsystem}"
+  - dissect:
+      if: "ctx.event?.code == '4503'"
+      tag: self_test_event_4503
+      field: "message"
+      description: "logs the selftest failure of a particular subsystem"
+      pattern: "Selftest has failed on subsystem %{aruba.subsystem} with error code %{event.reason}"
+  - dissect:
+      if: "ctx.event?.code == '4504'"
+      tag: self_test_event_4504
+      field: "message"
+      description: "logs the port selftest failure on a given subsystem"
+      pattern: 'Selftest has failed on %{aruba.self_test.stack}/%{aruba.slot}/%{aruba.interface.id} with error code %{event.reason}'
+
+# REST events (46xx)
+# https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/RESTD.htm
+  - grok:
+      if: "['4601','4602'].contains(ctx.event?.code)"
+      tag: rest_event_4601_4602
+      field: "message"
+      description: "logs a [failed|successful] authentication attempt of a user via REST"
+      patterns:
+        - "^Authentication (failed|succeeded) for user %{DATA:user.name} in session %{GREEDYDATA:aruba.session.id}"
+  - dissect:
+      if: "ctx.event?.code == '4603'"
+      tag: rest_event_4603
+      field: "message"
+      description: "logs an authorization configuration conflict"
+      pattern: 'Conflict in authorization configuration. Existing config::URL(%{aruba.rest.match}), type(%{aruba.rest.type}) New config::(%{url.original}), type(%{aruba.rest.autztype})'
+  - grok:
+      if: "['4606','4607','4608'].contains(ctx.event?.code)"
+      tag: rest_event_4606_4607_4608
+      field: "message"
+      description: "logs a [failed|successful|allowed] authorization attempt of a user via REST "
+      patterns:
+        - "^Authorization (failed|succeeded|allowed) for user %{DATA:user.name}, for resource %{DATA:aruba.rest.resource}, with action %{GREEDYDATA:event.action}"
+  - dissect:
+      if: "ctx.event?.code == '4609'"
+      tag: rest_event_4609
+      field: "message"
+      description: "logs a successful add of a user via REST"
+      pattern: "User %{user.name} added %{aruba.rest.added_user} with role %{aruba.role}"
+  - grok:
+      if: "['4610','4653'].contains(ctx.event?.code)"
+      tag: rest_event_4610_4653
+      field: "message"
+      description: "logs a successful deletion of a user via REST | Logs a message when a user changes the REST configuration lockout mode"
+      patterns: 
+        - "^User %{DATA:user.name} deleted %{GREEDYDATA:aruba.rest.deleted_user}"
+        - "^User %{DATA:user.name} has configured %{DATA:aruba.rest.mode} for configuration lockout"
+  - grok:
+      if: "['4611','4612'].contains(ctx.event?.code)"
+      tag: rest_event_4611_4612
+      field: "message"
+      description: "logs a [unsuccessful|successful] password change for a user via REST"
+      patterns:
+        - "^User %{DATA:user.name} (successfully changed password|password change failed)"
+  - grok:
+      if: "['4613','4614','4615','4616'].contains(ctx.event?.code)"
+      tag: rest_event_4613_4614_4615_4616
+      field: "message"
+      description: "logs a success config write operation | success copy of saved | success when the nameserver is written to ovsdb | success when the nameserver is deleted from ovsdb"
+      patterns:
+        - "%{USER_PATTERN} written a new switch configuration to %{GREEDYDATA:aruba.rest.config_name}"
+        - "%{USER_PATTERN} copied switch configuration %{DATA:aruba.rest.config_from_name} to %{GREEDYDATA:aruba.rest.config_to_name}"
+        - "%{USER_PATTERN} configured %{DATA:aruba.rest.dns_nameserver} DNS nameserver to %{GREEDYDATA:aruba.rest.dns}"
+        - "%{USER_PATTERN} deleted all DNS nameservers"
+      pattern_definitions:
+        USER_PATTERN: "^%{DATA:user.name} has"
+  - grok:
+      if: "['4617','4618','4619'].contains(ctx.event?.code)"
+      tag: rest_event_4617_4618_4619
+      field: "message"
+      description: "A user has successfully [created|deleted|modified] a new resource in OVSDB"
+      patterns:
+        - "^%{DATA:user.name} (created|deleted|modified)( %{GREEDYDATA:url.original})?"
+  - grok:
+      if: "['4620','4621'].contains(ctx.event?.code)"
+      tag: rest_event_4620_4621
+      field: "message"
+      description: "A user has [added|removed] new notification subscriber"
+      patterns:
+        - "^User: %{DATA:user.name} (added|removed) subscriber: %{GREEDYDATA:aruba.rest.subscriber}."
+  - grok:
+      if: "['4622','4623','4625'].contains(ctx.event?.code)"
+      tag: rest_event_4622_4623_4625
+      field: "message"
+      description: "A subscriber has [added|removed] new subscription | Unable to add new subscription as max number reached for the specified subscriber"
+      patterns:
+        - "^Subscriber: %{DATA:aruba.rest.subscriber} (added|removed) subscription: %{GREEDYDATA:aruba.rest.subscription}."
+        - "^Unable to add new subscription. Max number of subscriptions for %{DATA:aruba.rest.subscriber} has been reached."
+  - grok:
+      if: "['4626','4627','4628','4629','4630','4631'].contains(ctx.event?.code)"
+      tag: rest_event_4626_4627_4628_4629_4630_4631
+      field: "message"
+      description: "NAE [Script|Agent] has been [created|deleted] successfully | Logs an error if a reboot fails"
+      patterns:
+        - "^NAE (Script|Agent) %{DATA:aruba.rest.name} has been (created|updated|deleted) by user %{GREEDYDATA:user.name}."
+        - "^Error rebooting switch, reboot command: %{DATA:aruba.rest.command}, error received: %{GREEDYDATA:event.reason}"
+  - grok:
+      if: "['4632','4633','4634','4635','4636','4637','4639','4640','4642'].contains(ctx.event?.code)"
+      tag: rest_event_4632_4633_4634_4635_4636_4637_4639_4640_4642
+      field: "message"
+      description: "HPE Aruba Networking Central type logs"
+      patterns:
+        - "location %{DATA:aruba.rest.central_location} on VRF %{DATA:aruba.vrf.id} (with|and) Source IP %{IP:source.ip}"
+  - grok:
+      if: "['4645','4649'].contains(ctx.event?.code)"
+      tag: rest_event_4645_4649
+      field: "message"
+      description: "Aruba Activate server is reachable via an active VRF | Unable to sync switch time with Aruba Activate Server"
+      patterns:
+        - "(S|s)erver %{DATA:server.address}( is reachable)? via VRF %{GREEDYDATA:aruba.vrf.id}."
+  - grok:
+      if: "['4646','4648'].contains(ctx.event?.code)"
+      tag: rest_event_4646_4648
+      field: "message"
+      description: "Aruba Activate server is not reachable through any supported VRF | Switch time is synced with Aruba Activate Server"
+      patterns:
+        - "server %{DATA:server.address} "
+        - "Server %{GREEDYDATA:server.address}."
+  - grok:
+      if: "['4650', '4651'].contains(ctx.event?.code)"
+      tag: rest_event_4650_4651
+      field: "message"
+      description: "(Unable|Successfully) to fetch HPE Aruba Networking Central location from Central Source (CLI/DHCP/Aruba Activate Server)"
+      patterns:
+        - "location( %{DATA:aruba.rest.central_location})? successfully fetched from %{DATA:aruba.rest.central_source} via VRF( %{GREEDYDATA:aruba.vrf.id})?"
+        - "location( %{DATA:aruba.rest.central_location})? from %{DATA:aruba.rest.central_source} via VRF( %{GREEDYDATA:aruba.vrf.id})?."
+  - grok:
+      if: "ctx.event?.code == '4652'"
+      tag: rest_event_4652
+      field: "message"
+      description: "Central connected, any config change through rest may not be persistent, Central can overwrite the change"
+      patterns: 
+        - "Central connected, any config change through rest %{DATA:aruba.rest.operation} operation may not be persistent. If central reapplies the config, change can be overwritten"
+  - grok:
+      if: "ctx.event?.code == '4654'"
+      tag: rest_event_4654
+      field: "message"
+      description: "Logs a message when a HPE Aruba Networking Central support mode is enabled or disabled"
+      patterns: 
+        - "support mode is %{DATA:aruba.rest.mode} for a vtysh session"
+  - grok:
+      if: "['4655','4656','4657'].contains(ctx.event?.code)"
+      tag: rest_event_4655_4656_4657
+      field: "message"
+      description: "Logs a message when a user login is [successful|failed] | Logs a message when a user logs out of a session"
+      patterns:
+        - "^User %{DATA:user.name} (logged in|login) from %{DATA:aruba.rest.identity} "
+        - "^User %{DATA:user.name} logged out of REST session from %{GREEDYDATA:aruba.rest.identity}"
+  - grok:
+      if: "['4658','4659'].contains(ctx.event?.code)"
+      tag: rest_event_4658_4659
+      field: "message"
+      description: "Logs a message when a user tries to login while maximum number of sessions are reached | when a REST session timed out due to the session being idle"
+      patterns:
+        - "^REST session from %{DATA:aruba.rest.identity} with User %{DATA:user.name} is rejected because maximum session limit is reached"
+        - "^%{DATA:user_agent.name:} session from %{DATA:aruba.rest.identity} with User %{DATA:user.name} timed out due to idle timeout"
+  - grok:
+      if: "['4660','4661','4662'].contains(ctx.event?.code)"
+      tag: rest_event_4660_4661_4662
+      field: "message"
+      description: "Logs a message when the REST server is [enabled|disabled] on a VRF | when a user login fails since the access through this management interface is not allowed"
+      patterns:
+        - "^REST server is (enabled|disabled) on VRF %{GREEDYDATA:aruba.vrf.name}"
+        - "^User %{DATA:user.name} login from %{IP:client.ip} for REST session has failed since the user is trying to login through an interface which is not allowed. Allowed interfaces are: %{GREEDYDATA:aruba.interface.id}"
+
 
     # MAC Learning events (480x)
     # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MAC-LEARN.htm

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -951,6 +951,69 @@
         - name: mgmt_module
           type: keyword
           description: ""
+    - name: rest
+      type: group
+      fields:
+        - name: added_user
+          type: keyword
+          description: ""
+        - name: autztype
+          type: keyword
+          description: ""
+        - name: central_location
+          type: keyword
+          description: ""
+        - name: central_source
+          type: keyword
+          description: ""
+        - name: command
+          type: keyword
+          description: ""
+        - name: config_name
+          type: keyword
+          description: ""
+        - name: config_from_name
+          type: keyword
+          description: ""
+        - name: config_to_name
+          type: keyword
+          description: ""
+        - name: deleted_user
+          type: keyword
+          description: ""
+        - name: dns_nameserver
+          type: keyword
+          description: ""
+        - name: dns
+          type: keyword
+          description: ""
+        - name: identity
+          type: keyword
+          description: ""
+        - name: match
+          type: keyword
+          description: ""
+        - name: mode
+          type: keyword
+          description: ""
+        - name: name
+          type: keyword
+          description: ""
+        - name: operation
+          type: keyword
+          description: ""
+        - name: resource
+          type: keyword
+          description: ""
+        - name: subscriber
+          type: keyword
+          description: ""
+        - name: subscription
+          type: keyword
+          description: ""
+        - name: type
+          type: keyword
+          description: ""
     - name: role
       type: keyword
       description: ""
@@ -984,6 +1047,12 @@
         - name: pvid
           type: keyword
           description: ""
+    - name: self_test
+      type: group
+      fields:
+        - name: stack
+          type: keyword
+          description: ""
     - name: sequence
       type: keyword
       description: ""
@@ -1003,6 +1072,33 @@
           type: keyword
           description: ""
         - name: name
+          type: keyword
+          description: ""
+    - name: sflow
+      type: group
+      fields:
+        - name: bridge
+          type: keyword
+          description: ""
+        - name: chain
+          type: keyword
+          description: ""
+        - name: dgramsize
+          type: long
+          description: ""
+        - name: intvl
+          type: keyword
+          description: ""
+        - name: mode
+          type: keyword
+          description: ""
+        - name: new_rate
+          type: keyword
+          description: ""
+        - name: old_rate
+          type: keyword
+          description: ""
+        - name: operation
           type: keyword
           description: ""
     - name: slot

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -992,67 +992,78 @@ Note: Descriptions have not been filled out
 |------------|------------------------------|
 | <uuid_str> | aruba.instance.id            |
 
-#### [REST events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/RESTD.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.rest.action         |             |      | event.action                 |
-| aruba.rest.activate_address |           |      | server.address               |
-| aruba.rest.added_user     |             |      |                              |
-| aruba.rest.added_user_role |            |      | aruba.role                   |
-| aruba.rest.agent_name     |             |      | agent.name                   |
-| aruba.rest.autztype       |             |      |                              |
-| aruba.rest.central_location |           |      | server.address               |
-| aruba.rest.reboot_command |             |      |                              |
-| aruba.rest.config_from_name |           |      |                              |
-| aruba.rest.config_to_name |             |      |                              |
-| aruba.rest.deleted_user   |             |      |                              |
-| aruba.rest.dns            |             |      |                              |
-| aruba.rest.dns_nameserver |             |      | dns.id                       |
-| aruba.rest.error          |             |      | error.message                |
-| aruba.rest.match          |             |      |                              |
-| aruba.rest.mode           |             |      |                              |
-| aruba.rest.resource       |             |      |                              |
-| aruba.rest.rest_operation |             |      |                              |
-| aruba.rest.script_name    |             |      |                              |
-| aruba.rest.sessionid      |             |      |                              |
-| aruba.rest.source_ip      |             |      | source.ip                    |
-| aruba.rest.subscriber     |             |      |                              |
-| aruba.rest.subscription   |             |      |                              |
-| aruba.rest.config_value   |             |      |                              |
-| aruba.rest.uri            |             |      | url.full                     |
-| aruba.rest.url            |             |      | url.full                     |
-| aruba.rest.user           |             |      | user.name                    |
-| aruba.rest.vrf            |             |      | aruba.vrf.id                 |
+#### [REST events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/RESTD.htm)
+| Docs Field           | Schema Mapping             |
+|----------------------|----------------------------|
+| `<action>`           | event.action               |
+| `<activate_address>` | aruba.rest.activate_address|
+| `<added_user>`       | aruba.rest.added_user      |
+| `<added_user_role>`  | aruba.role                 |
+| `<autztype>`         | aruba.rest.autztype        |
+| `<central_location>` | aruba.rest.central_location|
+| `<central_source>`   | aruba.rest.central_source  |
+| `<command>`          | aruba.rest.command         |
+| `<config_name>`      | aruba.rest.config_name     |
+| `<deleted_user>`     | aruba.rest.deleted_user    |
+| `<dns>`              | aruba.rest.ip              |
+| `<dns_nameserver>`   | aruba.rest.dns_nameserver  |
+| `<error>`            | event.reason               |
+| `<from_name>`        | aruba.rest.config_from_name|
+| `<identity>`         | aruba.rest.identity        |
+| `<ip_address>`       | client.ip                  |
+| `<match>`            | aruba.rest.match           |
+| `<mgmt_intf>`        | aruba.interface.id         |
+| `<mode>`             | aruba.rest.mode            |
+| `<name>`             | aruba.rest.name            |
+| `<resource>`         | aruba.rest.resource        |
+| `<rest_operation>`   | aruba.rest.operation       |
+| `<sessionid>`        | aruba.session.id           |
+| `<source_ip>`        | source.ip                  |
+| `<subscriber>`       | aruba.rest.subscriber      |
+| `<subscription>`     | aruba.rest.subscription    |
+| `<to_name>`          | aruba.rest.config_to_name  |
+| `<uri>`              | url.original               |
+| `<url>`              | url.original               |
+| `<user>`             | user.name                  |
+| `<vrf>`              | aruba.vrf.id               |
+| `<vrf_name>`         | aruba.vrf.name             |
+| `<value>`            | aruba.rest.type            |
 
-#### [Self Test events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/SELFTEST.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.self_test.error     |             |      | error.message                |
-| aruba.self_test.interface |             |      |                              |
-| aruba.self_test.slot      |             |      | aruba.slot                   |
-| aruba.self_test.stack     |             |      |                              |
-| aruba.self_test.subsystem |             |      | aruba.subsystem              |
+#### [Self Test events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SELFTEST.htm)
+| Docs Field   | Schema Mapping              |
+|--------------|-----------------------------|
+| `<interface>`| aruba.interface.id          |
+| `<slot>`     | aruba.slot                  |
+| `<stack>`    | aruba.self_test.stack       |
+| `<subsystem>`| aruba.subsystem             |
+| `<value>`    | event.reason                |
+
+#### [Self Test Monitor events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SelfTestMonitor.htm)
+| Docs Field   | Schema Mapping              |
+|--------------|-----------------------------|
 
 #### [sFlow events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/SFLOW.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.sflow.bridge        |             |      |                              |
-| aruba.sflow.chain         |             |      |                              |
-| aruba.sflow.desc          |             |      |                              |
-| aruba.sflow.dgramsize     |             |      |                              |
-| aruba.sflow.error         |             |      | error.message                |
-| aruba.sflow.file          |             |      | file.name                    |
-| aruba.sflow.hdrlen        |             |      | aruba.len                    |
-| aruba.sflow.ifIndex       |             |      | observer.ingress.interface.id|
-| aruba.sflow.intvl         |             |      |                              |
-| aruba.sflow.ip_address    |             |      | destination.ip               |
-| aruba.sflow.mode          |             |      |                              |
-| aruba.sflow.new_rate      |             |      |                              |
-| aruba.sflow.old_rate      |             |      |                              |
-| aruba.sflow.operation     |             |      | event.action                 |
-| aruba.sflow.port          |             |      | server.port                  |
-| aruba.sflow.port_name     |             |      | server.port                  |
-| aruba.sflow.unit          |             |      | aruba.unit                   |
+| Docs Field        | Schema Mapping                             |
+|-------------------|--------------------------------------------|
+| `<bridge>`        | aruba.sflow.bridge                         |
+| `<chain>`         | aruba.sflow.chain                          |
+| `<desc>`          | aruba.error.description                    |
+| `<dgramsize>`     | aruba.sflow.dgramsize                      |
+| `<error>`         | event.reason                               |
+| `<file>`          | file.name                                  |
+| `<hdrlen>`        | aruba.len                                  |
+| `<ifIndex>`       | aruba.interface.id                         |
+| `<interface>`     | aruba.interface.id                         |
+| `<intvl>`         | aruba.sflow.intvl                          |
+| `<ip_addr>`       | client.ip                                  |
+| `<ip_address>`    | client.ip                                  |
+| `<mode>`          | aruba.sflow.mode                           |
+| `<new_rate>`      | aruba.sflow.new_rate                       |
+| `<old_rate>`      | aruba.sflow.old_rate                       |
+| `<operation>`     | aruba.sflow.operation                      |
+| `<port>`          | aruba.port                                 |
+| `<port_name>`     | aruba.port                                 |
+| `<unit>`          | aruba.unit                                 |
 
 #### [SFTP Client events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/SFTP_CLIENT.htm)
 | Field                | Description | Type | Common                       |
@@ -1582,6 +1593,26 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.qos.new_slot |  | keyword |
 | aruba.qos.queue |  | keyword |
 | aruba.redundant.mgmt_module |  | keyword |
+| aruba.rest.added_user |  | keyword |
+| aruba.rest.autztype |  | keyword |
+| aruba.rest.central_location |  | keyword |
+| aruba.rest.central_source |  | keyword |
+| aruba.rest.command |  | keyword |
+| aruba.rest.config_from_name |  | keyword |
+| aruba.rest.config_name |  | keyword |
+| aruba.rest.config_to_name |  | keyword |
+| aruba.rest.deleted_user |  | keyword |
+| aruba.rest.dns |  | keyword |
+| aruba.rest.dns_nameserver |  | keyword |
+| aruba.rest.identity |  | keyword |
+| aruba.rest.match |  | keyword |
+| aruba.rest.mode |  | keyword |
+| aruba.rest.name |  | keyword |
+| aruba.rest.operation |  | keyword |
+| aruba.rest.resource |  | keyword |
+| aruba.rest.subscriber |  | keyword |
+| aruba.rest.subscription |  | keyword |
+| aruba.rest.type |  | keyword |
 | aruba.role |  | keyword |
 | aruba.rpvst.new_mode |  | keyword |
 | aruba.rpvst.npvid |  | keyword |
@@ -1592,11 +1623,20 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.rpvst.pkt_type |  | keyword |
 | aruba.rpvst.proto |  | keyword |
 | aruba.rpvst.pvid |  | keyword |
+| aruba.self_test.stack |  | keyword |
 | aruba.sequence |  | keyword |
 | aruba.server.mode |  | keyword |
 | aruba.server.sessions |  | long |
 | aruba.session.id |  | keyword |
 | aruba.session.name |  | keyword |
+| aruba.sflow.bridge |  | keyword |
+| aruba.sflow.chain |  | keyword |
+| aruba.sflow.dgramsize |  | long |
+| aruba.sflow.intvl |  | keyword |
+| aruba.sflow.mode |  | keyword |
+| aruba.sflow.new_rate |  | keyword |
+| aruba.sflow.old_rate |  | keyword |
+| aruba.sflow.operation |  | keyword |
 | aruba.slot |  | long |
 | aruba.state |  | keyword |
 | aruba.status |  | keyword |


### PR DESCRIPTION
## Parent Ticket:
https://github.com/elastic/integrations/issues/12118

## Change Log:
- sFlow events (10xx)
- Self Test events (450x)
- REST events (46xx)

Note: this is based on OS 10.15 message types different than 10.07. Will allow the rest of the already mapped fields in another PR
