### PR TITLE
Ensure filestream fingerprint is disabled in system tests

### DIFF
--- a/packages/goflow2/changelog.yml
+++ b/packages/goflow2/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.0"
+  changes:
+    - description: Add configuration for custom filestream options. Ensure filestream fingerprint is disabled in system test.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.1.1"
   changes:
     - description: Use triple-brace Mustache templating when referencing variables in ingest pipelines.

--- a/packages/goflow2/changelog.yml
+++ b/packages/goflow2/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add configuration for custom filestream options. Ensure filestream fingerprint is disabled in system test.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/12349
 - version: "0.1.1"
   changes:
     - description: Use triple-brace Mustache templating when referencing variables in ingest pipelines.

--- a/packages/goflow2/data_stream/sflow/_dev/test/system/test-filestream-config.yml
+++ b/packages/goflow2/data_stream/sflow/_dev/test/system/test-filestream-config.yml
@@ -6,5 +6,10 @@ data_stream:
     preserve_original_event: true
     paths:
       - "{{{SERVICE_LOGS_DIR}}}/*goflow2-sflow*.log"
+    filestream_options: |-
+      file_identity.native: ~
+      prospector:
+        scanner:
+          fingerprint.enabled: false
 assert:
   hit_count: 9

--- a/packages/goflow2/data_stream/sflow/agent/stream/filestream.yml.hbs
+++ b/packages/goflow2/data_stream/sflow/agent/stream/filestream.yml.hbs
@@ -32,3 +32,6 @@ processors:
 {{#if ignore_older}}
 ignore_older: {{ignore_older}}
 {{/if}}
+{{#if filestream_options}}
+{{filestream_options}}
+{{/if}}

--- a/packages/goflow2/data_stream/sflow/manifest.yml
+++ b/packages/goflow2/data_stream/sflow/manifest.yml
@@ -49,6 +49,13 @@ streams:
         default:
           - sflow
           - forwarded
+      - name: filestream_options
+        type: yaml
+        title: Custom Filestream Options
+        multi: false
+        required: false
+        show_user: false
+        description: Specify custom configuration options for the Filestream input. See [filestream input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-filestream.html) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/goflow2/manifest.yml
+++ b/packages/goflow2/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: goflow2
 title: "GoFlow2 logs"
-version: 0.1.1
+version: 0.2.0
 description: "Collect logs from goflow2 with Elastic Agent."
 type: integration
 categories:

--- a/packages/imperva/changelog.yml
+++ b/packages/imperva/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Add configuration for custom filestream options. Ensure filestream fingerprint is disabled in system test.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.1.0"
   changes:
     - description: Update package spec to 3.0.3.

--- a/packages/imperva/changelog.yml
+++ b/packages/imperva/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add configuration for custom filestream options. Ensure filestream fingerprint is disabled in system test.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/12349
 - version: "1.1.0"
   changes:
     - description: Update package spec to 3.0.3.

--- a/packages/imperva/data_stream/securesphere/_dev/test/system/test-logfile-config.yml
+++ b/packages/imperva/data_stream/securesphere/_dev/test/system/test-logfile-config.yml
@@ -6,6 +6,11 @@ data_stream:
       - "{{SERVICE_LOGS_DIR}}/*imperva*.log"
     preserve_original_event: true
     preserve_duplicate_custom_fields: true
+    filestream_options: |-
+      file_identity.native: ~
+      prospector:
+        scanner:
+          fingerprint.enabled: false
 numeric_keyword_fields:
   - log.file.device_id
   - log.file.inode

--- a/packages/imperva/data_stream/securesphere/agent/stream/filestream.yml.hbs
+++ b/packages/imperva/data_stream/securesphere/agent/stream/filestream.yml.hbs
@@ -32,3 +32,6 @@ fields:
 processors:
 {{processors}}
 {{/if}}
+{{#if filestream_options}}
+{{filestream_options}}
+{{/if}}

--- a/packages/imperva/data_stream/securesphere/manifest.yml
+++ b/packages/imperva/data_stream/securesphere/manifest.yml
@@ -222,6 +222,13 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: filestream_options
+        type: yaml
+        title: Custom Filestream Options
+        multi: false
+        required: false
+        show_user: false
+        description: Specify custom configuration options for the Filestream input. See [filestream input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-filestream.html) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/imperva/manifest.yml
+++ b/packages/imperva/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: imperva
 title: Imperva
-version: "1.1.0"
+version: "1.2.0"
 description: Collect logs from Imperva devices with Elastic Agent.
 categories: ["network", "security"]
 type: integration

--- a/packages/proxysg/changelog.yml
+++ b/packages/proxysg/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.4.0
+  changes:
+    - description: Add configuration for custom filestream options. Ensure filestream fingerprint is disabled in system test.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: 0.3.1
   changes:
     - description: Add format config to all inputs

--- a/packages/proxysg/changelog.yml
+++ b/packages/proxysg/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add configuration for custom filestream options. Ensure filestream fingerprint is disabled in system test.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/12349
 - version: 0.3.1
   changes:
     - description: Add format config to all inputs

--- a/packages/proxysg/data_stream/log/_dev/test/system/test-logfile-config.yml
+++ b/packages/proxysg/data_stream/log/_dev/test/system/test-logfile-config.yml
@@ -4,5 +4,10 @@ data_stream:
   vars:
     paths:
       - "{{SERVICE_LOGS_DIR}}/proxysg.log"
+    filestream_options: |-
+      file_identity.native: ~
+      prospector:
+        scanner:
+          fingerprint.enabled: false
 assert:
   hit_count: 5

--- a/packages/proxysg/data_stream/log/agent/stream/stream.yml.hbs
+++ b/packages/proxysg/data_stream/log/agent/stream/stream.yml.hbs
@@ -22,3 +22,6 @@ processors:
 {{#if processors}}
 {{processors}}
 {{/if}}
+{{#if filestream_options}}
+{{filestream_options}}
+{{/if}}

--- a/packages/proxysg/data_stream/log/manifest.yml
+++ b/packages/proxysg/data_stream/log/manifest.yml
@@ -49,6 +49,13 @@ streams:
 
         required: true
         show_user: true
+      - name: filestream_options
+        type: yaml
+        title: Custom Filestream Options
+        multi: false
+        required: false
+        show_user: false
+        description: Specify custom configuration options for the Filestream input. See [filestream input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-filestream.html) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/proxysg/manifest.yml
+++ b/packages/proxysg/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.1
 name: proxysg
 title: "Broadcom ProxySG"
-version: 0.3.1
+version: 0.4.0
 source:
   license: "Elastic-2.0"
 description: "Collect access logs from Broadcom ProxySG with Elastic Agent."

--- a/packages/syslog_router/changelog.yml
+++ b/packages/syslog_router/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Ensure filestream fingerprint is disabled in system test.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.1.0"
   changes:
     - description: Initial draft of the package

--- a/packages/syslog_router/changelog.yml
+++ b/packages/syslog_router/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Ensure filestream fingerprint is disabled in system test.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/12349
 - version: "0.1.0"
   changes:
     - description: Initial draft of the package

--- a/packages/syslog_router/data_stream/log/_dev/test/system/test-filestream-config.yml
+++ b/packages/syslog_router/data_stream/log/_dev/test/system/test-filestream-config.yml
@@ -6,5 +6,10 @@ data_stream:
     paths:
       - "{{SERVICE_LOGS_DIR}}/*.log"
     preserve_original_event: true
+    filestream_options: |-
+      file_identity.native: ~
+      prospector:
+        scanner:
+          fingerprint.enabled: false
 assert:
   hit_count: 1

--- a/packages/syslog_router/manifest.yml
+++ b/packages/syslog_router/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: syslog_router
 title: "Syslog Router"
-version: 0.1.0
+version: 0.1.1
 description: "Route syslog events to integrations with Elastic Agent."
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- Disabled filestream fingerprint (defaults to enabled in 9.0) in goflow2, imperva, proxysg, and syslog_router system tests
- Exposed filestream options configuration for goflow2, imperva, and proxysg in order to disable fingerprint in the system tests

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~


## How to test this PR locally

```
# Stack version must be 9.0.0(-SNAPSHOT)

cd packages/<pkg>
elastic-package test system
```

Note: I have run each package's system test against the latest 9.0.0-SNAPSHOT and all tests passed.

```
--- Test results for package: goflow2 - START ---
╭─────────┬─────────────┬───────────┬────────────┬────────┬────────────────╮
│ PACKAGE │ DATA STREAM │ TEST TYPE │ TEST NAME  │ RESULT │   TIME ELAPSED │
├─────────┼─────────────┼───────────┼────────────┼────────┼────────────────┤
│ goflow2 │ sflow       │ system    │ filestream │ PASS   │ 2m8.976144917s │
╰─────────┴─────────────┴───────────┴────────────┴────────┴────────────────╯
--- Test results for package: goflow2 - END   ---

--- Test results for package: imperva - START ---
╭─────────┬──────────────┬───────────┬───────────┬────────┬────────────────╮
│ PACKAGE │ DATA STREAM  │ TEST TYPE │ TEST NAME │ RESULT │   TIME ELAPSED │
├─────────┼──────────────┼───────────┼───────────┼────────┼────────────────┤
│ imperva │ securesphere │ system    │ logfile   │ PASS   │ 2m4.819573375s │
│ imperva │ securesphere │ system    │ tcp       │ PASS   │ 2m6.046617958s │
│ imperva │ securesphere │ system    │ tls       │ PASS   │ 2m8.223399708s │
│ imperva │ securesphere │ system    │ udp       │ PASS   │ 2m6.222934083s │
╰─────────┴──────────────┴───────────┴───────────┴────────┴────────────────╯
--- Test results for package: imperva - END   ---

--- Test results for package: proxysg - START ---
╭─────────┬─────────────┬───────────┬───────────┬────────┬─────────────────╮
│ PACKAGE │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │    TIME ELAPSED │
├─────────┼─────────────┼───────────┼───────────┼────────┼─────────────────┤
│ proxysg │ log         │ system    │ logfile   │ PASS   │ 2m10.754771125s │
│ proxysg │ log         │ system    │ tcp       │ PASS   │ 2m12.350897209s │
│ proxysg │ log         │ system    │ tls       │ PASS   │   36.883552916s │
│ proxysg │ log         │ system    │ udp       │ PASS   │ 2m10.295640084s │
╰─────────┴─────────────┴───────────┴───────────┴────────┴─────────────────╯
--- Test results for package: proxysg - END   ---

--- Test results for package: syslog_router - START ---
╭───────────────┬─────────────┬───────────┬────────────┬────────┬────────────────╮
│ PACKAGE       │ DATA STREAM │ TEST TYPE │ TEST NAME  │ RESULT │   TIME ELAPSED │
├───────────────┼─────────────┼───────────┼────────────┼────────┼────────────────┤
│ syslog_router │ log         │ system    │ filestream │ PASS   │ 2m5.138502875s │
│ syslog_router │ log         │ system    │ tcp        │ PASS   │ 2m9.551055542s │
│ syslog_router │ log         │ system    │ tls        │ PASS   │  37.642996584s │
│ syslog_router │ log         │ system    │ udp        │ PASS   │ 2m8.906954792s │
╰───────────────┴─────────────┴───────────┴────────────┴────────┴────────────────╯
--- Test results for package: syslog_router - END   ---

```

## Related issues

- Closes #12312
- Closes #12313
- Closes #12323
- Closes #12325

