### PR TITLE
Kubernetes Audit log update - added datatype for annotations.pod-security_kubernetes_io/audit-violation

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.68.2
+  changes:
+    - description: Added datatype for audit log field annotations.pod-security_kubernetes_io/audit-violation
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12227
 - version: 1.68.1
   changes:
     - description: Fix Overview dashboard Kibana id

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: 1.68.2
+- version: 1.69.0
   changes:
     - description: Added datatype for audit log field annotations.pod-security_kubernetes_io/audit-violation
       type: enhancement

--- a/packages/kubernetes/data_stream/audit_logs/fields/fields.yml
+++ b/packages/kubernetes/data_stream/audit_logs/fields/fields.yml
@@ -229,3 +229,5 @@
           type: keyword
         - name: authorization_k8s_io/reason
           type: text
+        - name: pod-security_kubernetes_io/audit-violations
+          type: text

--- a/packages/kubernetes/docs/audit-logs.md
+++ b/packages/kubernetes/docs/audit-logs.md
@@ -128,6 +128,7 @@ An example event for `audit` looks as following:
 | input.type | Type of input. | keyword |
 | kubernetes.audit.annotations.authorization_k8s_io/decision |  | keyword |
 | kubernetes.audit.annotations.authorization_k8s_io/reason |  | text |
+| kubernetes.audit.annotations.pod-security_kubernetes_io/audit-violations |  | text |
 | kubernetes.audit.apiVersion | Audit event api version | keyword |
 | kubernetes.audit.auditID | Unique audit ID, generated for each request | keyword |
 | kubernetes.audit.impersonatedUser.extra.\* | Any additional information provided by the authenticator | object |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: kubernetes
 title: Kubernetes
-version: 1.68.2
+version: 1.69.0
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: kubernetes
 title: Kubernetes
-version: 1.68.1
+version: 1.68.2
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Enhancement

## Proposed commit message
Added the data type for the 'audit-violation' field as type TEXT in the Kubernetes Audit logs ingest mapping. This will allow users  to search for and do alerts on this field. In Kubernetes, this field is generated in the audit logs when a user tries to deploy a deployment/pod into a namespace that has security restrictions applied to it. Alerts for this sort of violation are important.

Kubernetes documentation regarding the audit logs annotation `pod-security.kubernetes.io/audit-violations`: https://kubernetes.io/docs/reference/labels-annotations-taints/audit-annotations/#pod-security-kubernetes-io-audit-violations

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [] I have added an entry to my package's `changelog.yml` file.
- [>=8.16.0 ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [n/a ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

- [ ] 

## How to test this PR locally
Add a Kubernetes Pod Security standard of type audit=restricted to the namespace. Try to deploy a pod or deployment and a new field will be generated in the Kubernetes Audit log file which will be picked up by elastic and ingested with the correct datatype.

## Related issues


## Screenshots


