### PR TITLE
[GCP] Sanity tests for 9.0.0

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.41.0"
+  changes:
+    - description: Upgrade to Kibana `9.0.0`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1 #FIX ME
 - version: "2.40.1"
   changes:
     - description: Add missing category.

--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Upgrade to Kibana `9.0.0`.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1 #FIX ME
+      link: https://github.com/elastic/integrations/pull/12254
 - version: "2.40.1"
   changes:
     - description: Add missing category.

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.40.1"
+version: "2.41.0"
 description: Collect logs and metrics from Google Cloud Platform with Elastic Agent.
 type: integration
 icons:
@@ -15,7 +15,7 @@ categories:
   - observability
 conditions:
   kibana:
-    version: "^8.13.0"
+    version: "^8.13.0 || ^9.0.0"
 screenshots:
   - src: /img/filebeat-gcp-audit.png
     title: filebeat gcp audit


### PR DESCRIPTION
- Enhancement

# Google Cloud
- tested for elastic stack.
- datastreams `access`, `error`, and `stubstatus` are tested as part of the sanity.


  | Metrics | Logs | Dashboards | Test Cases
-- | -- | -- | -- | --
Elastic Stack | Pass | Pass | Pass | Fail


## Screen Shots
Please find screenshots of the tested data in the zip files attached below.

### Elastic Stack
[GCP Elastic Stack Screen Shots](https://github.com/user-attachments/files/18315076/gcp.zip)

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## Related issues
- Relates https://github.com/elastic/obs-integration-team/issues/148

