### PR TITLE
#12249-1 Driving to 10.15 OS support for all events including missed events from previous iteration of implementation (part 1)

### DIFF
--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -82,7 +82,7 @@ Note: Descriptions have not been filled out
 | `<interface_name>`  | aruba.interface.name   |
 | `<name>`            | aruba.acl.name         |
 
-#### [Alarm events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ACL.htm)
+#### [Alarm events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ALARM.htm)
 | Doc Fields       | Schema Mapping           |
 |------------------|--------------------------|
 | `<id>`           | aruba.instance.id        |
@@ -96,7 +96,7 @@ Note: Descriptions have not been filled out
 #### [ARC events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ARC.htm)
 | Doc Fields       | Schema Mapping           |
 |------------------|--------------------------|
-| `<log>`          | aruba.arc.lob            |
+| `<log>`          | aruba.arc.log            |
 | `<node_id>`      | aruba.instance.id        |
 | `<status>`       | aruba.status             |
 

--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -43,11 +43,13 @@ To Be Removed
 Note: Field types are defined within `fields.yml`
 Note: Descriptions have not been filled out
 
-#### [AAA events (Aruba Docs)](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/AAA.htm)
+#### [AAA events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/AAA.htm)
 | Doc Fields           | Schema Mapping               |
 |----------------------|------------------------------|
 | `<aaa_config_type>`  | aruba.aaa.config_event       |
 | `<aaa_config_event>` | aruba.aaa.config_type        |
+| `<key_length>`       | aruba.len                    |
+| `<max_key_length>`   | aruba.limit.threshold        |
 | `<tacacs_action>`    | aruba.aaa.radius_action      |
 | `<radius_event>`     | aruba.aaa.radius_event       |
 | `<server_address>`   | server.address               |
@@ -62,7 +64,13 @@ Note: Descriptions have not been filled out
 | `<server_vrfid>`     | aruba.vrf.id                 |
 | `<tacacs_type>`      | aruba.aaa.tacacs_type        |
 
-#### [ACLs events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ACL.htm)
+#### [Accounting events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ACCOUNTING.htm)
+| Doc Fields           | Schema Mapping               |
+|----------------------|------------------------------|
+| `<ip_address>`       | client.ip                    |
+| `<user_name>`        | user.name                    |
+
+#### [ACLs events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ACL.htm)
 | Doc Fields          | Schema Mapping         |
 |---------------------|------------------------|
 | `<log>`             | message                |
@@ -73,6 +81,24 @@ Note: Descriptions have not been filled out
 | `<hit_delta>`       | aruba.acl.hit_delta    |
 | `<interface_name>`  | aruba.interface.name   |
 | `<name>`            | aruba.acl.name         |
+
+#### [Alarm events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ACL.htm)
+| Doc Fields       | Schema Mapping           |
+|------------------|--------------------------|
+| `<id>`           | aruba.instance.id        |
+| `<length>`       | aruba.len                |
+| `<log_and_trap>` | aruba.alarm.log_and_trap |
+| `<name>`         | aruba.alarm.name         |
+| `<relay>`        | aruba.alarm.relay        |
+| `<trigger>`      | aruba.alarm.trigger      |
+| `<type>`         | aruba.alarm.type         |
+
+#### [ARC events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ARC.htm)
+| Doc Fields       | Schema Mapping           |
+|------------------|--------------------------|
+| `<log>`          | aruba.arc.lob            |
+| `<node_id>`      | aruba.instance.id        |
+| `<status>`       | aruba.status             |
 
 #### [ARP security events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ARP-SECURITY.htm)
 | Doc Fields    | Schema Mapping  |

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
@@ -3942,7 +3942,7 @@
             "aruba": {
                 "aaa": {
                     "tacacs_action": "update",
-                    "tacacs_event": "  -> reacted>",
+                    "tacacs_event": "  -> redact>",
                     "tacacs_type": "global default tacacs_passkey"
                 },
                 "component": {
@@ -3962,7 +3962,7 @@
                     "network"
                 ],
                 "code": "2302",
-                "original": "2024-06-19T14:21:13.194235-05:00 8360-Primaire aaautilscfgd[712]: Event|2302|LOG_INFO|AMM|1/1|TACACS global default tacacs_passkey update:   -> reacted>",
+                "original": "2024-06-19T14:21:13.194235-05:00 8360-Primaire aaautilscfgd[712]: Event|2302|LOG_INFO|AMM|1/1|TACACS global default tacacs_passkey update:   -> redact>",
                 "sequence": 1
             },
             "log": {
@@ -3972,7 +3972,7 @@
                     "procid": "712"
                 }
             },
-            "message": "TACACS global default tacacs_passkey update:   -> reacted>",
+            "message": "TACACS global default tacacs_passkey update:   -> redact>",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
@@ -283,8 +283,13 @@
 2024-06-18T12:52:38.182641-05:00 8360-Primaire hpe-rm[1234]: Event|2208|LOG_INFO|REDUNDMGMT|-|standby_module is waiting for filesync
 2024-06-18T12:53:38.182641-05:00 8360-Primaire hpe-rm[1234]: Event|2209|LOG_INFO|REDUNDMGMT|-|standby_module is starting ISSU operation
 2024-06-19T14:22:07.025544-05:00 8360-Primaire acctd[358]: Event|2303|LOG_INFO|AMM|1/1|RADIUS radius type radius_action: radius_event
