### PR TITLE
[Cloud Security] add required_vars validation rules and default CSPM and Asset Inventory to agentless deployment

### DIFF
--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -1,6 +1,11 @@
 # newer versions go on top
 # version map:
 # 0.1.x - 8.15.x
+- version: "0.8.0"
+  changes:
+    - description: Default to agentless deployment
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12363
 - version: "0.7.0"
   changes:
     - description: Refactor field names to entity and use ECS

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.2
 name: cloud_asset_inventory
 title: "Cloud Asset Inventory"
-version: "0.7.0"
+version: "0.8.0"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Inventory"
@@ -32,6 +32,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        is_default: true
         organization: security
         division: engineering
         team: cloud-security-posture

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,4 +1,4 @@
-format_version: 3.2.2
+format_version: 3.3.2
 name: cloud_asset_inventory
 title: "Cloud Asset Inventory"
 version: "0.8.0"

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -44,53 +44,53 @@ policy_templates:
     data_streams:
       - asset_inventory
     inputs:
-        - type: cloudbeat/asset_inventory_aws
-          title: AWS Asset Inventory
-          description: AWS Asset Inventory
-          vars:
-            - name: cloud_formation_template
-              type: text
-              title: CloudFormation Template
-              multi: false
-              required: true
-              show_user: false
-              description: Template URL to Cloud Formation Quick Create Stack
-              # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
-              default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-asset-inventory-ACCOUNT_TYPE-8.17.0.yml&stackName=Elastic-Cloud-Security-Posture-Management&param_EnrollmentToken=FLEET_ENROLLMENT_TOKEN&param_FleetUrl=FLEET_URL&param_ElasticAgentVersion=KIBANA_VERSION&param_ElasticArtifactServer=https://artifacts.elastic.co/downloads/beats/elastic-agent
-            - name: cloud_formation_credentials_template
-              type: text
-              title: CloudFormation Credentials Template
-              multi: false
-              required: true
-              show_user: false
-              description: Template URL to Cloud Formation Cloud Credentials Stack
-              # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
-              default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-asset-inventory-direct-access-key-ACCOUNT_TYPE-8.17.0.yml
-        - type: cloudbeat/asset_inventory_azure
-          title: Azure Asset Inventory
-          description: Azure Asset Inventory
-          vars:
-            - name: arm_template_url
-              type: text
-              title: ARM Template URL
-              multi: false
-              required: true
-              show_user: false
-              description: A URL to the ARM Template for creating a new deployment
-              # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
-              default: https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fcloudbeat%2F8.17%2Fdeploy%2Fasset-inventory-arm%2FARM-for-ACCOUNT_TYPE.json
-        - type: cloudbeat/asset_inventory_gcp
-          title: GCP Asset Inventory
-          description: GCP Asset Inventory
-          vars:
-            - name: cloud_shell_url
-              type: text
-              title: CloudShell URL
-              multi: false
-              required: true
-              show_user: false
-              description: A URL to CloudShell for creating a new deployment
-              default: https://shell.cloud.google.com/cloudshell/?ephemeral=true&cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Felastic%2Fcloudbeat&cloudshell_git_branch=8.17&cloudshell_workspace=deploy%2Fdeployment-manager&show=terminal
+      - type: cloudbeat/asset_inventory_aws
+        title: AWS Asset Inventory
+        description: AWS Asset Inventory
+        vars:
+          - name: cloud_formation_template
+            type: text
+            title: CloudFormation Template
+            multi: false
+            required: true
+            show_user: false
+            description: Template URL to Cloud Formation Quick Create Stack
+            # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
+            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-asset-inventory-ACCOUNT_TYPE-8.17.0.yml&stackName=Elastic-Cloud-Security-Posture-Management&param_EnrollmentToken=FLEET_ENROLLMENT_TOKEN&param_FleetUrl=FLEET_URL&param_ElasticAgentVersion=KIBANA_VERSION&param_ElasticArtifactServer=https://artifacts.elastic.co/downloads/beats/elastic-agent
+          - name: cloud_formation_credentials_template
+            type: text
+            title: CloudFormation Credentials Template
+            multi: false
+            required: true
+            show_user: false
+            description: Template URL to Cloud Formation Cloud Credentials Stack
+            # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
+            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-asset-inventory-direct-access-key-ACCOUNT_TYPE-8.17.0.yml
+      - type: cloudbeat/asset_inventory_azure
+        title: Azure Asset Inventory
+        description: Azure Asset Inventory
+        vars:
+          - name: arm_template_url
+            type: text
+            title: ARM Template URL
+            multi: false
+            required: true
+            show_user: false
+            description: A URL to the ARM Template for creating a new deployment
+            # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
+            default: https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fcloudbeat%2F8.17%2Fdeploy%2Fasset-inventory-arm%2FARM-for-ACCOUNT_TYPE.json
+      - type: cloudbeat/asset_inventory_gcp
+        title: GCP Asset Inventory
+        description: GCP Asset Inventory
+        vars:
+          - name: cloud_shell_url
+            type: text
+            title: CloudShell URL
+            multi: false
+            required: true
+            show_user: false
+            description: A URL to CloudShell for creating a new deployment
+            default: https://shell.cloud.google.com/cloudshell/?ephemeral=true&cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Felastic%2Fcloudbeat&cloudshell_git_branch=8.17&cloudshell_workspace=deploy%2Fdeployment-manager&show=terminal
     categories:
       - security
       - cloud

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -12,6 +12,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "1.13.0-preview02"
+  changes:
+    - description: Add support for conditional required fields
+      type: enhancement
+      link:
 - version: "1.13.0-preview01"
   changes:
     - description: Add AWS external_id for cloud connectors flow"

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -14,7 +14,7 @@
 # 1.2.x - 8.7.x
 - version: "1.13.0-preview02"
   changes:
