### PR TITLE
zscaler_zia: Use `source.nat.ip` as an alternate for geo IPs in `firewall` and `web` logs.

### DIFF
--- a/packages/zscaler_zia/changelog.yml
+++ b/packages/zscaler_zia/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
-- version: "3.7.0"
+- version: "3.6.3"
   changes:
     - description: Use source.nat.ip as alternate for geo IPs in firewall and web logs.
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12356
 - version: "3.6.2"
   changes:
     - description: Drop 'Unknown' values in the audit data stream.

--- a/packages/zscaler_zia/changelog.yml
+++ b/packages/zscaler_zia/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.7.0"
+  changes:
+    - description: Use source.nat.ip as alternate for geo IPs in firewall and web logs.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.6.2"
   changes:
     - description: Drop 'Unknown' values in the audit data stream.

--- a/packages/zscaler_zia/data_stream/firewall/_dev/test/pipeline/test-firewall-http-endpoint.log-expected.json
+++ b/packages/zscaler_zia/data_stream/firewall/_dev/test/pipeline/test-firewall-http-endpoint.log-expected.json
@@ -83,7 +83,16 @@
             "source": {
                 "bytes": 10000,
                 "geo": {
-                    "country_name": "United States"
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
                 },
                 "ip": "0.0.0.0",
                 "nat": {
@@ -430,7 +439,16 @@
             "source": {
                 "bytes": 10000,
                 "geo": {
-                    "country_name": "United States"
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
                 },
                 "ip": "0.0.0.0",
                 "nat": {

--- a/packages/zscaler_zia/data_stream/firewall/_dev/test/pipeline/test-firewall.log-expected.json
+++ b/packages/zscaler_zia/data_stream/firewall/_dev/test/pipeline/test-firewall.log-expected.json
@@ -82,7 +82,16 @@
             "source": {
                 "bytes": 10000,
                 "geo": {
-                    "country_name": "United States"
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
                 },
                 "ip": "1.128.0.0",
                 "nat": {
@@ -322,7 +331,16 @@
             "source": {
                 "bytes": 10000,
                 "geo": {
-                    "country_name": "United States"
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
                 },
                 "ip": "0.0.0.0",
                 "nat": {

--- a/packages/zscaler_zia/data_stream/firewall/_dev/test/pipeline/test-unicode.json-expected.json
+++ b/packages/zscaler_zia/data_stream/firewall/_dev/test/pipeline/test-unicode.json-expected.json
@@ -91,7 +91,16 @@
             "source": {
                 "bytes": 10000,
                 "geo": {
-                    "country_name": "United States"
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
                 },
                 "ip": "0.0.0.0",
                 "nat": {

--- a/packages/zscaler_zia/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zscaler_zia/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
@@ -884,12 +884,6 @@ processors:
       tag: rename_srcipcountry
       target_field: zscaler_zia.firewall.source_ip_country
       ignore_missing: true
-  - set:
-      field: source.geo.country_name
-      tag: set_source_geo_country_name_from_firewall_source_ip_country
-      copy_from: zscaler_zia.firewall.source_ip_country
-      if: ctx.source?.geo?.country_name == null
-      ignore_empty_value: true
   - rename:
       field: json.stateful
       tag: rename_stateful
@@ -976,6 +970,13 @@ processors:
       tag: set_source_nat_ip_from_zscaler_zia_firewall_tunnel_ip
       copy_from: zscaler_zia.firewall.tunnel.ip
       ignore_empty_value: true
+  - geoip:
+      field: source.nat.ip
+      target_field: source.geo
+      tag: geoip_source_nat_ip
+      if: ctx.source?.geo == null
+      description: If source.ip fails to populate geo fields.
+      ignore_missing: true
   - append:
       field: related.ip
       value: '{{{zscaler_zia.firewall.tunnel.ip}}}'
@@ -1071,7 +1072,6 @@ processors:
         - zscaler_zia.firewall.rule_label
         - zscaler_zia.firewall.server.destination.port
         - zscaler_zia.firewall.server.source.port
-        - zscaler_zia.firewall.source_ip_country
         - zscaler_zia.firewall.time
         - zscaler_zia.firewall.user
       tag: remove_custom_duplicate_fields

--- a/packages/zscaler_zia/data_stream/web/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zscaler_zia/data_stream/web/elasticsearch/ingest_pipeline/default.yml
@@ -239,6 +239,13 @@ processors:
       target_field: source.geo
       tag: geoip_source_ip
       ignore_missing: true
+  - geoip:
+      field: source.nat.ip
+      target_field: source.geo
+      tag: geoip_source_nat_ip
+      if: ctx.source?.geo == null
+      description: If source.ip fails to populate geo fields.
+      ignore_missing: true
   - convert:
       field: json.cltpubip
       tag: convert_cltpubip_to_ip

--- a/packages/zscaler_zia/manifest.yml
+++ b/packages/zscaler_zia/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: zscaler_zia
 title: Zscaler Internet Access
-version: "3.6.2"
+version: "3.7.0"
 description: Collect logs from Zscaler Internet Access (ZIA) with Elastic Agent.
 type: integration
 categories:

--- a/packages/zscaler_zia/manifest.yml
+++ b/packages/zscaler_zia/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: zscaler_zia
 title: Zscaler Internet Access
-version: "3.7.0"
+version: "3.6.3"
 description: Collect logs from Zscaler Internet Access (ZIA) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
Users may have private IPs inside `source.ip` which prevents `geo` fields from getting populated. 
This PR:
- Uses `source.nat.ip` as an alternate for populating `geo` fields if not already populated by `source.ip`.
- Removes processor explicitly populating `geo.country_name` as it is added by `geoip` processor.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
`cd packages/zscaler_zia && elastic-package build && elastic-package stack up --version=8.13.0 -d -v  && eval "$(elastic-package stack shellinit)" && elastic-package test pipeline --generate -v`
```
--- Test results for package: zscaler_zia - START ---
╭─────────────┬─────────────┬───────────┬────────────────────────────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE     │ DATA STREAM │ TEST TYPE │ TEST NAME                                                  │ RESULT │ TIME ELAPSED │
├─────────────┼─────────────┼───────────┼────────────────────────────────────────────────────────────┼────────┼──────────────┤
│ zscaler_zia │ firewall    │ pipeline  │ (ingest pipeline warnings test-firewall-http-endpoint.log) │ PASS   │ 348.205541ms │
│ zscaler_zia │ firewall    │ pipeline  │ (ingest pipeline warnings test-firewall.log)               │ PASS   │ 333.986667ms │
│ zscaler_zia │ firewall    │ pipeline  │ (ingest pipeline warnings test-unicode.json)               │ PASS   │ 372.179208ms │
│ zscaler_zia │ firewall    │ pipeline  │ test-firewall-http-endpoint.log                            │ PASS   │   94.69425ms │
│ zscaler_zia │ firewall    │ pipeline  │ test-firewall.log                                          │ PASS   │  88.065417ms │
│ zscaler_zia │ firewall    │ pipeline  │ test-unicode.json                                          │ PASS   │  65.712959ms │
╰─────────────┴─────────────┴───────────┴────────────────────────────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: zscaler_zia - END   ---
Done
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
