### PR TITLE
#12248 8/9/10/11 Adding last 4 event types (VSX, VXLAN (and agent) and Zero Touch)

### DIFF
--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -1364,32 +1364,43 @@ Note: Descriptions have not been filled out
 | `<value>`         | aruba.vrrp.mode             |
 | `<vrid>`          | aruba.instance.id           |
 
+#### [VSX Sync events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VSX_SYNC.htm)
+| Docs Field | Schema Mapping               |
+|------------|------------------------------|
+| `<id>`     | aruba.instance.id            |
 
-#### [VSX Sync events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VSX_SYNC.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.vsx.id              |             |      | aruba.instance.id            |
+#### [VXLAN agent events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VXLAN_AGENT.htm)
+| Docs Field  | Schema Mapping               |
+|-------------|------------------------------|
+| `<ecmp_id>`   | aruba.vxlan.ecmp_id          |
+| `<tunnel_id>` | aruba.vxlan.tunnel_id        |
+| `<vlan>`      | network.vlan.id              |
+| `<vni_id>`    | aruba.vxlan.vni_id           |
 
+#### [VXLAN events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VXLAN.htm)
+| Docs Field    | Schema Mapping         |
+|---------------|------------------------|
+| `<action>`    | event.action           |
+| `<port>`      | aruba.port             |
+| `<port_name>` | aruba.port             |
+| `<remote_ip>` | client.ip              |
+| `<state>`     | aruba.state            |
+| `<vlan_id>`   | network.vlan.id        |
+| `<vni_id>`    | aruba.vxlan.vni_id     |
+| `<vtep>`      | aruba.vxlan.vtep       |
+| `<vtep_peer>` | aruba.vxlan.vtep_peer  |
 
-#### [VXLAN events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VXLAN.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.vxlan.port_name     |             |      | server.port                  |
-| aruba.vxlan.remote_ip     |             |      | destination.ip               |
-| aruba.vxlan.vlan_id       |             |      | network.vlan.id              |
-| aruba.vxlan.vni_id        |             |      |                              |
-| aruba.vxlan.vtep          |             |      |                              |
-| aruba.vxlan.vtep_peer     |             |      |                              |
-
-#### [Zero touch provisioning events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ZTPD.htm)
-| Field                              | Description | Type | Common                       |
-|------------------------------------|-------------|------|------------------------------|
-| aruba.zero_touch.central_location  |             |      | server.address               |
-| aruba.zero_touch.config_file       |             |      | file.name                    |
-| aruba.zero_touch.filename          |             |      | file.name                    |
-| aruba.zero_touch.http_proxy_location |           |      | server.address               |
-| aruba.zero_touch.image_file        |             |      | file.name                    |
-| aruba.zero_touch.tftp_ip           |             |      | destination.ip               |
+#### [Zero touch provisioning events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ZTPD.htm)
+| Docs Field                | Schema Mapping                   |
+|---------------------------|----------------------------------|
+| `<alt_aruba_central_loc>` | aruba.ztp.alt_aruba_central_loc  |
+| `<central_location>`      | aruba.ztp.central_location       |
+| `<config_file>`           | file.name                        |
+| `<filename>`              | file.name                        |
+| `<http_proxy_location>`   | aruba.ztp.http_proxy_location    |
+| `<image_file>`            | file.name                        |
+| `<reason>`                | event.reason                     |
+| `<tftp_ip>`               | server.ip                        |
 
 ## Generated Logs
 

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
@@ -813,6 +813,9 @@
 2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-ipsla[1234]: Event|7408|LOG_ERR|IP-SLA|-|IP-SLA session:session1 failed to initialize socket, reason: socket_error
 2024-06-19T13:56:24.900661-05:00 8360-Primaire hpe-cpud[1980]: Event|7501|LOG_ERR|CPU_RX|-|Kernel filter "someAction" failed on unit myUnit for myFilter
 2024-06-19T13:56:24.900661-05:00 8360-Primaire hpe-cpud[1980]: Event|7502|LOG_ERR|CPU_RX|-|Cannot create kernel filter on unit myUnit for myFilter. All filters are in use. Configuring fewer per-port features can help with this issue.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire vsx[1234]: Event|7601|LOG_ERR|VSXSYNC|-|Configuration sync error: 12345