-    - description: Add support for conditional required fields
+    - description: Add support for conditional required fields and default deployment mode agentless
       type: enhancement
       link:
 - version: "1.13.0-preview01"

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -16,7 +16,7 @@
   changes:
     - description: Add support for conditional required fields and default deployment mode agentless
       type: enhancement
-      link:
+      link: https://github.com/elastic/integrations/pull/12363
 - version: "1.13.0-preview01"
   changes:
     - description: Add AWS external_id for cloud connectors flow"

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -227,6 +227,32 @@ streams:
         - name: gcp.organization_id
         - name: gcp.project_id
         - name: gcp.credentials.json
+      single_account_cloud_shell:
+        - name: gcp.account_type
+          value: single-account
+        - name: gcp.credentials.type
+          value: credentials-none
+        - name: setup_access
+          value: google_cloud_shell
+        - name: gcp.project_id
+      single_account_manual-file:
+        - name: gcp.account_type
+          value: single-account
+        - name: gcp.credentials.type
+          value: credentials-file
+        - name: setup_access
+          value: manual
+        - name: gcp.project_id
+        - name: gcp.credentials.file
+      single_account_manual-json:
+        - name: gcp.account_type
+          value: single-account
+        - name: gcp.credentials.type
+          value: credentials-json
+        - name: setup_access
+          value: manual
+        - name: gcp.project_id
+        - name: gcp.credentials.json
     vars:
       - name: condition
         title: Condition
@@ -278,6 +304,61 @@ streams:
     description: CIS Benchmark for Microsoft Azure Foundations
     template_path: azure.yml.hbs
     enabled: false