+2024-06-18T12:47:38.182641-05:00 8360-Primaire acctd[358]: Event|2303|LOG_INFO|AMM|1/1|RADIUS server update: server group update
 2024-06-19T14:22:07.025546-05:00 8360-Primaire acctd[358]: Event|2304|LOG_INFO|AMM|1/1|RADIUS Server with Address: 127.0.0.1, Authport:1/1/6, VRF_ID:vpn-Internet is "aruba_status"
+2024-06-18T12:48:38.182641-05:00 8360-Primaire acctd[358]: Event|2304|LOG_INFO|AMM|1/1|RADIUS Server with Address: 192.168.1.1, Authport:1812, VRF_ID:default is "reachable"
 2024-06-19T14:22:07.025547-05:00 8360-Primaire acctd[358]: Event|2305|LOG_INFO|AMM|1/1|TACACS server host 127.0.0.1 port 1/1/6 vrf vpn-Internet aruba_status
+2024-06-18T12:49:38.182641-05:00 8360-Primaire acctd[358]: Event|2305|LOG_INFO|AMM|1/1|TACACS server host 192.168.1.2 port 49 vrf default reachable
+2024-06-18T12:50:38.182641-05:00 8360-Primaire acctd[358]: Event|2306|LOG_INFO|AMM|1/1|RADIUS Server route with Address: 192.168.1.3, VRF_ID:default is "unreachable"
+2024-06-18T12:51:38.182641-05:00 8360-Primaire acctd[358]: Event|2307|LOG_ERR|AMM|-|Decrypted TACACS passkey length 128 exceeded the maximum allowed plaintext key length 64
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-ospf[1234]: Event|2401|LOG_INFO|OSPFv2|-|AdjChg: Nbr 192.168.1.1 on eth0(0.0.0.0): INIT -> FULL
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-ospf[1234]: Event|2402|LOG_INFO|OSPFv2|-|Interface eth0(0.0.0.0) changed from DOWN to UP, input: 1
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-ospf[1234]: Event|2403|LOG_INFO|OSPFv2|-|ROUTE_ADD with 192.168.1.0/24 2
@@ -1164,7 +1169,9 @@
 2024-06-18T12:47:38.182641-05:00 8360-Primaire vsf[1234]: Event|9959|LOG_WARN|VSF|-|Egress port shape rate 1000 Mbps applied for all VSF interfaces
 2024-06-18T12:48:38.182641-05:00 8360-Primaire vsf[1234]: Event|9960|LOG_WARN|VSF|-|Egress port shape rate 1000 Mbps update is failed to apply for interface eth0
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|10002|LOG_INFO|AMM|-|mock_acl_name on 1/1/25 (route-in): 10 mock ace string
+2024-06-18T12:45:38.182641-05:00 8360-Primaire acld[1234]: Event|10002|LOG_INFO|ACL|-|ACL example_acl (standard) eth0 (in): 5 permit ip any any
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|10003|LOG_ERR|AMM|-|ACL mock_acl_type mock_acl_name failed to apply on mock_application
+2024-06-18T12:46:38.182641-05:00 8360-Primaire acld[1234]: Event|10003|LOG_ERR|ACL|-|ACL standard example_acl failed to apply on firewall
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-policy[1234]: Event|10101|LOG_ERR|POLICY|-|Policy security_policy failed to apply on firewall_application
 2024-06-18T12:45:38.182641-05:00 8360-Primaire tcamd[1234]: Event|10201|LOG_ERR|TCAM|-|Policer installation has failed
 2024-06-18T12:46:38.182641-05:00 8360-Primaire tcamd[1234]: Event|10202|LOG_ERR|TCAM|-|TCAM entry installation has failed in table table1
@@ -1218,6 +1225,17 @@
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-smartlink[1234]: Event|11303|LOG_INFO|Smartlink|-|Backup link of the smartlink group 1 changed to eth2
 2024-06-20T13:54:38.182641-05:00 8360-Primaire hpe-cfmd[1204]: Event|11601|LOG_ERR|CFM|-|Connection lost for Maintenance Endpoint myEndpointId on eth0.
 2024-06-20T13:55:38.182641-05:00 8360-Primaire hpe-cfmd[1204]: Event|11602|LOG_INFO|CFM|-|Connection restored for Maintenance Endpoint myEndpointId on eth0.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11701|LOG_INFO|Alarm|-|Input alarm 123 config change: name: Alarm1, relay: Relay1, log_and_trap: Enabled, trigger: Trigger1
+2024-06-18T12:46:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11702|LOG_INFO|Alarm|-|System alarm (Critical) config change: relay: Relay2, log_and_trap: Enabled
+2024-06-18T12:47:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11703|LOG_INFO|Alarm|-|System alarm Alarm2 has activated through log-and-trap
+2024-06-18T12:48:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11704|LOG_INFO|Alarm|-|Input alarm Alarm3 has activated through log-and-trap, triggered at Trigger2
+2024-06-18T12:49:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11705|LOG_INFO|Alarm|-|Snooze alarm activated, disabling relay function for 10 min
+2024-06-18T12:50:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11706|LOG_INFO|Alarm|-|Snooze alarm has expired
+2024-06-18T12:51:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11707|LOG_INFO|Alarm|-|Alarm relay function is re-enabled
+2024-06-18T12:45:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11707|LOG_INFO|Alarm|-|Alarm relay function is re-enabled
+2024-06-18T12:46:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11708|LOG_INFO|Alarm|-|Snooze alarm repeats, disabling relay function for 10 min
+2024-06-18T12:47:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11709|LOG_INFO|Alarm|-|System alarm CriticalAlarm has activated through relay
+2024-06-18T12:48:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11710|LOG_INFO|Alarm|-|Input alarm InputAlarm has activated through relay, triggered at 12:00
 2024-06-21T13:56:38.182641-05:00 8360-Primaire hpe-container[1255]: Event|11801|LOG_INFO|CONTAINER|-|Container myContainerName is created
 2024-06-21T13:57:38.182641-05:00 8360-Primaire hpe-container[1255]: Event|11802|LOG_INFO|CONTAINER|-|Container myContainerName is removed
 2024-06-21T13:58:38.182641-05:00 8360-Primaire hpe-container[1255]: Event|11803|LOG_INFO|CONTAINER|-|Container myContainerName is operational
