### PR TITLE
crowdstrike.fdr: avoid mapping conflict when host metadata is not an object 

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.46.1"
+  changes:
+    - description: Fix mapping error when host metadata is string instead of object.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "1.46.0"
   changes:
     - description: Extract user and host names from the name field.

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "1.46.1"
   changes:
-    - description: Fix mapping error when host metadata is string instead of object.
+    - description: Fix mapping conflict when host metadata is not an object.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/12375
 - version: "1.46.0"
   changes:
     - description: Extract user and host names from the name field.

--- a/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
@@ -1529,6 +1529,11 @@ processors:
       copy_from: host.hostname
       ignore_empty_value: true
       ignore_failure: true
+  - rename:
+      field: crowdstrike.info.host
+      target_field: crowdstrike.info.host.ComputerName
+      ignore_missing: true
+      if: ctx.crowdstrike?.info?.host != null && ctx.crowdstrike.info.host instanceof String
   - append:
       field: related.hosts
       value: "{{{crowdstrike.info.host.ComputerName}}}"

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "1.46.0"
+version: "1.46.1"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: "3.0.3"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Found this error in a live scenario:
```
{\"type\":\"document_parsing_exception\",\"reason\":\"[1:2175] object mapping for [crowdstrike.info.host] tried to parse field [host] as object, but found a concrete value\"}, dropping event!
```

Where event being dropped contains metadata host info as follows:
```
{
  "metadata": {
    "host": "example_host_name"
  }
}
```

`metadata.host` is supposed to be an object with several host fields, so when it is renamed to `crowdstrike.info.host` it causes the error above, as this field is mapped as an object.

**This fix is being backported to skip the current minimum required Kibana version (8.16.0).**

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

