### PR TITLE
#12248-3/4/5/6/7 Adding 5 new event types (VLAN Interface, VLAN, VRRP, VRF Mgr and VRF)

### DIFF
--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -1301,49 +1301,62 @@ Note: Descriptions have not been filled out
 | aruba.vsf.new_standby_id    |             |      |                                 |
 | aruba.vsf.old_standby_id    |             |      |                                 |
 
-#### [VLAN events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VLAN.htm)
-| Field                | Description | Type | Common                       |
-|----------------------|-------------|------|------------------------------|
-| aruba.vlan.mac       |             |      | server.mac                   |
-| aruba.vlan.mode_from |             |      |                              |
-| aruba.vlan.mode_to   |             |      |                              |
-| aruba.vlan.port      |             |      | server.port                  |
-| aruba.vlan.vlan      |             |      | network.vlan.id              |
-| aruba.vlan.vid       |             |      | network.vlan.id              |
+#### [VLAN events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VLAN.htm)
+| Docs Field     | Schema Mapping               |
+|----------------|------------------------------|
+| `<from>`       | aruba.vlan.from              |
+| `<intf_name>`  | aruba.interface.name         |
+| `<local_node>` | aruba.vlan.local_node        |
+| `<mac>`        | server.mac                   |
+| `<orig_vlan>`  | aruba.vlan.orig_vlan         |
+| `<port>`       | aruba.port                   |
+| `<port_name>`  | aruba.port                   |
+| `<prim_admin>` | aruba.vlan.prim_admin        |
+| `<prim_vid>`   | aruba.vlan.prim_vid          |
+| `<reason>`     | event.reason                 |
+| `<rst>`        | event.reason                 |
+| `<remote_node>`| aruba.vlan.remote_node       |
+| `<sec_admin>`  | aruba.vlan.sec_admin         |
+| `<sec_type>`   | aruba.vlan.sec_type          |
+| `<sec_vid>`    | aruba.vlan.sec_vid           |
+| `<to>`         | aruba.vlan.to                |
+| `<trans_vlan>` | aruba.vlan.trans_vlan        |
+| `<vlan>`       | network.vlan.id              |
+| `<vid>`        | network.vlan.id              |
 
-#### [VLAN Interface events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VLANINTERFACE.htm)
-| Field                | Description | Type | Common                       |
-|----------------------|-------------|------|------------------------------|
-| aruba.vlan.error     |             |      | error.message                |
-| aruba.vlan.interface |             |      | observer.ingress.interface.name |
-| aruba.vlan.vlan      |             |      | network.vlan.id              |
+#### [VLAN Interface events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VLANINTERFACE.htm)
+| Docs Field    | Schema Mapping               |
+|---------------|------------------------------|
+| `<error>`     | event.reason                 |
+| `<interface>` | aruba.interface.id           |
+| `<vlan>`      | network.vlan.id              |
 
-#### [VRF events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VRF.htm)
-| Field                | Description | Type | Common                       |
-|----------------------|-------------|------|------------------------------|
-| aruba.vrf.vrf_name   |             |      | aruba.vrf.name               |
+#### [VRF events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VRF.htm)
+| Docs Field   | Schema Mapping       |
+|--------------|----------------------|
+| `<vrf_name>` | aruba.vrf.name       |
 
-#### [VRF Manager events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VRF_MGR.htm)
-| Field                | Description | Type | Common                       |
-|----------------------|-------------|------|------------------------------|
-| aruba.vrf.vrf_entity |             |      | aruba.vrf.id                 |
+#### [VRF Manager events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VRF_MGR.htm)
+| Docs Field     | Schema Mapping       |
+|----------------|----------------------|
+| `<vrf_entity>` | aruba.vrf.name       |
 
 #### [VRRP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VRRP.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.vrrp.address        |             |      | service.address              |
-| aruba.vrrp.address_type   |             |      | service.type                 |
-| aruba.vrrp.delay_value    |             |      |                              |
-| aruba.vrrp.interface      |             |      | observer.ingress.interface.name |
-| aruba.vrrp.inet_type      |             |      |                              |
-| aruba.vrrp.interval_value |             |      |                              |
-| aruba.vrrp.mode_value     |             |      | event.action                 |
-| aruba.vrrp.new_state      |             |      | service.state                |
-| aruba.vrrp.old_state      |             |      |                              |
-| aruba.vrrp.priority_value |             |      | aruba.priority               |
-| aruba.vrrp.track          |             |      |                              |
-| aruba.vrrp.version_value  |             |      |                              |
-| aruba.vrrp.vrid           |             |      | aruba.instance.id            |
+| Docs Field        | Schema Mapping              |
+|-------------------|-----------------------------|
+| `<address>`       | service.address             |
+| `<interface>`     | aruba.interface.id          |
+| `<inet_type>`     | aruba.vrrp.inet_type        |
+| `<new_state>`     | aruba.state                 |
+| `<old_state>`     | aruba.vrrp.old_state        |
+| `<track>`         | aruba.vrrp.track            |
+| `<type>`          | aruba.vrrp.type             |
+| `<value>`         | service.version             |
+| `<value>`         | aruba.vrrp.delay            |
+| `<value>`         | aruba.vrrp.interval         |
+| `<value>`         | aruba.priority              |
+| `<value>`         | aruba.vrrp.mode             |
+| `<vrid>`          | aruba.instance.id           |
 
 
 #### [VSX Sync events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VSX_SYNC.htm)

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
@@ -296,6 +296,7 @@
                 "hardware": {
                     "device": "6000RCSE4802"
                 },
+                "port": "1/1/18",
                 "sequence": "1/1"
             },
             "ecs": {
@@ -317,6 +318,14 @@
                 }
             },
             "message": "Created Mac based VLAN entry. VLAN 394 is mapped to client ab:cd:ef:12:34:56 on port 1/1/18",
+            "network": {
+                "vlan": {
+                    "id": "394"
+                }
+            },
+            "server": {
+                "mac": "AB-CD-EF-12-34-56"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -331,6 +340,7 @@
                 "hardware": {
                     "device": "6000RCSE4802"
                 },
+                "port": "1/1/18",
                 "sequence": "1/1"
             },
             "ecs": {
@@ -352,6 +362,14 @@
                 }
             },
             "message": "Deleted Mac based VLAN entry for ab:cd:ef:12:34:56 with VLAN 394 on port 1/1/18",
+            "network": {
+                "vlan": {
+                    "id": "394"
+                }
+            },
+            "server": {
+                "mac": "AB-CD-EF-12-34-56"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -366,6 +384,7 @@
                 "hardware": {
                     "device": "6000RCSE4802"
                 },
+                "port": "1/1/48",
                 "sequence": "1/1"
             },
             "ecs": {
@@ -387,6 +406,14 @@
                 }
             },
             "message": "Updated MAC based VLAN entry. VLAN 394 is mapped to client ab:cd:ef:12:34:56 on port 1/1/48",
+            "network": {
+                "vlan": {
+                    "id": "394"
+                }
+            },
+            "server": {
+                "mac": "AB-CD-EF-12-34-56"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -3738,6 +3765,11 @@
                 }
             },
             "message": "VLAN 1595 created in hardware",
+            "network": {
+                "vlan": {
+                    "id": "1595"
+                }
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -3773,6 +3805,11 @@
                 }
             },
             "message": "VLAN 1339 removed from hardware",
+            "network": {
+                "vlan": {
+                    "id": "1339"
+                }
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -3787,7 +3824,12 @@
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "sequence": "1/1"
+                "port": "1/1/23",
+                "sequence": "1/1",
+                "vlan": {
+                    "from": "native-untagged",
+                    "to": "access"
+                }
             },
             "ecs": {
                 "version": "8.11.0"
@@ -3808,6 +3850,11 @@
                 }
             },
             "message": "The mode for port 1/1/23 changed from native-untagged to access on VLAN 1091",
