### PR TITLE
#12248-1/2 added two event types (Virtual Switching Extension and Virtual Switching Framework)

### DIFF
--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -1256,50 +1256,56 @@ Note: Descriptions have not been filled out
 | `<vrf>`        | aruba.vrf.id               |
 | `<zone>`       | aruba.tunnel.zone          |
 
-#### [Virtual Switching Extension (VSX) events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VSX.htm)
-| Field                       | Description | Type | Common                       |
-|-----------------------------|-------------|------|------------------------------|
-| aruba.vsx.bank_name         |             |      |                              |
-| aruba.vsx.ifname            |             |      | observer.ingress.interface.name |
-| aruba.vsx.ip_address        |             |      | source.ip                    |
-| aruba.vsx.local_device_type |             |      |                              |
-| aruba.vsx.local_sw_ver      |             |      |                              |
-| aruba.vsx.local_vsx_role    |             |      |                              |
-| aruba.vsx.peer_device_type  |             |      |                              |
-| aruba.vsx.peer_sw_ver       |             |      |                              |
-| aruba.vsx.peer_vsx_role     |             |      |                              |
-| aruba.vsx.port              |             |      | server.port                  |
-| aruba.vsx.prev_state        |             |      |                              |
-| aruba.vsx.primary_version   |             |      |                              |
-| aruba.vsx.reason            |             |      | event.reason                 |
-| aruba.vsx.secondary_version |             |      |                              |
-| aruba.vsx.state             |             |      | service.state                |
-| aruba.vsx.sub_state         |             |      |                              |
-| aruba.vsx.vsx_id            |             |      | aruba.instance.id            |
-| aruba.vsx.vsx_role          |             |      | aruba.role                   |
+#### [Virtual Switching Extension (VSX) events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VSX.htm)
+| Docs Field            | Schema Mapping                       |
+|-----------------------|--------------------------------------|
+| `<bank_name>`         | aruba.vsx.bank_name                  |
+| `<ifname>`            | aruba.interface.name                 |
+| `<local_device_type>` | aruba.vsx.local_device_type          |
+| `<local_sw_ver>`      | aruba.vsx.local_sw_ver               |
+| `<local_vsx_role>`    | aruba.vsx.local_vsx_role             |
+| `<peer_device_type>`  | aruba.vsx.peer_device_type           |
+| `<peer_sw_ver>`       | aruba.vsx.peer_sw_ver                |
+| `<peer_vsx_role>`     | aruba.vsx.peer_vsx_role              |
+| `<port>`              | aruba.port                           |
+| `<prev_state>`        | aruba.vsx.prev_state                 |
+| `<primary_version>`   | aruba.vsx.primary_version            |
+| `<reason>`            | event.reason                         |
+| `<secondary_version>` | aruba.vsx.secondary_version          |
+| `<state>`             | aruba.state                          |
+| `<sub_state>`         | aruba.vsx.sub_state                  |
+| `<value>`             | server.ip                            |
+| `<vsx_id>`            | aruba.instance.id                    |
+| `<vsx_role>`          | aruba.role                           |
 
-#### [Virtual Switching Framework (VSF) events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VSF.htm)
-| Field                       | Description | Type | Common                          |
-|-----------------------------|-------------|------|---------------------------------|
-| aruba.vsf.link              |             |      | observer.ingress.interface.name |
-| aruba.vsf.link_id           |             |      | observer.ingress.interface.id   |
-| aruba.vsf.mac_add           |             |      | client.mac                      |
-| aruba.vsf.mac_addr1         |             |      |                                 |
-| aruba.vsf.mac_addr2         |             |      |                                 |
-| aruba.vsf.mac_address       |             |      | client.mac                      |
-| aruba.vsf.mbr_id            |             |      | aruba.instance.id               |
-| aruba.vsf.member_id         |             |      | aruba.instance.id               |
-| aruba.vsf.new_standby_id    |             |      |                                 |
-| aruba.vsf.old_standby_id    |             |      |                                 |
-| aruba.vsf.port              |             |      | server.port                     |
-| aruba.vsf.port_id           |             |      | server.port                     |
-| aruba.vsf.product_id        |             |      |                                 |
-| aruba.vsf.product_type      |             |      |                                 |
-| aruba.vsf.reason            |             |      | event.reason                    |
-| aruba.vsf.status            |             |      | aruba.status                    |
-| aruba.vsf.topo_type         |             |      |                                 |
-| aruba.vsf.new_standby_id    |             |      |                                 |
-| aruba.vsf.old_standby_id    |             |      |                                 |
+#### [Virtual Switching Framework (VSF) events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VSF.htm)
+| Docs Field           | Schema Mapping                            |
+|----------------------|-------------------------------------------|
+| `<id>`               | aruba.instance.id                         |
+| `<if_name>`          | aruba.interface.name                      |
+| `<link>`             | aruba.vsf.link                            |
+| `<link_id>`          | aruba.vsf.link                            |
+| `<lowest_speed>`     | aruba.vsf.lowest_speed                    |
+| `<mac_add>`          | aruba.vsf.mac_addr1 / aruba.vsf.mac_addr2 |
+| `<mac_addr>`         | aruba.vsf.mac_addr1 / aruba.vsf.mac_addr2 |
+| `<mac_addr1>`        | aruba.vsf.mac_addr1                       |
+| `<mac_addr2>`        | aruba.vsf.mac_addr2                       |
+| `<mac_address>`      | aruba.vsf.mac_addr1 / aruba.vsf.mac_addr2 |
+| `<mbr_id>`           | aruba.vsf.mbr_id                          |
+| `<member_id>`        | aruba.vsf.member_id                       |
+| `<new_standby_id>`   | aruba.vsf.new_standby_id                  |
+| `<old_standby_id>`   | aruba.vsf.old_standby_id                  |
+| `<operation>`        | aruba.vsf.operation                       |
+| `<port>`             | aruba.port                                |
+| `<port_id>`          | aruba.port                                |
+| `<port_id>`          | aruba.vsf.port2                           |
+| `<product_id>`       | aruba.vsf.product_id                      |
+| `<prod_type>`        | aruba.vsf.product_type                    |
+| `<product_type>`     | aruba.vsf.product_type                    |
+| `<reason>`           | event.reason                              |
+| `<status>`           | aruba.status                              |
+| `<topo_type>`        | aruba.vsf.topo_type                       |
+| `<type>`             | aruba.vsf.product_type                    |
 
 #### [VLAN events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VLAN.htm)
 | Field                | Description | Type | Common                       |

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
@@ -6179,6 +6179,9 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "instance": {
+                    "id": "50"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -6213,6 +6216,9 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "50"
                 },
                 "sequence": "1/1"
             },
@@ -6249,6 +6255,9 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
+                "interface": {
+                    "name": "12a345678901234"
+                },
                 "sequence": "1/1"
             },
             "ecs": {
@@ -6270,6 +6279,9 @@
                 }
             },
             "message": "Netdev 12a345678901234 configured with ipv4 address 127.0.0.1",
