### PR TITLE
#12185-1/2/3/4 4 new event types for Aruba (SSH Server/Client, Smartlink and SNMP)

### DIFF
--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -1054,33 +1054,44 @@ Note: Descriptions have not been filled out
 | aruba.sflow.port_name     |             |      | server.port                  |
 | aruba.sflow.unit          |             |      | aruba.unit                   |
 
-#### [SFTP Client events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/SFTP_CLIENT.htm)
-| Field                | Description | Type | Common                       |
-|----------------------|-------------|------|------------------------------|
-| aruba.sftp.from      |             |      | source.address               |
-| aruba.sftp.status    |             |      | aruba.status                 |
-| aruba.sftp.to        |             |      | destination.address          |
+#### [SFTP Client events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SFTP_CLIENT.htm)
+| Docs Field | Schema Mapping         |
+|------------|------------------------|
+| `<from>`   | source.address         |
+| `<status>` | aruba.status           |
+| `<to>`     | destination.address    |
 
-#### [SNMP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/SNMP.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.snmp.truth_value    |             |      |                              |
-| aruba.snmp.vrf            |             |      | aruba.vrf.id                 |
+#### [Smartlink events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SMARTLINK.htm)
+| Docs Field | Schema Mapping         |
+|------------|------------------------|
+| `<id>`     | group.id               |
+| `<id>`     | network.vlan.id        |
+| `<ifName>` | aruba.interface.name   |
 
-#### [SSH server events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/SSH_SERVER.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.ssh.key_name        |             |      |                              |
-| aruba.ssh.username        |             |      | user.name                    |
-| aruba.ssh.vrf_name        |             |      | aruba.vrf.name               |
+#### [SNMP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SNMP.htm)
+| Docs Field          | Schema Mapping               |
+|---------------------|------------------------------|
+| `<truth_value>`     | aruba.snmp.truth_value       |
+| `<vrf>`             | aruba.vrf.id                 |
 
-#### [SSH_CLIENT events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/SSH_CLIENT.htm)
-| Field                | Description | Type | Common                       |
-|----------------------|-------------|------|------------------------------|
-| aruba.ssh.ipaddr     |             |      | server.ip                    |
-| aruba.ssh.port_num   |             |      | server.port                  |
-| aruba.ssh.username   |             |      | user.name                    |
-| aruba.ssh.vrf_name   |             |      | aruba.vrf.name               |
+#### [SSH client events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SSH_CLIENT.htm)
+| Docs Field   | Schema Mapping        |
+|--------------|-----------------------|
+| `<ipaddr>`   | server.ip             |
+| `<port_num>` | server.port           |
+| `<username>` | user.name             |
+| `<vrf_name>` | aruba.vrf.name        |
+
+#### [SSH server events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SSH_SERVER.htm)
+| Docs Field       | Schema Mapping        |
+|------------------|-----------------------|
+| `<ip_address>`   | client.ip             |
+| `<key_name>`     | aruba.ssh.key_name    |
+| `<mgmt_intf>`    | aruba.interface.id    |
+| `<new_ip>`       | aruba.ssh.new_ip      |
+| `<original_ip>`  | client.ip             |
+| `<username>`     | user.name             |
+| `<vrf_name>`     | aruba.vrf.name        |
 
 #### [Supportability events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/SUPPORTABILITY.htm)
 | Field                                | Description | Type | Common                       |

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
@@ -1057,6 +1057,9 @@
                 },
                 "sequence": "1"
             },
+            "client": {
+                "ip": "127.0.0.1"
+            },
             "ecs": {
                 "version": "8.11.0"
             },
@@ -1077,7 +1080,10 @@
             "message": "User satori logged in from 127.0.0.1 through SSH session.",
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "user": {
+                "name": "satori"
+            }
         },
         {
             "@timestamp": "2024-08-01T05:22:26.478775-04:00",
@@ -1090,6 +1096,9 @@
                     "device": "6300-DIST-RDL"
                 },
                 "sequence": "1"
