### PR TITLE
[jamf_pro] Inventory pagination fix

### DIFF
--- a/packages/jamf_pro/changelog.yml
+++ b/packages/jamf_pro/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.1"
+  changes:
+    - description: Inventory pagination fix.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12231
 - version: "0.2.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` set to "pipeline_error".

--- a/packages/jamf_pro/data_stream/inventory/agent/stream/cel.yml.hbs
+++ b/packages/jamf_pro/data_stream/inventory/agent/stream/cel.yml.hbs
@@ -37,10 +37,7 @@ program: |-
   		"section": state.sections,
   		"page-size": [string(state.page_size)],
   		"sort": ["general.reportDate:asc"],
-  		?"filter": (has(state.?cursor.last_report_date) && state.?cursor.last_report_date.orValue("") != "") ?
-  			optional.of(["general.reportDate>=\"" + state.cursor.last_report_date + "\""])
-  		:
-  			optional.none(),
+  		?"filter": state.?cursor.last_report_date.optMap(d, ["general.reportDate>=\"" + d + "\""]),
   	}.format_query()
   ).with(
   	{

--- a/packages/jamf_pro/data_stream/inventory/agent/stream/cel.yml.hbs
+++ b/packages/jamf_pro/data_stream/inventory/agent/stream/cel.yml.hbs
@@ -64,13 +64,15 @@ program: |-
   						?"event.original": state.?preserve_original_event.orValue(false) ? optional.of(e.encode_json()) : optional.none(),
   					}
   				),
-  				"want_more": body.totalCount > size(body.results),
-  				"cursor": {
-  					"last_report_date": (size(body.results) == 0 || size(body.results) == body.totalCount) ?
-  						state.?cursor.last_report_date.orValue("")
-  					:
-  						string(body.results[size(body.results) - 1].general.reportDate),
-  				},
+  				"want_more": size(body.results) >= state.page_size,
+  				"cursor": state.?cursor.orValue({}).with(
+  					{
+  						?"last_report_date": (size(body.results) > 0) ?
+  							optional.of(body.results[size(body.results) - 1].general.reportDate)
+  						:
+  							optional.none(),
+  					}
+  				),
   			}
   		)
   	)

--- a/packages/jamf_pro/data_stream/inventory/agent/stream/cel.yml.hbs
+++ b/packages/jamf_pro/data_stream/inventory/agent/stream/cel.yml.hbs
@@ -82,9 +82,7 @@ state:
   preserve_original_event: {{preserve_original_event}}
   page_size: {{page_size}}
   sections:
