### PR TITLE
[Cloud Security] Default agentless deployment mode in CSPM and Asset Inventory

### DIFF
--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -1,6 +1,11 @@
 # newer versions go on top
 # version map:
 # 0.1.x - 8.15.x
+- version: "0.670"
+  changes:
+    - description: Agentless default deployment mode
+      type: enhancement
+      link: https://github.com/elastic/security-team/issues/11434
 - version: "0.6.0"
   changes:
     - description: Update cloud provider template URLs

--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 # version map:
 # 0.1.x - 8.15.x
-- version: "0.670"
+- version: "0.7.0"
   changes:
     - description: Agentless default deployment mode
       type: enhancement

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.2
 name: cloud_asset_inventory
 title: "Cloud Asset Inventory"
-version: "0.6.0"
+version: "0.7.0"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Inventory"

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -32,6 +32,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        is_default: true
         organization: security
         division: engineering
         team: cloud-security-posture
@@ -44,53 +45,53 @@ policy_templates:
     data_streams:
       - asset_inventory
     inputs:
-        - type: cloudbeat/asset_inventory_aws
-          title: AWS Asset Inventory
-          description: AWS Asset Inventory
-          vars:
-            - name: cloud_formation_template
-              type: text
-              title: CloudFormation Template
-              multi: false
-              required: true
-              show_user: false
-              description: Template URL to Cloud Formation Quick Create Stack
-              # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
-              default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-asset-inventory-ACCOUNT_TYPE-8.17.0.yml&stackName=Elastic-Cloud-Security-Posture-Management&param_EnrollmentToken=FLEET_ENROLLMENT_TOKEN&param_FleetUrl=FLEET_URL&param_ElasticAgentVersion=KIBANA_VERSION&param_ElasticArtifactServer=https://artifacts.elastic.co/downloads/beats/elastic-agent
-            - name: cloud_formation_credentials_template
-              type: text
-              title: CloudFormation Credentials Template
-              multi: false
-              required: true
-              show_user: false
-              description: Template URL to Cloud Formation Cloud Credentials Stack
-              # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
-              default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-asset-inventory-direct-access-key-ACCOUNT_TYPE-8.17.0.yml
-        - type: cloudbeat/asset_inventory_azure
-          title: Azure Asset Inventory
-          description: Azure Asset Inventory
-          vars:
-            - name: arm_template_url
-              type: text
-              title: ARM Template URL
-              multi: false
-              required: true
-              show_user: false
-              description: A URL to the ARM Template for creating a new deployment
-              # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
-              default: https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fcloudbeat%2F8.17%2Fdeploy%2Fasset-inventory-arm%2FARM-for-ACCOUNT_TYPE.json
-        - type: cloudbeat/asset_inventory_gcp
-          title: GCP Asset Inventory
-          description: GCP Asset Inventory
-          vars:
-            - name: cloud_shell_url
-              type: text
-              title: CloudShell URL
-              multi: false
-              required: true
-              show_user: false
-              description: A URL to CloudShell for creating a new deployment
-              default: https://shell.cloud.google.com/cloudshell/?ephemeral=true&cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Felastic%2Fcloudbeat&cloudshell_git_branch=8.17&cloudshell_workspace=deploy%2Fdeployment-manager&show=terminal
+      - type: cloudbeat/asset_inventory_aws
+        title: AWS Asset Inventory
+        description: AWS Asset Inventory
+        vars:
+          - name: cloud_formation_template
+            type: text
+            title: CloudFormation Template
+            multi: false
+            required: true
+            show_user: false
+            description: Template URL to Cloud Formation Quick Create Stack
+            # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
+            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-asset-inventory-ACCOUNT_TYPE-8.17.0.yml&stackName=Elastic-Cloud-Security-Posture-Management&param_EnrollmentToken=FLEET_ENROLLMENT_TOKEN&param_FleetUrl=FLEET_URL&param_ElasticAgentVersion=KIBANA_VERSION&param_ElasticArtifactServer=https://artifacts.elastic.co/downloads/beats/elastic-agent
+          - name: cloud_formation_credentials_template
+            type: text
+            title: CloudFormation Credentials Template
+            multi: false
+            required: true
+            show_user: false
+            description: Template URL to Cloud Formation Cloud Credentials Stack
+            # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
+            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-asset-inventory-direct-access-key-ACCOUNT_TYPE-8.17.0.yml
+      - type: cloudbeat/asset_inventory_azure
+        title: Azure Asset Inventory
+        description: Azure Asset Inventory
+        vars:
+          - name: arm_template_url
+            type: text
+            title: ARM Template URL
+            multi: false
+            required: true
+            show_user: false
+            description: A URL to the ARM Template for creating a new deployment
+            # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
+            default: https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fcloudbeat%2F8.17%2Fdeploy%2Fasset-inventory-arm%2FARM-for-ACCOUNT_TYPE.json
+      - type: cloudbeat/asset_inventory_gcp
+        title: GCP Asset Inventory
+        description: GCP Asset Inventory
+        vars:
+          - name: cloud_shell_url
+            type: text
+            title: CloudShell URL
+            multi: false
+            required: true
+            show_user: false
+            description: A URL to CloudShell for creating a new deployment
+            default: https://shell.cloud.google.com/cloudshell/?ephemeral=true&cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Felastic%2Fcloudbeat&cloudshell_git_branch=8.17&cloudshell_workspace=deploy%2Fdeployment-manager&show=terminal
     categories:
       - security
       - cloud

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -13,9 +13,14 @@
 # 1.2.x - 8.7.x
 - version: "1.12.0"
   changes:
-    - description: Changed the agentless tags to be a list
+    - description: Agentless default deployment mode
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/12066
+      link: https://github.com/elastic/security-team/issues/11434
+- version: "1.12.0-preview02"
+  changes:
+    - description: Agentless default deployment mode
+      type: enhancement
+      link: https://github.com/elastic/security-team/issues/11434
 - version: "1.12.0-preview01"
   changes:
     - description: Add cloud connectors support

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -11,11 +11,6 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
-- version: "1.12.0"
-  changes:
-    - description: Agentless default deployment mode
-      type: enhancement
-      link: https://github.com/elastic/security-team/issues/11434
 - version: "1.12.0-preview02"
   changes:
     - description: Agentless default deployment mode

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -107,6 +107,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        is_default: true
         organization: security
         division: engineering
         team: cloud-security-posture


### PR DESCRIPTION
## Proposed commit message

Default agentless deployment mode in CSPM and Asset Inventory


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally
1.  Add the CSPM integration
2. Agentless should be the default option selected in the Setup Technology drop-down
3. Add Cloud Asset Inventory
4. Agentless should be the default option selected in the Setup Technology drop-down

## Related issues
precedes https://github.com/elastic/kibana/pull/205965
precedes https://github.com/elastic/package-registry/issues/1263
procedes https://github.com/elastic/kibana/pull/206518
<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