+    required_vars:
+      organization_account_arm_template:
+        - name: azure.account_type
+          value: organization-account
+        - name: azure.credentials.type
+          value: arm_template
+      organization_account_managed_identity:
+        - name: azure.account_type
+          value: organization-account
+        - name: azure.credentials.type
+          value: managed_identity
+      organization_account_service_principal_secret:
+        - name: azure.account_type
+          value: organization-account
+        - name: azure.credentials.type
+          value: service_principal_with_client_secret
+        - name: azure.credentials.client_id
+        - name: azure.credentials.client_secret
+        - name: azure.credentials.tenant_id
+      organization_account_service_principal_certificate:
+        - name: azure.account_type
+          value: organization-account
+        - name: azure.credentials.type
+          value: service_principal_with_client_certificate
+        - name: azure.credentials.client_id
+        - name: azure.credentials.client_certificate_path
+        - name: azure.credentials.client_certificate_password
+        - name: azure.credentials.tenant_id
+      single_account_arm_template:
+        - name: azure.account_type
+          value: single-account
+        - name: azure.credentials.type
+          value: arm_template
+      single_account_managed_identity:
+        - name: azure.account_type
+          value: single-account
+        - name: azure.credentials.type
+          value: managed_identity
+      single_account_service_principal_secret:
+        - name: azure.account_type
+          value: single-account
+        - name: azure.credentials.type
+          value: service_principal_with_client_secret
+        - name: azure.credentials.client_id
+        - name: azure.credentials.client_secret
+        - name: azure.credentials.tenant_id
+      single_account_service_principal_certificate:
+        - name: azure.account_type
+          value: single-account
+        - name: azure.credentials.type
+          value: service_principal_with_client_certificate
+        - name: azure.credentials.client_id
+        - name: azure.credentials.client_certificate_path
+        - name: azure.credentials.client_certificate_password
+        - name: azure.credentials.tenant_id
     vars:
       - name: condition
         title: Condition

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -87,6 +87,32 @@ streams:
     description: CIS Benchmark for Amazon Web Services Foundations
     template_path: aws.yml.hbs
     enabled: false
+    required_vars:
+      - [
+          aws.credentials.type,
+          aws.credentials.type,
+          access_key_id,
+          secret_access_key,
+        ]
+      - [
+          aws.credentials.type,
+          aws.credentials.type,
+          access_key_id,
+          secret_access_key,
+          session_token,
+        ]
+      - [
+          aws.credentials.type,
+          aws.credentials.type,
+          shared_credential_file,
+          credential_profile_name,
+        ]
+      - [
+          cloud_formation_template,
+          cloud_formation_credentials_template,
+          cloud_formation_cloud_connectors_template,
+        ]
+      - [aws.credentials.type, aws.credentials.type, role_arn]
     vars:
       - name: condition
         title: Condition
@@ -167,6 +193,9 @@ streams:
     description: CIS Benchmark for Google Cloud Platform Foundation
     template_path: gcp.yml.hbs
     enabled: false
+    required_vars:
+      - [gcp.organization_id, gcp.project_id, gcp.credentials.json]
+      - [gcp.organization_id, gcp.project_id, gcp.credentials.file]
     vars:
       - name: condition
         title: Condition

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -117,6 +117,11 @@ streams:
           value: cloud_formation
         - name: aws.account_type
           value: organization-account
+      cloud_formation_single_account:
+        - name: aws.credentials.type
+          value: cloud_formation
+        - name: aws.account_type
+          value: single-account
     vars:
       - name: condition
         title: Condition

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -88,6 +88,11 @@ streams:
     template_path: aws.yml.hbs
     enabled: false
     required_vars:
+      assume_role:
+        - name: aws.credentials.type
+          value: assume_role
+        - name: role_arn
+        - name: aws.account_type
       direct_access_keys:
         - name: aws.credentials.type
           value: direct_access_keys

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -88,31 +88,35 @@ streams:
     template_path: aws.yml.hbs
     enabled: false
     required_vars:
-      - [
-          aws.credentials.type,
-          aws.credentials.type,
-          access_key_id,
-          secret_access_key,
-        ]
-      - [
-          aws.credentials.type,
-          aws.credentials.type,
-          access_key_id,
-          secret_access_key,
-          session_token,
-        ]
-      - [
-          aws.credentials.type,
-          aws.credentials.type,
-          shared_credential_file,
-          credential_profile_name,
-        ]
-      - [
-          cloud_formation_template,
-          cloud_formation_credentials_template,
-          cloud_formation_cloud_connectors_template,
-        ]
-      - [aws.credentials.type, aws.credentials.type, role_arn]
+      conditions:
+        - aws.credentials.type
+          aws.credentials.type
+          access_key_id
+          secret_access_key
+
+        - aws.credentials.type
+          aws.credentials.type
+          access_key_id
+          secret_access_key
+          session_token
+
+        - aws.credentials.type
+          aws.credentials.type
+          shared_credential_file
+          credential_profile_name
+
+        - cloud_formation_template
+          cloud_formation_credentials_template
+          cloud_formation_cloud_connectors_template
+
+        - aws.credentials.type
+          aws.credentials.type
+          role_arn
+      unless:
+        - name: aws.credentials.type
+          value: cloud_formation
+        - name: aws.account_type
+          value: organization-account
     vars:
       - name: condition
         title: Condition

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -116,6 +116,7 @@ streams:
         - name: aws.credentials.type
           value: cloud_formation
         - name: aws.account_type