@@ -1235,6 +1253,9 @@
 2024-06-18T12:52:38.182641-05:00 8360-Primaire telnetd[1234]: Event|12908|LOG_WARN|TELNETS|-|TELNET session from User admin is closed because maximum number of sessions per user is reached.
 2024-06-18T12:53:38.182641-05:00 8360-Primaire telnetd[1234]: Event|12908|LOG_ERR|TELNETS|-|User admin login from 192.168.1.1 for TELNET session has failed since the user is trying to login through an interface which is not allowed. Allowed interfaces are: mgmt_intf1
 2024-06-18T12:53:38.182641-05:00 8360-Primaire telnetd[1234]: Event|12909|LOG_ERR|TELNETS|-|User admin login from 192.168.1.1 for TELNET session has failed since the user is trying to login through an interface which is not allowed. Allowed interfaces are: mgmt_intf1
+2024-06-18T12:45:38.182641-05:00 8360-Primaire sshd[1234]: Event|13101|LOG_INFO|Accounting|-|SSH session from 192.168.1.1 for user admin closed due to inactivity.
+2024-06-18T12:46:38.182641-05:00 8360-Primaire telnetd[1234]: Event|13102|LOG_INFO|Accounting|-|TELNET session from 192.168.1.2 with User admin timed out due to idle timeout.
+2024-06-18T12:47:38.182641-05:00 8360-Primaire consoled[1234]: Event|13103|LOG_INFO|Accounting|-|CONSOLE session from 192.168.1.3 with User admin timed out due to idle timeout.
 2024-06-18T12:46:38.182641-05:00 8360-Primaire tpm-daemon[1234]: Event|13602|LOG_ERR|TPM|-|TPM_Sign requested by process2 failed with code error_code1
 2024-06-18T12:47:38.182641-05:00 8360-Primaire tpm-daemon[1234]: Event|13603|LOG_ERR|TPM|-|TPM selftest errors occurred on the current boot
 2024-06-18T12:48:38.182641-05:00 8360-Primaire tpm-daemon[1234]: Event|13604|LOG_ERR|TPM|-|Rebooted 3 times to retry TPM selftests
@@ -1246,3 +1267,14 @@
 2024-06-18T12:50:38.182641-05:00 8360-Primaire traffic-insight[1234]: Event|14006|LOG_INFO|TRAFFICINSIGHT|-|Traffic Insight instance instance1 disabled
 2024-06-18T12:51:38.182641-05:00 8360-Primaire traffic-insight[1234]: Event|14007|LOG_INFO|TRAFFICINSIGHT|-|Ignoring the flow for monitor monitor1 instance instance1, maximum application flow cache limit reached
 2024-06-18T12:52:38.182641-05:00 8360-Primaire traffic-insight[1234]: Event|14008|LOG_INFO|TRAFFICINSIGHT|-|DNS Average Latency statistics cache cleared for the monitor monitor1 and instance instance1