+2024-06-18T12:46:38.182641-05:00 8360-Primaire vsx[1234]: Event|7602|LOG_INFO|VSXSYNC|-|Configuration sync update: 12345
+2024-06-18T12:47:38.182641-05:00 8360-Primaire vsx[1234]: Event|7603|LOG_INFO|VSXSYNC|-|Configuration-persistence: 12345
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7701|LOG_INFO|AMM|-|TA Profile devices-v2.arubanetworks.com created
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7702|LOG_INFO|AMM|-|TA Profile devices-v2.arubanetworks.com deleted
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7703|LOG_INFO|AMM|-|Leaf certificate devices-v2.arubanetworks.com imported
@@ -882,6 +885,27 @@
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|8001|LOG_INFO|AMM|-|Bluetooth has been enabled
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|8003|LOG_INFO|AMM|-|Bluetooth adapter inserted
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|8004|LOG_INFO|AMM|-|Bluetooth device connected: ab:cd:ef:12:34:56
+2024-06-18T12:45:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8101|LOG_ERR|VXLAN|-|VNI id 1001 creation failed
+2024-06-18T12:46:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8102|LOG_INFO|VXLAN|-|VNI id 1001 created
+2024-06-18T12:47:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8103|LOG_ERR|VXLAN|-|VNI id 1001 deletion fails
+2024-06-18T12:48:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8104|LOG_INFO|VXLAN|-|VNI id 1001 has been deleted
+2024-06-18T12:49:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8105|LOG_INFO|VXLAN|-|Vtep-Peer 192.168.1.1 is created
+2024-06-18T12:50:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8106|LOG_INFO|VXLAN|-|Vtep-Peer 192.168.1.1 has been deleted
+2024-06-18T12:51:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8107|LOG_ERR|VXLAN|-|Vtep-Peer 192.168.1.1 deletion failed
+2024-06-18T12:52:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8108|LOG_INFO|VXLAN|-|Access-Port with vlan 10 and port eth0 has been created
+2024-06-18T12:53:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8109|LOG_INFO|VXLAN|-|Access-Port with port eth0 and vlan 10 has been deleted
+2024-06-18T12:54:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8110|LOG_INFO|VXLAN|-|Vtep-Peer 192.168.1.1 state is operational
+2024-06-18T12:55:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8111|LOG_WARN|VXLAN|-|Vtep-Peer 192.168.1.1 state is configuration_error
+2024-06-18T12:45:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8112|LOG_ERR|VXLAN|-|Vtep-Peer 192.168.1.1 state is no_hw_resources
+2024-06-18T12:46:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8113|LOG_INFO|VXLAN|-|Vtep-Peer 192.168.1.1 state is activating
+2024-06-18T12:47:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8114|LOG_INFO|VXLAN|-|Tunnel 192.168.1.2 added to hardware
+2024-06-18T12:48:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8115|LOG_INFO|VXLAN|-|Tunnel 192.168.1.2 deleted from hardware
+2024-06-18T12:49:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8116|LOG_INFO|VXLAN|-|Tunnel 192.168.1.2 delete deferred
+2024-06-18T12:50:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8117|LOG_INFO|VXLAN|-|Tunnel 192.168.1.2 deferred delete canceled
+2024-06-18T12:51:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8118|LOG_INFO|VXLAN|-|Event raised when vxlan interface admin state is changed.
+2024-06-18T12:52:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8119|LOG_INFO|VXLAN|-|Nexthop add received for tunnel 192.168.1.1
+2024-06-18T12:53:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8120|LOG_INFO|VXLAN|-|Tunnel 192.168.1.1 forwarding_state is up
+2024-06-18T12:54:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8121|LOG_ERR|VXLAN|-|Unsupported underlay port 1/1/1 configured for tunnel 192.168.1.1
 2024-07-29T14:23:24.900661-05:00 8360-Primaire hpe-dhcpd[1985]: Event|8201|LOG_WARN|DHCP|-|Server 10.4.5.6 packet received on untrusted port 1/1/7 dropped.
 2024-07-29T14:23:24.900661-05:00 8360-Primaire hpe-dhcpd[1985]: Event|8202|LOG_WARN|DHCP|-|Client packet destined to untrusted port 1/1/7 dropped.
 2024-07-29T14:23:24.900661-05:00 8360-Primaire hpe-dhcpd[1985]: Event|8203|LOG_WARN|DHCP|-|Packet received from unauthorized server 10.4.5.6 on port 1/1/7.
@@ -937,6 +961,33 @@
 2024-06-18T12:50:38.182641-05:00 8360-Primaire hpe-msdp[1234]: Event|8607|LOG_INFO|MSDP|-|Start server role for MSDP peer 192.168.1.1
 2024-06-18T12:51:38.182641-05:00 8360-Primaire hpe-msdp[1234]: Event|8608|LOG_INFO|MSDP|-|Finish packet was received on MSDP Peer 192.168.1.1
 2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-msdp[1234]: Event|8609|LOG_WARN|MSDP|-|Failed to add SA Cache entry: S=192.168.1.1, G=224.0.0.1, R=192.168.1.2 for Peer 192.168.1.3 as MSDP SA Cache Limit is reached