+            "server": {
+                "ip": "127.0.0.1"
+            },
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
@@ -668,6 +668,45 @@
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|6804|LOG_ERR|AMM|-|Error while copying configs. Error: error_message
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|6805|LOG_INFO|AMM|-|Information while copying configs. Info: info_message
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-nae[1234]: Event|6901|LOG_INFO|NAEAGENT|-|An action has been triggered by the NAE agent nae_agent_1
+2024-06-18T12:45:38.182641-05:00 8360-Primaire vsx[1234]: Event|7001|LOG_INFO|VSX|-|VSX ISL port 1/1 is down
+2024-06-18T12:46:38.182641-05:00 8360-Primaire vsx[1234]: Event|7002|LOG_INFO|VSX|-|VSX ISL port 1/1 is up
+2024-06-18T12:47:38.182641-05:00 8360-Primaire vsx[1234]: Event|7003|LOG_INFO|VSX|-|VSX ISL port 1/1 is In-Sync with the peer.
+2024-06-18T12:48:38.182641-05:00 8360-Primaire vsx[1234]: Event|7004|LOG_ERR|VSX|-|VSX ISL port 1/1 is Out-Of-Sync with the peer: link_failure
+2024-06-18T12:49:38.182641-05:00 8360-Primaire vsx[1234]: Event|7005|LOG_WARN|VSX|-|VSX Keepalive failed
+2024-06-18T12:50:38.182641-05:00 8360-Primaire vsx[1234]: Event|7006|LOG_INFO|VSX|-|VSX Keepalive succeeded
+2024-06-18T12:51:38.182641-05:00 8360-Primaire vsx[1234]: Event|7007|LOG_INFO|VSX|-|VSX role is primary
+2024-06-18T12:52:38.182641-05:00 8360-Primaire vsx[1234]: Event|7008|LOG_INFO|VSX|-|VSX role is secondary
+2024-06-18T12:53:38.182641-05:00 8360-Primaire vsx[1234]: Event|7009|LOG_INFO|VSX|-|VSX Software version mismatch: peer version 10.01, local version 10.02
+2024-06-18T12:54:38.182641-05:00 8360-Primaire vsx[1234]: Event|7010|LOG_INFO|VSX|-|VSX Device mismatch: peer device 8360, local device 8320
+2024-06-18T12:55:38.182641-05:00 8360-Primaire vsx[1234]: Event|7011|LOG_INFO|VSX|-|VSX 1 state local up, remote down
+2024-06-18T12:56:38.182641-05:00 8360-Primaire vsx[1234]: Event|7012|LOG_INFO|VSX|-|VSX 1 state local down, remote up
+2024-06-18T12:57:38.182641-05:00 8360-Primaire vsx[1234]: Event|7013|LOG_INFO|VSX|-|VSX 1 state local up, remote up
+2024-06-18T12:58:38.182641-05:00 8360-Primaire vsx[1234]: Event|7014|LOG_INFO|VSX|-|VSX 1 state local down, remote down
+2024-06-18T12:59:38.182641-05:00 8360-Primaire vsx[1234]: Event|7015|LOG_INFO|VSX|-|VSX ISL sliding window parameters are reset.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire vsx[1234]: Event|7016|LOG_INFO|VSX|-|VSX own ISL hello packet received, ignoring the packet.
+2024-06-18T12:46:38.182641-05:00 8360-Primaire vsx[1234]: Event|7017|LOG_INFO|VSX|-|Rebooting the VSX primary device with newly updated bank1 image.
+2024-06-18T12:47:38.182641-05:00 8360-Primaire vsx[1234]: Event|7018|LOG_INFO|VSX|-|VSX primary ISL version 1.0 dose not match with VSX secondary ISL version 2.0. Performing a non-hitless image update.
+2024-06-18T12:47:38.182641-05:00 8360-Primaire vsx[1234]: Event|7018|LOG_INFO|VSX|-|VSX primary ISL version 1.0 does not match with VSX secondary ISL version 2.0. Performing a non-hitless image update.
+2024-06-18T12:48:38.182641-05:00 8360-Primaire vsx[1234]: Event|7019|LOG_ERR|VSX|-|VSX primary image update failed due to timeout.
+2024-06-18T12:49:38.182641-05:00 8360-Primaire vsx[1234]: Event|7020|LOG_INFO|VSX|-|ISL out-of-sync and keepalive is in established
+2024-06-18T12:50:38.182641-05:00 8360-Primaire vsx[1234]: Event|7021|LOG_INFO|VSX|-|ISL out-of-sync and keepalive also failed
+2024-06-18T12:51:38.182641-05:00 8360-Primaire vsx[1234]: Event|7022|LOG_INFO|VSX|-|Linkup delay timer started
+2024-06-18T12:52:38.182641-05:00 8360-Primaire vsx[1234]: Event|7023|LOG_INFO|VSX|-|Linkup delay timer expired
+2024-06-18T12:53:38.182641-05:00 8360-Primaire vsx[1234]: Event|7024|LOG_INFO|VSX|-|VSX primary state changed from INIT to ACTIVE.
+2024-06-18T12:54:38.182641-05:00 8360-Primaire vsx[1234]: Event|7025|LOG_INFO|VSX|-|Bailout timer started
+2024-06-18T12:55:38.182641-05:00 8360-Primaire vsx[1234]: Event|7026|LOG_INFO|VSX|-|Bailout timer expired
+2024-06-18T12:56:38.182641-05:00 8360-Primaire vsx[1234]: Event|7027|LOG_INFO|VSX|-|Bailout timer stopped
+2024-06-18T12:57:38.182641-05:00 8360-Primaire vsx[1234]: Event|7028|LOG_INFO|VSX|-|Linkup-delay timer stopped
+2024-06-18T12:45:38.182641-05:00 8360-Primaire vsx[1234]: Event|7029|LOG_ERR|VSX|-|VSX device roles are inconsistent: local VSX device role primary, peer VSX device role secondary
+2024-06-18T12:46:38.182641-05:00 8360-Primaire vsx[1234]: Event|7029|LOG_INFO|VSX|-|VSX primary state changed to active-updating.
+2024-06-18T12:47:38.182641-05:00 8360-Primaire vsx[1234]: Event|7030|LOG_INFO|VSX|-|VSX Keepalive is configured without creating VRF
+2024-06-18T12:48:38.182641-05:00 8360-Primaire vsx[1234]: Event|7031|LOG_INFO|VSX|-|VSX Keepalive is configured without configuring IP address
+2024-06-18T12:49:38.182641-05:00 8360-Primaire vsx[1234]: Event|7032|LOG_ERR|VSX|-|Active-gateway is enabled on port1. Cannot program Active-forwarding
+2024-06-18T12:50:38.182641-05:00 8360-Primaire vsx[1234]: Event|7033|LOG_ERR|VSX|-|Active-forwarding is enabled on port1. Cannot program Active-gateway
+2024-06-18T12:51:38.182641-05:00 8360-Primaire vsx[1234]: Event|7034|LOG_INFO|VSX|-|Netdev eth0 configured with ipv4 address 192.168.1.1
+2024-06-18T12:52:38.182641-05:00 8360-Primaire vsx[1234]: Event|7035|LOG_INFO|VSX|-|Netdev eth0 configured with ipv6 address FE80::C000:1DFF:FEE0:C01/64
+2024-06-18T12:53:38.182641-05:00 8360-Primaire vsx[1234]: Event|7036|LOG_INFO|VSX|-|VSX primary state changed to active-updating.
+2024-06-18T12:54:38.182641-05:00 8360-Primaire vsx[1234]: Event|7037|LOG_INFO|VSX|-|VSX secondary has better MCLAG state compared to VSX primary. MCLAGs and SVIs are brought down on VSX primary.
 2024-06-18T12:45:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7101|LOG_INFO|SNMP|-|Snmp agent is up and running in namespace default
 2024-06-18T12:46:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7102|LOG_INFO|SNMP|-|Snmp sub agent is up and running in namespace default
 2024-06-18T12:47:38.182641-05:00 8360-Primaire snmpd[1234]: Event|7103|LOG_INFO|SNMP|-|Snmp agent is disabled for namespace default
@@ -954,6 +993,65 @@
 2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|9805|LOG_INFO|IP|-|IPV4_SOURCE_LOCKDOWN is disabled on interface eth0
 2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|9806|LOG_INFO|IP|-|IPV6_SOURCE_LOCKDOWN is enabled on interface eth1
 2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|9807|LOG_INFO|IP|-|IPV6_SOURCE_LOCKDOWN is disabled on interface eth1