+            },
+            "client": {
+                "ip": "127.0.0.1"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -1111,7 +1120,10 @@
             "message": "User oxidized logged out of SSH session from 127.0.0.1.",
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "user": {
+                "name": "oxidized"
+            }
         },
         {
             "@timestamp": "2024-08-01T13:12:03.990790-04:00",

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
@@ -394,6 +394,28 @@
 2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5124|LOG_INFO|PIM|-|Candidate RP 192.168.1.1 is configured on interface eth0
 2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5125|LOG_INFO|PIM|-|BFD Session created for neighbor 192.168.1.2 on interface eth0
 2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-pim[1234]: Event|5126|LOG_INFO|PIM|-|BFD Session deleted for neighbor 192.168.1.2 on interface eth0
+2024-06-18T12:45:38.182641-05:00 8360-Primaire sshd[1234]: Event|5201|LOG_INFO|SSHS|-|SSH host-key host_key_1 is installed.
+2024-06-18T12:46:38.182641-05:00 8360-Primaire sshd[1234]: Event|5202|LOG_INFO|SSHS|-|SSH server is enabled on VRF vrf1.
+2024-06-18T12:47:38.182641-05:00 8360-Primaire sshd[1234]: Event|5203|LOG_INFO|SSHS|-|SSH server is disabled on VRF vrf1.
+2024-06-18T12:48:38.182641-05:00 8360-Primaire sshd[1234]: Event|5204|LOG_INFO|SSHS|-|SSH client-public-key key1 was installed for the user user1.
+2024-06-18T12:49:38.182641-05:00 8360-Primaire sshd[1234]: Event|5205|LOG_INFO|SSHS|-|SSH client-public-key key1 was removed for the user user1.
+2024-06-18T12:50:38.182641-05:00 8360-Primaire sshd[1234]: Event|5207|LOG_ERR|SSHS|-|An internal error occurred while reading the SSH host-key host_key_1.
+2024-06-18T12:51:38.182641-05:00 8360-Primaire sshd[1234]: Event|5208|LOG_ERR|SSHS|-|Failed to enable SSH server on VRF vrf1. Admin password is not set.
+2024-06-18T12:53:38.182641-05:00 8360-Primaire sshd[1234]: Event|5210|LOG_ERR|SSHS|-|User user1 login from 192.168.1.1 for SSH session failed during password based authentication.
+2024-06-18T12:55:38.182641-05:00 8360-Primaire sshd[1234]: Event|5212|LOG_WARN|SSHS|-|SSH session from 192.168.1.1 is rejected because maximum number of SSH sessions is reached.
+2024-06-18T12:56:38.182641-05:00 8360-Primaire sshd[1234]: Event|5213|LOG_WARN|SSHS|-|SSH session from user user1 closed because maximum number of sessions per user is reached.
+2024-06-18T12:57:38.182641-05:00 8360-Primaire sshd[1234]: Event|5214|LOG_WARN|SSHS|-|SSH session from 192.168.1.1 denied due to host key verification failure.
+2024-06-18T12:58:38.182641-05:00 8360-Primaire sshd[1234]: Event|5215|LOG_ERR|SSHS|-|SSH session from 192.168.1.1 for user user1 denied. The allowed user management interfaces are: mgmt_intf1
+2024-06-18T12:59:38.182641-05:00 8360-Primaire sshd[1234]: Event|5216|LOG_ERR|SSHS|-|SSH session from 192.168.1.1 for user user1 rejected due to failed public key validation
+2024-06-18T13:00:38.182641-05:00 8360-Primaire sshd[1234]: Event|5217|LOG_ERR|SSHS|-|SSH server on VRF vrf1 is in an error state.
+2024-06-18T13:01:38.182641-05:00 8360-Primaire sshd[1234]: Event|5218|LOG_INFO|SSHS|-|Converting configured SSH server allow-list entry 192.168.1.1 to CIDR format (192.168.1.0/24)
+2024-06-18T13:02:38.182641-05:00 8360-Primaire sshd[1234]: Event|5219|LOG_ERR|SSHS|-|Failed to convert configured SSH server allow-list entry 192.168.1.1 to CIDR format, using original address as-is
+2024-06-18T13:03:38.182641-05:00 8360-Primaire sshd[1234]: Event|5220|LOG_ERR|SSHS|-|RADIUS authorize-only request failed for SSH session from 192.168.1.1 for user user1.
+2024-06-18T13:04:38.182641-05:00 8360-Primaire sshd[1234]: Event|5221|LOG_ERR|SSHS|-|SSH session from 192.168.1.1 denied because username user1 not found in authenticating certificate Common Name or User Principal Name fields.
+2024-06-18T13:05:38.182641-05:00 8360-Primaire sshd[1234]: Event|5222|LOG_ERR|SSHS|-|SSH session from 192.168.1.1 for user user1 denied by SSH server allow-list
+2024-06-18T13:06:38.182641-05:00 8360-Primaire sshd[1234]: Event|5223|LOG_WARN|SSHS|-|An empty SSH allow-list has been enabled and all new SSH connections will be denied.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire sftp-client[1234]: Event|5301|LOG_INFO|SFTPC|-|SFTP file transfer from server1 to server2 completed.
+2024-06-18T12:46:38.182641-05:00 8360-Primaire sftp-client[1234]: Event|5302|LOG_ERR|SFTPC|-|SFTP file transfer from server1 to server2 failed - connection_lost.
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5601|LOG_INFO|HTTPSSERVER|-|User admin has enabled read-only for REST mode
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5602|LOG_INFO|HTTPSSERVER|-|User admin has enabled HTTPS Server on VRF default
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5603|LOG_INFO|HTTPSSERVER|-|User admin closed all HTTPS sessions
@@ -469,6 +491,17 @@
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|6804|LOG_ERR|AMM|-|Error while copying configs. Error: error_message
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|6805|LOG_INFO|AMM|-|Information while copying configs. Info: info_message
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-nae[1234]: Event|6901|LOG_INFO|NAEAGENT|-|An action has been triggered by the NAE agent nae_agent_1
+2024-06-18T12:45:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7101|LOG_INFO|SNMP|-|Snmp agent is up and running in namespace default
+2024-06-18T12:46:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7102|LOG_INFO|SNMP|-|Snmp sub agent is up and running in namespace default
+2024-06-18T12:47:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7103|LOG_INFO|SNMP|-|Snmp agent is disabled for namespace default
+2024-06-18T12:48:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7104|LOG_INFO|SNMP|-|Snmp sub agent is disabled for namespace default
+2024-06-18T12:49:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7105|LOG_ERR|SNMP|-|Failed to poll snmp
+2024-06-18T12:50:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7106|LOG_ERR|SNMP|-|Snmp and credential manager integration failed
+2024-06-18T12:51:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7107|LOG_INFO|SNMP|-|Snmp system now configured
+2024-06-18T12:52:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7108|LOG_INFO|SNMP|-|Snmp and database Integration has been initialized
+2024-06-18T12:53:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7109|LOG_INFO|SNMP|-|Successfully initialized all SNMP plugins
+2024-06-18T12:54:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7110|LOG_INFO|SNMP|-|Destroyed all SNMP plugins
+2024-06-18T12:54:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7111|LOG_INFO|SNMP|-|SNMP cache sync on-demand is set to: truth_value_mock
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7200|LOG_ERR|INSYSTEM|-|Internal fatal error at main.c:42
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7210|LOG_ERR|INSYSTEM|-|Non-failsafe update needed for device123. Please run the allow-unsafe-updates command
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|7211|LOG_ERR|INSYSTEM|-|Do not interrupt non-failsafe update for device123
@@ -640,6 +673,9 @@
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8810|LOG_INFO|AMM|-|Unicast Remote MAC 00:1A:2B:3C:4D:5E learnt on VNI 100 is added to the switch
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8811|LOG_INFO|AMM|-|Unicast Remote MAC 00:1A:2B:3C:4D:5E learnt on VNI 100 is removed from the switch
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8812|LOG_INFO|AMM|-|Tunnel 192.168.1.1 is removed from Hardware VTEP DB
+2024-06-18T12:45:38.182641-05:00 8360-Primaire sshd[1234]: Event|9001|LOG_INFO|SSHC|-|Connection to SSH server 192.168.1.100 on VRF default is established for user admin over port 22
+2024-06-18T12:46:38.182641-05:00 8360-Primaire sshd[1234]: Event|9002|LOG_ERR|SSHC|-|Connection to SSH server 192.168.1.100 on VRF default over port 22 is denied
+2024-06-18T12:47:38.182641-05:00 8360-Primaire sshd[1234]: Event|9003|LOG_INFO|SSHC|-|Connection to SSH server 192.168.1.100 on VRF default is successfully closed for user admin over port 22
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-storage[1234]: Event|9101|LOG_ERR|AMM|-|Failed to report storage Storage1 details for module 5. Error: Disk failure
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-storage[1234]: Event|9102|LOG_INFO|AMM|-|Storage Storage1 health alert. Endurance utilization at 85% in module 5
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-storage[1234]: Event|9103|LOG_INFO|AMM|-|Storage Storage1 endurance utilization at 85% in module 5
@@ -735,6 +771,9 @@
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-macsec[1234]: Event|11202|LOG_INFO|MACsec|-|MKA session secured for Connectivity Association 1234 on interface eth0.
 2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-macsec[1234]: Event|11203|LOG_INFO|MACsec|-|Secure Association key updated for Connectivity Association 1234 on interface eth0 - Latest AN/KN 1/2, Old AN/KN 3/4.
 2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-macsec[1234]: Event|11204|LOG_INFO|MACsec|-|Possible replay attempt detected on the Secure Channel 00:11:22:33:44:55.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-smartlink[1234]: Event|11301|LOG_INFO|Smartlink|-|Flush message received on eth0 with control VLAN 100
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-smartlink[1234]: Event|11302|LOG_INFO|Smartlink|-|Active link of the smartlink group 1 changed to eth1
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-smartlink[1234]: Event|11303|LOG_INFO|Smartlink|-|Backup link of the smartlink group 1 changed to eth2
 2024-06-20T13:54:38.182641-05:00 8360-Primaire hpe-cfmd[1204]: Event|11601|LOG_ERR|CFM|-|Connection lost for Maintenance Endpoint myEndpointId on eth0.
 2024-06-20T13:55:38.182641-05:00 8360-Primaire hpe-cfmd[1204]: Event|11602|LOG_INFO|CFM|-|Connection restored for Maintenance Endpoint myEndpointId on eth0.
 2024-06-21T13:56:38.182641-05:00 8360-Primaire hpe-container[1255]: Event|11801|LOG_INFO|CONTAINER|-|Container myContainerName is created

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -15104,6 +15104,832 @@
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",
             "aruba": {
                 "component": {
+                    "category": "SSHS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "ssh": {
+                    "key_name": "host_key_1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5201",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire sshd[1234]: Event|5201|LOG_INFO|SSHS|-|SSH host-key host_key_1 is installed."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "SSH host-key host_key_1 is installed.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SSHS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vrf": {
+                    "name": "vrf1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5202",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire sshd[1234]: Event|5202|LOG_INFO|SSHS|-|SSH server is enabled on VRF vrf1."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "SSH server is enabled on VRF vrf1.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SSHS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vrf": {
+                    "name": "vrf1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5203",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire sshd[1234]: Event|5203|LOG_INFO|SSHS|-|SSH server is disabled on VRF vrf1."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "SSH server is disabled on VRF vrf1.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SSHS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "ssh": {
+                    "key_name": "key1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5204",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire sshd[1234]: Event|5204|LOG_INFO|SSHS|-|SSH client-public-key key1 was installed for the user user1."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "SSH client-public-key key1 was installed for the user user1.",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "user1"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SSHS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "ssh": {
+                    "key_name": "key1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5205",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire sshd[1234]: Event|5205|LOG_INFO|SSHS|-|SSH client-public-key key1 was removed for the user user1."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "SSH client-public-key key1 was removed for the user user1.",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "user1"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SSHS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "ssh": {
+                    "key_name": "host_key_1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5207",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire sshd[1234]: Event|5207|LOG_ERR|SSHS|-|An internal error occurred while reading the SSH host-key host_key_1."
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "An internal error occurred while reading the SSH host-key host_key_1.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SSHS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vrf": {
+                    "name": "vrf1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5208",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire sshd[1234]: Event|5208|LOG_ERR|SSHS|-|Failed to enable SSH server on VRF vrf1. Admin password is not set."
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to enable SSH server on VRF vrf1. Admin password is not set.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SSHS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5210",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire sshd[1234]: Event|5210|LOG_ERR|SSHS|-|User user1 login from 192.168.1.1 for SSH session failed during password based authentication."
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "User user1 login from 192.168.1.1 for SSH session failed during password based authentication.",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "user1"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SSHS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5212",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire sshd[1234]: Event|5212|LOG_WARN|SSHS|-|SSH session from 192.168.1.1 is rejected because maximum number of SSH sessions is reached."
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "SSH session from 192.168.1.1 is rejected because maximum number of SSH sessions is reached.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:56:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SSHS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5213",
+                "original": "2024-06-18T12:56:38.182641-05:00 8360-Primaire sshd[1234]: Event|5213|LOG_WARN|SSHS|-|SSH session from user user1 closed because maximum number of sessions per user is reached."
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "SSH session from user user1 closed because maximum number of sessions per user is reached.",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "user1"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:57:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SSHS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5214",
+                "original": "2024-06-18T12:57:38.182641-05:00 8360-Primaire sshd[1234]: Event|5214|LOG_WARN|SSHS|-|SSH session from 192.168.1.1 denied due to host key verification failure."
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "SSH session from 192.168.1.1 denied due to host key verification failure.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:58:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SSHS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "mgmt_intf"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5215",
+                "original": "2024-06-18T12:58:38.182641-05:00 8360-Primaire sshd[1234]: Event|5215|LOG_ERR|SSHS|-|SSH session from 192.168.1.1 for user user1 denied. The allowed user management interfaces are: mgmt_intf1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "SSH session from 192.168.1.1 for user user1 denied. The allowed user management interfaces are: mgmt_intf1",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "user1"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:59:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SSHS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5216",
+                "original": "2024-06-18T12:59:38.182641-05:00 8360-Primaire sshd[1234]: Event|5216|LOG_ERR|SSHS|-|SSH session from 192.168.1.1 for user user1 rejected due to failed public key validation"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "SSH session from 192.168.1.1 for user user1 rejected due to failed public key validation",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "user1"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T13:00:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SSHS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vrf": {
+                    "name": "vrf1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5217",
+                "original": "2024-06-18T13:00:38.182641-05:00 8360-Primaire sshd[1234]: Event|5217|LOG_ERR|SSHS|-|SSH server on VRF vrf1 is in an error state."
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "SSH server on VRF vrf1 is in an error state.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:01:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SSHS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "ssh": {
+                    "new_ip": "192.168.1.0/24"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5218",
+                "original": "2024-06-18T13:01:38.182641-05:00 8360-Primaire sshd[1234]: Event|5218|LOG_INFO|SSHS|-|Converting configured SSH server allow-list entry 192.168.1.1 to CIDR format (192.168.1.0/24)"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Converting configured SSH server allow-list entry 192.168.1.1 to CIDR format (192.168.1.0/24)",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:02:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SSHS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5219",
+                "original": "2024-06-18T13:02:38.182641-05:00 8360-Primaire sshd[1234]: Event|5219|LOG_ERR|SSHS|-|Failed to convert configured SSH server allow-list entry 192.168.1.1 to CIDR format, using original address as-is"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to convert configured SSH server allow-list entry 192.168.1.1 to CIDR format, using original address as-is",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T13:03:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SSHS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5220",
+                "original": "2024-06-18T13:03:38.182641-05:00 8360-Primaire sshd[1234]: Event|5220|LOG_ERR|SSHS|-|RADIUS authorize-only request failed for SSH session from 192.168.1.1 for user user1."
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "RADIUS authorize-only request failed for SSH session from 192.168.1.1 for user user1.",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "user1"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T13:04:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SSHS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5221",
+                "original": "2024-06-18T13:04:38.182641-05:00 8360-Primaire sshd[1234]: Event|5221|LOG_ERR|SSHS|-|SSH session from 192.168.1.1 denied because username user1 not found in authenticating certificate Common Name or User Principal Name fields."
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "SSH session from 192.168.1.1 denied because username user1 not found in authenticating certificate Common Name or User Principal Name fields.",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "user1"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T13:05:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SSHS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5222",
+                "original": "2024-06-18T13:05:38.182641-05:00 8360-Primaire sshd[1234]: Event|5222|LOG_ERR|SSHS|-|SSH session from 192.168.1.1 for user user1 denied by SSH server allow-list"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "SSH session from 192.168.1.1 for user user1 denied by SSH server allow-list",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "user1"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T13:06:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SSHS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5223",
+                "original": "2024-06-18T13:06:38.182641-05:00 8360-Primaire sshd[1234]: Event|5223|LOG_WARN|SSHS|-|An empty SSH allow-list has been enabled and all new SSH connections will be denied."
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "An empty SSH allow-list has been enabled and all new SSH connections will be denied.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SFTPC"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "destination": {
+                "address": "server2"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5301",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire sftp-client[1234]: Event|5301|LOG_INFO|SFTPC|-|SFTP file transfer from server1 to server2 completed."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "sftp-client",
+                    "procid": "1234"
+                }
+            },
+            "message": "SFTP file transfer from server1 to server2 completed.",
+            "source": {
+                "address": "server1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SFTPC"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "status": "connection_lost"
+            },
+            "destination": {
+                "address": "server2"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5302",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire sftp-client[1234]: Event|5302|LOG_ERR|SFTPC|-|SFTP file transfer from server1 to server2 failed - connection_lost."
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "sftp-client",
+                    "procid": "1234"
+                }
+            },
+            "message": "SFTP file transfer from server1 to server2 failed - connection_lost.",
+            "source": {
+                "address": "server1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
                     "category": "HTTPSSERVER"
                 },
                 "event_type": "Event",
@@ -17815,6 +18641,384 @@
                 }
             },
             "message": "An action has been triggered by the NAE agent nae_agent_1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SNMP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vrf": {
+                    "id": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7101",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7101|LOG_INFO|SNMP|-|Snmp agent is up and running in namespace default"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "snmpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Snmp agent is up and running in namespace default",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SNMP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vrf": {
+                    "id": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7102",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7102|LOG_INFO|SNMP|-|Snmp sub agent is up and running in namespace default"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "snmpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Snmp sub agent is up and running in namespace default",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SNMP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vrf": {
+                    "id": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7103",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7103|LOG_INFO|SNMP|-|Snmp agent is disabled for namespace default"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "snmpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Snmp agent is disabled for namespace default",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SNMP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vrf": {
+                    "id": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7104",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7104|LOG_INFO|SNMP|-|Snmp sub agent is disabled for namespace default"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "snmpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Snmp sub agent is disabled for namespace default",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SNMP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7105",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7105|LOG_ERR|SNMP|-|Failed to poll snmp"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "snmpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to poll snmp",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SNMP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7106",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7106|LOG_ERR|SNMP|-|Snmp and credential manager integration failed"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "snmpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Snmp and credential manager integration failed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SNMP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7107",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7107|LOG_INFO|SNMP|-|Snmp system now configured"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "snmpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Snmp system now configured",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SNMP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7108",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7108|LOG_INFO|SNMP|-|Snmp and database Integration has been initialized"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "snmpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Snmp and database Integration has been initialized",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SNMP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7109",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7109|LOG_INFO|SNMP|-|Successfully initialized all SNMP plugins"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "snmpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Successfully initialized all SNMP plugins",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SNMP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7110",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7110|LOG_INFO|SNMP|-|Destroyed all SNMP plugins"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "snmpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Destroyed all SNMP plugins",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SNMP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "snmp": {
+                    "truth_value": "truth_value_mock"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7111",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7111|LOG_INFO|SNMP|-|SNMP cache sync on-demand is set to: truth_value_mock"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "snmpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "SNMP cache sync on-demand is set to: truth_value_mock",
             "tags": [
                 "preserve_original_event"
             ]
@@ -24297,6 +25501,132 @@
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",
             "aruba": {
                 "component": {
+                    "category": "SSHC"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "22",
+                "vrf": {
+                    "name": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9001",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire sshd[1234]: Event|9001|LOG_INFO|SSHC|-|Connection to SSH server 192.168.1.100 on VRF default is established for user admin over port 22"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Connection to SSH server 192.168.1.100 on VRF default is established for user admin over port 22",
+            "server": {
+                "ip": "192.168.1.100"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SSHC"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "22",
+                "vrf": {
+                    "name": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9002",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire sshd[1234]: Event|9002|LOG_ERR|SSHC|-|Connection to SSH server 192.168.1.100 on VRF default over port 22 is denied"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Connection to SSH server 192.168.1.100 on VRF default over port 22 is denied",
+            "server": {
+                "ip": "192.168.1.100"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "SSHC"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "22",
+                "vrf": {
+                    "name": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9003",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire sshd[1234]: Event|9003|LOG_INFO|SSHC|-|Connection to SSH server 192.168.1.100 on VRF default is successfully closed for user admin over port 22"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Connection to SSH server 192.168.1.100 on VRF default is successfully closed for user admin over port 22",
+            "server": {
+                "ip": "192.168.1.100"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
                     "category": "AMM"
                 },
                 "event_type": "Event",
@@ -27981,6 +29311,125 @@
                 }
             },
             "message": "Possible replay attempt detected on the Secure Channel 00:11:22:33:44:55.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Smartlink"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11301",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-smartlink[1234]: Event|11301|LOG_INFO|Smartlink|-|Flush message received on eth0 with control VLAN 100"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-smartlink",
+                    "procid": "1234"
+                }
+            },
+            "message": "Flush message received on eth0 with control VLAN 100",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Smartlink"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11302",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-smartlink[1234]: Event|11302|LOG_INFO|Smartlink|-|Active link of the smartlink group 1 changed to eth1"
+            },
+            "group": {
+                "id": "1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-smartlink",
+                    "procid": "1234"
+                }
+            },
+            "message": "Active link of the smartlink group 1 changed to eth1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Smartlink"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth2"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11303",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-smartlink[1234]: Event|11303|LOG_INFO|Smartlink|-|Backup link of the smartlink group 1 changed to eth2"
+            },
+            "group": {
+                "id": "1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-smartlink",
+                    "procid": "1234"
+                }
+            },
+            "message": "Backup link of the smartlink group 1 changed to eth2",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1434,7 +1434,7 @@ processors:
         - "^BFD Session (created|deleted) for neighbor %{IP:server.ip} on interface %{GREEDYDATA:aruba.interface.name}"
 
   # SSH server events (520x)
-  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SFTP_CLIENT.htm
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SSH_SERVER.htm
   - dissect:
       if: "ctx.event?.code == '5201'"
       tag: sftps_event_5201
@@ -1477,7 +1477,7 @@ processors:
         - "^User %{DATA:user.name} logged out of SSH session from %{IP:client.ip}."
   - grok:
       if: "['5212','5213','5214'].contains(ctx.event?.code)"
-      tag: sftps_event_
+      tag: sftps_event_5212_5213_5214
       field: "message"
       description: "Logs a message when a user tries to login while maximum number of sessions are reached | user session is closed while maximum number of sessions per user are reached | session is closed due to host key failurE"
       patterns:

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1433,6 +1433,96 @@ processors:
       patterns:
         - "^BFD Session (created|deleted) for neighbor %{IP:server.ip} on interface %{GREEDYDATA:aruba.interface.name}"
 
+  # SSH server events (520x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SFTP_CLIENT.htm
+  - dissect:
+      if: "ctx.event?.code == '5201'"
+      tag: sftps_event_5201
+      field: "message"
+      description: "Logs a message when the SSH host-key generated"
+      pattern: "SSH host-key %{aruba.ssh.key_name} is installed."
+  - grok:
+      if: "['5202', '5203'].contains(ctx.event?.code)"
+      tag: sftps_event_5202_5203
+      field: "message"
+      description: "Logs a message when the SSH server is [enabled|disabled] on a VRF"
+      patterns:
+        - "^SSH server is (enabled|disabled) on VRF %{GREEDYDATA:aruba.vrf.name}."
+  - grok:
+      if: "['5204', '5205'].contains(ctx.event?.code)"
+      tag: sftps_event_5204_5205
+      field: "message"
+      description: "Logs a message when [add|delete] ssh client-public-key into authorized_keys file"
+      patterns:
+        - "^SSH client-public-key %{DATA:aruba.ssh.key_name} was (installed|removed) for the user %{GREEDYDATA:user.name}."
+  - dissect:
+      if: "ctx.event?.code == '5207'"
+      tag: sftps_event_5207
+      field: "message"
+      description: "Logs a message when the SSH host-key is corrupted"
+      pattern: "An internal error occurred while reading the SSH host-key %{aruba.ssh.key_name}."
+  - dissect:
+      if: "ctx.event?.code == '5208'"
+      tag: sftps_event_5208
+      field: "message"
+      description: "Logs a message when a user tries to enable SSH server without setting admin password"
+      pattern: "Failed to enable SSH server on VRF %{aruba.vrf.name}. Admin password is not set."
+  - grok:
+      if: "['5209','5210','5211'].contains(ctx.event?.code)"
+      tag: sftps_event_5209_5210_5211
+      field: "message"
+      description: "Logs a message when a user login is successful | failed | logout"
+      patterns:
+        - "^User %{DATA:user.name} (logged in|login) from %{IP:client.ip} "
+        - "^User %{DATA:user.name} logged out of SSH session from %{IP:client.ip}."
+  - grok:
+      if: "['5212','5213','5214'].contains(ctx.event?.code)"
+      tag: sftps_event_
+      field: "message"
+      description: "Logs a message when a user tries to login while maximum number of sessions are reached | user session is closed while maximum number of sessions per user are reached | session is closed due to host key failurE"
+      patterns:
+        - "^SSH session from %{IP:client.ip} "
+        - "^SSH session from user %{DATA:user.name} closed because maximum number of sessions per user is reached."
+  - grok:
+      if: "['5215', '5216'].contains(ctx.event?.code)"
+      tag: sftps_event_5215_5216
+      field: "message"
+      description: "Logs a message when a user login fails since the access through this management interface is not allowed | when a user login fails due to public key failure"
+      patterns:
+        - "^SSH session from %{IP:client.ip} for user %{DATA:user.name} denied. The allowed user management interfaces are: %{GREEDYDATA:aruba.interface.id}."
+        - "^SSH session from %{IP:client.ip} for user %{DATA:user.name} rejected due to failed public key validation"
+  - dissect:
+      if: "ctx.event?.code == '5217'"
+      tag: sftps_event_5217
+      field: "message"
+      description: "Logs a message when SSH server goes into an error state."
+      pattern: "SSH server on VRF %{aruba.vrf.name} is in an error state."
+  - grok:
+      if: "['5218', '5219'].contains(ctx.event?.code)"
+      tag: sftps_event_5218_5219
+      field: "message"
+      description: "Logs a message when SSH server (fails)? converts an IP address to CIDR format | "
+      patterns:
+        - "^Converting configured SSH server allow-list entry %{IP:client.ip} to CIDR format \\(%{GREEDYDATA:aruba.ssh.new_ip}\\)"
+        - "^Failed to convert configured SSH server allow-list entry %{IP:client.ip} to CIDR format, using original address as-is"
+  - grok:
+      if: "['5220', '5221','5222'].contains(ctx.event?.code)"
+      tag: sftps_event_5220_5221_5222
+      field: "message"
+      description: "Logs a message when SSH connection fails due to authorize-only attempt | authenticating username was searched for and not found in the authenticating certificate | when the authenticating IP is denied due to the SSH server allow list"
+      patterns:
+        - "^RADIUS authorize-only request failed for SSH session from %{IP:client.ip} for user %{GREEDYDATA:user.name}."
+        - "^SSH session from %{IP:client.ip} (denied because username|for user) %{DATA:user.name} "
+
+  # SFTP Client events (530x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SFTP_CLIENT.htm
+  - grok:
+      if: "['5301', '5302'].contains(ctx.event?.code)"
+      tag: sftpc_event_5301_5302
+      field: "message"
+      description: "SFTP file transfer completed | failed"
+      patterns:
+        - "^SFTP file transfer from %{DATA:source.address} to %{DATA:destination.address} (completed|failed - %{GREEDYDATA:aruba.status})."
 
   # HTTPS Server events (560x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/HTTPS_SERVER.htm
@@ -1686,6 +1776,22 @@ processors:
       field: "message"
       description: "Action has been triggered by an NAE agent"
       pattern: "An action has been triggered by the NAE agent %{aruba.nae.name}"
+
+  # SNMP events (71xx)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SNMP.htm
+  - grok:
+      if: "['7101','7102','7103','7104'].contains(ctx.event?.code)"
+      tag: snmp_event_7101_7102_7103_7104
+      field: "message"
+      description: "SNMP (sub)? agent is [enabled|disabled]"
+      patterns:
+        - "namespace %{GREEDYDATA:aruba.vrf.id}"
+  - dissect:
+      if: "ctx.event.code == '7111'"
+      tag: snmp_event_7111
+      field: "message"
+      description: "SNMP on demand idl sync."
+      pattern: "SNMP cache sync on-demand is set to: %{aruba.snmp.truth_value}"
 
   # In-System Programming events (72xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ISP.htm
@@ -2417,6 +2523,17 @@ processors:
       patterns:
         - "^CDP neighbor %{MAC:source.mac} is (added|updated|deleted) on %{GREEDYDATA:aruba.interface.name}"
 
+  # SSH client events (900x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SSH_CLIENT.htm
+  - grok:
+      if: "['9001','9002','9003'].contains(ctx.event?.code)"
+      tag: sshc_event_9001_9002_9003
+      field: "message"
+      description: "SSH client session is successful|denied"
+      patterns:
+        - "^Connection to SSH server %{IP:server.ip} on VRF %{DATA:aruba.vrf.name} is (established|successfully closed) for user %{DATA:user.name} over port %{GREEDYDATA:aruba.port}"
+        - "^Connection to SSH server %{IP:server.ip} on VRF %{DATA:aruba.vrf.name} over port %{DATA:aruba.port} is denied"
+        
   # Internal storage events (910x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/INTERNAL-STORAGE.htm
   - grok:
@@ -2787,6 +2904,17 @@ processors:
         - "^MKA session secured for Connectivity Association %{DATA:aruba.mac.ckn} on interface %{GREEDYDATA:aruba.interface.name}"
         - "^Secure Association key updated for Connectivity Association %{DATA:aruba.mac.ckn} on interface %{DATA:aruba.interface.name} - Latest AN/KN %{DATA:aruba.mac.latest_an}/%{DATA:aruba.mac.latest_kn}, Old AN/KN %{DATA:aruba.mac.old_an}/%{GREEDYDATA:aruba.mac.old_kn}"
         - "^Possible replay attempt detected on the Secure Channel %{GREEDYDATA:aruba.mac.sci}."
+
+  # Smartlink events (1130x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SMARTLINK.htm
+  - grok:
+      field: message
+      tag: smartlink_event_11301_11302_11303
+      if: "['11301','11302','11303'].contains(ctx.event?.code)"
+      description: "flush message received on interface with control vlan | when [active|backup] link changed in the smartlink group"
+      patterns:
+        - "^Flush message received on %{DATA:aruba.interface.name} with control VLAN %{GREEDYDATA:network.vlan.id}"
+        - "^(Active|Backup) link of the smartlink group %{DATA:group.id} changed to %{GREEDYDATA:aruba.interface.name}"
 
   # L3 Resource Manager events (1150x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3_RESMGR.htm

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -1008,6 +1008,21 @@
     - name: slot
       type: long
       description: ""
+    - name: snmp
+      type: group
+      fields:
+        - name: truth_value
+          type: keyword
+          description: ""
+    - name: ssh
+      type: group
+      fields:
+        - name: key_name
+          type: keyword
+          description: ""
+        - name: new_ip
+          type: keyword
+          description: ""
     - name: state
       type: keyword
       description: ""

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -1054,33 +1054,44 @@ Note: Descriptions have not been filled out
 | aruba.sflow.port_name     |             |      | server.port                  |
 | aruba.sflow.unit          |             |      | aruba.unit                   |
 
-#### [SFTP Client events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/SFTP_CLIENT.htm)
-| Field                | Description | Type | Common                       |
-|----------------------|-------------|------|------------------------------|
-| aruba.sftp.from      |             |      | source.address               |
-| aruba.sftp.status    |             |      | aruba.status                 |
-| aruba.sftp.to        |             |      | destination.address          |
+#### [SFTP Client events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SFTP_CLIENT.htm)
+| Docs Field | Schema Mapping         |
+|------------|------------------------|
+| `<from>`   | source.address         |
+| `<status>` | aruba.status           |
+| `<to>`     | destination.address    |
 
-#### [SNMP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/SNMP.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.snmp.truth_value    |             |      |                              |
-| aruba.snmp.vrf            |             |      | aruba.vrf.id                 |
+#### [Smartlink events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SMARTLINK.htm)
+| Docs Field | Schema Mapping         |
+|------------|------------------------|
+| `<id>`     | group.id               |
+| `<id>`     | network.vlan.id        |
+| `<ifName>` | aruba.interface.name   |
 
-#### [SSH server events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/SSH_SERVER.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.ssh.key_name        |             |      |                              |
-| aruba.ssh.username        |             |      | user.name                    |
-| aruba.ssh.vrf_name        |             |      | aruba.vrf.name               |
+#### [SNMP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SNMP.htm)
+| Docs Field          | Schema Mapping               |
+|---------------------|------------------------------|
+| `<truth_value>`     | aruba.snmp.truth_value       |
+| `<vrf>`             | aruba.vrf.id                 |
 
-#### [SSH_CLIENT events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/SSH_CLIENT.htm)
-| Field                | Description | Type | Common                       |
-|----------------------|-------------|------|------------------------------|
-| aruba.ssh.ipaddr     |             |      | server.ip                    |
-| aruba.ssh.port_num   |             |      | server.port                  |
-| aruba.ssh.username   |             |      | user.name                    |
-| aruba.ssh.vrf_name   |             |      | aruba.vrf.name               |
+#### [SSH client events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SSH_CLIENT.htm)
+| Docs Field   | Schema Mapping        |
+|--------------|-----------------------|
+| `<ipaddr>`   | server.ip             |
+| `<port_num>` | server.port           |
+| `<username>` | user.name             |
+| `<vrf_name>` | aruba.vrf.name        |
+
+#### [SSH server events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SSH_SERVER.htm)
+| Docs Field       | Schema Mapping        |
+|------------------|-----------------------|
+| `<ip_address>`   | client.ip             |
+| `<key_name>`     | aruba.ssh.key_name    |
+| `<mgmt_intf>`    | aruba.interface.id    |
+| `<new_ip>`       | aruba.ssh.new_ip      |
+| `<original_ip>`  | client.ip             |
+| `<username>`     | user.name             |
+| `<vrf_name>`     | aruba.vrf.name        |
 
 #### [Supportability events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/SUPPORTABILITY.htm)
 | Field                                | Description | Type | Common                       |
@@ -1598,6 +1609,9 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.session.id |  | keyword |
 | aruba.session.name |  | keyword |
 | aruba.slot |  | long |
+| aruba.snmp.truth_value |  | keyword |
+| aruba.ssh.key_name |  | keyword |
+| aruba.ssh.new_ip |  | keyword |
 | aruba.state |  | keyword |
 | aruba.status |  | keyword |
 | aruba.storage.name |  | keyword |


### PR DESCRIPTION
## Parent Ticket:
https://github.com/elastic/integrations/issues/12185

## Change Log
SSH server events (520x)
SNMP events (71xx)
SSH client events (900x)
Smartlink events (1130x)

Note: this is against the 10.15 OS version, the links have been changed to reflect the new OS version
