### PR TITLE
[cisco_ftd] Ensure event message is saved to event.reason for IDs 101001 through 105052

### DIFF
--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.5.0"
+  changes:
+    - description: Ensure event message is saved to event.reason for IDs 101001 through 105052.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.4.4"
   changes:
     - description: Fixed grok errors on ftd message ID 305006. Added additional matching pattern per specification.

--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Ensure event message is saved to event.reason for IDs 101001 through 105052.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/12343
 - version: "3.4.4"
   changes:
     - description: Fixed grok errors on ftd message ID 305006. Added additional matching pattern per specification.

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log
@@ -24,3 +24,4 @@ May  5 17:51:17 dev01: %FTD-4-313005: No matching connection for ICMP error mess
 <164>Jul 16 2024 12:30:30: %FTD-5-305013: Asymmetric NAT rules matched for forward and reverse flows; Connection for protocol 47 src outside.int:175.16.199.1 dst inside.int:216.160.83.56 denied due to NAT reverse path failure
 <164>Jul 16 2024 12:30:30: %FTD-6-302023: Teardown director TCP connection for INSIDE:192.168.2.2/49001 to OUTSIDE:81.2.69.195/443 duration 0:00:30 forwarded bytes 0 Cluster flow with CLU closed on owner
 <164>Jul 16 2024 12:30:30: %FTD-6-302023: Teardown backup TCP connection for INSIDE:192.168.2.2/49001 to OUTSIDE:81.2.69.195/443 duration 0:00:12 forwarded bytes 5282 Cluster flow with CLU closed on owner
+2019-08-16T09:39:03Z myhost %FTD-1-103001: (Secondary) No response from other firewall (reason code = 4).

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log-expected.json
@@ -2026,6 +2026,47 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2019-08-16T09:39:03.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "103001",
+                "kind": "event",
+                "original": "2019-08-16T09:39:03Z myhost %FTD-1-103001: (Secondary) No response from other firewall (reason code = 4).",
+                "reason": "(Secondary) No response from other firewall (reason code = 4).",
+                "severity": 1,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "myhost"
+            },
+            "log": {
+                "level": "alert"
+            },
+            "observer": {
+                "hostname": "myhost",
+                "product": "ftd",
+                "type": "idps",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myhost"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -200,6 +200,15 @@ processors:
       if: 'ctx._temp_.cisco.message_id != ""'
       field: "event.action"
       value: "firewall-rule"
+  - script:
+      tag: "script_preserve_message"
+      if: 'ctx._temp_.cisco.message_id != ""'
+      lang: painless
+      source: |-
+        def messageID = Long.parseLong(ctx._temp_.cisco.message_id);
+        if (messageID >= 101001 && messageID <= 105052) {
+         ctx.event["reason"] = ctx.message;
+        }
   - dissect:
       if: "ctx._temp_.cisco.message_id == '106001'"
       field: "message"

--- a/packages/cisco_ftd/manifest.yml
+++ b/packages/cisco_ftd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ftd
 title: Cisco FTD
-version: "3.4.4"
+version: "3.5.0"
 description: Collect logs from Cisco FTD with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- Events with ID 101001 through 105052 were not explicitly handled by the pipeline, which means the reason text from the event would be discarded.
- Added a script processor to save off the message to event.reason for these events.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

## How to test this PR locally

```
cd packages/cisco_ftd
elastic-package test
```