+2024-06-18T12:45:38.182641-05:00 8360-Primaire arc[1234]: Event|14101|LOG_INFO|ARC|-|log_mockApp Recognition feature has been enabled - event_name: ARCD_LC_STATUS_CHANGE
+2024-06-18T12:46:38.182641-05:00 8360-Primaire arc[1234]: Event|14102|LOG_INFO|ARC|-|Linecard 1 is up - event_name: ARCD_BULK_SYN_RECEIVE
+2024-06-18T12:47:38.182641-05:00 8360-Primaire arc[1234]: Event|14103|LOG_INFO|ARC|-|BULK SYNC event received from linecard 2 - event_name: ARCD_BULK_SYN_ALL_SENT
+2024-06-18T12:48:38.182641-05:00 8360-Primaire arc[1234]: Event|14104|LOG_INFO|ARC|-|BULK SYNC ALL request sent to all LC - event_name: ARCD_PUBLISHER_STATUS_CHANGE
+2024-06-18T12:49:38.182641-05:00 8360-Primaire arc[1234]: Event|14105|LOG_INFO|ARC|-|ARCD Publisher is active - event_name: ARCD_FLUSH_TIMER
+2024-06-18T12:50:38.182641-05:00 8360-Primaire arc[1234]: Event|14106|LOG_INFO|ARC|-|FLUSH timer on LC 3 is started - event_name: ARCD_OVERFLOW_HIGH_THRESHOLD
+2024-06-18T12:51:38.182641-05:00 8360-Primaire arc[1234]: Event|14107|LOG_INFO|ARC|-|IP Flow table utilization has exceeded high threshold on linecard 4 - event_name: ARCD_OVERFLOW_LOW_THRESHOLD
+2024-06-18T12:52:38.182641-05:00 8360-Primaire arc[1234]: Event|14108|LOG_INFO|ARC|-|IP Flow table utilization back to lower threshold on linecard 5 - event_name: ARCD_GLOBAL_STATUS_CHANGE
+2024-06-18T12:53:38.182641-05:00 8360-Primaire arc[1234]: Event|14109|LOG_INFO|ARC|-|App Recognition feature has been disabled - event_name: ARCD_FEATURE_PACK_HONOR_MODE
+2024-06-18T12:54:38.182641-05:00 8360-Primaire arc[1234]: Event|14110|LOG_WARN|ARC|-|App Recognition is operating without a valid feature pack is_security_log : yes
+2024-06-18T12:55:38.182641-05:00 8360-Primaire arc[1234]: Event|14111|LOG_WARN|ARC|-|App Recognition is blocked due to invalid or missing feature pack is_security_log : yes

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -10549,6 +10549,46 @@
             ]
         },
         {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "aaa": {
+                    "radius_action": "update",
+                    "radius_event": "server group update",
+                    "radius_type": "server"
+                },
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "1/1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2303",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire acctd[358]: Event|2303|LOG_INFO|AMM|1/1|RADIUS server update: server group update",
+                "sequence": 1
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "acctd",
+                    "procid": "358"
+                }
+            },
+            "message": "RADIUS server update: server group update",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-06-19T14:22:07.025546-05:00",
             "aruba": {
                 "component": {
@@ -10586,6 +10626,49 @@
             "message": "RADIUS Server with Address: 127.0.0.1, Authport:1/1/6, VRF_ID:vpn-Internet is \"aruba_status\"",
             "server": {
                 "address": "127.0.0.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1812",
+                "sequence": "1/1",
+                "status": "reachable",
+                "vrf": {
+                    "id": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2304",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire acctd[358]: Event|2304|LOG_INFO|AMM|1/1|RADIUS Server with Address: 192.168.1.1, Authport:1812, VRF_ID:default is \"reachable\"",
+                "sequence": 1
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "acctd",
+                    "procid": "358"
+                }
+            },
+            "message": "RADIUS Server with Address: 192.168.1.1, Authport:1812, VRF_ID:default is \"reachable\"",
+            "server": {
+                "address": "192.168.1.1"
             },
             "tags": [
                 "preserve_original_event"
@@ -10630,6 +10713,128 @@
             "server": {
                 "address": "127.0.0.1"
             },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "49",
+                "sequence": "1/1",
+                "status": "reachable",
+                "vrf": {
+                    "id": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2305",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire acctd[358]: Event|2305|LOG_INFO|AMM|1/1|TACACS server host 192.168.1.2 port 49 vrf default reachable",
+                "sequence": 1
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "acctd",
+                    "procid": "358"
+                }
+            },
+            "message": "TACACS server host 192.168.1.2 port 49 vrf default reachable",
+            "server": {
+                "address": "192.168.1.2"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "1/1",
+                "status": "unreachable",
+                "vrf": {
+                    "id": "default"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2306",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire acctd[358]: Event|2306|LOG_INFO|AMM|1/1|RADIUS Server route with Address: 192.168.1.3, VRF_ID:default is \"unreachable\"",
+                "sequence": 1
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "acctd",
+                    "procid": "358"
+                }
+            },
+            "message": "RADIUS Server route with Address: 192.168.1.3, VRF_ID:default is \"unreachable\"",
+            "server": {
+                "address": " 192.168.1.3"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "len": 128,
+                "limit": {
+                    "threshold": "64"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2307",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire acctd[358]: Event|2307|LOG_ERR|AMM|-|Decrypted TACACS passkey length 128 exceeded the maximum allowed plaintext key length 64"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "acctd",
+                    "procid": "358"
+                }
+            },
+            "message": "Decrypted TACACS passkey length 128 exceeded the maximum allowed plaintext key length 64",
             "tags": [
                 "preserve_original_event"
             ]
@@ -43758,6 +43963,49 @@
             ]
         },
         {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "acl": {
+                    "ace_string": "permit ip any any",
+                    "direction": "in",
+                    "hit_delta": 5,
+                    "name": "example_acl",
+                    "type": "standard"
+                },
+                "component": {
+                    "category": "ACL"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "10002",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire acld[1234]: Event|10002|LOG_INFO|ACL|-|ACL example_acl (standard) eth0 (in): 5 permit ip any any"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "acld",
+                    "procid": "1234"
+                }
+            },
+            "message": "ACL example_acl (standard) eth0 (in): 5 permit ip any any",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-06-12T14:00:38.324517-05:00",
             "aruba": {
                 "acl": {
@@ -43791,6 +44039,44 @@
                 }
             },
             "message": "ACL mock_acl_type mock_acl_name failed to apply on mock_application",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "acl": {
+                    "application": "firewall",
+                    "name": "example_acl",
+                    "type": "standard"
+                },
+                "component": {
+                    "category": "ACL"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "10003",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire acld[1234]: Event|10003|LOG_ERR|ACL|-|ACL standard example_acl failed to apply on firewall"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "acld",
+                    "procid": "1234"
+                }
+            },
+            "message": "ACL standard example_acl failed to apply on firewall",
             "tags": [
                 "preserve_original_event"
             ]