+2024-06-18T12:45:38.182641-05:00 8360-Primaire ztp[1234]: Event|8701|LOG_INFO|ZTP|-|ZTP service has started
+2024-06-18T12:46:38.182641-05:00 8360-Primaire ztp[1234]: Event|8702|LOG_INFO|ZTP|-|ZTP service has stopped
+2024-06-18T12:47:38.182641-05:00 8360-Primaire ztp[1234]: Event|8703|LOG_INFO|ZTP|-|ZTP service status changed to in-progress
+2024-06-18T12:48:38.182641-05:00 8360-Primaire ztp[1234]: Event|8704|LOG_INFO|ZTP|-|ZTP service status changed to success
+2024-06-18T12:49:38.182641-05:00 8360-Primaire ztp[1234]: Event|8705|LOG_ERR|ZTP|-|ZTP service status changed to failed because of invalid configuration file
+2024-06-18T12:50:38.182641-05:00 8360-Primaire ztp[1234]: Event|8706|LOG_ERR|ZTP|-|ZTP service status changed to failed because of invalid image file
+2024-06-18T12:51:38.182641-05:00 8360-Primaire ztp[1234]: Event|8707|LOG_WARN|ZTP|-|ZTP service status changed to failed because TFTP info is not available
+2024-06-18T12:52:38.182641-05:00 8360-Primaire ztp[1234]: Event|8708|LOG_WARN|ZTP|-|ZTP service status changed to failed because TFTP server is not reachable
+2024-06-18T12:53:38.182641-05:00 8360-Primaire ztp[1234]: Event|8709|LOG_INFO|ZTP|-|ZTP service status changed to failed because of non-default startup configuration
+2024-06-18T12:54:38.182641-05:00 8360-Primaire ztp[1234]: Event|8710|LOG_INFO|ZTP|-|ZTP service status changed to failed because running configuration is modified
+2024-06-18T12:55:38.182641-05:00 8360-Primaire ztp[1234]: Event|8711|LOG_ERR|ZTP|-|ZTP service status changed to failed because of timeout
+2024-06-18T12:45:38.182641-05:00 8360-Primaire ztp[1234]: Event|8712|LOG_INFO|ZTP|-|ZTP: Image file not provided
+2024-06-18T12:46:38.182641-05:00 8360-Primaire ztp[1234]: Event|8713|LOG_INFO|ZTP|-|ZTP: Config file not provided
+2024-06-18T12:47:38.182641-05:00 8360-Primaire ztp[1234]: Event|8714|LOG_INFO|ZTP|-|ZTP: TFTP server option not provided
+2024-06-18T12:48:38.182641-05:00 8360-Primaire ztp[1234]: Event|8715|LOG_ERR|ZTP|-|ZTP: Exceeded max path length of TFTP server
+2024-06-18T12:49:38.182641-05:00 8360-Primaire ztp[1234]: Event|8718|LOG_INFO|ZTP|-|ZTP: Received TFTP server 192.168.1.1 from dhcp server
+2024-06-18T12:50:38.182641-05:00 8360-Primaire ztp[1234]: Event|8719|LOG_INFO|ZTP|-|ZTP: Received image file example.img from dhcp server
+2024-06-18T12:51:38.182641-05:00 8360-Primaire ztp[1234]: Event|8720|LOG_INFO|ZTP|-|ZTP: Received config file example.cfg from dhcp server
+2024-06-18T12:52:38.182641-05:00 8360-Primaire ztp[1234]: Event|8721|LOG_INFO|ZTP|-|ZTP: Received HPE Aruba Networking Central location central.example.com from DHCP server
+2024-06-18T12:53:38.182641-05:00 8360-Primaire ztp[1234]: Event|8723|LOG_INFO|ZTP|-|ZTP: HPE Aruba Networking Central location option not provided
+2024-06-18T12:54:38.182641-05:00 8360-Primaire ztp[1234]: Event|8724|LOG_INFO|ZTP|-|ZTP: Received HTTP proxy location proxy.example.com from DHCP server.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire ztp[1234]: Event|8726|LOG_INFO|ZTP|-|ZTP: HTTP proxy location was not received in the DHCP offer.
+2024-06-18T12:46:38.182641-05:00 8360-Primaire ztp[1234]: Event|8727|LOG_ERR|ZTP|-|ZTP service status changed to failed because example.cfg file download encountered unexpected error.
+2024-06-18T12:47:38.182641-05:00 8360-Primaire ztp[1234]: Event|8728|LOG_ERR|ZTP|-|ZTP service status changed to failed because example.cfg file did not get downloaded.
+2024-06-18T12:48:38.182641-05:00 8360-Primaire ztp[1234]: Event|8729|LOG_ERR|ZTP|-|ZTP service status changed to failed because the downloaded configuration could not be copied to start-up configuration.
+2024-06-18T12:49:38.182641-05:00 8360-Primaire ztp[1234]: Event|8730|LOG_ERR|ZTP|-|ZTP service status changed to failed because example.cfg file download encountered unexpected error. Reason: network_timeout
+2024-06-18T12:50:38.182641-05:00 8360-Primaire ztp[1234]: Event|8731|LOG_INFO|ZTP|-|Received Alternative HPE Aruba Networking Central location central.example.com from dhcp server.
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8801|LOG_INFO|AMM|-|Hardware VTEP DB setup is completed
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8802|LOG_INFO|AMM|-|Physical Port eth0 is created in Hardware VTEP DB
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-copp[1233]: Event|8803|LOG_INFO|AMM|-|Physical Port eth0 is deleted from Hardware VTEP DB
@@ -1172,6 +1223,8 @@
 2024-06-21T13:58:38.182641-05:00 8360-Primaire hpe-container[1255]: Event|11803|LOG_INFO|CONTAINER|-|Container myContainerName is operational
 2024-06-18T12:45:38.182641-05:00 8360-Primaire ufd[1234]: Event|12001|LOG_ERR|UFD|-|Uplink Failure Detection session-id 12345, state changed from UP to DOWN.
 2024-06-18T12:46:38.182641-05:00 8360-Primaire ufd[1234]: Event|12002|LOG_INFO|UFD|-|Uplink Failure Detection session-id 12345, state changed from DOWN to UP.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire vxlan[1234]: Event|12501|LOG_ERR|VXLANAGENT|-|Netvp add failed for vni_id: 1001, tunnel_id: 2001, vlan: 3001.