-  {{#if enable_section_general }}
     - GENERAL
-  {{/if}}
   {{#if enable_section_hardware }}
     - HARDWARE
   {{/if}}

--- a/packages/jamf_pro/data_stream/inventory/manifest.yml
+++ b/packages/jamf_pro/data_stream/inventory/manifest.yml
@@ -1,12 +1,14 @@
-title: "Inventory data"
+title: Inventory data
 type: logs
 streams:
   - input: cel
     template_path: cel.yml.hbs
-    title: inventory_data
+    title: Inventory data
     description: |
-      Inventory requests settings
-      "*NOTE* Many sections enabled may impact the query processing. It is not recommended to enable setions not required"
+      Settings for inventory requests.  
+      *NOTE* Enabling many sections may impact query processing.
+      It is recommended to only enable sections of interest.
+      The General section is always included.
     vars:
       - name: interval
         type: text
@@ -46,12 +48,6 @@ streams:
         show_user: false
         default:
           - forwarded
-      - name: enable_section_general
-        type: bool
-        show_user: false
-        default: true
-        title: "General"
-        description: "Enable General Settings for the API responce"
       - name: enable_section_hardware
         type: bool
         show_user: false

--- a/packages/jamf_pro/data_stream/inventory/manifest.yml
+++ b/packages/jamf_pro/data_stream/inventory/manifest.yml
@@ -178,7 +178,7 @@ streams:
         default: false
         title: "Extension Attributes"
         description: "Enable block with Extension Attributes"
-      - name: CONTENT_CACHING
+      - name: enable_section_content_caching
         type: bool
         show_user: false
         default: false

--- a/packages/jamf_pro/data_stream/inventory/manifest.yml
+++ b/packages/jamf_pro/data_stream/inventory/manifest.yml
@@ -20,7 +20,7 @@ streams:
         required: false
         title: Inventory request page size
         show_user: false
-        description: Set page size for computers-inventory API Call. 100 max, should be adjusted if size of request is growing to reduce parsing time
+        description: Set page size for computers-inventory API Call. Must not exceed 1000.
         default: 100
       - name: preserve_original_event
         type: bool

--- a/packages/jamf_pro/manifest.yml
+++ b/packages/jamf_pro/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.5
 name: jamf_pro
 title: "Jamf Pro"
-version: 0.2.0
+version: 0.2.1
 source:
   license: "Elastic-2.0"
 description: "Collect logs and inventory data from Jamf Pro with Elastic Agent"


### PR DESCRIPTION
## Proposed commit message

```
[jamf_pro] Inventory pagination fix

* Always include the General section of inventory data.
* Update the cursor whenever there is new data.
* Assume there isn't another page if the current page isn't full.
* Correct the name of the `enable_section_content_caching` variable.
* Adjust the `page_size` variable description to correct the maximum.
* Simplify code to set the inventory filter parameter.

This has been manually tested against the live API.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Discussion

I ran this against the live endpoint and checked a couple of pagination sequences. Here's some partial data from the logs (not the full results objects), that shows the cursor updates and sequence continuation/end are done correctly:

<details>
<summary>Expand for the partial request log data</summary>

```json
// first sequence

{
  "@timestamp": "2025-01-06T11:14:20.308Z",
  "url.query": "page-size=4&section=GENERAL&section=HARDWARE&section=OPERATING_SYSTEM&sort=general.reportDate%3Aasc"
}
{
  "http.response.body.content": {
    "totalCount": 8,
    "results": [
      { "reportDate": "2024-06-19T15:54:33.186Z" },
      { "reportDate": "2024-06-19T15:54:34.353Z" },
      { "reportDate": "2024-06-19T15:54:37.692Z" },
      { "reportDate": "2024-06-19T15:54:39.687Z" }
    ]
  }
}
{
  "@timestamp": "2025-01-06T11:14:21.195Z",
  "url.query": "filter=general.reportDate%3E%3D%222024-06-19T15%3A54%3A39.687Z%22&page-size=4&section=GENERAL&section=HARDWARE&section=OPERATING_SYSTEM&sort=general.reportDate%3Aasc"
}
{
  "http.response.body.content": {
    "totalCount": 5,
    "results": [
      { "reportDate": "2024-06-19T15:54:39.687Z" },
      { "reportDate": "2024-06-19T15:54:41.981Z" },
      { "reportDate": "2024-06-19T15:54:43.956Z" },
      { "reportDate": "2024-06-19T15:54:46.34Z" }
    ]
  }
}
{
  "@timestamp": "2025-01-06T11:14:21.939Z",
  "url.query": "filter=general.reportDate%3E%3D%222024-06-19T15%3A54%3A46.34Z%22&page-size=4&section=GENERAL&section=HARDWARE&section=OPERATING_SYSTEM&sort=general.reportDate%3Aasc"
}
{
  "http.response.body.content": {
    "totalCount": 2,
    "results": [
      { "reportDate": "2024-06-19T15:54:46.34Z" },
      { "reportDate": "2024-06-19T15:54:47.471Z" }
    ]
  }
}

// after interval, second sequence

{
  "@timestamp": "2025-01-06T11:16:22.707Z",
  "url.query": "filter=general.reportDate%3E%3D%222024-06-19T15%3A54%3A47.471Z%22&page-size=4&section=GENERAL&section=HARDWARE&section=OPERATING_SYSTEM&sort=general.reportDate%3Aasc"
}
{
  "http.response.body.content": {
    "totalCount": 1,
    "results": [
      { "reportDate": "2024-06-19T15:54:47.471Z" }
    ]
  }
}
```

</details>

API documentation: [`GET /api/v1/computers-inventory`](https://developer.jamf.com/jamf-pro/reference/get_v1-computers-inventory)

## Related issues

- Relates #12021