@@ -45745,6 +46031,399 @@
             ]
         },
         {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "alarm": {
+                    "log_and_trap": "Enabled",
+                    "name": "Alarm1",
+                    "relay": "Relay1",
+                    "trigger": "Trigger1"
+                },
+                "component": {
+                    "category": "Alarm"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "123"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11701",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11701|LOG_INFO|Alarm|-|Input alarm 123 config change: name: Alarm1, relay: Relay1, log_and_trap: Enabled, trigger: Trigger1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "alarmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Input alarm 123 config change: name: Alarm1, relay: Relay1, log_and_trap: Enabled, trigger: Trigger1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "alarm": {
+                    "log_and_trap": "Enabled",
+                    "relay": "Relay2",
+                    "type": "Critical"
+                },
+                "component": {
+                    "category": "Alarm"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11702",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11702|LOG_INFO|Alarm|-|System alarm (Critical) config change: relay: Relay2, log_and_trap: Enabled"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "alarmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "System alarm (Critical) config change: relay: Relay2, log_and_trap: Enabled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "alarm": {
+                    "name": "Alarm2"
+                },
+                "component": {
+                    "category": "Alarm"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11703",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11703|LOG_INFO|Alarm|-|System alarm Alarm2 has activated through log-and-trap"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "alarmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "System alarm Alarm2 has activated through log-and-trap",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "alarm": {
+                    "name": "Alarm3",
+                    "trigger": "Trigger2"
+                },
+                "component": {
+                    "category": "Alarm"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11704",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11704|LOG_INFO|Alarm|-|Input alarm Alarm3 has activated through log-and-trap, triggered at Trigger2"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "alarmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Input alarm Alarm3 has activated through log-and-trap, triggered at Trigger2",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Alarm"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "len": 10
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11705",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11705|LOG_INFO|Alarm|-|Snooze alarm activated, disabling relay function for 10 min"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "alarmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Snooze alarm activated, disabling relay function for 10 min",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Alarm"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11706",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11706|LOG_INFO|Alarm|-|Snooze alarm has expired"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "alarmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Snooze alarm has expired",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Alarm"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11707",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11707|LOG_INFO|Alarm|-|Alarm relay function is re-enabled"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "alarmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Alarm relay function is re-enabled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Alarm"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11707",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11707|LOG_INFO|Alarm|-|Alarm relay function is re-enabled"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "alarmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Alarm relay function is re-enabled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Alarm"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "len": 10
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11708",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11708|LOG_INFO|Alarm|-|Snooze alarm repeats, disabling relay function for 10 min"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "alarmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Snooze alarm repeats, disabling relay function for 10 min",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "alarm": {
+                    "name": "CriticalAlarm"
+                },
+                "component": {
+                    "category": "Alarm"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11709",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11709|LOG_INFO|Alarm|-|System alarm CriticalAlarm has activated through relay"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "alarmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "System alarm CriticalAlarm has activated through relay",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "alarm": {
+                    "name": "InputAlarm",
+                    "trigger": "12:00"
+                },
+                "component": {
+                    "category": "Alarm"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11710",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire alarmd[1234]: Event|11710|LOG_INFO|Alarm|-|Input alarm InputAlarm has activated through relay, triggered at 12:00"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "alarmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Input alarm InputAlarm has activated through relay, triggered at 12:00",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-06-21T13:56:38.182641-05:00",
             "aruba": {
                 "component": {
@@ -46393,6 +47072,123 @@
             }
         },
         {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Accounting"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "13101",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire sshd[1234]: Event|13101|LOG_INFO|Accounting|-|SSH session from 192.168.1.1 for user admin closed due to inactivity."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "sshd",
+                    "procid": "1234"
+                }
+            },
+            "message": "SSH session from 192.168.1.1 for user admin closed due to inactivity.",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Accounting"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.2"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "13102",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire telnetd[1234]: Event|13102|LOG_INFO|Accounting|-|TELNET session from 192.168.1.2 with User admin timed out due to idle timeout."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "telnetd",
+                    "procid": "1234"
+                }
+            },
+            "message": "TELNET session from 192.168.1.2 with User admin timed out due to idle timeout.",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Accounting"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.3"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "13103",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire consoled[1234]: Event|13103|LOG_INFO|Accounting|-|CONSOLE session from 192.168.1.3 with User admin timed out due to idle timeout."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "consoled",
+                    "procid": "1234"
+                }
+            },
+            "message": "CONSOLE session from 192.168.1.3 with User admin timed out due to idle timeout.",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
             "@timestamp": "2024-06-18T12:46:38.182641-05:00",
             "aruba": {
                 "component": {
@@ -46794,6 +47590,392 @@
                 }
             },
             "message": "DNS Average Latency statistics cache cleared for the monitor monitor1 and instance instance1",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "arc": {
+                    "log": "log_mock"
+                },
+                "component": {
+                    "category": "ARC"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "status": "enabled"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14101",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire arc[1234]: Event|14101|LOG_INFO|ARC|-|log_mockApp Recognition feature has been enabled - event_name: ARCD_LC_STATUS_CHANGE"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "arc",
+                    "procid": "1234"
+                }
+            },
+            "message": "log_mockApp Recognition feature has been enabled - event_name: ARCD_LC_STATUS_CHANGE",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ARC"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "status": "up"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14102",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire arc[1234]: Event|14102|LOG_INFO|ARC|-|Linecard 1 is up - event_name: ARCD_BULK_SYN_RECEIVE"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "arc",
+                    "procid": "1234"
+                }
+            },
+            "message": "Linecard 1 is up - event_name: ARCD_BULK_SYN_RECEIVE",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ARC"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "2"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14103",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire arc[1234]: Event|14103|LOG_INFO|ARC|-|BULK SYNC event received from linecard 2 - event_name: ARCD_BULK_SYN_ALL_SENT"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "arc",
+                    "procid": "1234"
+                }
+            },
+            "message": "BULK SYNC event received from linecard 2 - event_name: ARCD_BULK_SYN_ALL_SENT",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ARC"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14104",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire arc[1234]: Event|14104|LOG_INFO|ARC|-|BULK SYNC ALL request sent to all LC - event_name: ARCD_PUBLISHER_STATUS_CHANGE"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "arc",
+                    "procid": "1234"
+                }
+            },
+            "message": "BULK SYNC ALL request sent to all LC - event_name: ARCD_PUBLISHER_STATUS_CHANGE",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ARC"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "status": "active"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14105",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire arc[1234]: Event|14105|LOG_INFO|ARC|-|ARCD Publisher is active - event_name: ARCD_FLUSH_TIMER"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "arc",
+                    "procid": "1234"
+                }
+            },
+            "message": "ARCD Publisher is active - event_name: ARCD_FLUSH_TIMER",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ARC"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "3"
+                },
+                "status": "started"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14106",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire arc[1234]: Event|14106|LOG_INFO|ARC|-|FLUSH timer on LC 3 is started - event_name: ARCD_OVERFLOW_HIGH_THRESHOLD"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "arc",
+                    "procid": "1234"
+                }
+            },
+            "message": "FLUSH timer on LC 3 is started - event_name: ARCD_OVERFLOW_HIGH_THRESHOLD",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ARC"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14107",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire arc[1234]: Event|14107|LOG_INFO|ARC|-|IP Flow table utilization has exceeded high threshold on linecard 4 - event_name: ARCD_OVERFLOW_LOW_THRESHOLD"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "arc",
+                    "procid": "1234"
+                }
+            },
+            "message": "IP Flow table utilization has exceeded high threshold on linecard 4 - event_name: ARCD_OVERFLOW_LOW_THRESHOLD",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ARC"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "5"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14108",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire arc[1234]: Event|14108|LOG_INFO|ARC|-|IP Flow table utilization back to lower threshold on linecard 5 - event_name: ARCD_GLOBAL_STATUS_CHANGE"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "arc",
+                    "procid": "1234"
+                }
+            },
+            "message": "IP Flow table utilization back to lower threshold on linecard 5 - event_name: ARCD_GLOBAL_STATUS_CHANGE",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ARC"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "status": "disabled"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14109",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire arc[1234]: Event|14109|LOG_INFO|ARC|-|App Recognition feature has been disabled - event_name: ARCD_FEATURE_PACK_HONOR_MODE"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "arc",
+                    "procid": "1234"
+                }
+            },
+            "message": "App Recognition feature has been disabled - event_name: ARCD_FEATURE_PACK_HONOR_MODE",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ARC"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14110",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire arc[1234]: Event|14110|LOG_WARN|ARC|-|App Recognition is operating without a valid feature pack is_security_log : yes"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "arc",
+                    "procid": "1234"
+                }
+            },
+            "message": "App Recognition is operating without a valid feature pack is_security_log : yes",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "ARC"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14111",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire arc[1234]: Event|14111|LOG_WARN|ARC|-|App Recognition is blocked due to invalid or missing feature pack is_security_log : yes"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "arc",
+                    "procid": "1234"
+                }
+            },
+            "message": "App Recognition is blocked due to invalid or missing feature pack is_security_log : yes",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -12,9 +12,9 @@ processors:
       field: "event.original"
       tag: redact_passkey
       description: "Reacting passkey updates"
