### PR TITLE
[panw_cortex_xdr] Allow reprocessing of events with `event.original`

### DIFF
--- a/packages/panw_cortex_xdr/changelog.yml
+++ b/packages/panw_cortex_xdr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.32.0"
+  changes:
+    - description: Do not remove `event.original` in main ingest pipeline.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12342
 - version: "1.31.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/panw_cortex_xdr/data_stream/alerts/_dev/test/pipeline/test-reprocess.json
+++ b/packages/panw_cortex_xdr/data_stream/alerts/_dev/test/pipeline/test-reprocess.json
@@ -1,0 +1,125 @@
+{
+    "events": [
+        {
+            "@timestamp": "2021-07-15T11:01:07.000Z",
+            "destination": {
+                "geo": {
+                    "city_name": "Changchun",
+                    "continent_name": "Asia",
+                    "country_iso_code": "CN",
+                    "country_name": "China",
+                    "location": {
+                        "lat": 43.88,
+                        "lon": 125.3228
+                    },
+                    "region_iso_code": "CN-22",
+                    "region_name": "Jilin Sheng"
+                },
+                "ip": "175.16.199.1",
+                "port": 443
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "BLOCKED_9",
+                "category": [
+                    "malware"
+                ],
+                "created": "2021-07-15T11:00:49.000Z",
+                "id": "396239671",
+                "kind": "alert",
+                "original": "{\"external_id\":\"396239671\",\"severity\":\"high\",\"matching_status\":\"UNMATCHABLE\",\"end_match_attempt_ts\":null,\"local_insert_ts\":1626347122923,\"bioc_indicator\":null,\"matching_service_rule_id\":null,\"attempt_counter\":null,\"bioc_category_enum_key\":null,\"is_whitelisted\":false,\"starred\":false,\"deduplicate_tokens\":\"af4e477c1e284c3f9b1fff340fddb4d0,57f0d1f4096a45bdb4cd8d4b8a626f15\",\"filter_rule_id\":null,\"mitre_technique_id_and_name\":null,\"mitre_tactic_id_and_name\":null,\"agent_version\":null,\"agent_device_domain\":null,\"agent_fqdn\":null,\"agent_os_type\":\"NO_HOST\",\"agent_os_sub_type\":null,\"agent_data_collection_status\":null,\"mac\":\"4c:ae:a3:8e:c8:6a\",\"events\":{\"agent_install_type\":\"NA\",\"agent_host_boot_time\":null,\"event_sub_type\":null,\"module_id\":null,\"association_strength\":10,\"dst_association_strength\":10,\"story_id\":\"MzYzOTQ0MDE1MDI4OTE3NDUyNA==\",\"event_id\":\"MzYzOTQ0MDE1MDI4OTE3NDUyNA==\",\"event_type\":\"Network Connections\",\"event_timestamp\":1626346867000,\"actor_process_instance_id\":null,\"actor_process_image_path\":null,\"actor_process_image_name\":null,\"actor_process_command_line\":null,\"actor_process_signature_status\":\"N/A\",\"actor_process_signature_vendor\":null,\"actor_process_image_sha256\":null,\"actor_process_image_md5\":null,\"actor_process_causality_id\":null,\"actor_causality_id\":null,\"actor_process_os_pid\":null,\"actor_thread_thread_id\":null,\"causality_actor_process_image_name\":null,\"causality_actor_process_command_line\":null,\"causality_actor_process_image_path\":null,\"causality_actor_process_signature_vendor\":null,\"causality_actor_process_signature_status\":\"N/A\",\"causality_actor_causality_id\":null,\"causality_actor_process_execution_time\":null,\"causality_actor_process_image_md5\":null,\"causality_actor_process_image_sha256\":null,\"action_file_path\":null,\"action_file_name\":null,\"action_file_md5\":null,\"action_file_sha256\":null,\"action_file_macro_sha256\":null,\"action_registry_data\":null,\"action_registry_key_name\":null,\"action_registry_value_name\":null,\"action_registry_full_key\":null,\"action_local_ip\":\"10.10.10.10\",\"action_local_port\":58642,\"action_remote_ip\":\"175.16.199.1\",\"action_remote_port\":443,\"action_external_hostname\":\"175.16.199.1\",\"action_country\":\"DK\",\"action_process_instance_id\":null,\"action_process_causality_id\":null,\"action_process_image_name\":null,\"action_process_image_sha256\":null,\"action_process_image_command_line\":null,\"action_process_signature_status\":\"N/A\",\"action_process_signature_vendor\":null,\"os_actor_effective_username\":null,\"os_actor_process_instance_id\":null,\"os_actor_process_image_path\":null,\"os_actor_process_image_name\":null,\"os_actor_process_command_line\":null,\"os_actor_process_signature_status\":\"N/A\",\"os_actor_process_signature_vendor\":null,\"os_actor_process_image_sha256\":null,\"os_actor_process_causality_id\":null,\"os_actor_causality_id\":null,\"os_actor_process_os_pid\":null,\"os_actor_thread_thread_id\":null,\"fw_app_id\":\"web-browsing\",\"fw_interface_from\":\"INTERNET\",\"fw_interface_to\":\"INTERNET\",\"fw_rule\":\"INTERNET_INTERNET_GlobalProtect-443\",\"fw_rule_id\":null,\"fw_device_name\":\"FW-DEVICE_NAME\",\"fw_serial_number\":\"12352345\",\"fw_url_domain\":\"9.9.9.9\",\"fw_email_subject\":null,\"fw_email_sender\":null,\"fw_email_recipient\":null,\"fw_app_subcategory\":\"internet-utility\",\"fw_app_category\":\"general-internet\",\"fw_app_technology\":\"browser-based\",\"fw_vsys\":\"vsys1\",\"fw_xff\":null,\"fw_misc\":\"7.7.7.7/cgi-bin/config.exp\",\"fw_is_phishing\":\"No\",\"dst_agent_id\":\"6.6.6.6\",\"dst_causality_actor_process_execution_time\":null,\"dns_query_name\":null,\"dst_action_external_hostname\":null,\"dst_action_country\":\"US\",\"dst_action_external_port\":null,\"contains_featured_host\":\"NO\",\"contains_featured_user\":\"NO\",\"contains_featured_ip\":\"NO\",\"image_name\":null,\"container_id\":null,\"cluster_name\":null,\"user_name\":null},\"alert_id\":\"2879211\",\"detection_timestamp\":1626346849000,\"name\":\"Cisco RV320/RV325 Router Unauthenticated Configuration Export Vulnerability\",\"category\":\"Vulnerability\",\"endpoint_id\":\"192.168.2.2\",\"description\":\"Info-Leak (7.7.7.7/cgi-bin/config.exp)\",\"host_ip\":[\"192.168.2.2\"],\"host_name\":null,\"mac_addresses\":[\"ab:ae:f5:5d:c8:6a\"],\"source\":\"PAN NGFW\",\"action\":\"BLOCKED_9\",\"action_pretty\":\"Prevented (Terminated The Session And Sent a TCP Reset To Both Sides Of The Connection)\"}",
+                "reason": "Info-Leak (7.7.7.7/cgi-bin/config.exp)",
+                "severity": 4,
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "id": "192.168.2.2",
+                "ip": [
+                    "192.168.2.2"
+                ],
+                "mac": [
+                    "AB-AE-F5-5D-C8-6A"
+                ],
+                "os": {
+                    "name": "NO_HOST"
+                }
+            },
+            "message": "Cisco RV320/RV325 Router Unauthenticated Configuration Export Vulnerability",
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "INTERNET"
+                    }
+                },
+                "ingress": {
+                    "interface": {
+                        "name": "INTERNET"
+                    }
+                },
+                "serial_number": "12352345"
+            },
+            "panw_cortex": {
+                "xdr": {
+                    "action_pretty": "Prevented (Terminated The Session And Sent a TCP Reset To Both Sides Of The Connection)",
+                    "alert_id": "2879211",
+                    "category": "Vulnerability",
+                    "deduplicate_tokens": "af4e477c1e284c3f9b1fff340fddb4d0,57f0d1f4096a45bdb4cd8d4b8a626f15",
+                    "events": {
+                        "action_external_hostname": "175.16.199.1",
+                        "actor_process_signature_status": "N/A",
+                        "agent_install_type": "NA",
+                        "association_strength": 10,
+                        "contains_featured_host": "NO",
+                        "contains_featured_ip": "NO",
+                        "contains_featured_user": "NO",
+                        "dst_action_country": "US",
+                        "dst_agent_id": "6.6.6.6",
+                        "dst_association_strength": 10,
+                        "event_id": "MzYzOTQ0MDE1MDI4OTE3NDUyNA==",
+                        "event_type": "Network Connections",
+                        "fw_app_category": "general-internet",
+                        "fw_app_id": "web-browsing",
+                        "fw_app_subcategory": "internet-utility",
+                        "fw_app_technology": "browser-based",
+                        "fw_device_name": "FW-DEVICE_NAME",
+                        "fw_is_phishing": "No",
+                        "fw_misc": "7.7.7.7/cgi-bin/config.exp",
+                        "fw_url_domain": "9.9.9.9",
+                        "fw_vsys": "vsys1",
+                        "os_actor_process_signature_status": "N/A",
+                        "story_id": "MzYzOTQ0MDE1MDI4OTE3NDUyNA=="
+                    },
+                    "is_whitelisted": false,
+                    "local_insert_ts": "2021-07-15T11:05:22.923Z",
+                    "matching_status": "UNMATCHABLE",
+                    "source": "PAN NGFW",
+                    "starred": false
+                }
+            },
+            "process": {
+                "code_signature": {
+                    "status": "N/A"
+                },
+                "parent": {
+                    "code_signature": {
+                        "status": "N/A"
+                    }
+                }
+            },
+            "rule": {
+                "name": "INTERNET_INTERNET_GlobalProtect-443"
+            },
+            "source": {
+                "ip": "10.10.10.10",
+                "port": 58642
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/panw_cortex_xdr/data_stream/alerts/_dev/test/pipeline/test-reprocess.json-expected.json
+++ b/packages/panw_cortex_xdr/data_stream/alerts/_dev/test/pipeline/test-reprocess.json-expected.json
@@ -1,0 +1,125 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2021-07-15T11:01:07.000Z",
+            "destination": {
+                "geo": {
+                    "city_name": "Changchun",
+                    "continent_name": "Asia",
+                    "country_iso_code": "CN",
+                    "country_name": "China",
+                    "location": {
+                        "lat": 43.88,
+                        "lon": 125.3228
+                    },
+                    "region_iso_code": "CN-22",
+                    "region_name": "Jilin Sheng"
+                },
+                "ip": "175.16.199.1",
+                "port": 443
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "BLOCKED_9",
+                "category": [
+                    "malware"
+                ],
+                "created": "2021-07-15T11:00:49.000Z",
+                "id": "396239671",
+                "kind": "alert",
+                "original": "{\"external_id\":\"396239671\",\"severity\":\"high\",\"matching_status\":\"UNMATCHABLE\",\"end_match_attempt_ts\":null,\"local_insert_ts\":1626347122923,\"bioc_indicator\":null,\"matching_service_rule_id\":null,\"attempt_counter\":null,\"bioc_category_enum_key\":null,\"is_whitelisted\":false,\"starred\":false,\"deduplicate_tokens\":\"af4e477c1e284c3f9b1fff340fddb4d0,57f0d1f4096a45bdb4cd8d4b8a626f15\",\"filter_rule_id\":null,\"mitre_technique_id_and_name\":null,\"mitre_tactic_id_and_name\":null,\"agent_version\":null,\"agent_device_domain\":null,\"agent_fqdn\":null,\"agent_os_type\":\"NO_HOST\",\"agent_os_sub_type\":null,\"agent_data_collection_status\":null,\"mac\":\"4c:ae:a3:8e:c8:6a\",\"events\":{\"agent_install_type\":\"NA\",\"agent_host_boot_time\":null,\"event_sub_type\":null,\"module_id\":null,\"association_strength\":10,\"dst_association_strength\":10,\"story_id\":\"MzYzOTQ0MDE1MDI4OTE3NDUyNA==\",\"event_id\":\"MzYzOTQ0MDE1MDI4OTE3NDUyNA==\",\"event_type\":\"Network Connections\",\"event_timestamp\":1626346867000,\"actor_process_instance_id\":null,\"actor_process_image_path\":null,\"actor_process_image_name\":null,\"actor_process_command_line\":null,\"actor_process_signature_status\":\"N/A\",\"actor_process_signature_vendor\":null,\"actor_process_image_sha256\":null,\"actor_process_image_md5\":null,\"actor_process_causality_id\":null,\"actor_causality_id\":null,\"actor_process_os_pid\":null,\"actor_thread_thread_id\":null,\"causality_actor_process_image_name\":null,\"causality_actor_process_command_line\":null,\"causality_actor_process_image_path\":null,\"causality_actor_process_signature_vendor\":null,\"causality_actor_process_signature_status\":\"N/A\",\"causality_actor_causality_id\":null,\"causality_actor_process_execution_time\":null,\"causality_actor_process_image_md5\":null,\"causality_actor_process_image_sha256\":null,\"action_file_path\":null,\"action_file_name\":null,\"action_file_md5\":null,\"action_file_sha256\":null,\"action_file_macro_sha256\":null,\"action_registry_data\":null,\"action_registry_key_name\":null,\"action_registry_value_name\":null,\"action_registry_full_key\":null,\"action_local_ip\":\"10.10.10.10\",\"action_local_port\":58642,\"action_remote_ip\":\"175.16.199.1\",\"action_remote_port\":443,\"action_external_hostname\":\"175.16.199.1\",\"action_country\":\"DK\",\"action_process_instance_id\":null,\"action_process_causality_id\":null,\"action_process_image_name\":null,\"action_process_image_sha256\":null,\"action_process_image_command_line\":null,\"action_process_signature_status\":\"N/A\",\"action_process_signature_vendor\":null,\"os_actor_effective_username\":null,\"os_actor_process_instance_id\":null,\"os_actor_process_image_path\":null,\"os_actor_process_image_name\":null,\"os_actor_process_command_line\":null,\"os_actor_process_signature_status\":\"N/A\",\"os_actor_process_signature_vendor\":null,\"os_actor_process_image_sha256\":null,\"os_actor_process_causality_id\":null,\"os_actor_causality_id\":null,\"os_actor_process_os_pid\":null,\"os_actor_thread_thread_id\":null,\"fw_app_id\":\"web-browsing\",\"fw_interface_from\":\"INTERNET\",\"fw_interface_to\":\"INTERNET\",\"fw_rule\":\"INTERNET_INTERNET_GlobalProtect-443\",\"fw_rule_id\":null,\"fw_device_name\":\"FW-DEVICE_NAME\",\"fw_serial_number\":\"12352345\",\"fw_url_domain\":\"9.9.9.9\",\"fw_email_subject\":null,\"fw_email_sender\":null,\"fw_email_recipient\":null,\"fw_app_subcategory\":\"internet-utility\",\"fw_app_category\":\"general-internet\",\"fw_app_technology\":\"browser-based\",\"fw_vsys\":\"vsys1\",\"fw_xff\":null,\"fw_misc\":\"7.7.7.7/cgi-bin/config.exp\",\"fw_is_phishing\":\"No\",\"dst_agent_id\":\"6.6.6.6\",\"dst_causality_actor_process_execution_time\":null,\"dns_query_name\":null,\"dst_action_external_hostname\":null,\"dst_action_country\":\"US\",\"dst_action_external_port\":null,\"contains_featured_host\":\"NO\",\"contains_featured_user\":\"NO\",\"contains_featured_ip\":\"NO\",\"image_name\":null,\"container_id\":null,\"cluster_name\":null,\"user_name\":null},\"alert_id\":\"2879211\",\"detection_timestamp\":1626346849000,\"name\":\"Cisco RV320/RV325 Router Unauthenticated Configuration Export Vulnerability\",\"category\":\"Vulnerability\",\"endpoint_id\":\"192.168.2.2\",\"description\":\"Info-Leak (7.7.7.7/cgi-bin/config.exp)\",\"host_ip\":[\"192.168.2.2\"],\"host_name\":null,\"mac_addresses\":[\"ab:ae:f5:5d:c8:6a\"],\"source\":\"PAN NGFW\",\"action\":\"BLOCKED_9\",\"action_pretty\":\"Prevented (Terminated The Session And Sent a TCP Reset To Both Sides Of The Connection)\"}",
+                "reason": "Info-Leak (7.7.7.7/cgi-bin/config.exp)",
+                "severity": 4,
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "id": "192.168.2.2",
+                "ip": [
+                    "192.168.2.2"
+                ],
+                "mac": [
+                    "AB-AE-F5-5D-C8-6A"
+                ],
+                "os": {
+                    "name": "NO_HOST"
+                }
+            },
+            "message": "Cisco RV320/RV325 Router Unauthenticated Configuration Export Vulnerability",
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "INTERNET"
+                    }
+                },
+                "ingress": {
+                    "interface": {
+                        "name": "INTERNET"
+                    }
+                },
+                "serial_number": "12352345"
+            },
+            "panw_cortex": {
+                "xdr": {
+                    "action_pretty": "Prevented (Terminated The Session And Sent a TCP Reset To Both Sides Of The Connection)",
+                    "alert_id": "2879211",
+                    "category": "Vulnerability",
+                    "deduplicate_tokens": "af4e477c1e284c3f9b1fff340fddb4d0,57f0d1f4096a45bdb4cd8d4b8a626f15",
+                    "events": {
+                        "action_external_hostname": "175.16.199.1",
+                        "actor_process_signature_status": "N/A",
+                        "agent_install_type": "NA",
+                        "association_strength": 10,
+                        "contains_featured_host": "NO",
+                        "contains_featured_ip": "NO",
+                        "contains_featured_user": "NO",
+                        "dst_action_country": "US",
+                        "dst_agent_id": "6.6.6.6",
+                        "dst_association_strength": 10,
+                        "event_id": "MzYzOTQ0MDE1MDI4OTE3NDUyNA==",
+                        "event_type": "Network Connections",
+                        "fw_app_category": "general-internet",
+                        "fw_app_id": "web-browsing",
+                        "fw_app_subcategory": "internet-utility",
+                        "fw_app_technology": "browser-based",
+                        "fw_device_name": "FW-DEVICE_NAME",
+                        "fw_is_phishing": "No",
+                        "fw_misc": "7.7.7.7/cgi-bin/config.exp",
+                        "fw_url_domain": "9.9.9.9",
+                        "fw_vsys": "vsys1",
+                        "os_actor_process_signature_status": "N/A",
+                        "story_id": "MzYzOTQ0MDE1MDI4OTE3NDUyNA=="
+                    },
+                    "is_whitelisted": false,
+                    "local_insert_ts": "2021-07-15T11:05:22.923Z",
+                    "matching_status": "UNMATCHABLE",
+                    "source": "PAN NGFW",
+                    "starred": false
+                }
+            },
+            "process": {
+                "code_signature": {
+                    "status": "N/A"
+                },
+                "parent": {
+                    "code_signature": {
+                        "status": "N/A"
+                    }
+                }
+            },
+            "rule": {
+                "name": "INTERNET_INTERNET_GlobalProtect-443"
+            },
+            "source": {
+                "ip": "10.10.10.10",
+                "port": 58642
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/panw_cortex_xdr/data_stream/alerts/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/panw_cortex_xdr/data_stream/alerts/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,19 @@
 ---
 description: Pipeline for Palo Alto XDR API.
 processors:
+  - rename:
+      description: Use 'event.original' if present (e.g. when reprocessing), otherwise 'message'.
+      field: message
+      target_field: event.original
+      ignore_missing: true
+      if: ctx.event?.original == null
+  - remove:
+      description: In case of reprocessing, remove all fields that will be repopulated.
+      keep:
+        - event.original
+        - tags
+        - "@timestamp"
+      ignore_missing: true
   - set:
       field: ecs.version
       value: '8.11.0'
@@ -13,11 +26,6 @@ processors:
   - append:
       field: event.type
       value: info
-  - rename:
-      field: message
-      target_field: event.original
-      ignore_missing: true
-      if: ctx.event?.original == null
   - json:
       field: event.original
       target_field: panw_cortex.xdr

--- a/packages/panw_cortex_xdr/data_stream/incidents/_dev/test/pipeline/test-reprocess.json
+++ b/packages/panw_cortex_xdr/data_stream/incidents/_dev/test/pipeline/test-reprocess.json
@@ -1,0 +1,100 @@
+{
+    "events": [
+        {
+            "@timestamp": "2023-08-14T00:01:28.775Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "malware"
+                ],
+                "created": "2023-08-12T23:58:32.575Z",
+                "id": "891",
+                "kind": "alert",
+                "original": "{\"incident_id\": \"891\", \"incident_name\": null, \"creation_time\": 1691884712575, \"modification_time\": 1691971288775, \"detection_time\": null, \"status\": \"new\", \"severity\": \"low\", \"description\": \"2 'Large Upload (Generic)' alerts detected by XDR Analytics on host computer1  involving user nt authority\\\\system\", \"assigned_user_mail\": null, \"assigned_user_pretty_name\": null, \"alert_count\": 2, \"low_severity_alert_count\": 2, \"med_severity_alert_count\": 0, \"high_severity_alert_count\": 0, \"critical_severity_alert_count\": 0, \"user_count\": 1, \"host_count\": 1, \"notes\": null, \"resolve_comment\": null, \"resolved_timestamp\": null, \"manual_severity\": null, \"manual_description\": null, \"xdr_url\": \"https://test.xdr.eu.paloaltonetworks.com/incident-view?caseId=891\", \"starred\": false, \"hosts\": [\"computer1:7a7370f8934c4e60b1e7dc5d0c8b0477\"], \"users\": [\"nt authority\\\\system\"], \"incident_sources\": [\"XDR Analytics\"], \"rule_based_score\": null, \"predicted_score\": 5, \"manual_score\": null, \"aggregated_score\": 5, \"wildfire_hits\": 0, \"alerts_grouping_status\": \"Enabled\", \"mitre_tactics_ids_and_names\": [\"TA0010 - Exfiltration\"], \"mitre_techniques_ids_and_names\": [\"T1048 - Exfiltration Over Alternative Protocol\"], \"alert_categories\": [\"Exfiltration\"], \"original_tags\": [\"EG:win-server-ex-ransomeware_report\", \"DS:PANW/XDR Agent\", \"EG:win-server-default\"], \"tags\": [\"DS:PANW/XDR Agent\", \"EG:win-server-default\", \"EG:win-server-ex-ransomeware_report\"]}",
+                "reason": "2 'Large Upload (Generic)' alerts detected by XDR Analytics on host computer1  involving user nt authority\\system",
+                "severity": 2,
+                "type": [
+                    "info"
+                ]
+            },
+            "panw_cortex": {
+                "xdr": {
+                    "aggregated_score": 5,
+                    "alert_categories": [
+                        "Exfiltration"
+                    ],
+                    "alert_count": 2,
+                    "alerts_grouping_status": "Enabled",
+                    "creation_time": "2023-08-12T23:58:32.575Z",
+                    "critical_severity_alert_count": 0,
+                    "high_severity_alert_count": 0,
+                    "host_count": 1,
+                    "hosts": [
+                        "computer1:7a7370f8934c4e60b1e7dc5d0c8b0477"
+                    ],
+                    "incident_sources": [
+                        "XDR Analytics"
+                    ],
+                    "low_severity_alert_count": 2,
+                    "med_severity_alert_count": 0,
+                    "mitre_tactics_ids_and_names": [
+                        "TA0010 - Exfiltration"
+                    ],
+                    "mitre_techniques_ids_and_names": [
+                        "T1048 - Exfiltration Over Alternative Protocol"
+                    ],
+                    "modification_time": "2023-08-14T00:01:28.775Z",
+                    "original_tags": [
+                        "EG:win-server-ex-ransomeware_report",
+                        "DS:PANW/XDR Agent",
+                        "EG:win-server-default"
+                    ],
+                    "predicted_score": 5,
+                    "starred": false,
+                    "status": "new",
+                    "user_count": 1,
+                    "users": [
+                        "nt authority\\system"
+                    ],
+                    "wildfire_hits": 0,
+                    "xdr_url": "https://test.xdr.eu.paloaltonetworks.com/incident-view?caseId=891"
+                }
+            },
+            "related": {
+                "hosts": [
+                    "computer1"
+                ],
+                "user": [
+                    "system"
+                ]
+            },
+            "tags": [
+                "preserve_original_event",
+                "DS:PANW/XDR Agent",
+                "EG:win-server-default",
+                "EG:win-server-ex-ransomeware_report"
+            ],
+            "threat": {
+                "framework": "MITRE ATT&CK",
+                "tactic": {
+                    "id": [
+                        "TA0010"
+                    ],
+                    "name": [
+                        "Exfiltration"
+                    ]
+                },
+                "technique": {
+                    "id": [
+                        "T1048"
+                    ],
+                    "name": [
+                        "Exfiltration Over Alternative Protocol"
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/packages/panw_cortex_xdr/data_stream/incidents/_dev/test/pipeline/test-reprocess.json-expected.json
+++ b/packages/panw_cortex_xdr/data_stream/incidents/_dev/test/pipeline/test-reprocess.json-expected.json
@@ -1,0 +1,100 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2023-08-14T00:01:28.775Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "malware"
+                ],
+                "created": "2023-08-12T23:58:32.575Z",
+                "id": "891",
+                "kind": "alert",
+                "original": "{\"incident_id\": \"891\", \"incident_name\": null, \"creation_time\": 1691884712575, \"modification_time\": 1691971288775, \"detection_time\": null, \"status\": \"new\", \"severity\": \"low\", \"description\": \"2 'Large Upload (Generic)' alerts detected by XDR Analytics on host computer1  involving user nt authority\\\\system\", \"assigned_user_mail\": null, \"assigned_user_pretty_name\": null, \"alert_count\": 2, \"low_severity_alert_count\": 2, \"med_severity_alert_count\": 0, \"high_severity_alert_count\": 0, \"critical_severity_alert_count\": 0, \"user_count\": 1, \"host_count\": 1, \"notes\": null, \"resolve_comment\": null, \"resolved_timestamp\": null, \"manual_severity\": null, \"manual_description\": null, \"xdr_url\": \"https://test.xdr.eu.paloaltonetworks.com/incident-view?caseId=891\", \"starred\": false, \"hosts\": [\"computer1:7a7370f8934c4e60b1e7dc5d0c8b0477\"], \"users\": [\"nt authority\\\\system\"], \"incident_sources\": [\"XDR Analytics\"], \"rule_based_score\": null, \"predicted_score\": 5, \"manual_score\": null, \"aggregated_score\": 5, \"wildfire_hits\": 0, \"alerts_grouping_status\": \"Enabled\", \"mitre_tactics_ids_and_names\": [\"TA0010 - Exfiltration\"], \"mitre_techniques_ids_and_names\": [\"T1048 - Exfiltration Over Alternative Protocol\"], \"alert_categories\": [\"Exfiltration\"], \"original_tags\": [\"EG:win-server-ex-ransomeware_report\", \"DS:PANW/XDR Agent\", \"EG:win-server-default\"], \"tags\": [\"DS:PANW/XDR Agent\", \"EG:win-server-default\", \"EG:win-server-ex-ransomeware_report\"]}",
+                "reason": "2 'Large Upload (Generic)' alerts detected by XDR Analytics on host computer1  involving user nt authority\\system",
+                "severity": 2,
+                "type": [
+                    "info"
+                ]
+            },
+            "panw_cortex": {
+                "xdr": {
+                    "aggregated_score": 5,
+                    "alert_categories": [
+                        "Exfiltration"
+                    ],
+                    "alert_count": 2,
+                    "alerts_grouping_status": "Enabled",
+                    "creation_time": "2023-08-12T23:58:32.575Z",
+                    "critical_severity_alert_count": 0,
+                    "high_severity_alert_count": 0,
+                    "host_count": 1,
+                    "hosts": [
+                        "computer1:7a7370f8934c4e60b1e7dc5d0c8b0477"
+                    ],
+                    "incident_sources": [
+                        "XDR Analytics"
+                    ],
+                    "low_severity_alert_count": 2,
+                    "med_severity_alert_count": 0,
+                    "mitre_tactics_ids_and_names": [
+                        "TA0010 - Exfiltration"
+                    ],
+                    "mitre_techniques_ids_and_names": [
+                        "T1048 - Exfiltration Over Alternative Protocol"
+                    ],
+                    "modification_time": "2023-08-14T00:01:28.775Z",
+                    "original_tags": [
+                        "EG:win-server-ex-ransomeware_report",
+                        "DS:PANW/XDR Agent",
+                        "EG:win-server-default"
+                    ],
+                    "predicted_score": 5,
+                    "starred": false,
+                    "status": "new",
+                    "user_count": 1,
+                    "users": [
+                        "nt authority\\system"
+                    ],
+                    "wildfire_hits": 0,
+                    "xdr_url": "https://test.xdr.eu.paloaltonetworks.com/incident-view?caseId=891"
+                }
+            },
+            "related": {
+                "hosts": [
+                    "computer1"
+                ],
+                "user": [
+                    "system"
+                ]
+            },
+            "tags": [
+                "preserve_original_event",
+                "DS:PANW/XDR Agent",
+                "EG:win-server-default",
+                "EG:win-server-ex-ransomeware_report"
+            ],
+            "threat": {
+                "framework": "MITRE ATT&CK",
+                "tactic": {
+                    "id": [
+                        "TA0010"
+                    ],
+                    "name": [
+                        "Exfiltration"
+                    ]
+                },
+                "technique": {
+                    "id": [
+                        "T1048"
+                    ],
+                    "name": [
+                        "Exfiltration Over Alternative Protocol"
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/packages/panw_cortex_xdr/data_stream/incidents/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/panw_cortex_xdr/data_stream/incidents/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,19 @@
 ---
 description: Pipeline for Palo Alto XDR Incident API.
 processors:
+  - rename:
+      description: Use 'event.original' if present (e.g. when reprocessing), otherwise 'message'.
+      field: message
+      target_field: event.original
+      ignore_missing: true
+      if: ctx.event?.original == null
+  - remove:
+      description: In case of reprocessing, remove all fields that will be repopulated.
+      keep:
+        - event.original
+        - tags
+        - "@timestamp"
+      ignore_missing: true
   - set:
       field: ecs.version
       value: '8.11.0'
@@ -13,11 +26,6 @@ processors:
   - append:
       field: event.type
       value: info
-  - rename:
-      field: message
-      target_field: event.original
-      ignore_missing: true
-      if: ctx.event?.original == null
   - json:
       field: event.original
       target_field: panw_cortex.xdr

--- a/packages/panw_cortex_xdr/manifest.yml
+++ b/packages/panw_cortex_xdr/manifest.yml
@@ -1,6 +1,6 @@
 name: panw_cortex_xdr
 title: Palo Alto Cortex XDR
-version: "1.31.0"
+version: "1.32.0"
 description: Collect logs from Palo Alto Cortex XDR with Elastic Agent.
 type: integration
 format_version: "3.0.2"


### PR DESCRIPTION
## Proposed commit message

```
[panw_cortex_xdr] Allow reprocessing of events with `event.original` (#)

For both data streams, if the `event.original` field is populated,
discard the `message` and other fields that will be regenerated by the
pipeline.

This allows reprocessing of events (if they contain `event.original`),
and it allows the processing of events received from Logstash with the
`ecs_compatibility` mode[1] enabled (which populates `event.original`).

Pipeline tests are added to confirm correction function.

[1]: https://www.elastic.co/guide/en/logstash/current/ecs-ls.html
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