+          value: organization-account
     vars:
       - name: condition
         title: Condition
@@ -197,8 +198,35 @@ streams:
     template_path: gcp.yml.hbs
     enabled: false
     required_vars:
-      - [gcp.organization_id, gcp.project_id, gcp.credentials.json]
-      - [gcp.organization_id, gcp.project_id, gcp.credentials.file]
+      organization_account_cloud_shell:
+        - name: gcp.account_type
+          value: organization-account
+        - name: gcp.credentials.type
+          value: credentials-none
+        - name: setup_access
+          value: google_cloud_shell
+        - name: gcp.organization_id
+        - name: gcp.project_id
+      organization_account_manual-file:
+        - name: gcp.account_type
+          value: organization-account
+        - name: gcp.credentials.type
+          value: credentials-file
+        - name: setup_access
+          value: manual
+        - name: gcp.organization_id
+        - name: gcp.project_id
+        - name: gcp.credentials.file
+      organization_account_manual-json:
+        - name: gcp.account_type
+          value: organization-account
+        - name: gcp.credentials.type
+          value: credentials-json
+        - name: setup_access
+          value: manual
+        - name: gcp.organization_id
+        - name: gcp.project_id
+        - name: gcp.credentials.json
     vars:
       - name: condition
         title: Condition

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -203,8 +203,6 @@ streams:
           value: organization-account
         - name: gcp.credentials.type
           value: credentials-none
-        - name: setup_access
-          value: google_cloud_shell
         - name: gcp.organization_id
         - name: gcp.project_id
       organization_account_manual_file:
@@ -212,8 +210,6 @@ streams:
           value: organization-account
         - name: gcp.credentials.type
           value: credentials-file
-        - name: setup_access
-          value: manual
         - name: gcp.organization_id
         - name: gcp.project_id
         - name: gcp.credentials.file
@@ -222,8 +218,6 @@ streams:
           value: organization-account
         - name: gcp.credentials.type
           value: credentials-json
-        - name: setup_access
-          value: manual
         - name: gcp.organization_id
         - name: gcp.project_id
         - name: gcp.credentials.json
@@ -232,16 +226,12 @@ streams:
           value: single-account
         - name: gcp.credentials.type
           value: credentials-none
-        - name: setup_access
-          value: google_cloud_shell
         - name: gcp.project_id
       single_account_manual_file:
         - name: gcp.account_type
           value: single-account
         - name: gcp.credentials.type
           value: credentials-file
-        - name: setup_access
-          value: manual
         - name: gcp.project_id
         - name: gcp.credentials.file
       single_account_manual_json:
@@ -249,8 +239,6 @@ streams:
           value: single-account
         - name: gcp.credentials.type
           value: credentials-json
-        - name: setup_access
-          value: manual
         - name: gcp.project_id
         - name: gcp.credentials.json
     vars:
@@ -266,7 +254,7 @@ streams:
         type: text
         title: Account Type
         multi: false
-        required: true
+        required: false
         show_user: false
       - name: gcp.organization_id
         type: text

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -88,35 +88,34 @@ streams:
     template_path: aws.yml.hbs
     enabled: false
     required_vars:
-      conditions:
-        - aws.credentials.type
-          aws.credentials.type
-          access_key_id
-          secret_access_key
-
-        - aws.credentials.type
-          aws.credentials.type
-          access_key_id
-          secret_access_key
-          session_token
-
-        - aws.credentials.type
-          aws.credentials.type
-          shared_credential_file
-          credential_profile_name
-
-        - cloud_formation_template
-          cloud_formation_credentials_template
-          cloud_formation_cloud_connectors_template
-
-        - aws.credentials.type
-          aws.credentials.type
-          role_arn
-      unless:
+      assume_role:
+        - name: aws.credentials.type
+          value: assume_role
+        - name: role_arn
+        - name: aws.account_type
+      direct_access_keys:
+        - name: aws.credentials.type
+          value: direct_access_keys
+        - name: access_key_id
+        - name: secret_access_key
+        - name: aws.account_type
+      temporary_session:
+        - name: aws.credentials.type
+          value: temporary_keys
+        - name: access_key_id
+        - name: secret_access_key
+        - name: session_token
+        - name: aws.account_type
+      shared_credentials:
+        - name: aws.credentials.type
+          value: shared_credentials
+        - name: shared_credential_file
+        - name: credential_profile_name
+        - name: aws.account_type
+      cloud_formation:
         - name: aws.credentials.type
           value: cloud_formation
         - name: aws.account_type
-          value: organization-account
     vars:
       - name: condition
         title: Condition

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -88,11 +88,6 @@ streams:
     template_path: aws.yml.hbs
     enabled: false
     required_vars:
-      assume_role:
-        - name: aws.credentials.type
-          value: assume_role
-        - name: role_arn
-        - name: aws.account_type
       direct_access_keys:
         - name: aws.credentials.type
           value: direct_access_keys

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -207,7 +207,7 @@ streams:
           value: google_cloud_shell
         - name: gcp.organization_id
         - name: gcp.project_id
-      organization_account_manual-file:
+      organization_account_manual_file:
         - name: gcp.account_type
           value: organization-account
         - name: gcp.credentials.type
@@ -217,7 +217,7 @@ streams:
         - name: gcp.organization_id
         - name: gcp.project_id
         - name: gcp.credentials.file
-      organization_account_manual-json:
+      organization_account_manual_json:
         - name: gcp.account_type
           value: organization-account
         - name: gcp.credentials.type
@@ -235,7 +235,7 @@ streams:
         - name: setup_access
           value: google_cloud_shell
         - name: gcp.project_id
-      single_account_manual-file:
+      single_account_manual_file:
         - name: gcp.account_type
           value: single-account
         - name: gcp.credentials.type
@@ -244,7 +244,7 @@ streams:
           value: manual
         - name: gcp.project_id
         - name: gcp.credentials.file
-      single_account_manual-json:
+      single_account_manual_json:
         - name: gcp.account_type
           value: single-account
         - name: gcp.credentials.type

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,4 +1,4 @@
-format_version: 3.2.3
+format_version: 3.3.2
 name: cloud_security_posture
 title: "Security Posture Management"
 version: "1.13.0-preview01"

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.13.0-preview01"
+version: "1.13.0-preview02"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -4,7 +4,7 @@ title: "Security Posture Management"
 version: "1.13.0-preview01"
 source:
   license: "Elastic-2.0"
-description: "Sean...Identify & remediate configuration risks in your Cloud infrastructure"
+description: "Identify & remediate configuration risks in your Cloud infrastructure"
 type: integration
 categories:
   - security

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -4,7 +4,7 @@ title: "Security Posture Management"
 version: "1.13.0-preview02"
 source:
   license: "Elastic-2.0"
-description: "Identify & remediate configuration risks in your Cloud infrastructure"
+description: "Sean...Identify & remediate configuration risks in your Cloud infrastructure"
 type: integration
 categories:
   - security

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.13.0-preview02"
+version: "1.13.0-preview01"
 source:
   license: "Elastic-2.0"
 description: "Sean...Identify & remediate configuration risks in your Cloud infrastructure"
@@ -107,6 +107,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        is_default: true
         organization: security
         division: engineering
         team: cloud-security-posture


### PR DESCRIPTION

## Proposed commit message
required_vars validation rules for CSPM integration and default agentless deployments.
  

Add required_vars validation rules for CSPM integration for conditionally required fields.
Defaulting CSPM and Asset Inventory to agentless deployments.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

- [ ] package-spec version 3.3.2 released

## How to test this PR locally


## Related issues
- Relates https://github.com/elastic/package-spec/pull/855
- Relates https://github.com/elastic/security-team/issues/10623
- Relates https://github.com/elastic/security-team/issues/10623

## Screenshots
![Screenshot 2025-01-23 at 12 34 13 PM](https://github.com/user-attachments/assets/8e6f04cf-e443-4872-8266-38767355787c)

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