+            "network": {
+                "vlan": {
+                    "id": "1091"
+                }
+            },
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
@@ -194,6 +194,8 @@
 2024-06-18T12:55:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|1511|LOG_ERR|COPP|-|CoPP deinitialization failed on slot 3
 2024-06-18T12:56:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|1512|LOG_ERR|COPP|-|Failed to configure hardware for CoPP on slot 3 class myClass
 2024-06-18T12:57:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|1513|LOG_ERR|COPP|-|Failed to retrieve CoPP statistics from slot 3 class myClass
+2024-06-18T12:45:38.182641-05:00 8360-Primaire vlan[1234]: Event|1601|LOG_ERR|VLANIF|-|Vlaninterface vlan100, failed to create an l3 interface, error: hardware_error
+2024-06-18T12:46:38.182641-05:00 8360-Primaire vlan[1234]: Event|1602|LOG_INFO|VLANIF|-|Vlan Interface eth0, created
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1701|LOG_INFO|LAYER3INTF|-|L3-Interface eth0, created
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1702|LOG_INFO|LAYER3INTF|-|L3-Interface eth0, deleted
 2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-l3interface[1234]: Event|1704|LOG_ERR|LAYER3INTF|-|Failed to create 100 for layer 3 interface eth0
@@ -251,6 +253,26 @@
 2024-06-18T12:59:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2017|LOG_INFO|MSTP|-|Port eth9 unblocked on MST1
 2024-06-18T13:00:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2018|LOG_INFO|MSTP|-|MSTP Root Port changed from eth10 to eth11
 2024-06-18T13:01:38.182641-05:00 8360-Primaire mstpd[1234]: Event|2019|LOG_INFO|MSTP|-|spanning tree mode changed from RSTP to MSTP, it will trigger the reconvergence
+2024-06-18T12:46:38.182641-05:00 8360-Primaire vlan[1234]: Event|2102|LOG_ERR|VLAN|-|Failed to create VLAN 100 in Hardware
+2024-06-18T12:48:38.182641-05:00 8360-Primaire vlan[1234]: Event|2104|LOG_ERR|VLAN|-|Failed to remove VLAN 100 from hardware
+2024-06-18T12:49:38.182641-05:00 8360-Primaire vlan[1234]: Event|2105|LOG_INFO|VLAN|-|Internal VLAN 100 is allocated to port 1/1/1
+2024-06-18T12:50:38.182641-05:00 8360-Primaire vlan[1234]: Event|2106|LOG_ERR|VLAN|-|Failed to allocate internal VLAN to port 1/1/1
+2024-06-18T12:53:38.182641-05:00 8360-Primaire vlan[1234]: Event|2109|LOG_ERR|VLAN|-|Failed to create Mac based VLAN entry for 00:11:22:33:44:55 with VLAN 100 on port 1/1/1
+2024-06-18T12:46:38.182641-05:00 8360-Primaire vlan[1234]: Event|2111|LOG_ERR|VLAN|-|Failed to remove Mac based VLAN entry for 00:11:22:33:44:55 with VLAN 100 on port 1/1/1
+2024-06-18T12:48:38.182641-05:00 8360-Primaire vlan[1234]: Event|2113|LOG_ERR|VLAN|-|Failed to update Mac based VLAN entry for 00:11:22:33:44:55 with VLAN 100 on port 1/1/1
+2024-06-18T12:49:38.182641-05:00 8360-Primaire vlan[1234]: Event|2114|LOG_INFO|VLAN|-|Internal VLAN changed to 200
+2024-06-18T12:50:38.182641-05:00 8360-Primaire vlan[1234]: Event|2115|LOG_INFO|VLAN|-|VLAN 100 is down due to pvlan misconfig reason misconfig_reason
+2024-06-18T12:51:38.182641-05:00 8360-Primaire vlan[1234]: Event|2116|LOG_INFO|VLAN|-|VLAN 100 is recovered from pvlan misconfig
+2024-06-18T12:52:38.182641-05:00 8360-Primaire vlan[1234]: Event|2117|LOG_ERR|VLAN|-|Remote node remote_node add for VLAN 100 on node local_node failed
+2024-06-18T12:53:38.182641-05:00 8360-Primaire vlan[1234]: Event|2118|LOG_ERR|VLAN|-|Remote node remote_node remove for VLAN 100 on node local_node failed
+2024-06-18T12:45:38.182641-05:00 8360-Primaire vlan[1234]: Event|2119|LOG_ERR|VLAN|-|VLAN translation rule addition failed for port:eth0, in_vlan:10, out_vlan:20, reason=hardware_error
+2024-06-18T12:46:38.182641-05:00 8360-Primaire vlan[1234]: Event|2120|LOG_INFO|VLAN|-|eth1 is now an SVLAN customer-network interface.
+2024-06-18T12:47:38.182641-05:00 8360-Primaire vlan[1234]: Event|2121|LOG_WARN|VLAN|-|eth2 is now an SVLAN provider-network interface.
+2024-06-18T12:48:38.182641-05:00 8360-Primaire vlan[1234]: Event|2122|LOG_INFO|VLAN|-|eth3 is no longer an SVLAN interface.
+2024-06-18T12:49:38.182641-05:00 8360-Primaire vlan[1234]: Event|2123|LOG_ERR|VLAN|-|Secondary VLAN 200 of type secondary_type is associated to primary VLAN 100
+2024-06-18T12:50:38.182641-05:00 8360-Primaire vlan[1234]: Event|2124|LOG_WARN|VLAN|-|Secondary VLAN 300 admin state disabled is ignored. Primary VLAN 200 admin state (enabled) will be applied
+2024-06-18T12:51:38.182641-05:00 8360-Primaire vlan[1234]: Event|2125|LOG_INFO|VLAN|-|UUFB eth4 enabled in hardware
+2024-06-18T12:52:38.182641-05:00 8360-Primaire vlan[1234]: Event|2126|LOG_ERR|VLAN|-|UUFB eth5 disabled in hardware
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-rm[1234]: Event|2201|LOG_INFO|REDUNDMGMT|-|Failover detected: Reason power_failure
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-rm[1234]: Event|2202|LOG_INFO|REDUNDMGMT|-|Lost standby_module as Standby Management Module, redundancy disabled
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-rm[1234]: Event|2203|LOG_INFO|REDUNDMGMT|-|Detected the removal of the Standby Management Module
@@ -389,6 +411,37 @@
 2024-06-21T18:32:07.025548-05:00 8360-Primaire dhcpd[999]: Event|3401|LOG_INFO|DHCPD|-|DHCP Relay Enabled
 2024-06-21T18:32:07.025548-05:00 8360-Primaire dhcpd[999]: Event|3402|LOG_INFO|DHCPD|-|DHCP Relay Disabled
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-irdp[1234]: Event|3501|LOG_INFO|IRDP|-|IRDP enabled on interface eth0
+2024-06-18T12:45:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3701|LOG_INFO|VRRP|-|VRRP has been enabled on this router
+2024-06-18T12:46:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3702|LOG_INFO|VRRP|-|VRRP has been disabled on this router
+2024-06-18T12:47:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3703|LOG_INFO|VRRP|-|IPv4 virtual router 1 on interface eth0 has taken owner IP
+2024-06-18T12:48:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3704|LOG_INFO|VRRP|-|IPv4 virtual router 1 on interface eth0 has taken standby IP
+2024-06-18T12:49:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3705|LOG_INFO|VRRP|-|IPv4 virtual router 1 on interface eth0 lost standby IP
+2024-06-18T12:50:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3706|LOG_INFO|VRRP|-|IPv4 virtual router 1 created on interface eth0
+2024-06-18T12:51:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3707|LOG_INFO|VRRP|-|IPv4 virtual router 1 deleted from interface eth0
+2024-06-18T12:52:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3708|LOG_INFO|VRRP|-|IPv4 address 192.168.1.1 is added to virtual router 1 on interface eth0
+2024-06-18T12:53:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3709|LOG_INFO|VRRP|-|IPv4 address 192.168.1.1 is deleted from virtual router 1 on interface eth0
+2024-06-18T12:54:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3710|LOG_INFO|VRRP|-|IPv4 virtual router 1 version changed to 2 on interface eth0
+2024-06-18T12:55:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3711|LOG_INFO|VRRP|-|IPv4 virtual router 1 advertisement interval has changed to 100 milliseconds on interface eth0
+2024-06-18T12:45:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3712|LOG_INFO|VRRP|-|IPv4 virtual router 1 preempt delay time has changed to 30 seconds on interface eth0
+2024-06-18T12:46:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3713|LOG_INFO|VRRP|-|IPv4 virtual router 1 state change from INIT to BACKUP on interface eth0
+2024-06-18T12:47:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3714|LOG_INFO|VRRP|-|Enabled preempt option for IPv4 virtual router 1 on interface eth0
+2024-06-18T12:48:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3715|LOG_INFO|VRRP|-|Enabled virtual IP ping for IPv4 virtual router 1 on interface eth0
+2024-06-18T12:49:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3716|LOG_INFO|VRRP|-|Enabled IPv4 virtual router 1 on interface eth0
+2024-06-18T12:50:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3717|LOG_INFO|VRRP|-|Disabled preempt option for IPv4 virtual router 1 on interface eth0
+2024-06-18T12:51:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3718|LOG_INFO|VRRP|-|Disabled virtual IP ping for IPv4 virtual router 1 on interface eth0
+2024-06-18T12:52:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3719|LOG_INFO|VRRP|-|Disabled IPv4 virtual router 1 on interface eth0
+2024-06-18T12:53:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3720|LOG_INFO|VRRP|-|IPv4 virtual router 1 priority changed to 100 on interface eth0
+2024-06-18T12:54:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3721|LOG_INFO|VRRP|-|IPv4 virtual router 1 mode changed to MASTER on interface eth0
+2024-06-18T12:55:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3722|LOG_INFO|VRRP|-|Track object 1 is associated with IPv4 virtual router 1
+2024-06-18T12:56:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3723|LOG_INFO|VRRP|-|Track object 1 is de-associated from IPv4 virtual router 1
+2024-06-18T12:57:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3724|LOG_INFO|VRRP|-|Track object 1 is created
+2024-06-18T12:45:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3725|LOG_INFO|VRRP|-|Track object track1 is deleted
+2024-06-18T12:46:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3726|LOG_INFO|VRRP|-|Track object track1 state changed from UP to DOWN
+2024-06-18T12:47:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3727|LOG_INFO|VRRP|-|Track object track1 associated with interface eth0
+2024-06-18T12:48:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3728|LOG_ERR|VRRP|-|IPv4 virtual router 1 received packet with authentication type mismatch on interface eth0
+2024-06-18T12:49:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3729|LOG_ERR|VRRP|-|IPv4 virtual router 1 received packet with authentication key mismatch on interface eth0
+2024-06-18T12:50:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3730|LOG_INFO|VRRP|-|Enabled vrrpv3 checksum for IPv4 virtual router 1 on interface eth0
+2024-06-18T12:51:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3731|LOG_INFO|VRRP|-|Disabled vrrpv3 checksum for IPv4 virtual router 1 on interface eth0
 2024-06-18T12:45:38.182641-05:00 8360-Primaire transceiver[1234]: Event|3801|LOG_INFO|Transceiver|-|allow-unsupported-transceiver feature enabled
 2024-06-18T12:46:38.182641-05:00 8360-Primaire transceiver[1234]: Event|3802|LOG_INFO|Transceiver|-|allow-unsupported-transceiver feature disabled
 2024-06-18T12:47:38.182641-05:00 8360-Primaire transceiver[1234]: Event|3803|LOG_INFO|Transceiver|-|allow-unsupported-transceiver feature enabled: Unsupported transceivers found in: transceiver1, transceiver2
