### PR TITLE
[O365_metrics] Add teams_user_activity datastream

### DIFF
--- a/packages/o365_metrics/_dev/build/docs/README.md
+++ b/packages/o365_metrics/_dev/build/docs/README.md
@@ -83,3 +83,13 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 Please refer to the following [document](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) for detailed information on ECS fields.
 
 {{fields "active_users"}}
+
+### Teams User Activity
+
+{{event "teams_user_activity"}}
+
+**ECS Field Reference**
+
+Please refer to the following [document](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) for detailed information on ECS fields.
+
+{{fields "teams_user_activity"}}

--- a/packages/o365_metrics/changelog.yml
+++ b/packages/o365_metrics/changelog.yml
@@ -1,6 +1,9 @@
 # newer versions go on top
 - version: "0.2.0-next"
   changes:
+    - description: Add `teams_user_activity` data stream.
+      type: enhancement
+      link: tba 
     - description: Add `active_users` data stream.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/11934

--- a/packages/o365_metrics/data_stream/teams_user_activity/_dev/test/pipeline/test-common-config.yml
+++ b/packages/o365_metrics/data_stream/teams_user_activity/_dev/test/pipeline/test-common-config.yml
@@ -1,0 +1,2 @@
+dynamic_fields:
+  "event.ingested": ".*"

--- a/packages/o365_metrics/data_stream/teams_user_activity/_dev/test/pipeline/test-metrics.json
+++ b/packages/o365_metrics/data_stream/teams_user_activity/_dev/test/pipeline/test-metrics.json
@@ -1,0 +1,7 @@
+{
+    "events": [
+        {
+            "teamsuseractivity": "{\"Calls\":\"10\",\"Meetings\":\"8\",\"Other Actions\":\"7\",\"Private Chat Messages\":\"15\",\"Report Date\":\"2024-12-25\",\"Report Period\":\"7\",\"Team Chat Messages\":\"9\",\"Report Refresh Date\":\"2024-12-31\"}"
+        }
+    ]
+}