+2024-06-18T12:46:38.182641-05:00 8360-Primaire vxlan[1234]: Event|12502|LOG_ERR|VXLANAGENT|-|Tunnel add failed for tunnel_id: 2002, ecmp_id: 3002.
 2024-06-18T12:45:38.182641-05:00 8360-Primaire telnetd[1234]: Event|12901|LOG_INFO|TELNETS|-|TELNET server is enabled on VRF vrf1.
 2024-06-18T12:46:38.182641-05:00 8360-Primaire telnetd[1234]: Event|12902|LOG_INFO|TELNETS|-|TELNET server is disabled on VRF vrf1.
 2024-06-18T12:47:38.182641-05:00 8360-Primaire telnetd[1234]: Event|12903|LOG_ERR|TELNETS|-|Failed to enable Telnet server on VRF vrf1. Admin password is not set.

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -30592,6 +30592,114 @@
             ]
         },
         {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSXSYNC"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "12345"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7601",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire vsx[1234]: Event|7601|LOG_ERR|VSXSYNC|-|Configuration sync error: 12345"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "Configuration sync error: 12345",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSXSYNC"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "12345"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7602",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire vsx[1234]: Event|7602|LOG_INFO|VSXSYNC|-|Configuration sync update: 12345"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "Configuration sync update: 12345",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VSXSYNC"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "12345"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7603",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire vsx[1234]: Event|7603|LOG_INFO|VSXSYNC|-|Configuration-persistence: 12345"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vsx",
+                    "procid": "1234"
+                }
+            },
+            "message": "Configuration-persistence: 12345",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-06-12T14:00:38.324517-05:00",
             "aruba": {
                 "cm": {
@@ -33127,6 +33235,768 @@
             ]
         },
         {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vxlan": {
+                    "vni_id": "1001"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8101",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8101|LOG_ERR|VXLAN|-|VNI id 1001 creation failed"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "VNI id 1001 creation failed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vxlan": {
+                    "vni_id": "1001"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8102",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8102|LOG_INFO|VXLAN|-|VNI id 1001 created"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "VNI id 1001 created",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vxlan": {
+                    "vni_id": "1001"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8103",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8103|LOG_ERR|VXLAN|-|VNI id 1001 deletion fails"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "VNI id 1001 deletion fails",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vxlan": {
+                    "vni_id": "1001"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8104",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8104|LOG_INFO|VXLAN|-|VNI id 1001 has been deleted"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "VNI id 1001 has been deleted",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vxlan": {
+                    "vtep_peer": "192.168.1.1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8105",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8105|LOG_INFO|VXLAN|-|Vtep-Peer 192.168.1.1 is created"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Vtep-Peer 192.168.1.1 is created",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vxlan": {
+                    "vtep_peer": "192.168.1.1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8106",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8106|LOG_INFO|VXLAN|-|Vtep-Peer 192.168.1.1 has been deleted"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Vtep-Peer 192.168.1.1 has been deleted",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vxlan": {
+                    "vtep_peer": "192.168.1.1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8107",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8107|LOG_ERR|VXLAN|-|Vtep-Peer 192.168.1.1 deletion failed"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Vtep-Peer 192.168.1.1 deletion failed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8108",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8108|LOG_INFO|VXLAN|-|Access-Port with vlan 10 and port eth0 has been created"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Access-Port with vlan 10 and port eth0 has been created",
+            "network": {
+                "vlan": {
+                    "id": "10"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8109",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8109|LOG_INFO|VXLAN|-|Access-Port with port eth0 and vlan 10 has been deleted"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Access-Port with port eth0 and vlan 10 has been deleted",
+            "network": {
+                "vlan": {
+                    "id": "10"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vxlan": {
+                    "vtep": "192.168.1.1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8110",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8110|LOG_INFO|VXLAN|-|Vtep-Peer 192.168.1.1 state is operational"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Vtep-Peer 192.168.1.1 state is operational",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vxlan": {
+                    "vtep": "192.168.1.1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8111",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8111|LOG_WARN|VXLAN|-|Vtep-Peer 192.168.1.1 state is configuration_error"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Vtep-Peer 192.168.1.1 state is configuration_error",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vxlan": {
+                    "vtep": "192.168.1.1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8112",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8112|LOG_ERR|VXLAN|-|Vtep-Peer 192.168.1.1 state is no_hw_resources"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Vtep-Peer 192.168.1.1 state is no_hw_resources",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vxlan": {
+                    "vtep": "192.168.1.1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8113",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8113|LOG_INFO|VXLAN|-|Vtep-Peer 192.168.1.1 state is activating"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Vtep-Peer 192.168.1.1 state is activating",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.2"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8114",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8114|LOG_INFO|VXLAN|-|Tunnel 192.168.1.2 added to hardware"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel 192.168.1.2 added to hardware",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.2"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8115",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8115|LOG_INFO|VXLAN|-|Tunnel 192.168.1.2 deleted from hardware"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel 192.168.1.2 deleted from hardware",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.2"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8116",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8116|LOG_INFO|VXLAN|-|Tunnel 192.168.1.2 delete deferred"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel 192.168.1.2 delete deferred",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.2"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8117",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8117|LOG_INFO|VXLAN|-|Tunnel 192.168.1.2 deferred delete canceled"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel 192.168.1.2 deferred delete canceled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8118",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8118|LOG_INFO|VXLAN|-|Event raised when vxlan interface admin state is changed."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Event raised when vxlan interface admin state is changed.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vxlan": {
+                    "vtep_peer": "192.168.1.1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "add",
+                "category": [
+                    "network"
+                ],
+                "code": "8119",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8119|LOG_INFO|VXLAN|-|Nexthop add received for tunnel 192.168.1.1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Nexthop add received for tunnel 192.168.1.1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "state": "up",
+                "vxlan": {
+                    "vtep_peer": "192.168.1.1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8120",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8120|LOG_INFO|VXLAN|-|Tunnel 192.168.1.1 forwarding_state is up"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel 192.168.1.1 forwarding_state is up",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLAN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/1",
+                "vxlan": {
+                    "vtep_peer": "192.168.1.1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8121",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire vxlan[1234]: Event|8121|LOG_ERR|VXLAN|-|Unsupported underlay port 1/1/1 configured for tunnel 192.168.1.1"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Unsupported underlay port 1/1/1 configured for tunnel 192.168.1.1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-07-29T14:23:24.900661-05:00",
             "aruba": {
                 "component": {
@@ -35255,6 +36125,925 @@
             "source": {
                 "ip": "192.168.1.1"
             },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8701",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire ztp[1234]: Event|8701|LOG_INFO|ZTP|-|ZTP service has started"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP service has started",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8702",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire ztp[1234]: Event|8702|LOG_INFO|ZTP|-|ZTP service has stopped"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP service has stopped",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8703",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire ztp[1234]: Event|8703|LOG_INFO|ZTP|-|ZTP service status changed to in-progress"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP service status changed to in-progress",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8704",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire ztp[1234]: Event|8704|LOG_INFO|ZTP|-|ZTP service status changed to success"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP service status changed to success",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8705",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire ztp[1234]: Event|8705|LOG_ERR|ZTP|-|ZTP service status changed to failed because of invalid configuration file"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP service status changed to failed because of invalid configuration file",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8706",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire ztp[1234]: Event|8706|LOG_ERR|ZTP|-|ZTP service status changed to failed because of invalid image file"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP service status changed to failed because of invalid image file",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8707",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire ztp[1234]: Event|8707|LOG_WARN|ZTP|-|ZTP service status changed to failed because TFTP info is not available"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP service status changed to failed because TFTP info is not available",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8708",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire ztp[1234]: Event|8708|LOG_WARN|ZTP|-|ZTP service status changed to failed because TFTP server is not reachable"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP service status changed to failed because TFTP server is not reachable",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8709",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire ztp[1234]: Event|8709|LOG_INFO|ZTP|-|ZTP service status changed to failed because of non-default startup configuration"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP service status changed to failed because of non-default startup configuration",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8710",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire ztp[1234]: Event|8710|LOG_INFO|ZTP|-|ZTP service status changed to failed because running configuration is modified"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP service status changed to failed because running configuration is modified",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8711",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire ztp[1234]: Event|8711|LOG_ERR|ZTP|-|ZTP service status changed to failed because of timeout"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP service status changed to failed because of timeout",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8712",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire ztp[1234]: Event|8712|LOG_INFO|ZTP|-|ZTP: Image file not provided"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP: Image file not provided",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8713",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire ztp[1234]: Event|8713|LOG_INFO|ZTP|-|ZTP: Config file not provided"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP: Config file not provided",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8714",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire ztp[1234]: Event|8714|LOG_INFO|ZTP|-|ZTP: TFTP server option not provided"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP: TFTP server option not provided",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8715",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire ztp[1234]: Event|8715|LOG_ERR|ZTP|-|ZTP: Exceeded max path length of TFTP server"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP: Exceeded max path length of TFTP server",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8718",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire ztp[1234]: Event|8718|LOG_INFO|ZTP|-|ZTP: Received TFTP server 192.168.1.1 from dhcp server"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP: Received TFTP server 192.168.1.1 from dhcp server",
+            "server": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8719",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire ztp[1234]: Event|8719|LOG_INFO|ZTP|-|ZTP: Received image file example.img from dhcp server"
+            },
+            "file": {
+                "name": "example.img"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP: Received image file example.img from dhcp server",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8720",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire ztp[1234]: Event|8720|LOG_INFO|ZTP|-|ZTP: Received config file example.cfg from dhcp server"
+            },
+            "file": {
+                "name": "example.cfg"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP: Received config file example.cfg from dhcp server",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "ztp": {
+                    "central_location": "central.example.com"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8721",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire ztp[1234]: Event|8721|LOG_INFO|ZTP|-|ZTP: Received HPE Aruba Networking Central location central.example.com from DHCP server"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP: Received HPE Aruba Networking Central location central.example.com from DHCP server",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8723",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire ztp[1234]: Event|8723|LOG_INFO|ZTP|-|ZTP: HPE Aruba Networking Central location option not provided"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP: HPE Aruba Networking Central location option not provided",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "ztp": {
+                    "http_proxy_location": "proxy.example.com"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8724",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire ztp[1234]: Event|8724|LOG_INFO|ZTP|-|ZTP: Received HTTP proxy location proxy.example.com from DHCP server."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP: Received HTTP proxy location proxy.example.com from DHCP server.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8726",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire ztp[1234]: Event|8726|LOG_INFO|ZTP|-|ZTP: HTTP proxy location was not received in the DHCP offer."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP: HTTP proxy location was not received in the DHCP offer.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8727",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire ztp[1234]: Event|8727|LOG_ERR|ZTP|-|ZTP service status changed to failed because example.cfg file download encountered unexpected error."
+            },
+            "file": {
+                "name": "example.cfg"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP service status changed to failed because example.cfg file download encountered unexpected error.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8728",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire ztp[1234]: Event|8728|LOG_ERR|ZTP|-|ZTP service status changed to failed because example.cfg file did not get downloaded."
+            },
+            "file": {
+                "name": "example.cfg"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP service status changed to failed because example.cfg file did not get downloaded.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8729",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire ztp[1234]: Event|8729|LOG_ERR|ZTP|-|ZTP service status changed to failed because the downloaded configuration could not be copied to start-up configuration."
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP service status changed to failed because the downloaded configuration could not be copied to start-up configuration.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8730",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire ztp[1234]: Event|8730|LOG_ERR|ZTP|-|ZTP service status changed to failed because example.cfg file download encountered unexpected error. Reason: network_timeout",
+                "reasonreason": "network_timeout"
+            },
+            "file": {
+                "name": "example.cfg"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "ZTP service status changed to failed because example.cfg file download encountered unexpected error. Reason: network_timeout",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ZTP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "ztp": {
+                    "alt_aruba_central_loc": "central.example.com"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8731",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire ztp[1234]: Event|8731|LOG_INFO|ZTP|-|Received Alternative HPE Aruba Networking Central location central.example.com from dhcp server."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "ztp",
+                    "procid": "1234"
+                }
+            },
+            "message": "Received Alternative HPE Aruba Networking Central location central.example.com from dhcp server.",
             "tags": [
                 "preserve_original_event"
             ]
@@ -44139,6 +45928,85 @@
                 }
             },
             "message": "Uplink Failure Detection session-id 12345, state changed from DOWN to UP.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLANAGENT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vxlan": {
+                    "tunnel_id": "2001",
+                    "vni_id": "1001"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "12501",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire vxlan[1234]: Event|12501|LOG_ERR|VXLANAGENT|-|Netvp add failed for vni_id: 1001, tunnel_id: 2001, vlan: 3001."
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Netvp add failed for vni_id: 1001, tunnel_id: 2001, vlan: 3001.",
+            "network": {
+                "vlan": {
+                    "id": "3001"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "VXLANAGENT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "vxlan": {
+                    "ecmp_id": "3002",
+                    "tunnel_id": "2002"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "12502",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire vxlan[1234]: Event|12502|LOG_ERR|VXLANAGENT|-|Tunnel add failed for tunnel_id: 2002, ecmp_id: 3002."
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Tunnel add failed for tunnel_id: 2002, ecmp_id: 3002.",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -2826,6 +2826,16 @@ processors:
       if: "ctx.event?.code == '7502'"
       pattern: "Cannot create kernel filter on unit %{aruba.instance.id} for %{aruba.cpu_rx.filter_description}. All filters are in use. Configuring fewer per-port features can help with this issue."
 
+  # VSX Sync events (760x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VSX_SYNC.htm
+  - grok:
+      field: message
+      tag: vsx_sync_event_7601_7602_7603
+      description: "Logs event when error in synchronizing config between two VSX peers | when there is an update for config sync | when config is copied to startup-config on any of the VSX peer"
+      if: "['7601','7602','7603'].contains(ctx.event?.code)"
+      patterns: 
+        - "(error|update|persistence): %{GREEDYDATA:aruba.instance.id}"
+
   # Certificate management events (77xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CERTMGR.htm
   - grok:
@@ -3053,6 +3063,63 @@ processors:
       description: "Event raised when btd receives signal for Bluetooth device event"
       patterns:
         - "^Bluetooth device %{DATA:event.action}: %{MAC:client.mac}"
+
+  # VXLAN events (81xx)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/BLUETOOTH_MGMT.htm
+  - grok:
+      if: "['8101','8102','8103','8104'].contains(ctx.event?.code)"
+      tag: vxlan_event_8101_8102_8103_8104
+      field: "message"
+      description: "Event raised when VNI creation fails | when VNI created | when VNI deletion fails | when VNI is deleted"
+      patterns:
+        - "^VNI id %{DATA:aruba.vxlan.vni_id} "
+  - grok:
+      if: "['8105','8106','8107'].contains(ctx.event?.code)"
+      tag: vxlan_event_8105_8106_8107
+      field: "message"
+      description: "Event raised when Vtep-Peer is created | has been deleted | deletion fails"
+      patterns:
+        - "^Vtep-Peer %{DATA:aruba.vxlan.vtep_peer} "
+  - grok:
+      if: "['8108','8109'].contains(ctx.event?.code)"
+      tag: vxlan_event_8108_8109
+      field: "message"
+      description: "Event raised when Access-Port has been created | has been deleted"
+      patterns:
+        - "^Access-Port with vlan %{DATA:network.vlan.id} and port %{DATA:aruba.port} has been created"
+        - "^Access-Port with port %{DATA:aruba.port} and vlan %{DATA:network.vlan.id} has been deleted"
+  - grok:
+      if: "['8110','8111','8112','8113'].contains(ctx.event?.code)"
+      tag: vxlan_event_8110_8111_8112_8113
+      field: "message"
+      description: "Event raised when Vtep-Peer status is changed to operational | to configuration error | to no hardware resources | to activating"
+      patterns:
+        - "^Vtep-Peer %{DATA:aruba.vxlan.vtep} state is"
+  - grok:
+      if: "['8114','8115','8116','8117'].contains(ctx.event?.code)"
+      tag: vxlan_event_8114_8115_8116_8117
+      field: "message"
+      description: "Event raised when a VxLAN tunnel is deleted from hardware | has its deletion deferred by L3PD | has its deferred deletion canceled"
+      patterns:
+        - "^Tunnel %{IP:client.ip} (added|deleted|delete|deferred)"
+  - dissect:
+      if: "ctx.event?.code == '8119'"
+      tag: vxlan_event_8119
+      field: "message"
+      description: "Event raised when nexthop operation add/delete/modify is triggered on a vtep-peer"
+      pattern: "Nexthop %{event.action} received for tunnel %{aruba.vxlan.vtep_peer}"
+  - dissect:
+      if: "ctx.event?.code == '8120'"
+      tag: vxlan_event_8120
+      field: "message"
+      description: "Event raised when Vtep-Peer forwarding_state is changed"
+      pattern: "Tunnel %{aruba.vxlan.vtep_peer} forwarding_state is %{aruba.state}"
+  - dissect:
+      if: "ctx.event?.code == '8121'"
+      tag: vxlan_event_8121
+      field: "message"
+      description: "Event raised when unsupported underlay port configured as tunnel nexthop"
+      pattern: "Unsupported underlay port %{aruba.port} configured for tunnel %{aruba.vxlan.vtep_peer}"
 
   # DHCPv4 Snooping events (82xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DHCPv4-SNOOPING.htm
@@ -3367,6 +3434,54 @@ processors:
         - "^Start %{DATA:aruba.msdp.tcp_entity} role for MSDP peer %{IP:client.ip}"
         - "^Finish packet was received on MSDP Peer %{IP:client.ip}"
         - "^Failed to add SA Cache entry: S=%{IP:source.ip}, G=%{IP:aruba.msdp.grp_ip}, R=%{IP:aruba.msdp.rp_ip} for Peer %{IP:client.ip} as MSDP SA Cache Limit is reached"
+
+    # Zero touch provisioning events (87xx)
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ZTPD.htm
+  - dissect:
+      field: message
+      tag: ztp_event_8718
+      description: "Logs related to ztp configurations - TFTP IP received"
+      if: "ctx.event?.code == '8718'"
+      pattern: "ZTP: Received TFTP server %{server.ip} from dhcp server"
+  - dissect:
+      field: message
+      tag: ztp_event_8719
+      description: "Logs related to ztp configurations - TFTP IP received"
+      if: "ctx.event?.code == '8719'"
+      pattern: "ZTP: Received image file %{file.name} from dhcp server"
+  - dissect:
+      field: message
+      tag: ztp_event_8720
+      description: "Logs related to ztp configurations - Config filename received"
+      if: "ctx.event?.code == '8720'"
+      pattern: "ZTP: Received config file %{file.name} from dhcp server"
+  - dissect:
+      field: message
+      tag: ztp_event_8721
+      description: "Logs related to ztp configurations - HPE Aruba Networking Central FQDN or IPv4 received"
+      if: "ctx.event?.code == '8721'"
+      pattern: "ZTP: Received HPE Aruba Networking Central location %{aruba.ztp.central_location} from DHCP server"
+  - dissect:
+      field: message
+      tag: ztp_event_8724
+      description: "Logs related to ztp configurations - Aruba HTTP proxy FQDN or IPv4 received"
+      if: "ctx.event?.code == '8724'"
+      pattern: "ZTP: Received HTTP proxy location %{aruba.ztp.http_proxy_location} from DHCP server."
+  - grok:
+      field: message
+      tag: ztp_event_8727_8728_8730
+      description: "Log event when ZTP fails because of unexpected error in config/image file download | because of config/image file download error | because of unexpected error in config file download"
+      if: "['8727','8728','8730'].contains(ctx.event?.code)"
+      patterns:
+        - "^ZTP service status changed to failed because %{DATA:file.name} file download encountered unexpected error.( Reason: %{GREEDYDATA:event.reasonreason})?"
+        - "^ZTP service status changed to failed because %{DATA:file.name} file did not get downloaded."
+  - dissect:
+      field: message
+      tag: ztp_event_8731
+      description: "Log event when ZTP receives the Alternative HPE Aruba Networking Central location."
+      if: "ctx.event?.code == '8731'"
+      pattern: "Received Alternative HPE Aruba Networking Central location %{aruba.ztp.alt_aruba_central_loc} from dhcp server."
+
 
   # Hardware switch controller sync events (88xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/HSC-SYNCD.htm
@@ -4187,6 +4302,17 @@ processors:
       if: "['12001','12002'].contains(ctx.event?.code)"
       patterns:
         - "^Uplink Failure Detection session-id %{DATA:aruba.instance.id}, state changed from %{DATA:aruba.ufd.from_state} to %{GREEDYDATA:aruba.state}."
+
+  # VXLAN agent events (1250x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VXLAN_AGENT.htm
+  - grok:
+      field: message
+      tag: vxlan_event_12501_12502
+      description: "Event raised when netvp add fails in agent | Event raised when tunnel add fails in agent"
+      if: "['12501','12502'].contains(ctx.event?.code)"
+      patterns:
+        - "^Netvp add failed for vni_id: %{DATA:aruba.vxlan.vni_id}, tunnel_id: %{DATA:aruba.vxlan.tunnel_id}, vlan: %{GREEDYDATA:network.vlan.id}."
+        - "^Tunnel add failed for tunnel_id: %{DATA:aruba.vxlan.tunnel_id}, ecmp_id: %{GREEDYDATA:aruba.vxlan.ecmp_id}."
 
 # Telnet server events (1290x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/TELNET_SERVER.htm

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -3045,7 +3045,6 @@ processors:
       field: "message"
       description: "Powered device requested power down on interface."
       pattern: "Powered device requested power down on interface %{aruba.interface.name} %{aruba.poe.duration}"
-        
 
   # Bluetooth Management events (80xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/BLUETOOTH_MGMT.htm
@@ -3065,7 +3064,7 @@ processors:
         - "^Bluetooth device %{DATA:event.action}: %{MAC:client.mac}"
 
   # VXLAN events (81xx)
-  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/BLUETOOTH_MGMT.htm
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VXLAN.htm
   - grok:
       if: "['8101','8102','8103','8104'].contains(ctx.event?.code)"
       tag: vxlan_event_8101_8102_8103_8104

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -1481,6 +1481,24 @@
         - name: sub_state
           type: keyword
           description: ""
+    - name: vxlan
+      type: group
+      fields:
+        - name: ecmp_id
+          type: keyword
+          description: ""
+        - name: tunnel_id
+          type: keyword
+          description: ""
+        - name: vni_id
+          type: keyword
+          description: ""
+        - name: vtep
+          type: keyword
+          description: ""
+        - name: vtep_peer
+          type: keyword
+          description: ""
     - name: xcvr
       type: group
       fields:
@@ -1493,14 +1511,16 @@
         - name: path
           type: keyword
           description: ""
-    - name: zero_touch
+    - name: ztp
       type: group
       fields:
+        - name: alt_aruba_central_loc
+          type: keyword
+          description: ""
         - name: central_location
           type: keyword
           description: ""
         - name: http_proxy_location
           type: keyword
           description: ""
-        - name: image_file
-          type: keyword
+

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -1364,32 +1364,43 @@ Note: Descriptions have not been filled out
 | `<value>`         | aruba.vrrp.mode             |
 | `<vrid>`          | aruba.instance.id           |
 
+#### [VSX Sync events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VSX_SYNC.htm)
+| Docs Field | Schema Mapping               |
+|------------|------------------------------|
+| `<id>`     | aruba.instance.id            |
 
-#### [VSX Sync events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VSX_SYNC.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.vsx.id              |             |      | aruba.instance.id            |
+#### [VXLAN agent events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VXLAN_AGENT.htm)
+| Docs Field  | Schema Mapping               |
+|-------------|------------------------------|
+| `<ecmp_id>`   | aruba.vxlan.ecmp_id          |
+| `<tunnel_id>` | aruba.vxlan.tunnel_id        |
+| `<vlan>`      | network.vlan.id              |
+| `<vni_id>`    | aruba.vxlan.vni_id           |
 
+#### [VXLAN events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VXLAN.htm)
+| Docs Field    | Schema Mapping         |
+|---------------|------------------------|
+| `<action>`    | event.action           |
+| `<port>`      | aruba.port             |
+| `<port_name>` | aruba.port             |
+| `<remote_ip>` | client.ip              |
+| `<state>`     | aruba.state            |
+| `<vlan_id>`   | network.vlan.id        |
+| `<vni_id>`    | aruba.vxlan.vni_id     |
+| `<vtep>`      | aruba.vxlan.vtep       |
+| `<vtep_peer>` | aruba.vxlan.vtep_peer  |
 
-#### [VXLAN events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/VXLAN.htm)
-| Field                     | Description | Type | Common                       |
-|---------------------------|-------------|------|------------------------------|
-| aruba.vxlan.port_name     |             |      | server.port                  |
-| aruba.vxlan.remote_ip     |             |      | destination.ip               |
-| aruba.vxlan.vlan_id       |             |      | network.vlan.id              |
-| aruba.vxlan.vni_id        |             |      |                              |
-| aruba.vxlan.vtep          |             |      |                              |
-| aruba.vxlan.vtep_peer     |             |      |                              |
-
-#### [Zero touch provisioning events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ZTPD.htm)
-| Field                              | Description | Type | Common                       |
-|------------------------------------|-------------|------|------------------------------|
-| aruba.zero_touch.central_location  |             |      | server.address               |
-| aruba.zero_touch.config_file       |             |      | file.name                    |
-| aruba.zero_touch.filename          |             |      | file.name                    |
-| aruba.zero_touch.http_proxy_location |           |      | server.address               |
-| aruba.zero_touch.image_file        |             |      | file.name                    |
-| aruba.zero_touch.tftp_ip           |             |      | destination.ip               |
+#### [Zero touch provisioning events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ZTPD.htm)
+| Docs Field                | Schema Mapping                   |
+|---------------------------|----------------------------------|
+| `<alt_aruba_central_loc>` | aruba.ztp.alt_aruba_central_loc  |
+| `<central_location>`      | aruba.ztp.central_location       |
+| `<config_file>`           | file.name                        |
+| `<filename>`              | file.name                        |
+| `<http_proxy_location>`   | aruba.ztp.http_proxy_location    |
+| `<image_file>`            | file.name                        |
+| `<reason>`                | event.reason                     |
+| `<tftp_ip>`               | server.ip                        |
 
 ## Generated Logs
 
@@ -1819,12 +1830,17 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.vsx.primary_version |  | keyword |
 | aruba.vsx.secondary_version |  | keyword |
 | aruba.vsx.sub_state |  | keyword |
+| aruba.vxlan.ecmp_id |  | keyword |
+| aruba.vxlan.tunnel_id |  | keyword |
+| aruba.vxlan.vni_id |  | keyword |
+| aruba.vxlan.vtep |  | keyword |
+| aruba.vxlan.vtep_peer |  | keyword |
 | aruba.xcvr.desc |  | keyword |
 | aruba.xcvr.list |  | keyword |
 | aruba.xcvr.path |  | keyword |
-| aruba.zero_touch.central_location |  | keyword |
-| aruba.zero_touch.http_proxy_location |  | keyword |
-| aruba.zero_touch.image_file |  | keyword |
+| aruba.ztp.alt_aruba_central_loc |  | keyword |
+| aruba.ztp.central_location |  | keyword |
+| aruba.ztp.http_proxy_location |  | keyword |
 | client.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | client.ip | IP address of the client (IPv4 or IPv6). | ip |
 | client.mac | MAC address of the client. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |


### PR DESCRIPTION
## Parent Ticket:
https://github.com/elastic/integrations/issues/12248

## Description
VSX Sync events (760x)
VXLAN events (81xx)
VXLAN agent events (1250x)
Zero-touch provisioning events (87xx)

logs, parsing and docs against OS 10.15