-      prefix: "passkey update:   -> "
+      prefix: "tacacs_passkey update:   -> "
       patterns:
-        - "passkey %{GREEDYDATA:reacted}"
+        - "tacacs_passkey %{GREEDYDATA:reacted}"
   - set:
       field: ecs.version
       value: "8.11.0"
@@ -1101,7 +1101,7 @@ processors:
         - "^%{DATA:aruba.redundant.mgmt_module} is (waiting for filesync|starting ISSU operation)"
 
   # AAA events (23xx)
-  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/AAA.htm
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/AAA.htm
   - grok:
       if: "ctx.event.code == '2301'"
       tag: aaa_event_2301
@@ -1135,6 +1135,19 @@ processors:
       field: "message"
       description: "Logs changes in TACACS server reachability status"
       pattern: "TACACS server host %{server.address} port %{aruba.port} vrf %{aruba.vrf.id} %{aruba.status}"
+  - dissect:
+      if: "ctx.event.code == '2306'"
+      tag: aaa_event_2306
+      field: "message"
+      description: "Logs changes in RADIUS server route reachability status"
+      pattern: 'RADIUS Server route with Address:%{server.address}, VRF_ID:%{aruba.vrf.id} is "%{aruba.status}"'
+  - grok:
+      if: "ctx.event.code == '2307'"
+      tag: aaa_event_2307
+      field: "message"
+      description: "Decrypted TACACS server key length exceeded the maximum length allowed"
+      patterns: 
+        - "^Decrypted TACACS passkey length %{NUMBER:aruba.len:long} exceeded the maximum allowed plaintext key length %{GREEDYDATA:aruba.limit.threshold}"
 
     # OSPFv2 events (2401)
     # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/OSPFv2.htm
@@ -4032,14 +4045,17 @@ processors:
         - "^Egress port shape rate %{DATA:aruba.vsf.lowest_speed} update is failed to apply for interface %{GREEDYDATA:aruba.interface.name}"
 
   # ACLs events (100xx)
-  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ACL.htm
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ACL.htm
   - grok:
       if: "ctx.event.code == '10002'"
       tag: acl_event_10002
       field: "message"
       description: "ACL log statistics"
       patterns:
+        # OS 10.7
         - "^%{DATA:aruba.acl.name} on %{DATA:aruba.interface.name} \\(%{DATA:aruba.acl.direction}\\): %{NUMBER:aruba.acl.hit_delta:long} %{GREEDYDATA:aruba.acl.ace_string}"