@@ -582,6 +635,9 @@
 2024-06-18T13:06:38.182641-05:00 8360-Primaire sshd[1234]: Event|5223|LOG_WARN|SSHS|-|An empty SSH allow-list has been enabled and all new SSH connections will be denied.
 2024-06-18T12:45:38.182641-05:00 8360-Primaire sftp-client[1234]: Event|5301|LOG_INFO|SFTPC|-|SFTP file transfer from server1 to server2 completed.
 2024-06-18T12:46:38.182641-05:00 8360-Primaire sftp-client[1234]: Event|5302|LOG_ERR|SFTPC|-|SFTP file transfer from server1 to server2 failed - connection_lost.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire vrf_mgr[1234]: Event|5401|LOG_INFO|VRFMGR|-|Created a vrf entity vrf1
+2024-06-18T12:46:38.182641-05:00 8360-Primaire vrf_mgr[1234]: Event|5402|LOG_INFO|VRFMGR|-|Deleted a vrf entity vrf1
+2024-06-18T12:47:38.182641-05:00 8360-Primaire vrf_mgr[1234]: Event|5403|LOG_ERR|VRFMGR|-|vrf entity creation failed vrf1
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5601|LOG_INFO|HTTPSSERVER|-|User admin has enabled read-only for REST mode
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5602|LOG_INFO|HTTPSSERVER|-|User admin has enabled HTTPS Server on VRF default
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|5603|LOG_INFO|HTTPSSERVER|-|User admin closed all HTTPS sessions
@@ -646,6 +702,10 @@
 2024-06-18T12:51:38.182641-05:00 8360-Primaire sysmon[1234]: Event|6307|LOG_WARN|SYSMON|-|Excessive write to swap in module swap1 observed. 30GB written over past 1 hour
 2024-06-18T12:52:38.182641-05:00 8360-Primaire sysmon[1234]: Event|6308|LOG_ERR|SYSMON|-|Excessive write to root partition in module storage1 observed. 100GB written over past 1 hour
 2024-06-18T12:53:38.182641-05:00 8360-Primaire sysmon[1234]: Event|6309|LOG_ERR|SYSMON|-|Excessive write to swap in module swap1 observed. 60GB written over past 1 hour
+2024-06-18T12:45:38.182641-05:00 8360-Primaire vrf[1234]: Event|6401|LOG_INFO|VRF|-|VRF with vrf name vrf1 is configured in the switch
+2024-06-18T12:46:38.182641-05:00 8360-Primaire vrf[1234]: Event|6402|LOG_ERR|VRF|-|Failed to configure VRF with vrf name vrf1 in the switch
+2024-06-18T12:47:38.182641-05:00 8360-Primaire vrf[1234]: Event|6403|LOG_INFO|VRF|-|VRF with vrf name vrf1 is deleted from the switch
+2024-06-18T12:48:38.182641-05:00 8360-Primaire vrf[1234]: Event|6404|LOG_ERR|VRF|-|Failed to delete VRF with vrf name vrf1 from the switch
 2024-06-20T15:52:07.025548-05:00 8360-Primaire credmgrd[456]: Event|6501|LOG_WARN|CREDMGR|-|An internal error occurred while reading the export password and default export password was used instead.
 2024-06-20T15:52:07.025548-05:00 8360-Primaire credmgrd[456]: Event|6502|LOG_WARN|CREDMGR|-|A critical system file has been corrupted. Please configure your export password to the one used by your most recent configuration export and import your most recent configuration.
 2024-06-20T15:52:07.025548-05:00 8360-Primaire credmgrd[456]: Event|6504|LOG_INFO|CREDMGR|-|Self-signed certificate successfully created for the https-server.

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -7181,6 +7181,81 @@
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",
             "aruba": {
                 "component": {
+                    "category": "VLANIF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1601",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire vlan[1234]: Event|1601|LOG_ERR|VLANIF|-|Vlaninterface vlan100, failed to create an l3 interface, error: hardware_error",
+                "reason": "hardware_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Vlaninterface vlan100, failed to create an l3 interface, error: hardware_error",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VLANIF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "1602",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire vlan[1234]: Event|1602|LOG_INFO|VLANIF|-|Vlan Interface eth0, created"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Vlan Interface eth0, created",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
                     "category": "LAYER3INTF"
                 },
                 "event_type": "Event",
@@ -9347,6 +9422,772 @@
                 }
             },
             "message": "spanning tree mode changed from RSTP to MSTP, it will trigger the reconvergence",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2102",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire vlan[1234]: Event|2102|LOG_ERR|VLAN|-|Failed to create VLAN 100 in Hardware"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to create VLAN 100 in Hardware",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2104",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire vlan[1234]: Event|2104|LOG_ERR|VLAN|-|Failed to remove VLAN 100 from hardware"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to remove VLAN 100 from hardware",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2105",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire vlan[1234]: Event|2105|LOG_INFO|VLAN|-|Internal VLAN 100 is allocated to port 1/1/1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Internal VLAN 100 is allocated to port 1/1/1",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2106",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire vlan[1234]: Event|2106|LOG_ERR|VLAN|-|Failed to allocate internal VLAN to port 1/1/1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to allocate internal VLAN to port 1/1/1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2109",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire vlan[1234]: Event|2109|LOG_ERR|VLAN|-|Failed to create Mac based VLAN entry for 00:11:22:33:44:55 with VLAN 100 on port 1/1/1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to create Mac based VLAN entry for 00:11:22:33:44:55 with VLAN 100 on port 1/1/1",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "server": {