+2024-06-18T12:45:38.182641-05:00 8360-Primaire vsf[1234]: Event|9901|LOG_INFO|VSF|-|Member 1 boot complete
+2024-06-18T12:46:38.182641-05:00 8360-Primaire vsf[1234]: Event|9902|LOG_INFO|VSF|-|Standby 2 boot complete
+2024-06-18T12:47:38.182641-05:00 8360-Primaire vsf[1234]: Event|9903|LOG_INFO|VSF|-|Conductor 3 boot complete
+2024-06-18T12:48:38.182641-05:00 8360-Primaire vsf[1234]: Event|9905|LOG_INFO|VSF|-|Resetting member 4
+2024-06-18T12:49:38.182641-05:00 8360-Primaire vsf[1234]: Event|9906|LOG_WARN|VSF|-|Member 5 conflict detected on link 1/1/1
+2024-06-18T12:50:38.182641-05:00 8360-Primaire vsf[1234]: Event|9907|LOG_WARN|VSF|-|Incompatible version detected
+2024-06-18T12:51:38.182641-05:00 8360-Primaire vsf[1234]: Event|9908|LOG_INFO|VSF|-|Topology is ring
+2024-06-18T12:52:38.182641-05:00 8360-Primaire vsf[1234]: Event|9910|LOG_INFO|VSF|-|Member 6 removed
+2024-06-18T12:53:38.182641-05:00 8360-Primaire vsf[1234]: Event|9911|LOG_WARN|VSF|-|Maximum number of switches in the stack has reached. Cannot add MAC 00:11:22:33:44:55 product type 8360
+2024-06-18T12:54:38.182641-05:00 8360-Primaire vsf[1234]: Event|9912|LOG_INFO|VSF|-|Stack state is no-split with conductor id 7
+2024-06-18T12:54:38.182641-05:00 8360-Primaire vsf[1234]: Event|9912|LOG_INFO|VSF|-|Throttled 100 Messages
+2024-06-18T12:55:38.182641-05:00 8360-Primaire vsf[1234]: Event|9913|LOG_WARN|VSF|-|Lost member 8 with timeout
+2024-06-18T12:56:38.182641-05:00 8360-Primaire vsf[1234]: Event|9914|LOG_INFO|VSF|-|Reboot of MAC 00:11:22:33:44:56 status-success
+2024-06-18T12:57:38.182641-05:00 8360-Primaire vsf[1234]: Event|9915|LOG_INFO|VSF|-|Member 9 elected as conductor reason-vote
+2024-06-18T12:45:38.182641-05:00 8360-Primaire vsf[1234]: Event|9916|LOG_INFO|VSF|-|Member 1 elected as standby reason-vote
+2024-06-18T12:46:38.182641-05:00 8360-Primaire vsf[1234]: Event|9917|LOG_WARN|VSF|-|Switch with MAC 00:11:22:33:44:55 cannot join stack due to incorrect product id 8360
+2024-06-18T12:47:38.182641-05:00 8360-Primaire vsf[1234]: Event|9919|LOG_WARN|VSF|-|Found Unsupported switch with MAC 00:11:22:33:44:56 and Product type 8320, connected to switch with MAC 00:11:22:33:44:57 on stack port 1/1/1
+2024-06-18T12:48:38.182641-05:00 8360-Primaire vsf[1234]: Event|9920|LOG_WARN|VSF|-|Heart beat lost for member 2
+2024-06-18T12:49:38.182641-05:00 8360-Primaire vsf[1234]: Event|9921|LOG_WARN|VSF|-|OS version mismatch detected for member 3
+2024-06-18T12:50:38.182641-05:00 8360-Primaire vsf[1234]: Event|9922|LOG_WARN|VSF|-|Attempt to connect member 4 from a different stack
+2024-06-18T12:51:38.182641-05:00 8360-Primaire vsf[1234]: Event|9923|LOG_INFO|VSF|-|VSF link 1/1/1 is up
+2024-06-18T12:52:38.182641-05:00 8360-Primaire vsf[1234]: Event|9924|LOG_INFO|VSF|-|VSF link 1/1/1 is down
+2024-06-18T12:53:38.182641-05:00 8360-Primaire vsf[1234]: Event|9925|LOG_WARN|VSF|-|Invalid MAC 00:11:22:33:44:58 detected on link 1/1/1 with peer MAC 00:11:22:33:44:59
+2024-06-18T12:54:38.182641-05:00 8360-Primaire vsf[1234]: Event|9926|LOG_WARN|VSF|-|2 member loop detected on ring topology
+2024-06-18T12:55:38.182641-05:00 8360-Primaire vsf[1234]: Event|9927|LOG_INFO|VSF|-|Fragment with conductor 5 is Active
+2024-06-18T12:55:38.182641-05:00 8360-Primaire vsf[1234]: Event|9927|LOG_INFO|VSF|-|Throttled 100 Messages
+2024-06-18T12:56:38.182641-05:00 8360-Primaire vsf[1234]: Event|9928|LOG_INFO|VSF|-|Fragment with conductor 6 is Inactive
+2024-06-18T12:57:38.182641-05:00 8360-Primaire vsf[1234]: Event|9929|LOG_INFO|VSF|-|Active fragment detection timeout
+2024-06-18T12:45:38.182641-05:00 8360-Primaire vsf[1234]: Event|9930|LOG_INFO|VSF|-|Member 1 is configured as Secondary
+2024-06-18T12:46:38.182641-05:00 8360-Primaire vsf[1234]: Event|9931|LOG_INFO|VSF|-|Secondary configuration removed
+2024-06-18T12:47:38.182641-05:00 8360-Primaire vsf[1234]: Event|9932|LOG_INFO|VSF|-|Attempt to connect a member with MAC 00:11:22:33:44:55 and product type 8360 having different airflows
+2024-06-18T12:48:38.182641-05:00 8360-Primaire vsf[1234]: Event|9933|LOG_WARN|VSF|-|Peer timeout on interface 1/1/1
+2024-06-18T12:49:38.182641-05:00 8360-Primaire vsf[1234]: Event|9934|LOG_WARN|VSF|-|Loop detected on interface 1/1/1
+2024-06-18T12:50:38.182641-05:00 8360-Primaire vsf[1234]: Event|9935|LOG_WARN|VSF|-|Interface 1/1/1 detected a peer with a different VSF handshake version
+2024-06-18T12:51:38.182641-05:00 8360-Primaire vsf[1234]: Event|9936|LOG_INFO|VSF|-|Interface 1/1/1 added to VSF link 1
+2024-06-18T12:52:38.182641-05:00 8360-Primaire vsf[1234]: Event|9937|LOG_INFO|VSF|-|Interface 1/1/1 removed from VSF link 1
+2024-06-18T12:53:38.182641-05:00 8360-Primaire vsf[1234]: Event|9938|LOG_WARN|VSF|-|Switch with MAC 00:11:22:33:44:55 not able to autojoin as it is connected on interface 1/1/1 which is a non default autojoin VSF interface
+2024-06-18T12:54:38.182641-05:00 8360-Primaire vsf[1234]: Event|9939|LOG_WARN|VSF|-|Switch with MAC 00:11:22:33:44:55 not able to autojoin as it is connected to interface 1/1/1 which is not provisioned on the conductor for member 1
+2024-06-18T12:55:38.182641-05:00 8360-Primaire vsf[1234]: Event|9940|LOG_WARN|VSF|-|Switch with MAC 00:11:22:33:44:55 is not autojoin eligible
+2024-06-18T12:56:38.182641-05:00 8360-Primaire vsf[1234]: Event|9941|LOG_WARN|VSF|-|Switch with MAC 00:11:22:33:44:55 attempting to autojoin via multiple interfaces
+2024-06-18T12:45:38.182641-05:00 8360-Primaire vsf[1234]: Event|9942|LOG_WARN|VSF|-|Switch with MAC 00:11:22:33:44:55 failed to autojoin as there is no free member number available
+2024-06-18T12:46:38.182641-05:00 8360-Primaire vsf[1234]: Event|9943|LOG_WARN|VSF|-|Switch with MAC 00:11:22:33:44:55 failed to autojoin on link 1, port 2
+2024-06-18T12:47:38.182641-05:00 8360-Primaire vsf[1234]: Event|9944|LOG_WARN|VSF|-|Switch has VSF configurations present. Force autojoin will not take into effect. Remove all VSF configurations followed by unconfiguring and reconfiguring force autojoin for it to take into effect
+2024-06-18T12:48:38.182641-05:00 8360-Primaire vsf[1234]: Event|9945|LOG_INFO|VSF|-|VSF force autojoin enabled
+2024-06-18T12:49:38.182641-05:00 8360-Primaire vsf[1234]: Event|9946|LOG_INFO|VSF|-|VSF force autojoin disabled
+2024-06-18T12:50:38.182641-05:00 8360-Primaire vsf[1234]: Event|9947|LOG_WARN|VSF|-|Switch with MAC 00:11:22:33:44:55 failed to autojoin. Connect the device 00:11:22:33:44:56 to member 1 link 2 to proceed
+2024-06-18T12:51:38.182641-05:00 8360-Primaire vsf[1234]: Event|9948|LOG_WARN|VSF|-|Interface 1/1/1 in VSF link 1 detected a peer with inconsistent VSF link configuration
+2024-06-18T12:52:38.182641-05:00 8360-Primaire vsf[1234]: Event|9949|LOG_INFO|VSF|-|Secondary member changed from 1 to 2
+2024-06-18T12:53:38.182641-05:00 8360-Primaire vsf[1234]: Event|9950|LOG_WARN|VSF|-|Switch with MAC 00:11:22:33:44:55 failed to autojoin as it is connected on interface 1/1/1 which has MACsec configuration
+2024-06-18T12:54:38.182641-05:00 8360-Primaire vsf[1234]: Event|9951|LOG_WARN|VSF|-|Bringing down MACsec configured interface 1/1/1 as it is added to a VSF link. VSF link and MACsec configurations needs to be removed from the interface 1/1/1 and VSF link needs to be reconfigured for it to take into effect
+2024-06-18T12:55:38.182641-05:00 8360-Primaire vsf[1234]: Event|9952|LOG_WARN|VSF|-|Switchover detected during ISSU operation: "upgrade"
+2024-06-18T12:56:38.182641-05:00 8360-Primaire vsf[1234]: Event|9953|LOG_WARN|VSF|-|ISSU state failed for member 1 during ISSU operation: "upgrade"
+2024-06-18T12:57:38.182641-05:00 8360-Primaire vsf[1234]: Event|9954|LOG_WARN|VSF|-|VSF member 1 going out of stack during ISSU operation: "upgrade", rebooting the stack
+2024-06-18T12:58:38.182641-05:00 8360-Primaire vsf[1234]: Event|9955|LOG_WARN|VSF|-|Unintentional failover detected during ISSU operation: "upgrade", rebooting the stack
+2024-06-18T12:59:38.182641-05:00 8360-Primaire vsf[1234]: Event|9956|LOG_WARN|VSF|-|ISSU complete timer expired. Rebooting switch 1 during ISSU operation: "upgrade"
+2024-06-18T12:45:38.182641-05:00 8360-Primaire vsf[1234]: Event|9957|LOG_WARN|VSF|-|Member 1 interface 1/1/1 in VSF link 1 detected a peer 00:11:22:33:44:55 with incompatible product type 8360
+2024-06-18T12:46:38.182641-05:00 8360-Primaire vsf[1234]: Event|9958|LOG_WARN|VSF|-|Egress port shape rate 1000 Mbps will be applied for all VSF interfaces
+2024-06-18T12:47:38.182641-05:00 8360-Primaire vsf[1234]: Event|9959|LOG_WARN|VSF|-|Egress port shape rate 1000 Mbps applied for all VSF interfaces
+2024-06-18T12:48:38.182641-05:00 8360-Primaire vsf[1234]: Event|9960|LOG_WARN|VSF|-|Egress port shape rate 1000 Mbps update is failed to apply for interface eth0
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|10002|LOG_INFO|AMM|-|mock_acl_name on 1/1/25 (route-in): 10 mock ace string
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|10003|LOG_ERR|AMM|-|ACL mock_acl_type mock_acl_name failed to apply on mock_application
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-policy[1234]: Event|10101|LOG_ERR|POLICY|-|Policy security_policy failed to apply on firewall_application

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -25122,6 +25122,1365 @@
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",
             "aruba": {
                 "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7001",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire vsx[1234]: Event|7001|LOG_INFO|VSX|-|VSX ISL port 1/1 is down"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX ISL port 1/1 is down",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7002",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire vsx[1234]: Event|7002|LOG_INFO|VSX|-|VSX ISL port 1/1 is up"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX ISL port 1/1 is up",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7003",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire vsx[1234]: Event|7003|LOG_INFO|VSX|-|VSX ISL port 1/1 is In-Sync with the peer."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX ISL port 1/1 is In-Sync with the peer.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7004",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire vsx[1234]: Event|7004|LOG_ERR|VSX|-|VSX ISL port 1/1 is Out-Of-Sync with the peer: link_failure",
+                "reason": "link_failure"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX ISL port 1/1 is Out-Of-Sync with the peer: link_failure",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7005",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire vsx[1234]: Event|7005|LOG_WARN|VSX|-|VSX Keepalive failed"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX Keepalive failed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7006",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire vsx[1234]: Event|7006|LOG_INFO|VSX|-|VSX Keepalive succeeded"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX Keepalive succeeded",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7007",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire vsx[1234]: Event|7007|LOG_INFO|VSX|-|VSX role is primary"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX role is primary",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7008",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire vsx[1234]: Event|7008|LOG_INFO|VSX|-|VSX role is secondary"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX role is secondary",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsx": {
+                    "local_sw_ver": "10.02",
+                    "peer_sw_ver": "10.01"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7009",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire vsx[1234]: Event|7009|LOG_INFO|VSX|-|VSX Software version mismatch: peer version 10.01, local version 10.02"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX Software version mismatch: peer version 10.01, local version 10.02",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsx": {
+                    "local_device_type": "8320",
+                    "peer_device_type": "8360"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7010",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire vsx[1234]: Event|7010|LOG_INFO|VSX|-|VSX Device mismatch: peer device 8360, local device 8320"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX Device mismatch: peer device 8360, local device 8320",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7011",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire vsx[1234]: Event|7011|LOG_INFO|VSX|-|VSX 1 state local up, remote down"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX 1 state local up, remote down",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:56:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7012",
+                "original": "2024-06-18T12:56:38.182641-05:00 8360-Primaire vsx[1234]: Event|7012|LOG_INFO|VSX|-|VSX 1 state local down, remote up"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX 1 state local down, remote up",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:57:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7013",
+                "original": "2024-06-18T12:57:38.182641-05:00 8360-Primaire vsx[1234]: Event|7013|LOG_INFO|VSX|-|VSX 1 state local up, remote up"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX 1 state local up, remote up",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:58:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7014",
+                "original": "2024-06-18T12:58:38.182641-05:00 8360-Primaire vsx[1234]: Event|7014|LOG_INFO|VSX|-|VSX 1 state local down, remote down"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX 1 state local down, remote down",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:59:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7015",
+                "original": "2024-06-18T12:59:38.182641-05:00 8360-Primaire vsx[1234]: Event|7015|LOG_INFO|VSX|-|VSX ISL sliding window parameters are reset."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX ISL sliding window parameters are reset.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7016",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire vsx[1234]: Event|7016|LOG_INFO|VSX|-|VSX own ISL hello packet received, ignoring the packet."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX own ISL hello packet received, ignoring the packet.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "role": "primary",
+                "vsx": {
+                    "bank_name": "bank1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7017",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire vsx[1234]: Event|7017|LOG_INFO|VSX|-|Rebooting the VSX primary device with newly updated bank1 image."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "Rebooting the VSX primary device with newly updated bank1 image.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsx": {
+                    "primary_version": "1.0",
+                    "secondary_version": "2.0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7018",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire vsx[1234]: Event|7018|LOG_INFO|VSX|-|VSX primary ISL version 1.0 dose not match with VSX secondary ISL version 2.0. Performing a non-hitless image update."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX primary ISL version 1.0 dose not match with VSX secondary ISL version 2.0. Performing a non-hitless image update.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsx": {
+                    "primary_version": "1.0",
+                    "secondary_version": "2.0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7018",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire vsx[1234]: Event|7018|LOG_INFO|VSX|-|VSX primary ISL version 1.0 does not match with VSX secondary ISL version 2.0. Performing a non-hitless image update."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX primary ISL version 1.0 does not match with VSX secondary ISL version 2.0. Performing a non-hitless image update.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "role": "primary"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7019",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire vsx[1234]: Event|7019|LOG_ERR|VSX|-|VSX primary image update failed due to timeout.",
+                "reason": "timeout"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX primary image update failed due to timeout.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7020",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire vsx[1234]: Event|7020|LOG_INFO|VSX|-|ISL out-of-sync and keepalive is in established"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "ISL out-of-sync and keepalive is in established",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7021",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire vsx[1234]: Event|7021|LOG_INFO|VSX|-|ISL out-of-sync and keepalive also failed"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "ISL out-of-sync and keepalive also failed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7022",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire vsx[1234]: Event|7022|LOG_INFO|VSX|-|Linkup delay timer started"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "Linkup delay timer started",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7023",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire vsx[1234]: Event|7023|LOG_INFO|VSX|-|Linkup delay timer expired"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "Linkup delay timer expired",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "role": "primary",
+                "state": "ACTIVE",
+                "vsx": {
+                    "prev_state": "INIT"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7024",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire vsx[1234]: Event|7024|LOG_INFO|VSX|-|VSX primary state changed from INIT to ACTIVE."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX primary state changed from INIT to ACTIVE.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7025",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire vsx[1234]: Event|7025|LOG_INFO|VSX|-|Bailout timer started"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "Bailout timer started",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7026",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire vsx[1234]: Event|7026|LOG_INFO|VSX|-|Bailout timer expired"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "Bailout timer expired",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:56:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7027",
+                "original": "2024-06-18T12:56:38.182641-05:00 8360-Primaire vsx[1234]: Event|7027|LOG_INFO|VSX|-|Bailout timer stopped"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "Bailout timer stopped",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:57:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7028",
+                "original": "2024-06-18T12:57:38.182641-05:00 8360-Primaire vsx[1234]: Event|7028|LOG_INFO|VSX|-|Linkup-delay timer stopped"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "Linkup-delay timer stopped",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsx": {
+                    "local_vsx_role": "primary",
+                    "peer_vsx_role": "secondary"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7029",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire vsx[1234]: Event|7029|LOG_ERR|VSX|-|VSX device roles are inconsistent: local VSX device role primary, peer VSX device role secondary"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX device roles are inconsistent: local VSX device role primary, peer VSX device role secondary",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "role": "primary",
+                "state": "active",
+                "vsx": {
+                    "sub_state": "updating"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7029",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire vsx[1234]: Event|7029|LOG_INFO|VSX|-|VSX primary state changed to active-updating."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX primary state changed to active-updating.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7030",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire vsx[1234]: Event|7030|LOG_INFO|VSX|-|VSX Keepalive is configured without creating VRF"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX Keepalive is configured without creating VRF",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7031",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire vsx[1234]: Event|7031|LOG_INFO|VSX|-|VSX Keepalive is configured without configuring IP address"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX Keepalive is configured without configuring IP address",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "port1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7032",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire vsx[1234]: Event|7032|LOG_ERR|VSX|-|Active-gateway is enabled on port1. Cannot program Active-forwarding"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "Active-gateway is enabled on port1. Cannot program Active-forwarding",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "port1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7033",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire vsx[1234]: Event|7033|LOG_ERR|VSX|-|Active-forwarding is enabled on port1. Cannot program Active-gateway"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "Active-forwarding is enabled on port1. Cannot program Active-gateway",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7034",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire vsx[1234]: Event|7034|LOG_INFO|VSX|-|Netdev eth0 configured with ipv4 address 192.168.1.1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "Netdev eth0 configured with ipv4 address 192.168.1.1",
+            "server": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7035",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire vsx[1234]: Event|7035|LOG_INFO|VSX|-|Netdev eth0 configured with ipv6 address FE80::C000:1DFF:FEE0:C01/64"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "Netdev eth0 configured with ipv6 address FE80::C000:1DFF:FEE0:C01/64",
+            "server": {
+                "ip": "FE80::C000:1DFF:FEE0:C01"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "role": "primary",
+                "state": "active",
+                "vsx": {
+                    "sub_state": "updating"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7036",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire vsx[1234]: Event|7036|LOG_INFO|VSX|-|VSX primary state changed to active-updating."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX primary state changed to active-updating.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSX"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7037",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire vsx[1234]: Event|7037|LOG_INFO|VSX|-|VSX secondary has better MCLAG state compared to VSX primary. MCLAGs and SVIs are brought down on VSX primary."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSX secondary has better MCLAG state compared to VSX primary. MCLAGs and SVIs are brought down on VSX primary.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
                     "category": "SNMP"
                 },
                 "event_type": "Event",
@@ -36058,6 +37417,2142 @@
                 }
             },
             "message": "IPV6_SOURCE_LOCKDOWN is disabled on interface eth1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "member_id": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9901",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire vsf[1234]: Event|9901|LOG_INFO|VSF|-|Member 1 boot complete"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Member 1 boot complete",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "member_id": "2"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9902",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire vsf[1234]: Event|9902|LOG_INFO|VSF|-|Standby 2 boot complete"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Standby 2 boot complete",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "member_id": "3"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9903",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire vsf[1234]: Event|9903|LOG_INFO|VSF|-|Conductor 3 boot complete"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Conductor 3 boot complete",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "member_id": "4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9905",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire vsf[1234]: Event|9905|LOG_INFO|VSF|-|Resetting member 4"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Resetting member 4",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "link": "1/1/1",
+                    "member_id": "5"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9906",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire vsf[1234]: Event|9906|LOG_WARN|VSF|-|Member 5 conflict detected on link 1/1/1"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Member 5 conflict detected on link 1/1/1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9907",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire vsf[1234]: Event|9907|LOG_WARN|VSF|-|Incompatible version detected"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Incompatible version detected",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "topo_type": "ring"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9908",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire vsf[1234]: Event|9908|LOG_INFO|VSF|-|Topology is ring"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Topology is ring",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "member_id": "6"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9910",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire vsf[1234]: Event|9910|LOG_INFO|VSF|-|Member 6 removed"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Member 6 removed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "mac_addr1": "00-11-22-33-44-55",
+                    "product_type": "8360"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9911",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire vsf[1234]: Event|9911|LOG_WARN|VSF|-|Maximum number of switches in the stack has reached. Cannot add MAC 00:11:22:33:44:55 product type 8360"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Maximum number of switches in the stack has reached. Cannot add MAC 00:11:22:33:44:55 product type 8360",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "member_id": "7"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9912",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire vsf[1234]: Event|9912|LOG_INFO|VSF|-|Stack state is no-split with conductor id 7"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Stack state is no-split with conductor id 7",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "throttle_count": 100
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9912",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire vsf[1234]: Event|9912|LOG_INFO|VSF|-|Throttled 100 Messages"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Throttled 100 Messages",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "member_id": "8"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9913",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire vsf[1234]: Event|9913|LOG_WARN|VSF|-|Lost member 8 with timeout",
+                "reason": "timeout"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Lost member 8 with timeout",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:56:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "status": "success",
+                "vsf": {
+                    "mac_addr1": "00-11-22-33-44-56"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9914",
+                "original": "2024-06-18T12:56:38.182641-05:00 8360-Primaire vsf[1234]: Event|9914|LOG_INFO|VSF|-|Reboot of MAC 00:11:22:33:44:56 status-success"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Reboot of MAC 00:11:22:33:44:56 status-success",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:57:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "member_id": "9"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9915",
+                "original": "2024-06-18T12:57:38.182641-05:00 8360-Primaire vsf[1234]: Event|9915|LOG_INFO|VSF|-|Member 9 elected as conductor reason-vote",
+                "reason": "vote"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Member 9 elected as conductor reason-vote",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "member_id": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9916",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire vsf[1234]: Event|9916|LOG_INFO|VSF|-|Member 1 elected as standby reason-vote",
+                "reason": "vote"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Member 1 elected as standby reason-vote",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "mac_addr1": "00-11-22-33-44-55",
+                    "product_id": "8360"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9917",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire vsf[1234]: Event|9917|LOG_WARN|VSF|-|Switch with MAC 00:11:22:33:44:55 cannot join stack due to incorrect product id 8360"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Switch with MAC 00:11:22:33:44:55 cannot join stack due to incorrect product id 8360",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/1",
+                "vsf": {
+                    "mac_addr1": "00-11-22-33-44-56",
+                    "mac_addr2": "00-11-22-33-44-57",
+                    "product_type": "8320"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9919",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire vsf[1234]: Event|9919|LOG_WARN|VSF|-|Found Unsupported switch with MAC 00:11:22:33:44:56 and Product type 8320, connected to switch with MAC 00:11:22:33:44:57 on stack port 1/1/1"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Found Unsupported switch with MAC 00:11:22:33:44:56 and Product type 8320, connected to switch with MAC 00:11:22:33:44:57 on stack port 1/1/1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "member_id": "2"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9920",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire vsf[1234]: Event|9920|LOG_WARN|VSF|-|Heart beat lost for member 2"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Heart beat lost for member 2",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "member_id": "3"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9921",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire vsf[1234]: Event|9921|LOG_WARN|VSF|-|OS version mismatch detected for member 3"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "OS version mismatch detected for member 3",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "member_id": "4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9922",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire vsf[1234]: Event|9922|LOG_WARN|VSF|-|Attempt to connect member 4 from a different stack"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Attempt to connect member 4 from a different stack",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "link": "1/1/1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9923",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire vsf[1234]: Event|9923|LOG_INFO|VSF|-|VSF link 1/1/1 is up"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSF link 1/1/1 is up",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "link": "1/1/1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9924",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire vsf[1234]: Event|9924|LOG_INFO|VSF|-|VSF link 1/1/1 is down"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSF link 1/1/1 is down",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "link": "1/1/1",
+                    "mac_addr1": "00-11-22-33-44-58",
+                    "mac_addr2": "00-11-22-33-44-59"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9925",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire vsf[1234]: Event|9925|LOG_WARN|VSF|-|Invalid MAC 00:11:22:33:44:58 detected on link 1/1/1 with peer MAC 00:11:22:33:44:59"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Invalid MAC 00:11:22:33:44:58 detected on link 1/1/1 with peer MAC 00:11:22:33:44:59",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9926",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire vsf[1234]: Event|9926|LOG_WARN|VSF|-|2 member loop detected on ring topology"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "2 member loop detected on ring topology",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "member_id": "5"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9927",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire vsf[1234]: Event|9927|LOG_INFO|VSF|-|Fragment with conductor 5 is Active"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Fragment with conductor 5 is Active",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "throttle_count": 100
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9927",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire vsf[1234]: Event|9927|LOG_INFO|VSF|-|Throttled 100 Messages"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Throttled 100 Messages",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:56:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "member_id": "6"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9928",
+                "original": "2024-06-18T12:56:38.182641-05:00 8360-Primaire vsf[1234]: Event|9928|LOG_INFO|VSF|-|Fragment with conductor 6 is Inactive"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Fragment with conductor 6 is Inactive",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:57:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9929",
+                "original": "2024-06-18T12:57:38.182641-05:00 8360-Primaire vsf[1234]: Event|9929|LOG_INFO|VSF|-|Active fragment detection timeout"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Active fragment detection timeout",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "member_id": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9930",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire vsf[1234]: Event|9930|LOG_INFO|VSF|-|Member 1 is configured as Secondary"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Member 1 is configured as Secondary",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9931",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire vsf[1234]: Event|9931|LOG_INFO|VSF|-|Secondary configuration removed"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Secondary configuration removed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "mac_addr1": "00-11-22-33-44-55",
+                    "product_id": "8360"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9932",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire vsf[1234]: Event|9932|LOG_INFO|VSF|-|Attempt to connect a member with MAC 00:11:22:33:44:55 and product type 8360 having different airflows"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Attempt to connect a member with MAC 00:11:22:33:44:55 and product type 8360 having different airflows",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9933",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire vsf[1234]: Event|9933|LOG_WARN|VSF|-|Peer timeout on interface 1/1/1"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Peer timeout on interface 1/1/1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9934",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire vsf[1234]: Event|9934|LOG_WARN|VSF|-|Loop detected on interface 1/1/1"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Loop detected on interface 1/1/1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9935",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire vsf[1234]: Event|9935|LOG_WARN|VSF|-|Interface 1/1/1 detected a peer with a different VSF handshake version"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface 1/1/1 detected a peer with a different VSF handshake version",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/1",
+                "vsf": {
+                    "link": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9936",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire vsf[1234]: Event|9936|LOG_INFO|VSF|-|Interface 1/1/1 added to VSF link 1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface 1/1/1 added to VSF link 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/1",
+                "vsf": {
+                    "link": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9937",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire vsf[1234]: Event|9937|LOG_INFO|VSF|-|Interface 1/1/1 removed from VSF link 1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface 1/1/1 removed from VSF link 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/1",
+                "vsf": {
+                    "mac_addr1": "00-11-22-33-44-55"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9938",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire vsf[1234]: Event|9938|LOG_WARN|VSF|-|Switch with MAC 00:11:22:33:44:55 not able to autojoin as it is connected on interface 1/1/1 which is a non default autojoin VSF interface"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Switch with MAC 00:11:22:33:44:55 not able to autojoin as it is connected on interface 1/1/1 which is a non default autojoin VSF interface",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/1",
+                "vsf": {
+                    "mac_addr1": "00-11-22-33-44-55",
+                    "member_id": ""
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9939",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire vsf[1234]: Event|9939|LOG_WARN|VSF|-|Switch with MAC 00:11:22:33:44:55 not able to autojoin as it is connected to interface 1/1/1 which is not provisioned on the conductor for member 1"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Switch with MAC 00:11:22:33:44:55 not able to autojoin as it is connected to interface 1/1/1 which is not provisioned on the conductor for member 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "mac_addr1": "00-11-22-33-44-55"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9940",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire vsf[1234]: Event|9940|LOG_WARN|VSF|-|Switch with MAC 00:11:22:33:44:55 is not autojoin eligible"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Switch with MAC 00:11:22:33:44:55 is not autojoin eligible",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:56:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "mac_addr1": "00-11-22-33-44-55"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9941",
+                "original": "2024-06-18T12:56:38.182641-05:00 8360-Primaire vsf[1234]: Event|9941|LOG_WARN|VSF|-|Switch with MAC 00:11:22:33:44:55 attempting to autojoin via multiple interfaces"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Switch with MAC 00:11:22:33:44:55 attempting to autojoin via multiple interfaces",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "mac_addr1": "00-11-22-33-44-55"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9942",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire vsf[1234]: Event|9942|LOG_WARN|VSF|-|Switch with MAC 00:11:22:33:44:55 failed to autojoin as there is no free member number available"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Switch with MAC 00:11:22:33:44:55 failed to autojoin as there is no free member number available",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "2",
+                "vsf": {
+                    "link": "1",
+                    "mac_addr1": "00-11-22-33-44-55"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9943",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire vsf[1234]: Event|9943|LOG_WARN|VSF|-|Switch with MAC 00:11:22:33:44:55 failed to autojoin on link 1, port 2"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Switch with MAC 00:11:22:33:44:55 failed to autojoin on link 1, port 2",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9944",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire vsf[1234]: Event|9944|LOG_WARN|VSF|-|Switch has VSF configurations present. Force autojoin will not take into effect. Remove all VSF configurations followed by unconfiguring and reconfiguring force autojoin for it to take into effect"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Switch has VSF configurations present. Force autojoin will not take into effect. Remove all VSF configurations followed by unconfiguring and reconfiguring force autojoin for it to take into effect",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9945",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire vsf[1234]: Event|9945|LOG_INFO|VSF|-|VSF force autojoin enabled"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSF force autojoin enabled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9946",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire vsf[1234]: Event|9946|LOG_INFO|VSF|-|VSF force autojoin disabled"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSF force autojoin disabled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "link": "2",
+                    "mac_addr1": "00-11-22-33-44-55",
+                    "mac_addr2": "00-11-22-33-44-56",
+                    "mbr_id": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9947",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire vsf[1234]: Event|9947|LOG_WARN|VSF|-|Switch with MAC 00:11:22:33:44:55 failed to autojoin. Connect the device 00:11:22:33:44:56 to member 1 link 2 to proceed"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Switch with MAC 00:11:22:33:44:55 failed to autojoin. Connect the device 00:11:22:33:44:56 to member 1 link 2 to proceed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/1",
+                "vsf": {
+                    "link": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9948",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire vsf[1234]: Event|9948|LOG_WARN|VSF|-|Interface 1/1/1 in VSF link 1 detected a peer with inconsistent VSF link configuration"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface 1/1/1 in VSF link 1 detected a peer with inconsistent VSF link configuration",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "new_standby_id": "2",
+                    "old_standby_id": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9949",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire vsf[1234]: Event|9949|LOG_INFO|VSF|-|Secondary member changed from 1 to 2"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Secondary member changed from 1 to 2",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/1",
+                "vsf": {
+                    "mac_addr1": "00-11-22-33-44-55"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9950",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire vsf[1234]: Event|9950|LOG_WARN|VSF|-|Switch with MAC 00:11:22:33:44:55 failed to autojoin as it is connected on interface 1/1/1 which has MACsec configuration"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Switch with MAC 00:11:22:33:44:55 failed to autojoin as it is connected on interface 1/1/1 which has MACsec configuration",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/1",
+                "vsf": {
+                    "port2": "1/1/1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9951",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire vsf[1234]: Event|9951|LOG_WARN|VSF|-|Bringing down MACsec configured interface 1/1/1 as it is added to a VSF link. VSF link and MACsec configurations needs to be removed from the interface 1/1/1 and VSF link needs to be reconfigured for it to take into effect"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Bringing down MACsec configured interface 1/1/1 as it is added to a VSF link. VSF link and MACsec configurations needs to be removed from the interface 1/1/1 and VSF link needs to be reconfigured for it to take into effect",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "operation": "upgrade"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9952",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire vsf[1234]: Event|9952|LOG_WARN|VSF|-|Switchover detected during ISSU operation: \"upgrade\""
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Switchover detected during ISSU operation: \"upgrade\"",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:56:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "vsf": {
+                    "operation": "upgrade"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9953",
+                "original": "2024-06-18T12:56:38.182641-05:00 8360-Primaire vsf[1234]: Event|9953|LOG_WARN|VSF|-|ISSU state failed for member 1 during ISSU operation: \"upgrade\""
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "ISSU state failed for member 1 during ISSU operation: \"upgrade\"",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:57:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "vsf": {
+                    "operation": "upgrade"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9954",
+                "original": "2024-06-18T12:57:38.182641-05:00 8360-Primaire vsf[1234]: Event|9954|LOG_WARN|VSF|-|VSF member 1 going out of stack during ISSU operation: \"upgrade\", rebooting the stack"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "VSF member 1 going out of stack during ISSU operation: \"upgrade\", rebooting the stack",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:58:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "operation": "upgrade"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9955",
+                "original": "2024-06-18T12:58:38.182641-05:00 8360-Primaire vsf[1234]: Event|9955|LOG_WARN|VSF|-|Unintentional failover detected during ISSU operation: \"upgrade\", rebooting the stack"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Unintentional failover detected during ISSU operation: \"upgrade\", rebooting the stack",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:59:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "vsf": {
+                    "operation": "upgrade"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9956",
+                "original": "2024-06-18T12:59:38.182641-05:00 8360-Primaire vsf[1234]: Event|9956|LOG_WARN|VSF|-|ISSU complete timer expired. Rebooting switch 1 during ISSU operation: \"upgrade\""
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "ISSU complete timer expired. Rebooting switch 1 during ISSU operation: \"upgrade\"",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/1",
+                "vsf": {
+                    "link": "1",
+                    "mac_addr1": "00-11-22-33-44-55",
+                    "member_id": "1",
+                    "product_type": "8360"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9957",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire vsf[1234]: Event|9957|LOG_WARN|VSF|-|Member 1 interface 1/1/1 in VSF link 1 detected a peer 00:11:22:33:44:55 with incompatible product type 8360"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Member 1 interface 1/1/1 in VSF link 1 detected a peer 00:11:22:33:44:55 with incompatible product type 8360",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "lowest_speed": "1000 Mbps"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9958",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire vsf[1234]: Event|9958|LOG_WARN|VSF|-|Egress port shape rate 1000 Mbps will be applied for all VSF interfaces"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Egress port shape rate 1000 Mbps will be applied for all VSF interfaces",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vsf": {
+                    "lowest_speed": "1000 Mbps"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9959",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire vsf[1234]: Event|9959|LOG_WARN|VSF|-|Egress port shape rate 1000 Mbps applied for all VSF interfaces"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Egress port shape rate 1000 Mbps applied for all VSF interfaces",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                },
+                "vsf": {
+                    "lowest_speed": "1000 Mbps"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9960",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire vsf[1234]: Event|9960|LOG_WARN|VSF|-|Egress port shape rate 1000 Mbps update is failed to apply for interface eth0"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vsf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Egress port shape rate 1000 Mbps update is failed to apply for interface eth0",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -2390,6 +2390,82 @@ processors:
       description: "Action has been triggered by an NAE agent"
       pattern: "An action has been triggered by the NAE agent %{aruba.nae.name}"
 
+  # Virtual Switching Extension (70xx)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VSX.htm
+  - grok:
+      if: "['7001','7002','7003','7004'].contains(ctx.event?.code)"
+      tag: vsx_event_7001_7002_7003_7004
+      field: "message"
+      description: "VSX ISL link is [down|up] | VSX ISL is [In-Sync|Out-Of-Sync] with the peer"
+      patterns:
+        - "^VSX ISL port %{DATA:aruba.port} is (down|up|In-Sync)"
+        - "^VSX ISL port %{DATA:aruba.port} is Out-Of-Sync with the peer: %{GREEDYDATA:event.reason}"
+  - dissect:
+      if: "ctx.event?.code == '7009'"
+      tag: vsx_event_7009
+      field: "message"
+      description: "VSX Software version mismatch: peer sw version is not same as local sw version"
+      pattern: "VSX Software version mismatch: peer version %{aruba.vsx.peer_sw_ver}, local version %{aruba.vsx.local_sw_ver}"
+  - dissect:
+      if: "ctx.event?.code == '7010'"
+      tag: vsx_event_7010
+      field: "message"
+      description: "VSX Device type mismatch: peer device type is not same as local device type"
+      pattern: "VSX Device mismatch: peer device %{aruba.vsx.peer_device_type}, local device %{aruba.vsx.local_device_type}"
+  - grok:
+      if: "['7011','7012','7013','7014'].contains(ctx.event?.code)"
+      tag: vsx_event_7011_7012_7013_7014
+      field: "message"
+      description: "VSX local up remote down | local down remote up | local up remote up | local down remote down"
+      patterns:
+        - "^VSX %{DATA:aruba.instance.id} state local"
+  - dissect:
+      if: "ctx.event?.code == '7017'"
+      tag: vsx_event_7017
+      field: "message"
+      description: "Switch reboot due to VSX software update"
+      pattern: "Rebooting the VSX %{aruba.role} device with newly updated %{aruba.vsx.bank_name} image."
+  - grok:
+      if: "ctx.event?.code == '7018'"
+      tag: vsx_event_7018
+      field: "message"
+      description: "VSX inter-switch-link protocol version mismatch after secondary reboot"
+      patterns:
+        - "^VSX primary ISL version %{DATA:aruba.vsx.primary_version} (dose|does) not match with VSX secondary ISL version %{DATA:aruba.vsx.secondary_version}. Performing a non-hitless image update."
+  - grok:
+      if: "['7019','7024'].contains(ctx.event?.code)"
+      tag: vsx_event_7019_7024
+      field: "message"
+      description: "VSX image update failed | software update state change "
+      patterns:
+        - "^VSX %{DATA:aruba.role} image update failed due to %{GREEDYDATA:event.reason}."
+        - "^VSX %{DATA:aruba.role} state changed from %{DATA:aruba.vsx.prev_state} to %{GREEDYDATA:aruba.state}."
+
+  # There is an oddity with 7029 and 7036 event ID, it maps to two messages with a duplicate fir 7936, assuming this is NOT a documentation error, handling both messages
+  - grok:
+      if: "['7029','7036'].contains(ctx.event?.code)"
+      tag: vsx_event_7029_7036
+      field: "message"
+      description: "VSX device roles are said to be consistent only if one VSX device is configured as primary and other VSX device is configured as secondary | VSX software update sub-state change "
+      patterns:
+        - "^VSX %{DATA:aruba.role} state changed to %{DATA:aruba.state}-%{GREEDYDATA:aruba.vsx.sub_state}."
+        - "^VSX device roles are inconsistent: local VSX device role %{DATA:aruba.vsx.local_vsx_role}, peer VSX device role %{GREEDYDATA:aruba.vsx.peer_vsx_role}"
+  - grok:
+      if: "['7032','7033'].contains(ctx.event?.code)"
+      tag: vsx_event_7032_7033
+      field: "message"
+      description: "Failed to program active-forwarding | active-gateway"
+      patterns:
+        - "^Active-(gateway|forwarding) is enabled on %{DATA:aruba.port}. Cannot program Active-(forwarding|gateway)"
+  - grok:
+      if: "['7034','7035'].contains(ctx.event?.code)"
+      tag: vsx_event_7034_7035
+      field: "message"
+      description: "programmed active-gateway [IP4|IP6] address successfully"
+      patterns:
+        - "^Netdev %{DATA:aruba.interface.name} configured with (ipv4|ipv6) address %{IP:server.ip}"
+
+
   # SNMP events (71xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SNMP.htm
   - grok:
@@ -3453,6 +3529,190 @@ processors:
         - "^IP_SOURCE_LOCKDOWN resource utilization has exceeded maximum supported limit of %{DATA:aruba.limit.threshold} on the system. IP source-lockdown functionality will not work for new entries"
         - "^(IPV4_SOURCE_LOCKDOWN|IPV6_SOURCE_LOCKDOWN) is (enabled|disabled) on interface %{GREEDYDATA:aruba.interface.id}"
 
+  # Virtual Switching Framework (VSF) events (99xx)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VSF.htm
+  - grok:
+      if: "['9901','9902','9903','9905','9906','9910'].contains(ctx.event?.code)"
+      tag: vsf_event_9901_9902_9903_9905_9906_9910
+      field: "message"
+      description: "log event for [standby|member|Conductor] boot complete | Event log indicates that member is reseting | Event log for Failed processing Hello packet because of member number conflict | indicates the member has been removed due to user request"
+      patterns:
+        - "^(Member|Standby|Conductor) %{DATA:aruba.vsf.member_id} boot complete"
+        - "^Resetting member %{GREEDYDATA:aruba.vsf.member_id}"
+        - "^Member %{DATA:aruba.vsf.member_id} conflict detected on link %{GREEDYDATA:aruba.vsf.link}"
+        - "^Member %{DATA:aruba.vsf.member_id} removed"
+  - dissect:
+      if: "ctx.event?.code == '9908'"
+      tag: vsf_event_9908
+      field: "message"
+      description: "Event log indicates the current topology"
+      pattern: "Topology is %{aruba.vsf.topo_type}"
+  - grok:
+      if: "ctx.event?.code == '9911'"
+      tag: vsf_event_9911
+      field: "message"
+      description: "Event log indicates that we would exceed the MAX switches if we add this new switch"
+      patterns:
+        - "^Maximum number of switches in the stack has reached. Cannot add MAC %{MAC:aruba.vsf.mac_addr1} product type %{GREEDYDATA:aruba.vsf.product_type}"
+  - grok:
+      if: "ctx.event?.code == '9912'"
+      tag: vsf_event_9912
+      field: "message"
+      description: "log event for stack state active"
+      patterns:
+        - "^Stack state is no-split with conductor id %{GREEDYDATA:aruba.vsf.member_id}"
+        - "^Throttled %{NUMBER:aruba.throttle_count:long} Messages"
+  - grok:
+      if: "['9913','9915','9916'].contains(ctx.event?.code)"
+      tag: vsf_event_9913_9915_9916
+      field: "message"
+      description: "Event log for lost member | log event for the switch won as [conductor|standby] "
+      patterns:
+        - "^Lost member %{DATA:aruba.vsf.member_id} with %{GREEDYDATA:event.reason}"
+        - "^Member %{DATA:aruba.vsf.member_id} elected as (conductor|standby) reason-%{GREEDYDATA:event.reason}"
+  - grok:
+      if: "['9914','9917','9919'].contains(ctx.event?.code)"
+      tag: vsf_event_9914_9917_9919
+      field: "message"
+      description: "Event log for status of a reboot request | log event for the member was not allowed to join due to a mismatched product-id | log event for switch running on a different platform and trying to join the stack"
+      patterns:
+        - "^Reboot of MAC %{MAC:aruba.vsf.mac_addr1} status-%{GREEDYDATA:aruba.status}"
+        - "^Switch with MAC %{MAC:aruba.vsf.mac_addr1} cannot join stack due to incorrect product id %{GREEDYDATA:aruba.vsf.product_id}"
+        - "^Found Unsupported switch with MAC %{MAC:aruba.vsf.mac_addr1} and Product type %{DATA:aruba.vsf.product_type}, connected to switch with MAC %{MAC:aruba.vsf.mac_addr2} on stack port %{GREEDYDATA:aruba.port}"
+  - grok:
+      if: "['9920','9921','9922'].contains(ctx.event?.code)"
+      tag: vsf_event_9920_9921_9922
+      field: "message"
+      description: "log event for heart beat lost | log event when os_version_mismatch happened on standby and member | log event when member attempt to connect to a different stack"
+      patterns:
+        - "for member %{GREEDYDATA:aruba.vsf.member_id}"
+        - "^Attempt to connect member %{DATA:aruba.vsf.member_id} from a different stack"
+  - grok:
+      if: "['9923','9924'].contains(ctx.event?.code)"
+      tag: vsf_event_9923_9924
+      field: "message"
+      description: "log event when vsf link is up|down"
+      patterns:
+        - "^VSF link %{DATA:aruba.vsf.link} "
+  - grok:
+      if: "ctx.event?.code == '9925'"
+      tag: vsf_event_9925
+      field: "message"
+      description: "log event when different MAC address on the same link"
+      patterns:
+        - "^Invalid MAC %{MAC:aruba.vsf.mac_addr1} detected on link %{DATA:aruba.vsf.link} with peer MAC %{MAC:aruba.vsf.mac_addr2}"
+  - grok:
+      if: "['9927','9928','9930'].contains(ctx.event?.code)"
+      tag: vsf_event_9927_9928_9930
+      field: "message"
+      description: "log event for [inactive|active] fragment | log event for standby configuration"
+      patterns:
+        - "^Fragment with conductor %{DATA:aruba.vsf.member_id} is (Active|Inactive)"
+        - "^Throttled %{NUMBER:aruba.throttle_count:long} Messages"
+        - "^Member %{DATA:aruba.vsf.member_id} is configured as Secondary"
+  - grok:
+      if: "ctx.event?.code == '9932'"
+      tag: vsf_event_9932
+      field: "message"
+      description: "log event when Mater SKU device joins the stack"
+      patterns:
+        - "^Attempt to connect a member with MAC %{MAC:aruba.vsf.mac_addr1} and product type %{DATA:aruba.vsf.product_id} having different airflows"
+  - grok:
+      if: "['9933','9934'].contains(ctx.event?.code)"
+      tag: vsf_event_9933_9934
+      field: "message"
+      description: "log event for peer time out as it did not receive any packet | log event for loop detection in link"
+      patterns:
+        - "on interface %{GREEDYDATA:aruba.port}"
+  - grok:
+      if: "['9935','9936','9937'].contains(ctx.event?.code)"
+      tag: vsf_event_9935_9936_9937
+      field: "message"
+      description: "log event when peer switch is in different VSF handshake version | when interface [added|removed] to a particular link"
+      patterns:
+        - "^Interface %{DATA:aruba.port} detected a peer with a different VSF handshake version"
+        - "^Interface %{DATA:aruba.port} (added to|removed from) VSF link %{GREEDYDATA:aruba.vsf.link}"
+  - grok:
+      if: "['9938','9939','9943'].contains(ctx.event?.code)"
+      tag: vsf_event_9938_9939_9943
+      field: "message"
+      description: "log event when the switch is not able to autojoin as it is connected with a non default VSF interface | there is an inconsistency detected between conductors provisioned VSF link configuration and the interface on which switch is attempting to autojoin | when two different switches are attempting to autojoin by connecting to the same VSF link on the peer"
+      patterns:
+        - "^%{BEGINNING_PATTERN} not able to autojoin as it is connected (on|to) interface %{DATA:aruba.port} which is (a non default autojoin VSF interface|not provisioned on the conductor for member %{DATA:aruba.vsf.member_id})"
+        - "^%{BEGINNING_PATTERN} failed to autojoin on link %{DATA:aruba.vsf.link}, port %{GREEDYDATA:aruba.port}"
+        - "^%{BEGINNING_PATTERN} failed to autojoin. Connect the device %{MAC:aruba.vsf.mac_addr2} to member %{DATA:aruba.vsf.mbr_id} link %{DATA:aruba.vsf.link} to proceed"
+      pattern_definitions:
+        BEGINNING_PATTERN: "^Switch with (mac|MAC) %{MAC:aruba.vsf.mac_addr1}"
+  - grok:
+      if: "['9940','9941','9942'].contains(ctx.event?.code)"
+      tag: vsf_event_9940_9941_9942
+      field: "message"
+      description: "log event when peer switch is not autojoin eligible | when there is more than one interface physically connected to same switch VSF link for autojoin | when switch is not allowed to autojoin because of insufficient resources"
+      patterns:
+        - "^Switch with MAC %{MAC:aruba.vsf.mac_addr1} "
+  - grok:
+      if: "ctx.event?.code == '9947'"
+      tag: vsf_event_9947
+      field: "message"
+      description: "log event when member connected to an unsupported interface"
+      patterns: 
+        - "^Switch with MAC %{MAC:aruba.vsf.mac_addr1} failed to autojoin. Connect the device %{MAC:aruba.vsf.mac_addr2} to member %{DATA:aruba.vsf.mbr_id} link %{DATA:aruba.vsf.link} to proceed"
+  - dissect:
+      if: "ctx.event?.code == '9948'"
+      tag: vsf_event_9948
+      field: "message"
+      description: "log event when interface is in inconsistent link configuration error"
+      pattern: "Interface %{aruba.port} in VSF link %{aruba.vsf.link} detected a peer with inconsistent VSF link configuration"
+  - dissect:
+      if: "ctx.event?.code == '9949'"
+      tag: vsf_event_9949
+      field: "message"
+      description: "log event when existing secondary changes to new specified secondary member"
+      pattern: "Secondary member changed from %{aruba.vsf.old_standby_id} to %{aruba.vsf.new_standby_id}"
+  - grok:
+      if: "ctx.event?.code == '9950'"
+      tag: vsf_event_9950
+      field: "message"
+      description: "log event when a VSF interface is connected to another interface with MACsec configuration"
+      patterns: 
+        - "^Switch with MAC %{MAC:aruba.vsf.mac_addr1} failed to autojoin as it is connected on interface %{DATA:aruba.port} which has MACsec configuration"
+  - dissect:
+      if: "ctx.event?.code == '9951'"
+      tag: vsf_event_9951
+      field: "message"
+      description: "Log event when an interface with MACsec configuration is added to VSF link"
+      pattern: "Bringing down MACsec configured interface %{aruba.port} as it is added to a VSF link. VSF link and MACsec configurations needs to be removed from the interface %{aruba.vsf.port2} and VSF link needs to be reconfigured for it to take into effect"
+  - grok:
+      if: "['9953','9954','9956'].contains(ctx.event?.code)"
+      tag: vsf_event_9953_9954_9956
+      field: "message"
+      description: "VSF_Member issu_state failed in conductor | when standby/member goes out of the stack | when ISSU timer expires before ISSU is complete"
+      patterns:
+        - "(member|switch) %{DATA:aruba.instance.id} during ISSU operation: \"%{DATA:aruba.vsf.operation}\""
+        - "^VSF member %{DATA:aruba.instance.id} going out of stack during ISSU operation: \"%{DATA:aruba.vsf.operation}\", rebooting the stack"
+  - grok:
+      if: "['9952','9955'].contains(ctx.event?.code)"
+      tag: vsf_event_9952_9955
+      field: "message"
+      description: "Log event when ISSU switchover is detected | when unintentional failover occurs during issu in_progress"
+      patterns:
+        - "detected during ISSU operation: \"%{DATA:aruba.vsf.operation}\""
+  - grok:
+      if: "ctx.event?.code == '9957'"
+      tag: vsf_event_9957
+      field: "message"
+      description: "Log event when member attempt to connect to incompatible peer jtypes"
+      patterns:
+        - "^Member %{DATA:aruba.vsf.member_id} interface %{DATA:aruba.port} in VSF link %{DATA:aruba.vsf.link} detected a peer %{MAC:aruba.vsf.mac_addr1} with incompatible product type %{GREEDYDATA:aruba.vsf.product_type}"
+  - grok:
+      if: "['9958','9959','9960'].contains(ctx.event?.code)"
+      tag: vsf_event_9958_9959_9960
+      field: "message"
+      description: "Log event when port shape is updated with uniform speed | capture the QOS applied failures"
+      patterns:
+        - "^Egress port shape rate %{DATA:aruba.vsf.lowest_speed}( will be)? applied for all VSF interfaces"
+        - "^Egress port shape rate %{DATA:aruba.vsf.lowest_speed} update is failed to apply for interface %{GREEDYDATA:aruba.interface.name}"
+
   # ACLs events (100xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ACL.htm
   - grok:
@@ -3867,6 +4127,22 @@ processors:
       ignore_missing: true
   - gsub:
       field: aruba.rpvst.old_mac
+      pattern: "[:.]"
+      replacement: "-"
+      ignore_missing: true
+  - uppercase:
+      field: aruba.vsf.mac_addr1
+      ignore_missing: true
+  - gsub:
+      field: aruba.vsf.mac_addr1
+      pattern: "[:.]"
+      replacement: "-"
+      ignore_missing: true
+  - uppercase:
+      field: aruba.vsf.mac_addr2
+      ignore_missing: true
+  - gsub:
+      field: aruba.vsf.mac_addr2
       pattern: "[:.]"
       replacement: "-"
       ignore_missing: true

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -1345,6 +1345,84 @@
         - name: name
           type: keyword
           description: ""
+    - name: vsf
+      type: group
+      fields:
+        - name: link
+          type: keyword
+          description: ""
+        - name: lowest_speed
+          type: keyword
+          description: ""
+        - name: mac_addr1
+          type: keyword
+          description: ""
+        - name: mac_addr2
+          type: keyword
+          description: ""
+        - name: mbr_id
+          type: keyword
+          description: ""
+        - name: member_id
+          type: keyword
+          description: ""
+        - name: new_standby_id
+          type: keyword
+          description: ""
+        - name: old_standby_id
+          type: keyword
+          description: ""
+        - name: operation
+          type: keyword
+          description: ""
+        - name: port2
+          type: keyword
+          description: ""
+        - name: product_id
+          type: keyword
+          description: ""
+        - name: product_type
+          type: keyword
+          description: ""
+        - name: topo_type
+          type: keyword
+          description: ""
+    - name: vsx
+      type: group
+      fields:
+        - name: bank_name
+          type: keyword
+          description: ""
+        - name: local_device_type
+          type: keyword
+          description: ""
+        - name: local_sw_ver
+          type: keyword
+          description: ""
+        - name: local_vsx_role
+          type: keyword
+          description: ""
+        - name: peer_device_type
+          type: keyword
+          description: ""
+        - name: peer_sw_ver
+          type: keyword
+          description: ""
+        - name: peer_vsx_role
+          type: keyword
+          description: ""
+        - name: prev_state
+          type: keyword
+          description: ""
+        - name: primary_version
+          type: keyword
+          description: ""
+        - name: secondary_version
+          type: keyword
+          description: ""
+        - name: sub_state
+          type: keyword
+          description: ""
     - name: xcvr
       type: group
       fields:

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -1256,50 +1256,56 @@ Note: Descriptions have not been filled out
 | `<vrf>`        | aruba.vrf.id               |
 | `<zone>`       | aruba.tunnel.zone          |
 
-#### [Virtual Switching Extension (VSX) events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VSX.htm)
-| Field                       | Description | Type | Common                       |
-|-----------------------------|-------------|------|------------------------------|
-| aruba.vsx.bank_name         |             |      |                              |
-| aruba.vsx.ifname            |             |      | observer.ingress.interface.name |
-| aruba.vsx.ip_address        |             |      | source.ip                    |
-| aruba.vsx.local_device_type |             |      |                              |
-| aruba.vsx.local_sw_ver      |             |      |                              |
-| aruba.vsx.local_vsx_role    |             |      |                              |
-| aruba.vsx.peer_device_type  |             |      |                              |
-| aruba.vsx.peer_sw_ver       |             |      |                              |
-| aruba.vsx.peer_vsx_role     |             |      |                              |
-| aruba.vsx.port              |             |      | server.port                  |
-| aruba.vsx.prev_state        |             |      |                              |
-| aruba.vsx.primary_version   |             |      |                              |
-| aruba.vsx.reason            |             |      | event.reason                 |
-| aruba.vsx.secondary_version |             |      |                              |
-| aruba.vsx.state             |             |      | service.state                |
-| aruba.vsx.sub_state         |             |      |                              |
-| aruba.vsx.vsx_id            |             |      | aruba.instance.id            |
-| aruba.vsx.vsx_role          |             |      | aruba.role                   |
+#### [Virtual Switching Extension (VSX) events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VSX.htm)
+| Docs Field            | Schema Mapping                       |
+|-----------------------|--------------------------------------|
+| `<bank_name>`         | aruba.vsx.bank_name                  |
+| `<ifname>`            | aruba.interface.name                 |
+| `<local_device_type>` | aruba.vsx.local_device_type          |
+| `<local_sw_ver>`      | aruba.vsx.local_sw_ver               |
+| `<local_vsx_role>`    | aruba.vsx.local_vsx_role             |
+| `<peer_device_type>`  | aruba.vsx.peer_device_type           |
+| `<peer_sw_ver>`       | aruba.vsx.peer_sw_ver                |
+| `<peer_vsx_role>`     | aruba.vsx.peer_vsx_role              |
+| `<port>`              | aruba.port                           |
+| `<prev_state>`        | aruba.vsx.prev_state                 |
+| `<primary_version>`   | aruba.vsx.primary_version            |
+| `<reason>`            | event.reason                         |
+| `<secondary_version>` | aruba.vsx.secondary_version          |
+| `<state>`             | aruba.state                          |
+| `<sub_state>`         | aruba.vsx.sub_state                  |
+| `<value>`             | server.ip                            |
+| `<vsx_id>`            | aruba.instance.id                    |
+| `<vsx_role>`          | aruba.role                           |
 
-#### [Virtual Switching Framework (VSF) events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VSF.htm)
-| Field                       | Description | Type | Common                          |
-|-----------------------------|-------------|------|---------------------------------|
-| aruba.vsf.link              |             |      | observer.ingress.interface.name |
-| aruba.vsf.link_id           |             |      | observer.ingress.interface.id   |
-| aruba.vsf.mac_add           |             |      | client.mac                      |
-| aruba.vsf.mac_addr1         |             |      |                                 |
-| aruba.vsf.mac_addr2         |             |      |                                 |
-| aruba.vsf.mac_address       |             |      | client.mac                      |
-| aruba.vsf.mbr_id            |             |      | aruba.instance.id               |
-| aruba.vsf.member_id         |             |      | aruba.instance.id               |
-| aruba.vsf.new_standby_id    |             |      |                                 |
-| aruba.vsf.old_standby_id    |             |      |                                 |
-| aruba.vsf.port              |             |      | server.port                     |
-| aruba.vsf.port_id           |             |      | server.port                     |
-| aruba.vsf.product_id        |             |      |                                 |
-| aruba.vsf.product_type      |             |      |                                 |
-| aruba.vsf.reason            |             |      | event.reason                    |
-| aruba.vsf.status            |             |      | aruba.status                    |
-| aruba.vsf.topo_type         |             |      |                                 |
-| aruba.vsf.new_standby_id    |             |      |                                 |
-| aruba.vsf.old_standby_id    |             |      |                                 |
+#### [Virtual Switching Framework (VSF) events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VSF.htm)
+| Docs Field           | Schema Mapping                            |
+|----------------------|-------------------------------------------|
+| `<id>`               | aruba.instance.id                         |
+| `<if_name>`          | aruba.interface.name                      |
+| `<link>`             | aruba.vsf.link                            |
+| `<link_id>`          | aruba.vsf.link                            |
+| `<lowest_speed>`     | aruba.vsf.lowest_speed                    |
+| `<mac_add>`          | aruba.vsf.mac_addr1 / aruba.vsf.mac_addr2 |
+| `<mac_addr>`         | aruba.vsf.mac_addr1 / aruba.vsf.mac_addr2 |
+| `<mac_addr1>`        | aruba.vsf.mac_addr1                       |
+| `<mac_addr2>`        | aruba.vsf.mac_addr2                       |
+| `<mac_address>`      | aruba.vsf.mac_addr1 / aruba.vsf.mac_addr2 |
+| `<mbr_id>`           | aruba.vsf.mbr_id                          |
+| `<member_id>`        | aruba.vsf.member_id                       |
+| `<new_standby_id>`   | aruba.vsf.new_standby_id                  |
+| `<old_standby_id>`   | aruba.vsf.old_standby_id                  |
+| `<operation>`        | aruba.vsf.operation                       |
+| `<port>`             | aruba.port                                |
+| `<port_id>`          | aruba.port                                |
+| `<port_id>`          | aruba.vsf.port2                           |
+| `<product_id>`       | aruba.vsf.product_id                      |
+| `<prod_type>`        | aruba.vsf.product_type                    |
+| `<product_type>`     | aruba.vsf.product_type                    |
+| `<reason>`           | event.reason                              |
+| `<status>`           | aruba.status                              |
+| `<topo_type>`        | aruba.vsf.topo_type                       |
+| `<type>`             | aruba.vsf.product_type                    |
 
 #### [VLAN events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VLAN.htm)
 | Field                | Description | Type | Common                       |
@@ -1758,6 +1764,30 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.user.role |  | keyword |
 | aruba.vrf.id |  | keyword |
 | aruba.vrf.name |  | keyword |
+| aruba.vsf.link |  | keyword |
+| aruba.vsf.lowest_speed |  | keyword |
+| aruba.vsf.mac_addr1 |  | keyword |
+| aruba.vsf.mac_addr2 |  | keyword |
+| aruba.vsf.mbr_id |  | keyword |
+| aruba.vsf.member_id |  | keyword |
+| aruba.vsf.new_standby_id |  | keyword |
+| aruba.vsf.old_standby_id |  | keyword |
+| aruba.vsf.operation |  | keyword |
+| aruba.vsf.port2 |  | keyword |
+| aruba.vsf.product_id |  | keyword |
+| aruba.vsf.product_type |  | keyword |
+| aruba.vsf.topo_type |  | keyword |
+| aruba.vsx.bank_name |  | keyword |
+| aruba.vsx.local_device_type |  | keyword |
+| aruba.vsx.local_sw_ver |  | keyword |
+| aruba.vsx.local_vsx_role |  | keyword |
+| aruba.vsx.peer_device_type |  | keyword |
+| aruba.vsx.peer_sw_ver |  | keyword |
+| aruba.vsx.peer_vsx_role |  | keyword |
+| aruba.vsx.prev_state |  | keyword |
+| aruba.vsx.primary_version |  | keyword |
+| aruba.vsx.secondary_version |  | keyword |
+| aruba.vsx.sub_state |  | keyword |
 | aruba.xcvr.desc |  | keyword |
 | aruba.xcvr.list |  | keyword |
 | aruba.xcvr.path |  | keyword |


### PR DESCRIPTION
## Parent Ticket:
https://github.com/elastic/integrations/issues/12248

## Description
Virtual Switching Extension (70xx)
Virtual Switching Framework (VSF) events (99xx)

Added docs, mac address transform, parsing and generated logs 

Note: Against 10.15 OS