+        # OS 10.15
+        - "^ACL %{DATA:aruba.acl.name} \\(%{DATA:aruba.acl.type}\\) %{DATA:aruba.interface.name} \\(%{DATA:aruba.acl.direction}\\): %{NUMBER:aruba.acl.hit_delta:long} %{GREEDYDATA:aruba.acl.ace_string}"
   - dissect:
       if: "ctx.event.code == '10003'"
       tag: acl_event_10003
@@ -4274,6 +4290,42 @@ processors:
       if: "ctx.event?.code == '11602'"
       pattern: "Connection restored for Maintenance Endpoint %{aruba.cfm.id} on %{aruba.cfm.interface}."
 
+  # Alarm events (117xx)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ALARM.htm
+  - dissect:
+      field: message
+      tag: alarm_event_11701
+      if: "ctx.event?.code == '11701'"
+      description: "Event reported when there is a change in input alarm configuration."
+      pattern: "Input alarm %{aruba.instance.id} config change: name: %{aruba.alarm.name}, relay: %{aruba.alarm.relay}, log_and_trap: %{aruba.alarm.log_and_trap}, trigger: %{aruba.alarm.trigger}"
+  - dissect:
+      field: message
+      tag: alarm_event_11702
+      if: "ctx.event?.code == '11702'"
+      description: "Event reported when there is a change in system alarm configuration."
+      pattern: 'System alarm (%{aruba.alarm.type}) config change: relay: %{aruba.alarm.relay}, log_and_trap: %{aruba.alarm.log_and_trap}'
+  - grok:
+      field: message
+      tag: alarm_event_11703_11704
+      if: "['11703','11704'].contains(ctx.event?.code)"
+      description: "Event reported when system alarm has activated | when input alarm has activated"
+      patterns:
+        - "^(System|Input) alarm %{DATA:aruba.alarm.name} has activated through log-and-trap(, triggered at %{GREEDYDATA:aruba.alarm.trigger})?"
+  - grok:
+      field: message
+      tag: alarm_event_11705_11708
+      if: "['11705','11708'].contains(ctx.event?.code)"
+      description: "Event reported when alarm snooze timer has activated | Event reported when alarm snooze timer repeats"
+      patterns:
+        - "^Snooze alarm (activated|repeats), disabling relay function for %{NUMBER:aruba.len:long} min"
+  - grok:
+      field: message
+      tag: alarm_event_11709_11710
+      if: "['11709','11710'].contains(ctx.event?.code)"
+      description: "Event reported when system alarm has activated through relay | when input alarm has activated through relay"
+      patterns:
+        - "^(System|Input) alarm %{DATA:aruba.alarm.name} has activated through relay(, triggered at %{GREEDYDATA:aruba.alarm.trigger})?"
+
   # Container Manager Events (118xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CONTAINER.htm
   - dissect:
@@ -4341,6 +4393,16 @@ processors:
         - "^TELNET session from User %{DATA:user.name} is closed because maximum number of sessions per user is reached."
         - "^User %{DATA:user.name} login from %{IP:client.ip} for TELNET session has failed since the user is trying to login through an interface which is not allowed. Allowed interfaces are: %{GREEDYDATA:aruba.interface.id}."
 
+  # Accounting events (1310x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ACCOUNTING.htm
+  - grok:
+      field: message
+      tag: accounting_event_13101_13102_13103
+      description: "Logs a message when a SSH session timed out due to the session being idle | when a TELNET session timed out due to the session being idle | when a CONSOLE session timed out due to the session being idle"
+      if: "['13101','13102','13103'].contains(ctx.event?.code)"
+      patterns:
+        - "^(SSH|TELNET|CONSOLE) session from %{IP:client.ip} (for|with) (U|u)ser %{DATA:user.name} "
+
   # TPM events (1360x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/TPMD.htm
   - dissect:
@@ -4393,7 +4455,37 @@ processors:
       patterns:
         - "^Ignoring the flow for monitor %{DATA:aruba.traffic.monitor_name} instance %{DATA:aruba.instance.id}, maximum application flow cache limit reached"
         - "^DNS Average Latency statistics cache cleared for the monitor %{DATA:aruba.traffic.monitor_name} and instance %{GREEDYDATA:aruba.instance.id}"
-  
+
+  # ARC events (141xx)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ARC.htm
+  - dissect:
+      field: message
+      tag: arc_event_14101
+      description: "Log event that indicates global configuration for App Recognition feature"
+      if: "ctx.event?.code == '14101'"
+      pattern: "%{aruba.arc.log}App Recognition feature has been %{aruba.status} - event_name: ARCD_LC_STATUS_CHANGE"
+  - grok:
+      field: message
+      tag: arc_event_14102_14106
+      description: "linecard up event | flush timer start/expire status"
+      if: "['14102','14106'].contains(ctx.event?.code)"
+      patterns: 
+        - "(Linecard|LC) %{DATA:aruba.instance.id} is %{DATA:aruba.status}(.| )- event_name:"
+  - grok:
+      field: message
+      tag: arc_event_14103_14107_14108
+      description: "Bulk sync event received | IP Flow table utilization reached high threshold on a LC | IP Flow table utilization back to lower threshold on a LC"
+      if: "['14103','14107','14108'].contains(ctx.event?.code)"
+      patterns: 
+        - "linecard %{DATA:aruba.instance.id} - "
+  - grok:
+      field: message
+      tag: arc_event_14105_14109
+      description: "ARCD Publisher status | Log event that indicates global configuration for App Recognition feature"
+      if: "['14105','14109'].contains(ctx.event?.code)"
+      patterns: 
+        - "(is|been) %{DATA:aruba.status} - event_name"
+
   # Cleanup MAC addresses for different fields
   - uppercase:
       field: client.mac

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -11,10 +11,10 @@ processors:
   - redact:
       field: "event.original"
       tag: redact_passkey
