### PR TITLE
Fix missing `event.action` in S1 Network Events

### DIFF
--- a/packages/sentinel_one_cloud_funnel/changelog.yml
+++ b/packages/sentinel_one_cloud_funnel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: Fix missing event.action in network events.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12285
 - version: "1.8.0"
   changes:
     - description: Add support for Access Point ARN when collecting logs via the AWS S3 Bucket.

--- a/packages/sentinel_one_cloud_funnel/changelog.yml
+++ b/packages/sentinel_one_cloud_funnel/changelog.yml
@@ -2,7 +2,7 @@
 - version: "1.8.1"
   changes:
     - description: Fix missing event.action in network events.
-      type: enhancement
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/12285
 - version: "1.8.0"
   changes:

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-network-action.log-expected.json
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-network-action.log-expected.json
@@ -11,6 +11,9 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": [
+                    "connection_attempted"
+                ],
                 "category": [
                     "network"
                 ],

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-network-action.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-network-action.yml
@@ -12,12 +12,12 @@ processors:
       field: event.action
       value: [connection_attempted]
       if: (ctx.sentinel_one_cloud_funnel?.event?.type == 'IPConnect' || ctx.sentinel_one_cloud_funnel?.event?.type == 'IP Connect') &&
-          ctx.sentinel_one_cloud_funnel?.event?.network?.direction == "OUTGOING"
+          ctx.json.event?.network?.direction == "OUTGOING"
   - set:
       field: event.action
       value: [connection_accepted]
       if: (ctx.sentinel_one_cloud_funnel?.event?.type == 'IPConnect' || ctx.sentinel_one_cloud_funnel?.event?.type == 'IP Connect') &&
-          ctx.sentinel_one_cloud_funnel?.event?.network?.direction == "INCOMING"
+          ctx.json.event?.network?.direction == "INCOMING"
   - rename:
       field: json.k8sCluster.containerId
       target_field: sentinel_one_cloud_funnel.event.k8s_cluster.container.id

--- a/packages/sentinel_one_cloud_funnel/manifest.yml
+++ b/packages/sentinel_one_cloud_funnel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: sentinel_one_cloud_funnel
 title: SentinelOne Cloud Funnel
-version: "1.8.0"
+version: "1.8.1"
 description: Collect logs from SentinelOne Cloud Funnel with Elastic Agent.
 type: integration
 categories: ["security", "edr_xdr"]


### PR DESCRIPTION
## Summary

Fixes the previous condition which resulted in `event.action` not being populated.

## How to test this PR locally

`elastic-package.exe test pipeline -v`

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


