### PR TITLE
Add Amazon Bedrock Guardrail metrics routing rules

### DIFF
--- a/packages/awsfirehose/changelog.yml
+++ b/packages/awsfirehose/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Add support for Amazon Bedrock guardrails metrics.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.3.2"
   changes:
     - description: Add missing category.

--- a/packages/awsfirehose/data_stream/metrics/routing_rules.yml
+++ b/packages/awsfirehose/data_stream/metrics/routing_rules.yml
@@ -110,3 +110,8 @@
       namespace:
         - "{{data_stream.namespace}}"
         - default
+    - target_dataset: aws_bedrock.guardrails
+      if: ctx.aws?.cloudwatch?.namespace == "AWS/Bedrock/Guardrails"
+      namespace:
+        - "{{data_stream.namespace}}"
+        - default

--- a/packages/awsfirehose/manifest.yml
+++ b/packages/awsfirehose/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.1.0"
 name: awsfirehose
 title: Amazon Data Firehose
-version: 1.3.2
+version: 1.4.0
 description: Stream logs and metrics from Amazon Data Firehose into Elastic Cloud.
 type: integration
 categories:


### PR DESCRIPTION

- Enhancement

## Proposed commit message

Add routing rules to support Amazon Bedrock routing rules

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

- [x] Package upgrade UI validation 

## How to test this PR locally

- `elastic-package build`
- `elastic-package stack up -v -d --services package-registry`

## Related issues


- Relates https://github.com/elastic/integrations/pull/12250

