### PR TITLE
[MySQL] Sanity tests for 9.0.0

### DIFF
--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Upgrade to Kibana `9.0.0`.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1 #FIX ME
+      link: https://github.com/elastic/integrations/pull/12252
 - version: 1.25.2
   changes:
     - description: Fix optional chaining in the replica_status data stream pipeline.

--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.26.0
+  changes:
+    - description: Upgrade to Kibana `9.0.0`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1 #FIX ME
 - version: 1.25.2
   changes:
     - description: Fix optional chaining in the replica_status data stream pipeline.

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: mysql
 title: MySQL
-version: "1.25.2"
+version: "1.26.0"
 description: Collect logs and metrics from MySQL servers with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - observability
 conditions:
   kibana:
-    version: "^8.15.0"
+    version: "^8.15.0 || ^9.0.0"
   elastic:
     subscription: basic
 screenshots:


### PR DESCRIPTION
- Enhancement

# MySQL
- tested for elastic stack and server-less.
- datastreams `error`, `galera_status`, `performance`, `replica_status`, `slowlog`, and `status` are tested as part of the sanity.

## Steps performed for the testing
1. update manifest.yml, package minor version to `1.26.0` and kibana dependency to `^8.15.0 || ^9.0.0`.
2. build package
3. run package tests
4. install integration from kibana
5. check for any issues

  | Metrics | Logs | Dashboards
-- | -- | -- | --
Elastic Stack | Pass | Pass | Pass
Server-less | Pass | Pass | Pass

## Screen Shots
Please find screenshots of the tested data in the zip files attached below.

### Elastic Stack
[MySQL Elastic Stack Screen Shots](https://github.com/user-attachments/files/18314750/mysql.zip)

### Serverless
[MySQL Serverless Screen Shots](https://github.com/user-attachments/files/18314753/mysql.serverless.zip)


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## Related issues
- Relates https://github.com/elastic/obs-integration-team/issues/148

