### PR TITLE
[cisco_secure_email_gateway] Fix field name in remove processor

### DIFF
--- a/packages/cisco_secure_email_gateway/changelog.yml
+++ b/packages/cisco_secure_email_gateway/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.24.3"
+  changes:
+    - description: Fix field name in remove processor.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.24.2"
   changes:
     - description: Fix parsing the text_mail log lines for file uploads.

--- a/packages/cisco_secure_email_gateway/changelog.yml
+++ b/packages/cisco_secure_email_gateway/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix field name in remove processor.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/12371
 - version: "1.24.2"
   changes:
     - description: Fix parsing the text_mail log lines for file uploads.

--- a/packages/cisco_secure_email_gateway/data_stream/log/elasticsearch/ingest_pipeline/pipeline_consolidated_event.yml
+++ b/packages/cisco_secure_email_gateway/data_stream/log/elasticsearch/ingest_pipeline/pipeline_consolidated_event.yml
@@ -196,7 +196,7 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
-            field: _tmp.cfp1
+            field: _tmp.fields.cfp1
         - append:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'

--- a/packages/cisco_secure_email_gateway/manifest.yml
+++ b/packages/cisco_secure_email_gateway/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_secure_email_gateway
 title: Cisco Secure Email Gateway
-version: "1.24.2"
+version: "1.24.3"
 description: Collect logs from Cisco Secure Email Gateway with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- Fixed incorrect field name in a remove processor, which was in an on_failure processor

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

## Related issues

- Closes #12377