-      description: "Reacting passkey updates"
+      description: "Redacting passkey updates"
       prefix: "tacacs_passkey update:   -> "
       patterns:
-        - "tacacs_passkey %{GREEDYDATA:reacted}"
+        - "tacacs_passkey %{GREEDYDATA:redact}"
   - set:
       field: ecs.version
       value: "8.11.0"

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -50,6 +50,30 @@
         - name: type
           type: keyword
           description: ""
+    - name: alarm
+      type: group
+      fields:
+        - name: log_and_trap
+          type: keyword
+          description: ""
+        - name: name
+          type: keyword
+          description: ""
+        - name: relay
+          type: keyword
+          description: ""
+        - name: trigger
+          type: keyword
+          description: ""
+        - name: type
+          type: keyword
+          description: ""
+    - name: arc
+      type: group
+      fields:
+        - name: log
+          type: keyword
+          description: ""
     - name: bfd
       type: group
       fields:

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -82,7 +82,7 @@ Note: Descriptions have not been filled out
 | `<interface_name>`  | aruba.interface.name   |
 | `<name>`            | aruba.acl.name         |
 
-#### [Alarm events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ACL.htm)
+#### [Alarm events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ALARM.htm)
 | Doc Fields       | Schema Mapping           |
 |------------------|--------------------------|
 | `<id>`           | aruba.instance.id        |
@@ -96,7 +96,7 @@ Note: Descriptions have not been filled out
 #### [ARC events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ARC.htm)
 | Doc Fields       | Schema Mapping           |
 |------------------|--------------------------|
-| `<log>`          | aruba.arc.lob            |
+| `<log>`          | aruba.arc.log            |
 | `<node_id>`      | aruba.instance.id        |
 | `<status>`       | aruba.status             |
 

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -43,11 +43,13 @@ To Be Removed
 Note: Field types are defined within `fields.yml`
 Note: Descriptions have not been filled out
 
-#### [AAA events (Aruba Docs)](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/AAA.htm)
+#### [AAA events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/AAA.htm)
 | Doc Fields           | Schema Mapping               |
 |----------------------|------------------------------|
 | `<aaa_config_type>`  | aruba.aaa.config_event       |
 | `<aaa_config_event>` | aruba.aaa.config_type        |
+| `<key_length>`       | aruba.len                    |
+| `<max_key_length>`   | aruba.limit.threshold        |
 | `<tacacs_action>`    | aruba.aaa.radius_action      |
 | `<radius_event>`     | aruba.aaa.radius_event       |
 | `<server_address>`   | server.address               |
@@ -62,7 +64,13 @@ Note: Descriptions have not been filled out
 | `<server_vrfid>`     | aruba.vrf.id                 |
 | `<tacacs_type>`      | aruba.aaa.tacacs_type        |
 
-#### [ACLs events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ACL.htm)
+#### [Accounting events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ACCOUNTING.htm)
+| Doc Fields           | Schema Mapping               |
+|----------------------|------------------------------|
+| `<ip_address>`       | client.ip                    |
+| `<user_name>`        | user.name                    |
+
+#### [ACLs events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ACL.htm)
 | Doc Fields          | Schema Mapping         |
 |---------------------|------------------------|
 | `<log>`             | message                |
@@ -73,6 +81,24 @@ Note: Descriptions have not been filled out
 | `<hit_delta>`       | aruba.acl.hit_delta    |
 | `<interface_name>`  | aruba.interface.name   |
 | `<name>`            | aruba.acl.name         |
+
+#### [Alarm events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ACL.htm)
+| Doc Fields       | Schema Mapping           |
+|------------------|--------------------------|
+| `<id>`           | aruba.instance.id        |
+| `<length>`       | aruba.len                |
+| `<log_and_trap>` | aruba.alarm.log_and_trap |
+| `<name>`         | aruba.alarm.name         |
+| `<relay>`        | aruba.alarm.relay        |
+| `<trigger>`      | aruba.alarm.trigger      |
+| `<type>`         | aruba.alarm.type         |
+
+#### [ARC events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ARC.htm)
+| Doc Fields       | Schema Mapping           |
+|------------------|--------------------------|
+| `<log>`          | aruba.arc.lob            |
+| `<node_id>`      | aruba.instance.id        |
+| `<status>`       | aruba.status             |
 
 #### [ARP security events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ARP-SECURITY.htm)
 | Doc Fields    | Schema Mapping  |
@@ -1426,6 +1452,12 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.acl.hit_delta |  | long |
 | aruba.acl.name |  | keyword |
 | aruba.acl.type |  | keyword |
+| aruba.alarm.log_and_trap |  | keyword |
+| aruba.alarm.name |  | keyword |
+| aruba.alarm.relay |  | keyword |
+| aruba.alarm.trigger |  | keyword |
+| aruba.alarm.type |  | keyword |
+| aruba.arc.log |  | keyword |
 | aruba.bfd.applied_interval |  | long |
 | aruba.bfd.direction |  | keyword |
 | aruba.bfd.from |  | keyword |


### PR DESCRIPTION
## Parent Ticket
https://github.com/elastic/integrations/issues/12249

# Description:
- Updated AAA events, two additional events to support 10.15
- add new Accounting events: docs, parsing and fields
- Updated link for ACLs events
- added new Alarm events: docs, parsing and fields
- added new ARC events: docs, parsing and fields
- updated redact logic as it was interfering with the new AAA events 2306/2307 event ids
