### PR TITLE
[Windows] Fix mapping for `powershell.command.invocation_details` field

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.5"
+  changes:
+    - description: Fix mapping of `powershell.command.invocation_details` field
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12277
 - version: "2.3.4"
   changes:
     - description: Fix mapping of `dns.answers` ECS field

--- a/packages/windows/data_stream/forwarded/fields/fields.yml
+++ b/packages/windows/data_stream/forwarded/fields/fields.yml
@@ -76,31 +76,26 @@
       description: The invoked command.
       example: Import-LocalizedData  LocalizedData -filename ArchiveResources
     - name: invocation_details
-      type: object
-      object_type: object
-      description: >
-        An array of objects containing detailed information of the executed command.
-
-    - name: invocation_details.type
-      type: keyword
-      description: The type of detail.
-      example: CommandInvocation
-    - name: invocation_details.related_command
-      type: keyword
-      description: The command to which the detail is related to.
-      example: Add-Type
-    - name: invocation_details.name
-      type: keyword
-      description: >
-        Only used for ParameterBinding detail type. Indicates the parameter name.
-
-      example: AssemblyName
-    - name: invocation_details.value
-      type: text
-      description: >
-        The value of the detail. The meaning of it will depend on the detail type.
-
-      example: System.IO.Compression.FileSystem
+      type: group
+      fields:
+        - name: type
+          type: keyword
+          description: The type of detail.
+          example: CommandInvocation
+        - name: related_command
+          type: keyword
+          description: The command to which the detail is related to.
+          example: Add-Type
+        - name: name
+          type: keyword
+          description: >
+            Only used for ParameterBinding detail type. Indicates the parameter name.
+          example: AssemblyName
+        - name: value
+          type: text
+          description: >
+            The value of the detail. The meaning of it will depend on the detail type.
+          example: System.IO.Compression.FileSystem
 - name: powershell.connected_user
   type: group
   fields:

--- a/packages/windows/data_stream/powershell/fields/fields.yml
+++ b/packages/windows/data_stream/powershell/fields/fields.yml
@@ -38,31 +38,26 @@
       description: The invoked command.
       example: Import-LocalizedData  LocalizedData -filename ArchiveResources
     - name: invocation_details
-      type: object
-      object_type: object
-      description: >
-        An array of objects containing detailed information of the executed command.
-
-    - name: invocation_details.type
-      type: keyword
-      description: The type of detail.
-      example: CommandInvocation
-    - name: invocation_details.related_command
-      type: keyword
-      description: The command to which the detail is related to.
-      example: Add-Type
-    - name: invocation_details.name
-      type: keyword
-      description: >
-        Only used for ParameterBinding detail type. Indicates the parameter name.
-
-      example: AssemblyName
-    - name: invocation_details.value
-      type: text
-      description: >
-        The value of the detail. The meaning of it will depend on the detail type.
-
-      example: System.IO.Compression.FileSystem
+      type: group
+      fields:
+        - name: type
+          type: keyword
+          description: The type of detail.
+          example: CommandInvocation
+        - name: related_command
+          type: keyword
+          description: The command to which the detail is related to.
+          example: Add-Type
+        - name: name
+          type: keyword
+          description: >
+            Only used for ParameterBinding detail type. Indicates the parameter name.
+          example: AssemblyName
+        - name: value
+          type: text
+          description: >
+            The value of the detail. The meaning of it will depend on the detail type.
+          example: System.IO.Compression.FileSystem
 - name: powershell.connected_user
   type: group
   fields:

--- a/packages/windows/data_stream/powershell_operational/fields/fields.yml
+++ b/packages/windows/data_stream/powershell_operational/fields/fields.yml
@@ -38,31 +38,26 @@
       description: The invoked command.
       example: Import-LocalizedData  LocalizedData -filename ArchiveResources
     - name: invocation_details
-      type: object
-      object_type: object
-      description: >
-        An array of objects containing detailed information of the executed command.
-
-    - name: invocation_details.type
-      type: keyword
-      description: The type of detail.
-      example: CommandInvocation
-    - name: invocation_details.related_command
-      type: keyword
-      description: The command to which the detail is related to.
-      example: Add-Type
-    - name: invocation_details.name
-      type: keyword
-      description: >
-        Only used for ParameterBinding detail type. Indicates the parameter name.
-
-      example: AssemblyName
-    - name: invocation_details.value
-      type: text
-      description: >
-        The value of the detail. The meaning of it will depend on the detail type.
-
-      example: System.IO.Compression.FileSystem
+      type: group
+      fields:
+        - name: type
+          type: keyword
+          description: The type of detail.
+          example: CommandInvocation
+        - name: related_command
+          type: keyword
+          description: The command to which the detail is related to.
+          example: Add-Type
+        - name: name
+          type: keyword
+          description: >
+            Only used for ParameterBinding detail type. Indicates the parameter name.
+          example: AssemblyName
+        - name: value
+          type: text
+          description: >
+            The value of the detail. The meaning of it will depend on the detail type.
+          example: System.IO.Compression.FileSystem
 - name: powershell.connected_user
   type: group
   fields:

--- a/packages/windows/docs/README.md
+++ b/packages/windows/docs/README.md
@@ -1810,7 +1810,6 @@ An example event for `powershell` looks as following:
 | input.type | Type of Filebeat input. | keyword |
 | log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
-| powershell.command.invocation_details | An array of objects containing detailed information of the executed command. | object |
 | powershell.command.invocation_details.name | Only used for ParameterBinding detail type. Indicates the parameter name. | keyword |
 | powershell.command.invocation_details.related_command | The command to which the detail is related to. | keyword |
 | powershell.command.invocation_details.type | The type of detail. | keyword |
@@ -2151,7 +2150,6 @@ An example event for `powershell_operational` looks as following:
 | input.type | Type of Filebeat input. | keyword |
 | log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
-| powershell.command.invocation_details | An array of objects containing detailed information of the executed command. | object |
 | powershell.command.invocation_details.name | Only used for ParameterBinding detail type. Indicates the parameter name. | keyword |
 | powershell.command.invocation_details.related_command | The command to which the detail is related to. | keyword |
 | powershell.command.invocation_details.type | The type of detail. | keyword |

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 2.3.4
+version: 2.3.5
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Windows package is still failing to install on daily CI jobs.

This removes the invalid `object_type: object` mapping and replaces it with `type: group` for the `powershell.command.invocation_details` field.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).