### PR TITLE
Update threshold that limits the creation of issues in daily jobs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -97,6 +97,8 @@ steps:
   - label: ":github: Report failed tests"
     key: report-failed-tests
     command: ".buildkite/scripts/report_issues.sh"
+    env:
+      CI_MAX_TESTS_REPORTED: 30
     agents:
       image: "${LINUX_AGENT_IMAGE}"
       cpu: "8"


### PR DESCRIPTION
## Proposed commit message

Update the threshold that limits the creation of issues in daily jobs up to 30.

Environment variable that overwrites the value is defined here: https://github.com/elastic/integrations/blob/5468ed672708099ed7aabfbc95ccee36820dc091/magefile.go#L174