### PR TITLE
[IIS] Sanity tests for 9.0.0

### DIFF
--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Upgraded to Kibana `9.0.0`.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1 #FIX ME
+      link: https://github.com/elastic/integrations/pull/12253
 - version: "1.20.0"
   changes:
     - description: ECS version updated to 8.11.0. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.21.0"
+  changes:
+    - description: Upgraded to Kibana `9.0.0`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1 #FIX ME
 - version: "1.20.0"
   changes:
     - description: ECS version updated to 8.11.0. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/iis/manifest.yml
+++ b/packages/iis/manifest.yml
@@ -1,6 +1,6 @@
 name: iis
 title: IIS
-version: "1.20.0"
+version: "1.21.0"
 description: Collect logs and metrics from Internet Information Services (IIS) servers with Elastic Agent.
 type: integration
 icons:
@@ -14,7 +14,7 @@ categories:
   - observability
 conditions:
   kibana:
-    version: "^8.13.0"
+    version: "^8.13.0 || ^9.0.0"
   elastic:
     subscription: basic
 screenshots:


### PR DESCRIPTION
- Enhancement

# IIS
- tested for elastic stack and server-less.
- datastreams `access`, `application_pool`, `error`, `webserver`, and `website` are tested as part of the sanity.

## Steps performed for the testing
1. update manifest.yml, package minor version to `1.21.0` and kibana dependency to `^8.13.0 || ^9.0.0`.
2. build package
3. run package tests
4. install integration from kibana
5. check for any issues

  | Metrics | Logs | Dashboards
-- | -- | -- | --
Elastic Stack | Pass | Pass | Pass
Server-less | Pass | Pass | Pass

## Screen Shots
Please find screenshots of the tested data in the zip files attached below.

### Elastic Stack
[IIS Elastic Stack Screen Shots](https://github.com/user-attachments/files/18314868/iis.zip)

### Serverless
[IIS Serverless Screen Shots](https://github.com/user-attachments/files/18314876/iis.serverless.zip)

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## Related issues
- Relates https://github.com/elastic/obs-integration-team/issues/148
