### PR TITLE
[fortinet_forticlient] Deprecate package

### DIFF
--- a/.github/ISSUE_TEMPLATE/integration_bug.yml
+++ b/.github/ISSUE_TEMPLATE/integration_bug.yml
@@ -129,7 +129,7 @@ body:
         - Fleet Server [fleet_server]
         - Forcepoint Web Security [forcepoint_web]
         - ForgeRock [forgerock]
-        - Fortinet FortiClient Logs [fortinet_forticlient]
+        - Fortinet FortiClient Logs (Deprecated) [fortinet_forticlient]
         - Fortinet FortiEDR Logs [fortinet_fortiedr]
         - Fortinet FortiGate Firewall Logs [fortinet_fortigate]
         - Fortinet FortiMail [fortinet_fortimail]

--- a/packages/fortinet_forticlient/changelog.yml
+++ b/packages/fortinet_forticlient/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.0"
+  changes:
+    - description: Deprecate package.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.10.3"
   changes:
     - description: Use triple-brace Mustache templating when referencing variables in ingest pipelines.

--- a/packages/fortinet_forticlient/changelog.yml
+++ b/packages/fortinet_forticlient/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Deprecate package.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/12301
 - version: "1.10.3"
   changes:
     - description: Use triple-brace Mustache templating when referencing variables in ingest pipelines.

--- a/packages/fortinet_forticlient/manifest.yml
+++ b/packages/fortinet_forticlient/manifest.yml
@@ -1,12 +1,12 @@
 name: fortinet_forticlient
-title: Fortinet FortiClient Logs
-version: "1.10.3"
-description: Collect logs from Fortinet FortiClient instances with Elastic Agent.
+title: Fortinet FortiClient Logs (Deprecated)
+version: "1.11.0"
+description: Deprecated. Fortinet FortiClient Logs is no longer supported.
 type: integration
 format_version: 2.7.0
 categories: ["security", "edr_xdr"]
 conditions:
-  kibana.version: "^7.14.1 || ^8.0.0"
+  kibana.version: "^8.8.0"
 icons:
   - src: /img/fortinet-logo.svg
     title: Fortinet


### PR DESCRIPTION
It seems that fortinet_forticlient missed the initial pass of deprecating rsa2elk packages, so deprecating now. Package will NOT be removed for the foreseeable future, but it will not be available in stack 9.0 or later. A rewrite of the package will be necessary for 9.0 support.

## Proposed commit message

- Package is implemented using rsa2elk parsers, which are no longer maintained.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
~~- [ ] I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

