### PR TITLE
[jamf_pro] Inventory date formatting for filter

### DIFF
--- a/packages/jamf_pro/_dev/deploy/docker/files/config.yml
+++ b/packages/jamf_pro/_dev/deploy/docker/files/config.yml
@@ -18,7 +18,7 @@ rules:
   - path: /api/v1/computers-inventory
     methods: ["GET"]
     query_params:
-      filter: "{filter:.*}"
+      filter: 'general.reportDate>="2024-06-19T15:54:37.690Z"'
     responses:
       - status_code: 200
         body: |
@@ -110,7 +110,7 @@ rules:
                     "capable": false,
                     "capableUsers": []
                   },
-                  "reportDate": "2024-06-19T15:54:37.692Z",
+                  "reportDate": "2024-06-19T15:54:37.69Z",
                   "lastContactTime": "2024-04-18T14:26:51.514Z",
                   "lastEnrolledDate": "2023-02-22T10:46:17.199Z",
                   "initialEntryDate": "2024-06-19",

--- a/packages/jamf_pro/changelog.yml
+++ b/packages/jamf_pro/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.2"
+  changes:
+    - description: Inventory date formatting for filter.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12333
 - version: "0.2.1"
   changes:
     - description: Inventory pagination fix.

--- a/packages/jamf_pro/data_stream/inventory/agent/stream/cel.yml.hbs
+++ b/packages/jamf_pro/data_stream/inventory/agent/stream/cel.yml.hbs
@@ -68,7 +68,11 @@ program: |-
   				"cursor": state.?cursor.orValue({}).with(
   					{
   						?"last_report_date": (size(body.results) > 0) ?
-  							optional.of(body.results[size(body.results) - 1].general.reportDate)
+  							optional.of(
+  								body.results[size(body.results) - 1].general.reportDate.as(d,
+  									d.parse_time(time_layout.RFC3339).format("2006-01-02T15:04:05.000Z")
+  								)
+  							)
   						:
   							optional.none(),
   					}

--- a/packages/jamf_pro/data_stream/inventory/agent/stream/cel.yml.hbs
+++ b/packages/jamf_pro/data_stream/inventory/agent/stream/cel.yml.hbs
@@ -48,12 +48,10 @@ program: |-
   ).do_request().as(resp,
   	bytes(resp.Body).decode_json().as(body, (resp.StatusCode != 200) ?
   		{
-  			"events": [
-  				{
-  					"error": {"message": "response: " + string(resp.StatusCode)},
-  					"event": {"original": resp.Body},
-  				},
-  			],
+  			"events": {
+  				"error": {"message": "HTTP response code: " + string(resp.StatusCode)},
+  				"event": {"original": resp.Body},
+  			},
   		}
   	:
   		state.with(

--- a/packages/jamf_pro/manifest.yml
+++ b/packages/jamf_pro/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.5
 name: jamf_pro
 title: "Jamf Pro"
-version: 0.2.1
+version: 0.2.2
 source:
   license: "Elastic-2.0"
 description: "Collect logs and inventory data from Jamf Pro with Elastic Agent"


### PR DESCRIPTION
## Proposed commit message

```
[jamf_pro] Inventory date formatting for filter

Ensure that `reportDate` values with less than 3 digits of a fractional
second will be padded with zeros to 3 digits before they are used in
the `filter` parameter.

Avoids HTTP 400 responses saying:

> Date [2025-01-08T10:50:26.6Z] does not match any of supported formats:
> yyyy-MM-ddTHH:mm:ss.SSSZ, yyyy-MM-ddTHH:mm:ss.SSZ,
> yyyy-MM-ddTHH:mm:ssZ, yyyy-MM-dd*, yyyy-MM-dd, yyyy-MM*, yyyy*

Also improves the CEL error handling by returning a single event
outside of an array (which will be logged).

This has been manually tested against the live API.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

The system test has been updated to demonstrate the new functionality.

## Related issues

- Relates #12021