### PR TITLE
[Cloud Security] add external id field

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -16,6 +16,11 @@
     - description: Changed the agentless tags to be a list
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12066
+- version: "1.12.0-preview02"
+  changes:
+    - description: Add AWS external_id for cloud connectors flow"
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12329
 - version: "1.12.0-preview01"
   changes:
     - description: Add cloud connectors support

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,5 +1,6 @@
 # newer versions go on top
 # version map:
+# 1.13.x - 8.18.x
 # 1.12.x - 8.17.x
 # 1.11.x - 8.16.x
 # 1.10.x - 8.15.x
@@ -11,16 +12,16 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "1.13.0-preview01"
+  changes:
+    - description: Add AWS external_id for cloud connectors flow"
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12329
 - version: "1.12.0"
   changes:
     - description: Changed the agentless tags to be a list
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12066
-- version: "1.12.0-preview02"
-  changes:
-    - description: Add AWS external_id for cloud connectors flow"
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/12329
 - version: "1.12.0-preview01"
   changes:
     - description: Add cloud connectors support

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/aws.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/aws.yml.hbs
@@ -39,6 +39,8 @@ config:
         role_arn: {{role_arn}}
         {{/if}}
         type: {{aws.credentials.type}}
+        {{/if external_id}}
+        type: {{external_id}}
 {{#if condition}}
 condition: {{ condition }}
 {{/if}}

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/aws.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/aws.yml.hbs
@@ -38,9 +38,10 @@ config:
         {{#if role_arn}}
         role_arn: {{role_arn}}
         {{/if}}
+        {{#if aws.credentials.external_id}}
+        external_id: {{aws.credentials.external_id}}
+        {{/if}}
         type: {{aws.credentials.type}}
-        {{/if external_id}}
-        external_id: {{external_id}}
 {{#if condition}}
 condition: {{ condition }}
 {{/if}}

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/aws.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/aws.yml.hbs
@@ -40,7 +40,7 @@ config:
         {{/if}}
         type: {{aws.credentials.type}}
         {{/if external_id}}
-        type: {{external_id}}
+        external_id: {{external_id}}
 {{#if condition}}
 condition: {{ condition }}
 {{/if}}

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -155,7 +155,7 @@ streams:
         required: false
         show_user: false
         secret: false
-      - name: external_id
+      - name: aws.credentials.external_id
         type: text
         title: External ID
         multi: false

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -155,6 +155,13 @@ streams:
         required: false
         show_user: false
         secret: false
+      - name: external_id
+        type: text
+        title: External ID
+        multi: false
+        required: false
+        show_user: false
+        secret: true
   - input: cloudbeat/cis_gcp
     title: CIS GCP Benchmark
     description: CIS Benchmark for Google Cloud Platform Foundation

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.3
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.12.0"
+version: "1.13.0-preview01"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"
@@ -11,7 +11,7 @@ categories:
   - cloudsecurity_cdr
 conditions:
   kibana:
-    version: "^8.17.0 || ^9.0.0"
+    version: "^8.18.0 || ^9.0.0"
   elastic:
     subscription: basic
     capabilities:


### PR DESCRIPTION
## Proposed commit message
I'm adding `external_id` input var field for the `cloudbeat/cis_aws` input. We will use Role ARN and External ID fields  
to establish trust with Elastic.


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

Related ticket: [Add Cloud Connector Support for Agentless CSPM AWS Integration](https://github.com/elastic/security-team/issues/11078)