--- a/packages/o365_metrics/data_stream/teams_user_activity/_dev/test/pipeline/test-metrics.json-expected.json
+++ b/packages/o365_metrics/data_stream/teams_user_activity/_dev/test/pipeline/test-metrics.json-expected.json
@@ -1,0 +1,41 @@
+{
+    "expected": [
+        {
+            "ecs": {
+                "version": "8.16.0"
+            },
+            "o365": {
+                "metrics": {
+                    "teams": {
+                        "user": {
+                            "activity": {
+                                "calls": {
+                                    "count": "10"
+                                },
+                                "meetings": {
+                                    "count": "8"
+                                },
+                                "other_actions": {
+                                    "count": "7"
+                                },
+                                "private_chat_messages": {
+                                    "count": "15"
+                                },
+                                "report": {
+                                    "date": "2024-12-25",
+                                    "period": {
+                                        "day": "7"
+                                    },
+                                    "refresh_date": "2024-12-31"
+                                },
+                                "team_chat_messages": {
+                                    "count": "9"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/packages/o365_metrics/data_stream/teams_user_activity/agent/stream/cel.yml.hbs
+++ b/packages/o365_metrics/data_stream/teams_user_activity/agent/stream/cel.yml.hbs
@@ -1,0 +1,84 @@
+config_version: 2
+interval: {{interval}}
+auth.oauth2:
+    client.id: {{client_id}}
+    client.secret: {{client_secret}}
+    provider: azure
+    scopes:
+{{#each token_scopes as |token_scope|}}
+      - {{token_scope}}
+{{/each}}
+    endpoint_params: 
+        grant_type: client_credentials
+{{#if token_url}}
+    token_url: {{token_url}}/{{azure_tenant_id}}/oauth2/v2.0/token
+{{else if azure_tenant_id}}
+    azure.tenant_id: {{azure_tenant_id}}
+{{/if}}
+
+resource.url: {{url}}
+{{#if resource_ssl}}
+resource.ssl: 
+  {{resource_ssl}}
+{{/if}}
+
+{{#if enable_request_tracer}}
+resource.tracer.filename: "../../logs/cel/http-request-trace-*.ndjson"
+{{/if}}
+
+tags:
+{{#if preserve_original_event}}
+  - preserve_original_event
+{{/if}}
+{{#each tags as |tag|}}
+  - {{tag}}
+{{/each}}
+{{#contains "forwarded" tags}}
+publisher_pipeline.disable_host: true
+{{/contains}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}
+
+state:
+  want_more: false
+  base:
+    tenant_id: "{{azure_tenant_id}}"
+    period: "{{period}}"
+
+redact:
+  fields:
+    - base.tenant_id
+
+
+program: |
+    state.with(
+      request(
+        "GET",
+        state.url + "/reports/getTeamsUserActivityUserCounts(period='" + state.base.period + "')"
+      ).do_request().as(resp,
+        resp.StatusCode == 200
+        ?
+          bytes(resp.Body).mime("text/csv; header=present").as(events, {
+                                     "events": events.map(e, {"teamsuseractivity": e.encode_json()}),                     
+        
+          })
+        :
+          {
+            "events": {
+              "error": {
+                "code": string(resp.StatusCode),
+                "id": string(resp.Status),
+                "message": "GET:"+(
+                  size(resp.Body) != 0 ?
+                    string(resp.Body)
+                  :
+                    string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                ),
+              },
+            },
+            "want_more": false,
+          }
+      )
+    )

--- a/packages/o365_metrics/data_stream/teams_user_activity/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/o365_metrics/data_stream/teams_user_activity/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,72 @@
+---
+description: Pipeline for renaming object
+processors:
+  - set:
+      field: ecs.version
+      value: "8.16.0"
+  - json:
+      field: teamsuseractivity
+      target_field: o365.metrics.teams.user.activity
+  - script:
+      lang: painless
+      description: Replace spaces and dashes in field names under o365.metrics.teams.user.activity.
+      tag: painless_purge_spaces_and_dashes
+      if: ctx.o365.metrics?.teams.user.activity instanceof Map
+      source: |
+        String underscore(String s) {
+          String result = /[ -]/.matcher(s).replaceAll('_').toLowerCase();
+          return /[\ufeff]/.matcher(result).replaceAll('')
+        }
+        
+        def out = [:];
+        for (def item : ctx.o365.metrics.teams.user.activity.entrySet()) {
+          out[underscore(item.getKey())] = item.getValue();
+        }
+        ctx.o365.metrics.teams.user.activity = out;
+
+  - remove:
+      if: ctx.teamsuseractivity != null
+      field: teamsuseractivity
+      ignore_missing: true
+
+  - rename:
+      field: o365.metrics.teams.user.activity.calls
+      target_field: o365.metrics.teams.user.activity.calls.count
+      ignore_missing: true
+  - rename:
+      field: o365.metrics.teams.user.activity.meetings
+      target_field: o365.metrics.teams.user.activity.meetings.count
+      ignore_missing: true
+  - rename:
+      field: o365.metrics.teams.user.activity.other_actions
+      target_field: o365.metrics.teams.user.activity.other_actions.count
+      ignore_missing: true
+  - rename:
+      field: o365.metrics.teams.user.activity.private_chat_messages
+      target_field: o365.metrics.teams.user.activity.private_chat_messages.count
+      ignore_missing: true
+  - rename:
+      field: o365.metrics.teams.user.activity.team_chat_messages
+      target_field: o365.metrics.teams.user.activity.team_chat_messages.count
+      ignore_missing: true
+  - rename:
+      field: o365.metrics.teams.user.activity.report_date
+      target_field: o365.metrics.teams.user.activity.report.date
+      ignore_missing: true
+  - rename:
+      field: o365.metrics.teams.user.activity.report_period
+      target_field: o365.metrics.teams.user.activity.report.period.day
+      ignore_missing: true
+  - rename:
+      field: o365.metrics.teams.user.activity.report_refresh_date
+      target_field: o365.metrics.teams.user.activity.report.refresh_date
+      ignore_missing: true
+
+on_failure:
+  - append:
+      field: error.message
+      value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - append:
+      field: event.kind
+      value: pipeline_error
+      allow_duplicates: false

--- a/packages/o365_metrics/data_stream/teams_user_activity/fields/agent.yml
+++ b/packages/o365_metrics/data_stream/teams_user_activity/fields/agent.yml
@@ -1,0 +1,33 @@
+- name: cloud
+  title: Cloud
+  group: 2
+  description: Fields related to the cloud or infrastructure the events are coming from.
+  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  type: group
+  fields:
+    - name: image.id
+      type: keyword
+      description: Image ID for the cloud instance.
+- name: host
+  title: Host
+  group: 2
+  description: 'A host is defined as a general computing instance.  ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  type: group
+  fields:
+    - name: containerized
+      type: boolean
+      description: >
+        If the host is a container.
+
+    - name: os.build
+      type: keyword
+      example: "18D109"
+      description: >
+        OS build information.
+
+    - name: os.codename
+      type: keyword
+      example: "stretch"
+      description: >
+        OS codename, if any.
+

--- a/packages/o365_metrics/data_stream/teams_user_activity/fields/base-fields.yml
+++ b/packages/o365_metrics/data_stream/teams_user_activity/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.
+- name: '@timestamp'
+  type: date
+  description: Event timestamp.

--- a/packages/o365_metrics/data_stream/teams_user_activity/fields/fields.yml
+++ b/packages/o365_metrics/data_stream/teams_user_activity/fields/fields.yml
@@ -1,0 +1,39 @@
+- name: o365.metrics.teams.user.activity
+  type: group
+  fields:
+    - name: calls.count
+      type: integer
+      description: |
+        The number of calls made by Teams users.
+    - name: meetings.count
+      type: integer
+      description: |
+        The number of meetings attended or organized by Teams users.
+    - name: other_actions.count
+      type: integer
+      description: |
+        The count of other user actions within Teams.
+    - name: private_chat_messages.count
+      type: integer
+      description: |
+        The number of messages sent in private 1:1 or group chats.
+    - name: team_chat_messages.count
+      type: integer
+      description: |
+        The number of messages sent in Teams channels.
+    - name: report
+      type: group
+      fields:
+        - name: period.day
+          unit: d
+          type: integer
+          description: |
+            The duration (e.g., 7 days) over which the report data is aggregated.
+        - name: refresh_date
+          type: date
+          description: |
+            The date when the report data was last updated.
+        - name: date
+          type: date
+          description: |
+            The specific date for which the report data applies.

--- a/packages/o365_metrics/data_stream/teams_user_activity/manifest.yml
+++ b/packages/o365_metrics/data_stream/teams_user_activity/manifest.yml
@@ -1,0 +1,48 @@
+title: Microsoft Office 365 Teams User Activity metrics
+type: metrics
+streams:
+  - input: cel
+    title: Office 365 Teams User Activity metrics.
+    enabled: true
+    description: Collect Office 365 Teams User Activity metrics.
+    template_path: cel.yml.hbs
+    vars:
+      - name: interval
+        type: text
+        title: Interval
+        description: The interval at which the API is polled, supported in seconds, minutes, and hours.
+        show_user: true
+        required: true
+        default: 3m
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
+      - name: period
+        type: text
+        title: Period
+        description: >
+          Specifies the length of time over which the report is aggregated. The supported values are: D7, D30, D90, and D180.
+        show_user: true
+        required: true
+        default: D7
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        required: false
+        show_user: false
+        default:
+          - o365.metrics.outlook.activity
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          The request tracer logs HTTP requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_filename) for details.

--- a/packages/o365_metrics/data_stream/teams_user_activity/sample_event.json
+++ b/packages/o365_metrics/data_stream/teams_user_activity/sample_event.json
@@ -1,0 +1,83 @@
+{
+    "o365": {
+      "metrics": {
+        "teams": {
+          "user": {
+            "activity": {
+              "other_actions": {
+                "count": "0"
+              },
+              "calls": {
+                "count": "0"
+              },
+              "private_chat_messages": {
+                "count": "0"
+              },
+              "report": {
+                "date": "2024-12-25",
+                "period": {
+                  "day": "7"
+                },
+                "refresh_date": "2024-12-31"
+              },
+              "meetings": {
+                "count": "0"
+              },
+              "team_chat_messages": {
+                "count": "0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "agent": {
+      "name": "docker-fleet-agent",
+      "id": "912ee420-1a2f-468d-bd26-72e08cfa9db6",
+      "ephemeral_id": "47368821-c491-41df-bcdc-81be28c08ee3",
+      "type": "filebeat",
+      "version": "8.16.0"
+    },
+    "@timestamp": "2025-01-02T08:13:16.780Z",
+    "ecs": {
+      "version": "8.16.0"
+    },
+    "data_stream": {
+      "namespace": "default",
+      "type": "metrics",
+      "dataset": "o365_metrics.teams_user_activity"
+    },
+    "elastic_agent": {
+      "id": "912ee420-1a2f-468d-bd26-72e08cfa9db6",
+      "version": "8.16.0",
+      "snapshot": false
+    },
+    "host": {
+      "hostname": "docker-fleet-agent",
+      "os": {
+        "kernel": "5.10.104-linuxkit",
+        "name": "Wolfi",
+        "type": "linux",
+        "family": "",
+        "version": "20230201",
+        "platform": "wolfi"
+      },
+      "containerized": false,
+      "ip": [
+        "192.168.176.7"
+      ],
+      "name": "docker-fleet-agent",
+      "mac": [
+        "02-42-C0-A8-B0-07"
+      ],
+      "architecture": "aarch64"
+    },
+    "event": {
+      "agent_id_status": "verified",
+      "ingested": "2025-01-02T08:13:17Z",
+      "dataset": "o365_metrics.teams_user_activity"
+    },
+    "tags": [
+      "o365.metrics.outlook.activity"
+    ]
+}

--- a/packages/o365_metrics/docs/README.md
+++ b/packages/o365_metrics/docs/README.md
@@ -661,3 +661,119 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | o365.metrics.active.users.teams.inactive.count | Number of Teams inactive users. | integer |
 | o365.metrics.active.users.yammer.active.count | Number of Yammer active users. | integer |
 | o365.metrics.active.users.yammer.inactive.count | Number of Yammer inactive users. | integer |
+
+
+### Teams User Activity
+
+An example event for `teams_user_activity` looks as following:
+
+```json
+{
+    "o365": {
+        "metrics": {
+            "teams": {
+                "user": {
+                    "activity": {
+                        "other_actions": {
+                            "count": "0"
+                        },
+                        "calls": {
+                            "count": "0"
+                        },
+                        "private_chat_messages": {
+                            "count": "0"
+                        },
+                        "report": {
+                            "date": "2024-12-25",
+                            "period": {
+                                "day": "7"
+                            },
+                            "refresh_date": "2024-12-31"
+                        },
+                        "meetings": {
+                            "count": "0"
+                        },
+                        "team_chat_messages": {
+                            "count": "0"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "agent": {
+        "name": "docker-fleet-agent",
+        "id": "912ee420-1a2f-468d-bd26-72e08cfa9db6",
+        "ephemeral_id": "47368821-c491-41df-bcdc-81be28c08ee3",
+        "type": "filebeat",
+        "version": "8.16.0"
+    },
+    "@timestamp": "2025-01-02T08:13:16.780Z",
+    "ecs": {
+        "version": "8.16.0"
+    },
+    "data_stream": {
+        "namespace": "default",
+        "type": "metrics",
+        "dataset": "o365_metrics.teams_user_activity"
+    },
+    "elastic_agent": {
+        "id": "912ee420-1a2f-468d-bd26-72e08cfa9db6",
+        "version": "8.16.0",
+        "snapshot": false
+    },
+    "host": {
+        "hostname": "docker-fleet-agent",
+        "os": {
+            "kernel": "5.10.104-linuxkit",
+            "name": "Wolfi",
+            "type": "linux",
+            "family": "",
+            "version": "20230201",
+            "platform": "wolfi"
+        },
+        "containerized": false,
+        "ip": [
+            "192.168.176.7"
+        ],
+        "name": "docker-fleet-agent",
+        "mac": [
+            "02-42-C0-A8-B0-07"
+        ],
+        "architecture": "aarch64"
+    },
+    "event": {
+        "agent_id_status": "verified",
+        "ingested": "2025-01-02T08:13:17Z",
+        "dataset": "o365_metrics.teams_user_activity"
+    },
+    "tags": [
+        "o365.metrics.outlook.activity"
+    ]
+}
+```
+
+**ECS Field Reference**
+
+Please refer to the following [document](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) for detailed information on ECS fields.
+
+**Exported fields**
+
+| Field | Description | Type | Unit |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| host.containerized | If the host is a container. | boolean |  |
+| host.os.build | OS build information. | keyword |  |
+| host.os.codename | OS codename, if any. | keyword |  |
+| o365.metrics.teams.user.activity.calls.count | The number of calls made by Teams users. | integer |  |
+| o365.metrics.teams.user.activity.meetings.count | The number of meetings attended or organized by Teams users. | integer |  |
+| o365.metrics.teams.user.activity.other_actions.count | The count of other user actions within Teams. | integer |  |
+| o365.metrics.teams.user.activity.private_chat_messages.count | The number of messages sent in private 1:1 or group chats. | integer |  |
+| o365.metrics.teams.user.activity.report.date | The specific date for which the report data applies. | date |  |
+| o365.metrics.teams.user.activity.report.period.day | The duration (e.g., 7 days) over which the report data is aggregated. | integer | d |
+| o365.metrics.teams.user.activity.report.refresh_date | The date when the report data was last updated. | date |  |
+| o365.metrics.teams.user.activity.team_chat_messages.count | The number of messages sent in Teams channels. | integer |  |


### PR DESCRIPTION
- Enhancement


## Proposed commit message

Add teams_user_activity datastream to O365_metrics package.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## How to test this PR locally


## Related issues


## Screenshots
