### PR TITLE
[trend_micro_vision_one] - Added configurable page size option for the detection and audit data streams

### DIFF
--- a/packages/trend_micro_vision_one/changelog.yml
+++ b/packages/trend_micro_vision_one/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add configurable page size option for the detection and audit data streams.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1111
+      link: https://github.com/elastic/integrations/pull/12282
 - version: "1.23.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/trend_micro_vision_one/changelog.yml
+++ b/packages/trend_micro_vision_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.24.0"
+  changes:
+    - description: Add configurable page size option for the detection and audit data streams.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1111
 - version: "1.23.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/trend_micro_vision_one/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/trend_micro_vision_one/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -21,7 +21,7 @@ request.transforms:
       value: 'Bearer {{api_token}}'
   - set:
       target: url.params.top
-      value: '200'
+      value: '{{page_size}}'
   - set:
       target: url.params.startDateTime
       value: '[[formatDate (parseDate .cursor.last_update_at)]]'

--- a/packages/trend_micro_vision_one/data_stream/audit/manifest.yml
+++ b/packages/trend_micro_vision_one/data_stream/audit/manifest.yml
@@ -30,6 +30,14 @@ streams:
         required: true
         show_user: false
         default: 30s
+      - name: page_size
+        type: text
+        title: Page Size
+        multi: false
+        required: true
+        show_user: false
+        description: Page Size for the API response.
+        default: 200
       - name: tags
         type: text
         title: Tags

--- a/packages/trend_micro_vision_one/data_stream/audit/manifest.yml
+++ b/packages/trend_micro_vision_one/data_stream/audit/manifest.yml
@@ -35,7 +35,7 @@ streams:
         title: Page Size
         multi: false
         required: true
-        show_user: false
+        show_user: true
         description: Page Size for the API response.
         default: 200
       - name: tags

--- a/packages/trend_micro_vision_one/data_stream/detection/agent/stream/httpjson.yml.hbs
+++ b/packages/trend_micro_vision_one/data_stream/detection/agent/stream/httpjson.yml.hbs
@@ -24,7 +24,7 @@ request.transforms:
       value: "uuid:*"
   - set:
       target: url.params.top
-      value: '5000'
+      value: '{{page_size}}'
   - set:
       target: url.params.startDateTime
       value: '[[formatDate (parseDate .cursor.last_update_at)]]'

--- a/packages/trend_micro_vision_one/data_stream/detection/manifest.yml
+++ b/packages/trend_micro_vision_one/data_stream/detection/manifest.yml
@@ -35,7 +35,7 @@ streams:
         title: Page Size
         multi: false
         required: true
-        show_user: false
+        show_user: true
         description: Page Size for the API response.
         default: 1000
       - name: tags

--- a/packages/trend_micro_vision_one/data_stream/detection/manifest.yml
+++ b/packages/trend_micro_vision_one/data_stream/detection/manifest.yml
@@ -30,6 +30,14 @@ streams:
         required: true
         show_user: false
         default: 30s
+      - name: page_size
+        type: text
+        title: Page Size
+        multi: false
+        required: true
+        show_user: false
+        description: Page Size for the API response.
+        default: 1000
       - name: tags
         type: text
         title: Tags

--- a/packages/trend_micro_vision_one/manifest.yml
+++ b/packages/trend_micro_vision_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: trend_micro_vision_one
 title: Trend Micro Vision One
-version: "1.23.0"
+version: "1.24.0"
 description: Collect logs from Trend Micro Vision One with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Type of change
- Enhancement

## Proposed commit message
Made page size for audit and detection data streams configurable and set more modest default page size values to avoid 
buffer overflow/ heap errors.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