+                "mac": "00-11-22-33-44-55"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2111",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire vlan[1234]: Event|2111|LOG_ERR|VLAN|-|Failed to remove Mac based VLAN entry for 00:11:22:33:44:55 with VLAN 100 on port 1/1/1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to remove Mac based VLAN entry for 00:11:22:33:44:55 with VLAN 100 on port 1/1/1",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "server": {
+                "mac": "00-11-22-33-44-55"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2113",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire vlan[1234]: Event|2113|LOG_ERR|VLAN|-|Failed to update Mac based VLAN entry for 00:11:22:33:44:55 with VLAN 100 on port 1/1/1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to update Mac based VLAN entry for 00:11:22:33:44:55 with VLAN 100 on port 1/1/1",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "server": {
+                "mac": "00-11-22-33-44-55"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2114",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire vlan[1234]: Event|2114|LOG_INFO|VLAN|-|Internal VLAN changed to 200"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Internal VLAN changed to 200",
+            "network": {
+                "vlan": {
+                    "id": "200"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2115",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire vlan[1234]: Event|2115|LOG_INFO|VLAN|-|VLAN 100 is down due to pvlan misconfig reason misconfig_reason",
+                "reason": "misconfig_reason"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "VLAN 100 is down due to pvlan misconfig reason misconfig_reason",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2116",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire vlan[1234]: Event|2116|LOG_INFO|VLAN|-|VLAN 100 is recovered from pvlan misconfig"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "VLAN 100 is recovered from pvlan misconfig",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vlan": {
+                    "local_node": "local_node",
+                    "remote_node": "remote_node"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2117",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire vlan[1234]: Event|2117|LOG_ERR|VLAN|-|Remote node remote_node add for VLAN 100 on node local_node failed"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Remote node remote_node add for VLAN 100 on node local_node failed",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vlan": {
+                    "local_node": "local_node",
+                    "remote_node": "remote_node"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2118",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire vlan[1234]: Event|2118|LOG_ERR|VLAN|-|Remote node remote_node remove for VLAN 100 on node local_node failed"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Remote node remote_node remove for VLAN 100 on node local_node failed",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0",
+                "vlan": {
+                    "orig_vlan": "10",
+                    "trans_vlan": "20"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2119",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire vlan[1234]: Event|2119|LOG_ERR|VLAN|-|VLAN translation rule addition failed for port:eth0, in_vlan:10, out_vlan:20, reason=hardware_error",
+                "reason": "hardware_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "VLAN translation rule addition failed for port:eth0, in_vlan:10, out_vlan:20, reason=hardware_error",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2120",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire vlan[1234]: Event|2120|LOG_INFO|VLAN|-|eth1 is now an SVLAN customer-network interface."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "eth1 is now an SVLAN customer-network interface.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth2"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2121",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire vlan[1234]: Event|2121|LOG_WARN|VLAN|-|eth2 is now an SVLAN provider-network interface."
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "eth2 is now an SVLAN provider-network interface.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth3"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2122",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire vlan[1234]: Event|2122|LOG_INFO|VLAN|-|eth3 is no longer an SVLAN interface."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "eth3 is no longer an SVLAN interface.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vlan": {
+                    "prim_vid": "100",
+                    "sec_type": "secondary_type",
+                    "sec_vid": "200"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2123",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire vlan[1234]: Event|2123|LOG_ERR|VLAN|-|Secondary VLAN 200 of type secondary_type is associated to primary VLAN 100"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Secondary VLAN 200 of type secondary_type is associated to primary VLAN 100",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vlan": {
+                    "prim_admin": "enabled",
+                    "prim_vid": "200",
+                    "sec_admin": "disabled",
+                    "sec_vid": "300"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2124",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire vlan[1234]: Event|2124|LOG_WARN|VLAN|-|Secondary VLAN 300 admin state disabled is ignored. Primary VLAN 200 admin state (enabled) will be applied"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Secondary VLAN 300 admin state disabled is ignored. Primary VLAN 200 admin state (enabled) will be applied",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth4"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2125",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire vlan[1234]: Event|2125|LOG_INFO|VLAN|-|UUFB eth4 enabled in hardware"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "UUFB eth4 enabled in hardware",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth5"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2126",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire vlan[1234]: Event|2126|LOG_ERR|VLAN|-|UUFB eth5 disabled in hardware"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "UUFB eth5 disabled in hardware",
             "tags": [
                 "preserve_original_event"
             ]
@@ -14628,6 +15469,1282 @@
                 }
             },
             "message": "IRDP enabled on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3701",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3701|LOG_INFO|VRRP|-|VRRP has been enabled on this router"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "VRRP has been enabled on this router",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3702",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3702|LOG_INFO|VRRP|-|VRRP has been disabled on this router"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "VRRP has been disabled on this router",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "inet_type": "IPv4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3703",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3703|LOG_INFO|VRRP|-|IPv4 virtual router 1 on interface eth0 has taken owner IP"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "IPv4 virtual router 1 on interface eth0 has taken owner IP",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "inet_type": "IPv4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3704",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3704|LOG_INFO|VRRP|-|IPv4 virtual router 1 on interface eth0 has taken standby IP"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "IPv4 virtual router 1 on interface eth0 has taken standby IP",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "inet_type": "IPv4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3705",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3705|LOG_INFO|VRRP|-|IPv4 virtual router 1 on interface eth0 lost standby IP"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "IPv4 virtual router 1 on interface eth0 lost standby IP",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "inet_type": "IPv4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3706",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3706|LOG_INFO|VRRP|-|IPv4 virtual router 1 created on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "IPv4 virtual router 1 created on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "inet_type": "IPv4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3707",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3707|LOG_INFO|VRRP|-|IPv4 virtual router 1 deleted from interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "IPv4 virtual router 1 deleted from interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "type": "IPv4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3708",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3708|LOG_INFO|VRRP|-|IPv4 address 192.168.1.1 is added to virtual router 1 on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "IPv4 address 192.168.1.1 is added to virtual router 1 on interface eth0",
+            "service": {
+                "address": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "type": "IPv4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3709",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3709|LOG_INFO|VRRP|-|IPv4 address 192.168.1.1 is deleted from virtual router 1 on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "IPv4 address 192.168.1.1 is deleted from virtual router 1 on interface eth0",
+            "service": {
+                "address": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "inet_type": "IPv4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3710",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3710|LOG_INFO|VRRP|-|IPv4 virtual router 1 version changed to 2 on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "IPv4 virtual router 1 version changed to 2 on interface eth0",
+            "service": {
+                "version": "2"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "inet_type": "IPv4",
+                    "interval": 100
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3711",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3711|LOG_INFO|VRRP|-|IPv4 virtual router 1 advertisement interval has changed to 100 milliseconds on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "IPv4 virtual router 1 advertisement interval has changed to 100 milliseconds on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "delay": 30,
+                    "inet_type": "IPv4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3712",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3712|LOG_INFO|VRRP|-|IPv4 virtual router 1 preempt delay time has changed to 30 seconds on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "IPv4 virtual router 1 preempt delay time has changed to 30 seconds on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "state": "BACKUP",
+                "vrrp": {
+                    "inet_type": "IPv4",
+                    "old_state": "INIT"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3713",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3713|LOG_INFO|VRRP|-|IPv4 virtual router 1 state change from INIT to BACKUP on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "IPv4 virtual router 1 state change from INIT to BACKUP on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "inet_type": "IPv4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3714",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3714|LOG_INFO|VRRP|-|Enabled preempt option for IPv4 virtual router 1 on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Enabled preempt option for IPv4 virtual router 1 on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "inet_type": "IPv4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3715",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3715|LOG_INFO|VRRP|-|Enabled virtual IP ping for IPv4 virtual router 1 on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Enabled virtual IP ping for IPv4 virtual router 1 on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "inet_type": "IPv4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3716",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3716|LOG_INFO|VRRP|-|Enabled IPv4 virtual router 1 on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Enabled IPv4 virtual router 1 on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "inet_type": "IPv4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3717",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3717|LOG_INFO|VRRP|-|Disabled preempt option for IPv4 virtual router 1 on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Disabled preempt option for IPv4 virtual router 1 on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "inet_type": "IPv4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3718",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3718|LOG_INFO|VRRP|-|Disabled virtual IP ping for IPv4 virtual router 1 on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Disabled virtual IP ping for IPv4 virtual router 1 on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "inet_type": "IPv4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3719",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3719|LOG_INFO|VRRP|-|Disabled IPv4 virtual router 1 on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Disabled IPv4 virtual router 1 on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "priority": "100",
+                "vrrp": {
+                    "inet_type": "IPv4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3720",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3720|LOG_INFO|VRRP|-|IPv4 virtual router 1 priority changed to 100 on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "IPv4 virtual router 1 priority changed to 100 on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "inet_type": "IPv4",
+                    "mode": "MASTER"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3721",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3721|LOG_INFO|VRRP|-|IPv4 virtual router 1 mode changed to MASTER on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "IPv4 virtual router 1 mode changed to MASTER on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "vrrp": {
+                    "inet_type": "IPv4",
+                    "track": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3722",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3722|LOG_INFO|VRRP|-|Track object 1 is associated with IPv4 virtual router 1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Track object 1 is associated with IPv4 virtual router 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:56:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "vrrp": {
+                    "inet_type": "IPv4",
+                    "track": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3723",
+                "original": "2024-06-18T12:56:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3723|LOG_INFO|VRRP|-|Track object 1 is de-associated from IPv4 virtual router 1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Track object 1 is de-associated from IPv4 virtual router 1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:57:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vrrp": {
+                    "track": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3724",
+                "original": "2024-06-18T12:57:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3724|LOG_INFO|VRRP|-|Track object 1 is created"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Track object 1 is created",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vrrp": {
+                    "track": "track1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3725",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3725|LOG_INFO|VRRP|-|Track object track1 is deleted"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Track object track1 is deleted",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "state": "DOWN",
+                "vrrp": {
+                    "old_state": "from UP",
+                    "track": "track1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3726",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3726|LOG_INFO|VRRP|-|Track object track1 state changed from UP to DOWN"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Track object track1 state changed from UP to DOWN",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "track": "track1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3727",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3727|LOG_INFO|VRRP|-|Track object track1 associated with interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Track object track1 associated with interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "inet_type": "IPv4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3728",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3728|LOG_ERR|VRRP|-|IPv4 virtual router 1 received packet with authentication type mismatch on interface eth0"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "IPv4 virtual router 1 received packet with authentication type mismatch on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "inet_type": "IPv4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3729",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3729|LOG_ERR|VRRP|-|IPv4 virtual router 1 received packet with authentication key mismatch on interface eth0"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "IPv4 virtual router 1 received packet with authentication key mismatch on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "inet_type": "IPv4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3730",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3730|LOG_INFO|VRRP|-|Enabled vrrpv3 checksum for IPv4 virtual router 1 on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Enabled vrrpv3 checksum for IPv4 virtual router 1 on interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRRP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "vrrp": {
+                    "inet_type": "IPv4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3731",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire vrrp[1234]: Event|3731|LOG_INFO|VRRP|-|Disabled vrrpv3 checksum for IPv4 virtual router 1 on interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrrp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Disabled vrrpv3 checksum for IPv4 virtual router 1 on interface eth0",
             "tags": [
                 "preserve_original_event"
             ]
@@ -21989,6 +24106,114 @@
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",
             "aruba": {
                 "component": {
+                    "category": "VRFMGR"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vrf": {
+                    "name": "vrf1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5401",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire vrf_mgr[1234]: Event|5401|LOG_INFO|VRFMGR|-|Created a vrf entity vrf1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrf_mgr",
+                    "procid": "1234"
+                }
+            },
+            "message": "Created a vrf entity vrf1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRFMGR"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vrf": {
+                    "name": "vrf1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5402",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire vrf_mgr[1234]: Event|5402|LOG_INFO|VRFMGR|-|Deleted a vrf entity vrf1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrf_mgr",
+                    "procid": "1234"
+                }
+            },
+            "message": "Deleted a vrf entity vrf1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRFMGR"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vrf": {
+                    "name": "vrf1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "5403",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire vrf_mgr[1234]: Event|5403|LOG_ERR|VRFMGR|-|vrf entity creation failed vrf1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vrf_mgr",
+                    "procid": "1234"
+                }
+            },
+            "message": "vrf entity creation failed vrf1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
                     "category": "HTTPSSERVER"
                 },
                 "event_type": "Event",
@@ -24344,6 +26569,150 @@
                 }
             },
             "message": "Excessive write to swap in module swap1 observed. 60GB written over past 1 hour",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vrf": {
+                    "name": "vrf1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "6401",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire vrf[1234]: Event|6401|LOG_INFO|VRF|-|VRF with vrf name vrf1 is configured in the switch"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrf",
+                    "procid": "1234"
+                }
+            },
+            "message": "VRF with vrf name vrf1 is configured in the switch",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vrf": {
+                    "name": "vrf1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "6402",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire vrf[1234]: Event|6402|LOG_ERR|VRF|-|Failed to configure VRF with vrf name vrf1 in the switch"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vrf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to configure VRF with vrf name vrf1 in the switch",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vrf": {
+                    "name": "vrf1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "6403",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire vrf[1234]: Event|6403|LOG_INFO|VRF|-|VRF with vrf name vrf1 is deleted from the switch"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vrf",
+                    "procid": "1234"
+                }
+            },
+            "message": "VRF with vrf name vrf1 is deleted from the switch",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VRF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vrf": {
+                    "name": "vrf1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "6404",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire vrf[1234]: Event|6404|LOG_ERR|VRF|-|Failed to delete VRF with vrf name vrf1 from the switch"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vrf",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to delete VRF with vrf name vrf1 from the switch",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -793,6 +793,17 @@ processors:
       if: "ctx.event?.code == '1513'"
       pattern: "Failed to retrieve CoPP statistics from slot %{aruba.slot} class %{aruba.copp.class}"
 
+    # VLAN Interface events (160X)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VLANINTERFACE.htm
+  - grok:
+      field: message
+      tag: vlan_interface_event_1601_1602
+      description: "logs errors while creating vlaninterface | logs to create vlan interface "
+      if: "['1601','1602'].contains(ctx.event?.code)"
+      patterns:
+        - "^Vlaninterface vlan%{DATA:network.vlan.id}, failed to create an l3 interface, error: %{GREEDYDATA:event.reason}"
+        - "^Vlan Interface %{DATA:aruba.interface.id}, created"
+
     # Layer 3 Interface events (17xx)
     # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3INTERFACE.htm
   - grok:
@@ -967,6 +978,97 @@ processors:
       description: "the spanning tree mode is changed"
       if: "['2019'].contains(ctx.event?.code)"
       pattern: "spanning tree mode changed from %{aruba.mstp.old_mode} to %{aruba.mstp.new_mode}, it will trigger the reconvergence"
+
+  # VLAN events (21xx)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VLAN.htm
+  - grok:
+      if: "['2101','2102','2103','2104'].contains(ctx.event?.code)"
+      tag: vlan_event_2101_2102_2103_2104
+      field: "message"
+      description: "This log event informs the user that VLAN is (not)? created in Hardware | VLAN is (not)? removed from Hardware"
+      patterns:
+        - "VLAN %{DATA:network.vlan.id} "
+  - grok:
+      if: "['2105','2106'].contains(ctx.event?.code)"
+      tag: vlan_event_2105_2106
+      field: "message"
+      description: "This log event informs that internal VLAN is allocated to port | This log event informs that internal VLAN is not allocated"
+      patterns:
+        - "^Internal VLAN %{DATA:network.vlan.id} is allocated to port %{GREEDYDATA:aruba.port}"
+        - "^Failed to allocate internal VLAN to port %{GREEDYDATA:aruba.port}"
+  - dissect:
+      if: "ctx.event?.code == '2107'"
+      tag: vlan_event_2107
+      field: "message"
+      description: "This log event informs that the port mode has changed from one of the trunk types to access or vice versa"
+      pattern: "The mode for port %{aruba.port} changed from %{aruba.vlan.from} to %{aruba.vlan.to} on VLAN %{network.vlan.id}"
+  - grok:
+      if: "['2108','2112'].contains(ctx.event?.code)"
+      tag: vlan_event_2108_2112
+      field: "message"
+      description: "This log event informs the user that Mac based VLAN is created in Hardware | This log event informs the user that MAC based VLAN is updated in Hardware"
+      patterns: 
+        - "^(Created|Updated) (Mac|MAC) based VLAN entry. VLAN %{DATA:network.vlan.id} is mapped to client %{MAC:server.mac} on port %{GREEDYDATA:aruba.port}"
+  - grok:
+      if: "['2109','2110','2111','2113'].contains(ctx.event?.code)"
+      tag: vlan_event_2109_2110_2111_2113
+      field: "message"
+      description: "This log event informs the user that Mac based VLAN is not created in Hardware | is removed from Hardware | is not removed from Hardware | is not updated in Hardware"
+      patterns:
+        - "based VLAN entry for %{MAC:server.mac} with VLAN %{DATA:network.vlan.id} on port %{GREEDYDATA:aruba.port}"
+  - dissect:
+      if: "ctx.event?.code == '2114'"
+      tag: vlan_event_2114
+      field: "message"
+      description: "This log event informs that internal VLAN range is changed"
+      pattern: "Internal VLAN changed to %{network.vlan.id}"
+  - grok:
+      if: "['2115','2116'].contains(ctx.event?.code)"
+      tag: vlan_event_2115_2116
+      field: "message"
+      description: "This log event informs the user that VLAN is down due to pvlan misconfig | This log event informs the user that VLAN is recovered from pvlan misconfig"
+      patterns:
+        - "^VLAN %{DATA:network.vlan.id} is down due to pvlan misconfig reason %{GREEDYDATA:event.reason}"
+        - "^VLAN %{DATA:network.vlan.id} is recovered from pvlan misconfig"
+  - grok:
+      if: "['2117','2118'].contains(ctx.event?.code)"
+      tag: vlan_event_2117_2118
+      field: "message"
+      description: "This log event informs the user that remote node [add|remove] for a vlan failed | "
+      patterns:
+        - "^Remote node %{DATA:aruba.vlan.remote_node} (add|remove) for VLAN %{DATA:network.vlan.id} on node %{DATA:aruba.vlan.local_node} failed"
+  - dissect:
+      if: "ctx.event?.code == '2119'"
+      tag: vlan_event_2119
+      field: "message"
+      description: "Logs a message when vlan translation rule addition failed in hardware"
+      pattern: "VLAN translation rule addition failed for port:%{aruba.port}, in_vlan:%{aruba.vlan.orig_vlan}, out_vlan:%{aruba.vlan.trans_vlan}, reason=%{event.reason}"
+  - grok:
+      if: "['2120','2121','2122'].contains(ctx.event?.code)"
+      tag: vlan_event_2120_2121_2122
+      field: "message"
+      description: "Interface is now an SVLAN customer-network interface | Logs a message when port is part for QinQ provider-network | Logs a message when port is no longer part for QinQ' event_description_template"
+      patterns:
+        - "^%{DATA:aruba.interface.name} is"
+  - dissect:
+      if: "ctx.event?.code == '2123'"
+      tag: vlan_event_2123
+      field: "message"
+      description: "This log event informs the user that secondary VLAN is associated to a primary VLAN"
+      pattern: "Secondary VLAN %{aruba.vlan.sec_vid} of type %{aruba.vlan.sec_type} is associated to primary VLAN %{aruba.vlan.prim_vid}"
+  - dissect:
+      if: "ctx.event?.code == '2124'"
+      tag: vlan_event_2124
+      field: "message"
+      description: "This log event informs the user that secondary VLAN admin state is ignored"
+      pattern: 'Secondary VLAN %{aruba.vlan.sec_vid} admin state %{aruba.vlan.sec_admin} is ignored. Primary VLAN %{aruba.vlan.prim_vid} admin state (%{aruba.vlan.prim_admin}) will be applied'
+  - grok:
+      if: "['2125','2126'].contains(ctx.event?.code)"
+      tag: vlan_event_2125_2126
+      field: "message"
+      description: "This log event informs the user that UUFB has been [enabled|disabled] on a physical port"
+      patterns:
+        - "^UUFB %{DATA:aruba.port} (enabled|disabled) in hardware"
 
   # Redundant Management events (220x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/REDUNDANT_MANAGEMENT.htm
@@ -1349,6 +1451,88 @@ processors:
       description: "This command [enables|disable] the IRDP (ICMP Router Discovery Protocol) feature on interface."
       patterns:
         - "^IRDP (en|dis)abled on interface %{GREEDYDATA:aruba.interface.id}"
+
+  # VRRP events (370x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VRRP.htm
+  - grok:
+      if: "['3703','3704','3705'].contains(ctx.event?.code)"
+      tag: vrrp_event_3703_3704_3705
+      field: "message"
+      description: "Logs virtual router has taken control of [owner|standby] IP | virtual router has lost control of standby IP"
+      patterns:
+        - "^%{DATA:aruba.vrrp.inet_type} virtual router %{DATA:aruba.instance.id} on interface %{DATA:aruba.interface.id} "
+  - grok:
+      if: "['3706','3707'].contains(ctx.event?.code)"
+      tag: vrrp_event_3706_3707
+      field: "message"
+      description: "Logs creation of virtual router on interface | Logs deletion of virtual router from interface"
+      patterns:
+        - "^%{DATA:aruba.vrrp.inet_type} virtual router %{DATA:aruba.instance.id} (created on|deleted from) interface %{GREEDYDATA:aruba.interface.id}"
+  - grok:
+      if: "['3708','3709'].contains(ctx.event?.code)"
+      tag: vrrp_event_
+      field: "message"
+      description: "Logs [addition|deletion] of IP address to virtual router"
+      patterns:
+        - "^%{DATA:aruba.vrrp.type} address %{DATA:service.address} is (added to|deleted from) virtual router %{DATA:aruba.instance.id} on interface %{GREEDYDATA:aruba.interface.id}"
+  - grok:
+      if: "['3710','3711','3712','3713'].contains(ctx.event?.code)"
+      tag: vrrp_event_3710_3711_3712_3713
+      field: "message"
+      description: "Logs version change for virtual router | advertisement timer has changed for virtual router | preempt delay timer has changed for virtual router | state has changed for virtual router on interface"
+      patterns:
+        - "%{START_PATTERN} version changed to %{DATA:service.version} %{TAIL_PATTERN}"
+        - "%{START_PATTERN} advertisement interval has changed to %{NUMBER:aruba.vrrp.interval:long} milliseconds %{TAIL_PATTERN}"
+        - "%{START_PATTERN} preempt delay time has changed to %{NUMBER:aruba.vrrp.delay:long} seconds %{TAIL_PATTERN}"
+        - "%{START_PATTERN} state change from %{DATA:aruba.vrrp.old_state} to %{DATA:aruba.state} %{TAIL_PATTERN}"
+      pattern_definitions:
+        START_PATTERN: "^%{DATA:aruba.vrrp.inet_type} virtual router %{DATA:aruba.instance.id}"
+        TAIL_PATTERN: "on interface %{GREEDYDATA:aruba.interface.id}"
+  - grok:
+      if: "['3714','3715','3717','3718'].contains(ctx.event?.code)"
+      tag: vrrp_event_3714_3715_3717_3718
+      field: "message"
+      description: "preempt option has been enabled | virtual IP ping has been enabled | preempt option has been disabled for virtual router | virtual IP ping has been disabled for virtual router"
+      patterns:
+        - "for %{DATA:aruba.vrrp.inet_type} virtual router %{DATA:aruba.instance.id} on interface %{GREEDYDATA:aruba.interface.id}"
+  - grok:
+      if: "['3716','3719'].contains(ctx.event?.code)"
+      tag: vrrp_event_3716_3719
+      field: "message"
+      description: "virtual router has been [disabled|enabled] on interface"
+      patterns:
+        - "(Enabled|Disabled) %{DATA:aruba.vrrp.inet_type} virtual router %{DATA:aruba.instance.id} on interface %{GREEDYDATA:aruba.interface.id}"
+  - grok:
+      if: "['3720','3721'].contains(ctx.event?.code)"
+      tag: vrrp_event_3720_3721
+      field: "message"
+      description: "Logs priority has been changed for virtual router | virtual router mode has been changed"
+      patterns:
+        - "^%{DATA:aruba.vrrp.inet_type} virtual router %{DATA:aruba.instance.id} (priority changed to %{DATA:aruba.priority}|mode changed to %{DATA:aruba.vrrp.mode}) on interface %{GREEDYDATA:aruba.interface.id}"
+  - grok:
+      if: "['3722','3723','3724','3725','3726','3727'].contains(ctx.event?.code)"
+      tag: vrrp_event_3722_3723_3724_3725_3726_3727
+      field: "message"
+      description: "track object has been (de-associated|associated) with virtual router | track object has been [created|deleted] | track object state change | track object association with interface"
+      patterns:
+        - "^Track object %{DATA:aruba.vrrp.track} is (associated with|de-associated from) %{DATA:aruba.vrrp.inet_type} virtual router %{GREEDYDATA:aruba.instance.id}"
+        - "^Track object %{DATA:aruba.vrrp.track} is (created|deleted)"
+        - "^Track object %{DATA:aruba.vrrp.track} state changed %{DATA:aruba.vrrp.old_state} to %{GREEDYDATA:aruba.state}"
+        - "^Track object %{DATA:aruba.vrrp.track} associated with interface %{GREEDYDATA:aruba.interface.id}"
+  - grok:
+      if: "['3728','3729'].contains(ctx.event?.code)"
+      tag: vrrp_event_3728_3729
+      field: "message"
+      description: "Logs authentication failures on virtual router"
+      patterns:
+        - "^%{DATA:aruba.vrrp.inet_type} virtual router %{DATA:aruba.instance.id} (recieved|received) packet with authentication (type|key) mismatch on interface %{GREEDYDATA:aruba.interface.id}"
+  - grok:
+      if: "['3730','3731'].contains(ctx.event?.code)"
+      tag: vrrp_event_3730_3731
+      field: "message"
+      description: "vrrpv3 checksum has been [enabled|disabled] for virtual router"
+      patterns:
+        - "^(Enabled|Disabled) vrrpv3 checksum for %{DATA:aruba.vrrp.inet_type} virtual router %{DATA:aruba.instance.id} on interface %{GREEDYDATA:aruba.interface.id}"
 
   # Transceiver events (38xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/XCVR.htm
@@ -2088,6 +2272,17 @@ processors:
       patterns:
         - "^SFTP file transfer from %{DATA:source.address} to %{DATA:destination.address} (completed|failed - %{GREEDYDATA:aruba.status})."
 
+  # VRF Manager events (540x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VRF_MGR.htm
+  - grok:
+      if: "['5401','5402','5403'].contains(ctx.event?.code)"
+      tag: vrf_mgr_event_5401_5402_5403
+      field: "message"
+      description: "Created | deleted | created field vrf entity"
+      patterns:
+        - "^(Created|Deleted) a vrf entity %{GREEDYDATA:aruba.vrf.name}"
+        - "^vrf entity creation failed %{GREEDYDATA:aruba.vrf.name}"
+
   # HTTPS Server events (560x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/HTTPS_SERVER.htm
   - grok:
@@ -2152,7 +2347,6 @@ processors:
       field: "message"
       description: "Warning PFC priority sharing a queue"
       pattern: "Port: %{aruba.port} PFC priority %{aruba.priority} using queue %{aruba.qos.queue} should not be sharing the queue with other local-priorities"
-
 
   # NAE events (60xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/TSDBD.htm
@@ -2300,6 +2494,16 @@ processors:
         - "^Excessive write to %{DATA:aruba.sysmon.partition_name} partition in module %{DATA:aruba.sysmon.module_name} observed. %{NUMBER:aruba.sysmon.mem_usage:long}GB written over past %{NUMBER:aruba.sysmon.unit_count:long} %{GREEDYDATA:aruba.sysmon.unit}"
         - "^Excessive write to swap in module %{DATA:aruba.sysmon.module_name} observed. %{NUMBER:aruba.sysmon.mem_usage:long}GB written over past %{NUMBER:aruba.sysmon.unit_count:long} %{GREEDYDATA:aruba.sysmon.unit}"
   
+  # VRF events (640x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VRF.htm
+  - grok:
+      if: "['6401','6402','6403','6404'].contains(ctx.event?.code)"
+      tag: vrf_event_6401_6402_6403_6404
+      field: "message"
+      description: "Logs a message when VRF is configured (failed)? in the switch | when VRF is deleted (failed)? from the switch"
+      patterns: 
+        - "VRF with vrf name %{DATA:aruba.vrf.name} "
+
   # Credential Manager events (65xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CREDMGR.htm
   #

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -1336,6 +1336,42 @@
         - name: role
           type: keyword
           description: ""
+    - name: vlan
+      type: group
+      fields:
+        - name: from
+          type: keyword
+          description: ""
+        - name: local_node
+          type: keyword
+          description: ""
+        - name: orig_vlan
+          type: keyword
+          description: ""
+        - name: prim_admin
+          type: keyword
+          description: ""
+        - name: prim_vid
+          type: keyword
+          description: ""
+        - name: remote_node
+          type: keyword
+          description: ""
+        - name: sec_admin
+          type: keyword
+          description: ""
+        - name: sec_type
+          type: keyword
+          description: ""
+        - name: sec_vid
+          type: keyword
+          description: ""
+        - name: to
+          type: keyword
+          description: ""
+        - name: trans_vlan
+          type: keyword
+          description: ""
     - name: vrf
       type: group
       fields:
@@ -1343,6 +1379,30 @@
           type: keyword
           description: ""
         - name: name
+          type: keyword
+          description: ""
+    - name: vrrp
+      type: group
+      fields:
+        - name: delay
+          type: long
+          description: ""
+        - name: inet_type
+          type: keyword
+          description: ""
+        - name: interval
+          type: long
+          description: ""
+        - name: mode
+          type: keyword
+          description: ""
+        - name: old_state
+          type: keyword
+          description: ""
+        - name: track
+          type: keyword
+          description: ""
+        - name: type
           type: keyword
           description: ""
     - name: xcvr

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -1301,49 +1301,62 @@ Note: Descriptions have not been filled out
 | aruba.vsf.new_standby_id    |             |      |                                 |
 | aruba.vsf.old_standby_id    |             |      |                                 |
 
-#### [VLAN events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VLAN.htm)
-| Field                | Description | Type | Common                       |
-|----------------------|-------------|------|------------------------------|
-| aruba.vlan.mac       |             |      | server.mac                   |
-| aruba.vlan.mode_from |             |      |                              |
-| aruba.vlan.mode_to   |             |      |                              |
-| aruba.vlan.port      |             |      | server.port                  |
-| aruba.vlan.vlan      |             |      | network.vlan.id              |
-| aruba.vlan.vid       |             |      | network.vlan.id              |
+#### [VLAN events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VLAN.htm)
+| Docs Field     | Schema Mapping               |
+|----------------|------------------------------|
+| `<from>`       | aruba.vlan.from              |
+| `<intf_name>`  | aruba.interface.name         |
+| `<local_node>` | aruba.vlan.local_node        |
+| `<mac>`        | server.mac                   |
+| `<orig_vlan>`  | aruba.vlan.orig_vlan         |
+| `<port>`       | aruba.port                   |
+| `<port_name>`  | aruba.port                   |
+| `<prim_admin>` | aruba.vlan.prim_admin        |
+| `<prim_vid>`   | aruba.vlan.prim_vid          |
+| `<reason>`     | event.reason                 |
+| `<rst>`        | event.reason                 |
+| `<remote_node>`| aruba.vlan.remote_node       |
+| `<sec_admin>`  | aruba.vlan.sec_admin         |
+| `<sec_type>`   | aruba.vlan.sec_type          |
+| `<sec_vid>`    | aruba.vlan.sec_vid           |
+| `<to>`         | aruba.vlan.to                |
+| `<trans_vlan>` | aruba.vlan.trans_vlan        |
+| `<vlan>`       | network.vlan.id              |
+| `<vid>`        | network.vlan.id              |
 
-#### [VLAN Interface events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VLANINTERFACE.htm)
-| Field                | Description | Type | Common                       |
-|----------------------|-------------|------|------------------------------|
-| aruba.vlan.error     |             |      | error.message                |
-| aruba.vlan.interface |             |      | observer.ingress.interface.name |
-| aruba.vlan.vlan      |             |      | network.vlan.id              |
+#### [VLAN Interface events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VLANINTERFACE.htm)
+| Docs Field    | Schema Mapping               |
+|---------------|------------------------------|
+| `<error>`     | event.reason                 |
+| `<interface>` | aruba.interface.id           |
+| `<vlan>`      | network.vlan.id              |
 
-#### [VRF events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VRF.htm)
-| Field                | Description | Type | Common                       |
-|----------------------|-------------|------|------------------------------|
-| aruba.vrf.vrf_name   |             |      | aruba.vrf.name               |
+#### [VRF events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VRF.htm)
+| Docs Field   | Schema Mapping       |
+|--------------|----------------------|
+| `<vrf_name>` | aruba.vrf.name       |
 
-#### [VRF Manager events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VRF_MGR.htm)
-| Field                | Description | Type | Common                       |
-|----------------------|-------------|------|------------------------------|
-| aruba.vrf.vrf_entity |             |      | aruba.vrf.id                 |
+#### [VRF Manager events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VRF_MGR.htm)
+| Docs Field     | Schema Mapping       |
+|----------------|----------------------|
+| `<vrf_entity>` | aruba.vrf.name       |
 
 #### [VRRP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VRRP.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.vrrp.address        |             |      | service.address              |
-| aruba.vrrp.address_type   |             |      | service.type                 |
-| aruba.vrrp.delay_value    |             |      |                              |
-| aruba.vrrp.interface      |             |      | observer.ingress.interface.name |
-| aruba.vrrp.inet_type      |             |      |                              |
-| aruba.vrrp.interval_value |             |      |                              |
-| aruba.vrrp.mode_value     |             |      | event.action                 |
-| aruba.vrrp.new_state      |             |      | service.state                |
-| aruba.vrrp.old_state      |             |      |                              |
-| aruba.vrrp.priority_value |             |      | aruba.priority               |
-| aruba.vrrp.track          |             |      |                              |
-| aruba.vrrp.version_value  |             |      |                              |
-| aruba.vrrp.vrid           |             |      | aruba.instance.id            |
+| Docs Field        | Schema Mapping              |
+|-------------------|-----------------------------|
+| `<address>`       | service.address             |
+| `<interface>`     | aruba.interface.id          |
+| `<inet_type>`     | aruba.vrrp.inet_type        |
+| `<new_state>`     | aruba.state                 |
+| `<old_state>`     | aruba.vrrp.old_state        |
+| `<track>`         | aruba.vrrp.track            |
+| `<type>`          | aruba.vrrp.type             |
+| `<value>`         | service.version             |
+| `<value>`         | aruba.vrrp.delay            |
+| `<value>`         | aruba.vrrp.interval         |
+| `<value>`         | aruba.priority              |
+| `<value>`         | aruba.vrrp.mode             |
+| `<vrid>`          | aruba.instance.id           |
 
 
 #### [VSX Sync events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VSX_SYNC.htm)
@@ -1756,8 +1769,26 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.user.added_user |  | keyword |
 | aruba.user.deleted_user |  | keyword |
 | aruba.user.role |  | keyword |
+| aruba.vlan.from |  | keyword |
+| aruba.vlan.local_node |  | keyword |
+| aruba.vlan.orig_vlan |  | keyword |
+| aruba.vlan.prim_admin |  | keyword |
+| aruba.vlan.prim_vid |  | keyword |
+| aruba.vlan.remote_node |  | keyword |
+| aruba.vlan.sec_admin |  | keyword |
+| aruba.vlan.sec_type |  | keyword |
+| aruba.vlan.sec_vid |  | keyword |
+| aruba.vlan.to |  | keyword |
+| aruba.vlan.trans_vlan |  | keyword |
 | aruba.vrf.id |  | keyword |
 | aruba.vrf.name |  | keyword |
+| aruba.vrrp.delay |  | long |
+| aruba.vrrp.inet_type |  | keyword |
+| aruba.vrrp.interval |  | long |
+| aruba.vrrp.mode |  | keyword |
+| aruba.vrrp.old_state |  | keyword |
+| aruba.vrrp.track |  | keyword |
+| aruba.vrrp.type |  | keyword |
 | aruba.xcvr.desc |  | keyword |
 | aruba.xcvr.list |  | keyword |
 | aruba.xcvr.path |  | keyword |


### PR DESCRIPTION
## Parent Ticket
https://github.com/elastic/integrations/issues/12248

## Description
VLAN Interface events (160X)
VLAN events (21xx)
VRRP events (370x)
VRF Manager events (540x)
VRF events (640x)

Added logs, parsing and docs against OS 10.15