### PR TITLE
[Defender Endpoint] fix null ref for description description

### DIFF
--- a/packages/microsoft_defender_endpoint/changelog.yml
+++ b/packages/microsoft_defender_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.27.1"
+  changes:
+    - description: Fix null reference for description field
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12369
 - version: "2.27.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/microsoft_defender_endpoint/changelog.yml
+++ b/packages/microsoft_defender_endpoint/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.27.1"
   changes:
-    - description: Fix null reference for description field
+    - description: Fix null reference for description field.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/12369
 - version: "2.27.0"

--- a/packages/microsoft_defender_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_defender_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -188,7 +188,7 @@ processors:
       field: json.description
       target_field: rule.description
       ignore_missing: true
-      if: ctx?.json != null && (ctx.json?.description).length() < 1020
+      if: ctx?.json?.description != null && (ctx.json?.description).length() < 1020
 
 ######################
 ## ECS File Mapping ##

--- a/packages/microsoft_defender_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_defender_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -188,7 +188,7 @@ processors:
       field: json.description
       target_field: rule.description
       ignore_missing: true
-      if: ctx?.json?.description != null && (ctx.json?.description).length() < 1020
+      if: ctx.json?.description != null && ctx.json.description.length() < 1020
 
 ######################
 ## ECS File Mapping ##

--- a/packages/microsoft_defender_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_defender_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -188,7 +188,7 @@ processors:
       field: json.description
       target_field: rule.description
       ignore_missing: true
-      if: (ctx.json?.description).length() < 1020
+      if: ctx?.json != null && (ctx.json?.description).length() < 1020
 
 ######################
 ## ECS File Mapping ##

--- a/packages/microsoft_defender_endpoint/manifest.yml
+++ b/packages/microsoft_defender_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: microsoft_defender_endpoint
 title: Microsoft Defender for Endpoint
-version: "2.27.0"
+version: "2.27.1"
 description: Collect logs from Microsoft Defender for Endpoint with Elastic Agent.
 categories:
   - "security"


### PR DESCRIPTION
There can be events without a description, which leads the if condition to fail with:
cannot access method/field [length] from a null def reference