### PR TITLE
#12249-3 Driving to 10.15 OS (part 3)

### DIFF
--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -181,7 +181,54 @@ Note: Descriptions have not been filled out
 | `<cert_length>`     | aruba.len                    |
 | `<vrf>`             | aruba.vrf.id                 |
 
-#### [Certificate management events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CERTMGR.htm)
+#### [Client insight events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CLIENT_INSIGHT.htm)
+| Doc Fields                    | Schema Mapping                |
+|-------------------------------|-------------------------------|
+| `<arp_end_ts>`                | aruba.insight.arp_end_ts      |
+| `<assigned-role>`             | aruba.role                    |
+| `<assigned-role-type>`        | aruba.insight.role_type       |
+| `<auth-latency>`              | aruba.insight.auth_latency    |
+| `<auth-status>`               | aruba.status                  |
+| `<auth-type>`                 | aruba.insight.auth_type       |
+| `<client-number>`             | aruba.limit.threshold         |
+| `<dot1x-auth-failure-reason>` | aruba.insight.dot1x_auth_failure_reason |
+| `<dhcpv4-client>`             | aruba.insight.dhcp_client     |
+| `<dhcpv4-failure-reason>`     | event.reason                  |
+| `<dhcpv4-latency>`            | aruba.insight.dhcp_latency    |
+| `<dhcpv4-server>`             | aruba.insight.dhcp_server     |
+| `<dhcpv4-status>`             | aruba.status                  |
+| `<dhcpv6-client>`             | aruba.insight.dhcp_client     |
+| `<dhcpv6-failure-reason>`     | event.reason                  |
+| `<dhcpv6-latency>`            | aruba.insight.dhcp_latency    |
+| `<dhcpv6-server>`             | aruba.insight.dhcp_server     |
+| `<dhcpv6-status>`             | aruba.status                  |
+| `<dns_end_ts>`                | aruba.insight.dns_end_ts      |
+| `<dns_failure_reason>`        | event.reason                  |
+| `<dns-failure-reason>`        | event.reason                  |
+| `<dns-latency>`               | aruba.insight.dns_latency     |
+| `<dns_server_ip>`             | server.ip                     |
+| `<dns-server>`                | aruba.insight.dns_server      |
+| `<dns_status>`                | aruba.status                  |
+| `<dns-status>`                | aruba.status                  |
+| `<failed_vlans>`              | aruba.insight.failed_vlans    |
+| `<failure_phase_id>`          | aruba.insight.failure_phase_id|
+| `<failure_reason>`            | event.reason                  |
+| `<l2_end_ts>`                 | aruba.insight.l2_end_ts       |
+| `<l2_failure_reason>`         | aruba.insight.l2_failure_reason |
+| `<l2_ob_state>`               | aruba.insight.l2_ob_state     |
+| `<l3_end_ts>`                 | aruba.insight.l3_end_ts       |
+| `<l3_failure_reason>`         | aruba.insight.l3_failure_reason |
+| `<l3_ob_state>`               | aruba.insight.l3_ob_state     |
+| `<mac>`                       | client.mac                    |
+| `<mac-auth-failure-reason>`   | aruba.insight.mac_auth_failure_reason |
+| `<port>`                      | aruba.port                    |
+| `<ob_start_ts>`               | aruba.insight.ob_start_ts     |
+| `<onboarding_status>`         | aruba.status                  |
+| `<radius-server>`             | aruba.insight.radius_server   |
+| `<successfulvlan>`            | aruba.insight.successfulvlan  |
+| `<vlans>`                     | network.vlan.id               |
+
+#### [Certificate management events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CERTMGR.htm)
 | Doc Fields       | Schema Mapping        |
 |------------------|-----------------------|
 | `<cert_name>`    | aruba.cm.cert_name    |
@@ -191,7 +238,7 @@ Note: Descriptions have not been filled out
 | `<profile_name>` | aruba.cm.profile_name |
 | `<status>`       | aruba.status          |
 
-#### [Config Management events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CONFIG_MGMT.htm)
+#### [Config Management events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CONFIG_MGMT.htm)
 | Doc Fields     | Schema Mapping       |
 |----------------|----------------------|
 | `<error>`      | event.reason         |
@@ -201,41 +248,65 @@ Note: Descriptions have not been filled out
 | `<type>`       | aruba.config.type    |
 | `<value>`      | aruba.config.value   |
 
-#### [Connectivity Fault Management (CFM) events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ETH_OAM_CFM.htm)
+#### [Config validator events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CONFIG-VALIDATOR.htm)
+| Doc Fields     | Schema Mapping       |
+|----------------|----------------------|
+| `<name>`       | aruba.config.name    |
+| `<reason>`     | event.reason         |
+
+#### [Connectivity Fault Management (CFM) events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ETH_OAM_CFM.htm)
 | Doc Fields    | Schema Mapping      |
 |---------------|---------------------|
-| `<id>`        | aruba.cfm.id        |
-| `<interface>` | aruba.cfm.interfact |
+| `<id>`        | aruba.instance.id   |
+| `<interface>` | aruba.interface.id  |
+
+#### [Console events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CONSOLE.htm)
+| Doc Fields    | Schema Mapping      |
+|---------------|---------------------|
+| `<ip_address>`        | client.ip   |
+| `<mgmt_intf>`        | aruba.interface.id   |
+| `<user_name>` | user.name  |
 
 #### [Container manager events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CONTAINER.htm)
-| Doc Fields   | Schema Mapping   |
-|--------------|------------------|
-| `<name>`     | container.name   |
+| Doc Fields   | Schema Mapping          |
+|--------------|-------------------------|
+| `<name>`     | container.name          |
+| `<params>`   | aruba.container.params  |
 
-#### [CoPP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/COPP.htm)
+#### [CoPP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/COPP.htm)
 | Doc Field                      | Schema Mapping      |
 |--------------------------------|---------------------|
 | `<class>`                      | aruba.copp.class    |
 | `<slot>`                       | aruba.slot          |
 
-#### [CPU_RX events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CPU_RX.htm)
+#### [CPU_RX events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CPU_RX.htm)
 | Doc Field                      | Schema Mapping                  |
 |--------------------------------|---------------------------------|
 | `<action>`                     | event.action                    |
 | `<filter_description>`         | aruba.cpu_rx.filter_description |
 | `<unit>`                       | aruba.instance.id               |
 
-#### [Credential Manager events DHCP Relay events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CREDMGR.htm)
+#### [Credential Manager events DHCP Relay events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CREDMGR.htm)
 | Doc Field   | Schema Mapping |
 |-------------|----------------|
 | `<key-id>`  | user.id        |
 | `<user>`    | user.name      |
 
-#### [DHCP Relay events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DHCP-RELAY.htm)
+#### [CX LMS events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CX_LMS.htm)
 | Doc Field | Schema Mapping |
 |-----------|----------------|
 
-#### [DHCP Server events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DHCP-SERVER.htm)
+#### [Device fingerprinting events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DFP.htm)
+| Doc Field        | Schema Mapping        |
+|------------------|-----------------------|
+| `<client_limit>` | aruba.limit.threshold |
+| `<interface>`    | aruba.interface.id    |
+
+#### [DHCP Relay events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DHCP-RELAY.htm)
+| Doc Field | Schema Mapping |
+|-----------|----------------|
+
+#### [DHCP Server events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DHCP-SERVER.htm)
 | Doc Field       | Schema Mapping    |
 |-----------------|-------------------|
 | `<client_id>`   | user.id           |
@@ -247,45 +318,54 @@ Note: Descriptions have not been filled out
 | `<vfr>`         | aruba.vrf.id      |
 | `<vfr_name>`    | aruba.vrf.name    |
 
-#### [DHCPv4 Snooping events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DHCPv4-SNOOPING.htm)
-| Doc Field             | Schema Mapping      |
-|-----------------------|---------------------|
-| `<client_mac>`        | client.mac          |
-| `<existing_port>`     | server.port         |
-| `<filename>`          | file.name           |
-| `<ip_address>`        | client.ip           |
-| `<lease_ip_address>`  | client.ip           |
-| `<mac>`               | client.mac          |
-| `<new_port>`          | aruba.dhcp.new_port |
-| `<port>`              | aruba.port          |
-| `<server_ip_address>` | server.ip           |
-| `<source_mac>`        | client.mac          |
-| `<vid>`               | network.vlan.id     |
-| `<volume_name>`       | aruba.volume_name   |
+#### [DHCPv4 Snooping events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DHCPv4-SNOOPING.htm)
+| Doc Field             | Schema Mapping                |
+|-----------------------|-------------------------------|
+| `<bindings_imported>` | client.dhcp.bindings_imported |
+| `<client_mac>`        | client.mac                    |
+| `<existing_port>`     | server.port                   |
+| `<filename>`          | file.name                     |
+| `<file_path>`         | file.path                     |
+| `<gateway_ip>`        | aruba.dhcp.gateway_ip         |
+| `<ip_address>`        | client.ip                     |
+| `<lease>`             | aruba.dhcp.lease              |
+| `<lease_ip_address>`  | client.ip                     |
+| `<mac>`               | client.mac                    |
+| `<message_type>`      | aruba.dhcp.message_type       |
+| `<nameserver_ip>`     | client.mac                    |
+| `<new_port>`          | aruba.dhcp.new_port           |
+| `<port>`              | aruba.port                    |
+| `<server_ip_address>` | server.ip                     |
+| `<source_mac>`        | client.mac                    |
+| `<vid>`               | network.vlan.id               |
+| `<volume_name>`       | aruba.volume_name             |
 
-#### [DHCPv6 Relay events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DHCPv6-RELAY.htm)
-| Field | Description | Type | Common |
-|-------|-------------|------|--------|
+#### [DHCPv6 Relay events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DHCPv6-RELAY.htm)
+| Doc Field       | Schema Mapping    |
+|-----------------|-------------------|
 
+#### [DHCPv6 snooping events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DHCPv6-SNOOPING.htm)
+| Doc Fields            | Schema Mapping                |
+|-----------------------|-------------------------------|
+| `<bindings_imported>` | client.dhcp.bindings_imported |
+| `<existing_port>`     | aruba.port                    |
+| `<file_name>`         | file.name                     |
+| `<file_path>`         | file.path                     |
+| `<ip>`                | client.ip                     |
+| `<ipv6_address>`      | client.ip, server.ip          |
+| `<lease>`             | aruba.dhcp.lease              |
+| `<mac>`               | client.mac                    |
+| `<message_type>`      | aruba.dhcp.message_type       |
+| `<nameserver_ip>`     | client.mac                    |
+| `<new_port>`          | aruba.dhcp.new_port           |
+| `<port>`              | aruba.port                    |
+| `<vid>`               | network.vlan.id               |
+| `<volume_name>`       | aruba.dhcp.volume_name        |
 
-#### [DHCPv6 snooping events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DHCPv6-SNOOPING.htm)
-
-| Doc Fields                       | Schema Mapping         |
-|----------------------------------|------------------------|
-| `<ipv6_address>`                 | client.ip, server.ip   |
-| `<port>`                         | aruba.port             |
-| `<mac>`                          | client.mac             |
-| `<existing_port>`                | aruba.port             |
-| `<new_port>`                     | aruba.dhcp.new_port    |
-| `<ip>`                           | client.ip              |
-| `<vid>`                          | network.vlan.id        |
-| `<volume_name>`                  | aruba.dhcp.volume_name |
-| `<file_name>`                    | file.name              |
-
-#### [Discovery and Capability Exchange (DCBx) events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DCBX.htm)
-| Field                | Description | Type | Common                          |
-|----------------------|-------------|------|---------------------------------|
-| aruba.dcbx.intf_name | Interface name as reported by the system | keyword | |
+#### [Discovery and Capability Exchange (DCBx) events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DCBX.htm)
+| Doc Fields            | Schema Mapping                |
+|-----------------------|-------------------------------|
+| `<intf_name>` | aruba.interface.name |
 
 #### [DNS client events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DNS_CLIENT.htm)
 | Field            | Description | Type | Common           |

--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -261,11 +261,11 @@ Note: Descriptions have not been filled out
 | `<interface>` | aruba.interface.id  |
 
 #### [Console events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CONSOLE.htm)
-| Doc Fields    | Schema Mapping      |
-|---------------|---------------------|
-| `<ip_address>`        | client.ip   |
-| `<mgmt_intf>`        | aruba.interface.id   |
-| `<user_name>` | user.name  |
+| Doc Fields     | Schema Mapping        |
+|----------------|-----------------------|
+| `<ip_address>` | client.ip             |
+| `<mgmt_intf>`  | aruba.interface.id    |
+| `<user_name>`  | user.name             |
 
 #### [Container manager events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CONTAINER.htm)
 | Doc Fields   | Schema Mapping          |

--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -363,9 +363,9 @@ Note: Descriptions have not been filled out
 | `<volume_name>`       | aruba.dhcp.volume_name        |
 
 #### [Discovery and Capability Exchange (DCBx) events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DCBX.htm)
-| Doc Fields            | Schema Mapping                |
-|-----------------------|-------------------------------|
-| `<intf_name>` | aruba.interface.name |
+| Doc Fields   | Schema Mapping         |
+|--------------|------------------------|
+| `<intf_name>`| aruba.interface.name   |
 
 #### [DNS client events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DNS_CLIENT.htm)
 | Field            | Description | Type | Common           |

--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -267,7 +267,7 @@ Note: Descriptions have not been filled out
 | `<mgmt_intf>`  | aruba.interface.id    |
 | `<user_name>`  | user.name             |
 
-#### [Container manager events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CONTAINER.htm)
+#### [Container manager events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CONTAINER.htm)
 | Doc Fields   | Schema Mapping          |
 |--------------|-------------------------|
 | `<name>`     | container.name          |

--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -324,7 +324,7 @@ Note: Descriptions have not been filled out
 | `<bindings_imported>` | client.dhcp.bindings_imported |
 | `<client_mac>`        | client.mac                    |
 | `<existing_port>`     | server.port                   |
-| `<filename>`          | file.name                     |
+| `<file_name>`         | file.name                     |
 | `<file_path>`         | file.path                     |
 | `<gateway_ip>`        | aruba.dhcp.gateway_ip         |
 | `<ip_address>`        | client.ip                     |
@@ -335,6 +335,7 @@ Note: Descriptions have not been filled out
 | `<nameserver_ip>`     | client.mac                    |
 | `<new_port>`          | aruba.dhcp.new_port           |
 | `<port>`              | aruba.port                    |
+| `<server_ip>`         | server.ip                     |
 | `<server_ip_address>` | server.ip                     |
 | `<source_mac>`        | client.mac                    |
 | `<vid>`               | network.vlan.id               |
@@ -367,51 +368,78 @@ Note: Descriptions have not been filled out
 |--------------|------------------------|
 | `<intf_name>`| aruba.interface.name   |
 
-#### [DNS client events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DNS_CLIENT.htm)
-| Field            | Description | Type | Common           |
-|------------------|-------------|------|------------------|
-| aruba.dns.type   | DNS event type | keyword | event.type       |
-| aruba.dns.vrf_name | Virtual Routing and Forwarding name | keyword | aruba.vrf.name   |
+#### [Distributed services events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DIST-SERV.htm)
+| Doc Fields                | Schema Mapping                           |
+|---------------------------|------------------------------------------|
+| `<active_coordinates>`    | aruba.distributed.active_coordinates     |
+| `<configured_coordinates>`| aruba.distributed.configured_coordinates |
+| `<reason>`                | event.reason                             |
 
-#### [DPSE events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DPSE.htm)
-| Field                    | Description | Type | Common                          |
-|--------------------------|-------------|------|---------------------------------|
-| aruba.dpse.linecard_name |             |      |                                 |
+#### [DNS client events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DNS_CLIENT.htm)
+| Docs Field   | Schema Mapping       |
+|--------------|----------------------|
+| `<type>`     | aruba.dns.type       |
+| `<vrf_name>` | aruba.vrf.name       |
 
-#### [ECMP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ECMP.htm)
-| Field               | Schema Mapping  |
-|---------------------|-----------------|
-| aruba.ecmp.egressid |                 |
-| aruba.ecmp.err      |                 |
-| aruba.ecmp.route    |                 |
+#### [Dot1x supplicant events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DOT1X_SUPPLICANT.htm)
+| Docs Field | Schema Mapping         |
+|------------|------------------------|
+| `<ifname>` | aruba.interface.name   |
+| `<policy>` | aruba.dot1x.policy     |
+| `<port>`   | aruba.port             |
 
-#### [ERPS events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ERPS.htm)
+#### [Download events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DOWNLOAD.htm)
+| Docs Field | Schema Mapping             |
+|------------|----------------------------|
+| `<desc>`   | aruba.error.description    |
+| `<error>`  | error.code                 |
+| `<url>`    | aruba.port                 |
+
+#### [DPSE daemon events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DPSE.htm)
+| Docs Field        | Schema Mapping             |
+|-------------------|----------------------------|
+| `<linecard_name>` | aruba.dpse.linecard_name   |
+| `<operation_name>`| aruba.dpse.operation_name  |
+| `<plugin_name>`   | aruba.dpse.plugin_name     |
+
+#### [ECMP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ECMP.htm)
+| Field       | Schema Mapping       |
+|-------------|----------------------|
+| `<egressid>`| aruba.ecmp.egressid  |
+| `<err>`     | aruba.ecmp.err       |
+| `<route>`   | aruba.ecmp.route     |
+
+#### [ERPS events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ERPS.htm)
 | Field                  | Description | Type | Common                       |
 |------------------------|-------------|------|------------------------------|
 | `<ccvlan>`             |             |      | network.vlan.id              |
 | `<dataVlan>`           |             |      | network.vlan.id              |
-| `<ifID>`               |             |      | observer.ingress.interface.id|
+| `<ifID>`               |             |      | aruba.interface.id           |
 | `<instanceID>`         |             |      | aruba.instance.id            |
-| `<interfaceName>`      |             |      | observer.ingress.interface.name|
+| `<interfaceName>`      |             |      | aruba.interface.name         |
 | `<node>`               |             |      | client.mac                   |
-| `<portName>`           |             |      | aruba.erps.port_name         |
+| `<portName>`           |             |      | aruba.port                   |
 | `<reason>`             |             |      | event.reason                 |
 | `<ringID>`             |             |      | aruba.erps.ring_id           |
 | `<state>`              |             |      | aruba.status                 |
 | `<vlandID>`            |             |      | network.vlan.id              |
 
-#### [EVPN events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/EVPN.htm)
-| Doc Field   |  Schema Mapping   |
-|-------------|-------------------|
-| `<action>`  |  event.action     |
-| `<evi>`     |  network.vlan.id  |
-| `<ip_addr>` |  client.ip        |
-| `<mac_addr>`|  client.mac       |
-| `<rd>`      |  aruba.evpn.rd    |
-| `<rt>`      |  aruba.evpn.rt    |
-| `<vni>`     |  aruba.evpn.vni   |
-| `<vrf>`     |  aruba.vrf.id     |
-| `<vtep_ip>` |  aruba.evpn.vtep_ip|
+#### [EVPN events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/EVPN.htm)
+| Doc Field       | Schema Mapping     |
+|-----------------|--------------------|
+| `<action>`      | event.action       |
+| `<bundle_name>` | package.name       |
+| `<esi>`         | aruba.evpn.esi     |
+| `<eth_tag>`     | aruba.evpn.eth_tag |
+| `<evi>`         | network.vlan.id    |
+| `<ip_addr>`     | client.ip          |
+| `<mac_addr>`    | client.mac         |
+| `<rd>`          | aruba.evpn.rd      |
+| `<rt>`          | aruba.evpn.rt      |
+| `<rtt>`         | aruba.evpn.rtt     |
+| `<vni>`         | aruba.evpn.vni     |
+| `<vrf>`         | aruba.vrf.id       |
+| `<vtep_ip>`     | aruba.evpn.vtep_ip |
 
 #### [External Storage events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/EXTERNAL-STORAGE.htm)
 | Doc Field   | Schema Mapping              |

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-cx.log-expected.json
@@ -6498,14 +6498,16 @@
             "@timestamp": "2023-11-30T11:11:48.071368-05:00",
             "aruba": {
                 "dns": {
-                    "type": "Dynamic domain server update",
-                    "vrf_name": "mgmt"
+                    "type": "Dynamic domain server update"
                 },
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
                 },
-                "sequence": ""
+                "sequence": "",
+                "vrf": {
+                    "name": "mgmt"
+                }
             },
             "ecs": {
                 "version": "8.11.0"

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
@@ -832,11 +832,14 @@
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7705|LOG_WARN|AMM|-|Certificate devices-v2.arubanetworks.com will expire within 10 days
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7706|LOG_WARN|AMM|-|Certificate devices-v2.arubanetworks.com has not yet reached its start date
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7707|LOG_WARN|AMM|-|Certificate devices-v2.arubanetworks.com has expired and can no longer be used
+2024-08-01T15:15:35.145388-05:00 8360-Primaire hpe-restd[1956]: Event|7708|LOG_INFO|AMM|1/1|Throttled 100 Messages
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7709|LOG_WARN|AMM|-|Certificate devices-v2.arubanetworks.com rejected due to verification failure (mock error message)
+2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7709|LOG_WARN|AMM|-|Throttled 100 Messages
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7710|LOG_INFO|AMM|-|Certificate signing request devices-v2.arubanetworks.com created
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7711|LOG_INFO|AMM|-|Self-signed certificate devices-v2.arubanetworks.com created
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7712|LOG_ERR|AMM|-|Application association with the devices-v2.arubanetworks.com certificate is not permitted
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7713|LOG_WARN|AMM|-|Certificate devices-v2.arubanetworks.com failed OCSP verification (mock status), but was accepted because OCSP enforcement is set to optional.
+2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7713|LOG_WARN|AMM|-|Throttled 100 Messages
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7714|LOG_INFO|AMM|-|CA certificates successfully downloaded from EST server devices-v2.arubanetworks.com
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7715|LOG_ERR|AMM|-|Failed to download CA certificates from EST server devices-v2.arubanetworks.com
 2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7716|LOG_INFO|AMM|-|Certificate devices-v2.arubanetworks.com successfully enrolled by EST server mock_est_server
@@ -931,6 +934,16 @@
 2024-07-29T14:23:24.900661-05:00 8360-Primaire hpe-dhcpd[1985]: Event|8214|LOG_INFO|DHCP|-|Dynamic binding entries on the VLAN 10 were cleared.
 2024-07-29T14:23:24.900661-05:00 8360-Primaire hpe-dhcpd[1985]: Event|8215|LOG_INFO|DHCP|-|Dynamic binding entry with ip 10.1.2.3 on the VLAN 10 was cleared.
 2024-07-29T14:23:24.900661-05:00 8360-Primaire hpe-dhcpd[1985]: Event|8216|LOG_ERR|DHCP|-|Failed to import dynamic ip binding entries from external storage. volume: my_volume_name, filename: my_file_name.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire dhcpv4snoopd[1234]: Event|8217|LOG_ERR|DHCP|-|Failed to import dynamic ip binding entries from local storage. filepath: /var/lib/dhcp/dhcpd.leases
+2024-06-18T12:46:38.182641-05:00 8360-Primaire dhcpv4snoopd[1234]: Event|8218|LOG_WARN|DHCP|-|Flash-storage is active for DHCPv4-Snooping.
+2024-06-18T12:47:38.182641-05:00 8360-Primaire dhcpv4snoopd[1234]: Event|8219|LOG_INFO|DHCP|-|Successfully imported 100 dynamic ip binding entries from external storage. volume: vol1, filename: dhcpd.leases.
+2024-06-18T12:48:38.182641-05:00 8360-Primaire dhcpv4snoopd[1234]: Event|8220|LOG_INFO|DHCP|-|Successfully imported 100 dynamic ip binding entries from local storage.
+2024-06-18T12:49:38.182641-05:00 8360-Primaire dhcpv4snoopd[1234]: Event|8221|LOG_INFO|DHCP|-|Client 00:11:22:33:44:55 on vlan 100, port eth0 received 192.168.1.10 from server 192.168.1.1 with lease 3600. Nameserver:192.168.1.10, Gateway:192.168.1.254.
+2024-06-18T12:50:38.182641-05:00 8360-Primaire dhcpv4snoopd[1234]: Event|8222|LOG_INFO|DHCP|-|Client 00:11:22:33:44:55 on vlan 100, port eth0 released 192.168.1.10.
+2024-06-18T12:51:38.182641-05:00 8360-Primaire dhcpv4snoopd[1234]: Event|8223|LOG_INFO|DHCP|-|Client 00:11:22:33:44:55 on vlan 100, port eth0 lease period expired for 192.168.1.10.
+2024-06-18T12:52:38.182641-05:00 8360-Primaire dhcpv4snoopd[1234]: Event|8224|LOG_INFO|DHCP|-|Client 00:11:22:33:44:55 on vlan 100, port eth0 with 192.168.1.10. Client attributes updated: Gateway 192.168.1.254, Nameserver 192.168.1.10, Lease period 3600.
+2024-06-18T12:53:38.182641-05:00 8360-Primaire dhcpv4snoopd[1234]: Event|8225|LOG_WARN|DHCP|-|DHCPv4-Snooping dropped DHCP DISCOVER packet received on untrusted port eth0 from 192.168.1.1
+2024-06-18T12:54:38.182641-05:00 8360-Primaire dhcpv4snoopd[1234]: Event|8226|LOG_WARN|DHCP|-|DHCPv4-Snooping dropped DHCP OFFER packet received from unauthorized server 192.168.1.1 on trusted port eth0
 2024-06-18T13:01:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8301|LOG_WARN|DHCPv6|-|Server fd00:db8::1 packet received on untrusted port 1/1/7 dropped.
 2024-06-18T13:02:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8302|LOG_WARN|DHCPv6|-|Client packet destined to untrusted port 1/1/7 dropped.
 2024-06-18T13:03:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8303|LOG_WARN|DHCPv6|-|Packet received from unauthorized server fd00:db8::2 on port 1/1/7.
@@ -944,6 +957,16 @@
 2024-06-18T13:11:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8311|LOG_INFO|DHCPv6|-|Dynamic binding entries on the VLAN 100 were cleared.
 2024-06-18T13:12:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8312|LOG_INFO|DHCPv6|-|Dynamic binding entry with ip fd00:db8::5 on the VLAN 200 was cleared.
 2024-06-18T13:13:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8313|LOG_ERR|DHCPv6|-|Failed to import dynamic ip binding entries from external storage. volume: myVolume, filename: myFile.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8314|LOG_ERR|DHCPv6|-|Failed to import dynamic ip binding entries from local storage. filepath: /var/lib/dhcp/dhcpd6.leases
+2024-06-18T12:46:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8315|LOG_WARN|DHCPv6|-|Flash-storage is active for DHCPv6-Snooping.
+2024-06-18T12:47:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8316|LOG_INFO|DHCPv6|-|Successfully imported 50 dynamic ip binding entries from external storage. volume: vol1, filename: dhcpd6.leases
+2024-06-18T12:48:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8317|LOG_INFO|DHCPv6|-|Successfully imported 50 dynamic ip binding entries from local storage.
+2024-06-18T12:49:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8318|LOG_INFO|DHCPv6|-|Client 00:11:22:33:44:55 on vlan 100, port eth0 received fd00:db8::3 from server fd00:db8::3 with lease 3600. Nameserver:fd00:db8::3.
+2024-06-18T12:50:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8319|LOG_INFO|DHCPv6|-|Client 00:11:22:33:44:55 on vlan 100, port eth0 released fd00:db8::3.
+2024-06-18T12:51:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8320|LOG_INFO|DHCPv6|-|Client 00:11:22:33:44:55 on vlan 100, port eth0 lease period expired for fd00:db8::3.
+2024-06-18T12:52:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8321|LOG_INFO|DHCPv6|-|Client 00:11:22:33:44:55 on vlan 100, port eth0 with fd00:db8::3. Client attributes updated: Nameserver fd00:db8::3, Lease period 3600.
+2024-06-18T12:53:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8322|LOG_WARN|DHCPv6|-|DHCPv6-Snooping dropped DHCP SOLICIT packet received on untrusted port eth0 from fd00:db8::3
+2024-06-18T12:54:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8323|LOG_WARN|DHCPv6|-|DHCPv6-Snooping dropped DHCP ADVERTISE packet received from unauthorized server fd00:db8::3 on trusted port eth0
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-ndsnoop[1234]: Event|8401|LOG_INFO|NDSNOOP|-|All the dynamic binding entries were cleared.
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-ndsnoop[1234]: Event|8402|LOG_INFO|NDSNOOP|-|Dynamic binding entries on the port eth0 were cleared.
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-ndsnoop[1234]: Event|8403|LOG_INFO|NDSNOOP|-|Dynamic binding entries on the VLAN 10 were cleared.
@@ -1254,8 +1277,18 @@
 2024-06-21T13:56:38.182641-05:00 8360-Primaire hpe-container[1255]: Event|11801|LOG_INFO|CONTAINER|-|Container myContainerName is created
 2024-06-21T13:57:38.182641-05:00 8360-Primaire hpe-container[1255]: Event|11802|LOG_INFO|CONTAINER|-|Container myContainerName is removed
 2024-06-21T13:58:38.182641-05:00 8360-Primaire hpe-container[1255]: Event|11803|LOG_INFO|CONTAINER|-|Container myContainerName is operational
+2024-06-18T12:45:38.182641-05:00 8360-Primaire containerd[1234]: Event|11804|LOG_INFO|CONTAINER|-|Endpoint has been executed for container my_container with parameters: param1,param2
+2024-06-18T12:46:38.182641-05:00 8360-Primaire containerd[1234]: Event|11805|LOG_INFO|CONTAINER|-|Endpoint has been executed for container my_container with no parameters.
+2024-06-18T12:47:38.182641-05:00 8360-Primaire containerd[1234]: Event|11806|LOG_INFO|CONTAINER|-|Container my_container stopped
+2024-06-18T12:48:38.182641-05:00 8360-Primaire containerd[1234]: Event|11807|LOG_INFO|CONTAINER|-|Container my_container image signature verified and accepted
+2024-06-18T12:49:38.182641-05:00 8360-Primaire containerd[1234]: Event|11808|LOG_INFO|CONTAINER|-|Container my_container image failed signature verification
+2024-06-18T12:50:38.182641-05:00 8360-Primaire containerd[1234]: Event|11809|LOG_ERR|CONTAINER|-|Container my_container image is unsigned and not allowed in enhanced secure mode
+2024-06-18T12:51:38.182641-05:00 8360-Primaire containerd[1234]: Event|11810|LOG_WARN|CONTAINER|-|Container my_container image is unsigned and allowed by the user configuration
+2024-06-18T12:52:38.182641-05:00 8360-Primaire containerd[1234]: Event|11811|LOG_WARN|CONTAINER|-|Container my_container image is unsigned and not allowed by the user configuration
 2024-06-18T12:45:38.182641-05:00 8360-Primaire ufd[1234]: Event|12001|LOG_ERR|UFD|-|Uplink Failure Detection session-id 12345, state changed from UP to DOWN.
 2024-06-18T12:46:38.182641-05:00 8360-Primaire ufd[1234]: Event|12002|LOG_INFO|UFD|-|Uplink Failure Detection session-id 12345, state changed from DOWN to UP.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire vxlan[1234]: Event|12401|LOG_WARN|DEVICEF|-|Reached the maximum number of clients limit on the switch for device fingerprinting.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire vxlan[1234]: Event|12402|LOG_WARN|DEVICEF|-|Reached the maximum clients limit of 1 on the interface eth0 for device fingerprinting.
 2024-06-18T12:45:38.182641-05:00 8360-Primaire vxlan[1234]: Event|12501|LOG_ERR|VXLANAGENT|-|Netvp add failed for vni_id: 1001, tunnel_id: 2001, vlan: 3001.
 2024-06-18T12:46:38.182641-05:00 8360-Primaire vxlan[1234]: Event|12502|LOG_ERR|VXLANAGENT|-|Tunnel add failed for tunnel_id: 2002, ecmp_id: 3002.
 2024-06-18T12:45:38.182641-05:00 8360-Primaire telnetd[1234]: Event|12901|LOG_INFO|TELNETS|-|TELNET server is enabled on VRF vrf1.
@@ -1268,9 +1301,15 @@
 2024-06-18T12:52:38.182641-05:00 8360-Primaire telnetd[1234]: Event|12908|LOG_WARN|TELNETS|-|TELNET session from User admin is closed because maximum number of sessions per user is reached.
 2024-06-18T12:53:38.182641-05:00 8360-Primaire telnetd[1234]: Event|12908|LOG_ERR|TELNETS|-|User admin login from 192.168.1.1 for TELNET session has failed since the user is trying to login through an interface which is not allowed. Allowed interfaces are: mgmt_intf1
 2024-06-18T12:53:38.182641-05:00 8360-Primaire telnetd[1234]: Event|12909|LOG_ERR|TELNETS|-|User admin login from 192.168.1.1 for TELNET session has failed since the user is trying to login through an interface which is not allowed. Allowed interfaces are: mgmt_intf1
+2024-06-18T12:45:38.182641-05:00 8360-Primaire consoled[1234]: Event|13001|LOG_INFO|Console|-|User admin logged in from 192.168.1.1 through CONSOLE session.
+2024-06-18T12:46:38.182641-05:00 8360-Primaire consoled[1234]: Event|13002|LOG_ERR|Console|-|User admin login from 192.168.1.1 for CONSOLE session has failed.
+2024-06-18T12:47:38.182641-05:00 8360-Primaire consoled[1234]: Event|13003|LOG_INFO|Console|-|User admin logged out of CONSOLE session from 192.168.1.1.
+2024-06-18T12:48:38.182641-05:00 8360-Primaire consoled[1234]: Event|13004|LOG_WARN|Console|-|CONSOLE session from User admin is closed because maximum number of sessions per user is reached.
+2024-06-18T12:49:38.182641-05:00 8360-Primaire consoled[1234]: Event|13005|LOG_WARN|Console|-|User admin login from 192.168.1.1 for CONSOLE session has failed since the user is trying to login through an interface which is not allowed. Allowed interfaces are: mgmt_intf1
 2024-06-18T12:45:38.182641-05:00 8360-Primaire sshd[1234]: Event|13101|LOG_INFO|Accounting|-|SSH session from 192.168.1.1 for user admin closed due to inactivity.
 2024-06-18T12:46:38.182641-05:00 8360-Primaire telnetd[1234]: Event|13102|LOG_INFO|Accounting|-|TELNET session from 192.168.1.2 with User admin timed out due to idle timeout.
 2024-06-18T12:47:38.182641-05:00 8360-Primaire consoled[1234]: Event|13103|LOG_INFO|Accounting|-|CONSOLE session from 192.168.1.3 with User admin timed out due to idle timeout.
+2024-06-18T12:47:38.182641-05:00 8360-Primaire consoled[1234]: Event|13401|LOG_ERR|CONFIG_VALIDATOR|-|Config mock_config_name failed to validate. Reason mock_config_reason
 2024-06-18T12:46:38.182641-05:00 8360-Primaire tpm-daemon[1234]: Event|13602|LOG_ERR|TPM|-|TPM_Sign requested by process2 failed with code error_code1
 2024-06-18T12:47:38.182641-05:00 8360-Primaire tpm-daemon[1234]: Event|13603|LOG_ERR|TPM|-|TPM selftest errors occurred on the current boot
 2024-06-18T12:48:38.182641-05:00 8360-Primaire tpm-daemon[1234]: Event|13604|LOG_ERR|TPM|-|Rebooted 3 times to retry TPM selftests
@@ -1293,6 +1332,17 @@
 2024-06-18T12:53:38.182641-05:00 8360-Primaire arc[1234]: Event|14109|LOG_INFO|ARC|-|App Recognition feature has been disabled - event_name: ARCD_FEATURE_PACK_HONOR_MODE
 2024-06-18T12:54:38.182641-05:00 8360-Primaire arc[1234]: Event|14110|LOG_WARN|ARC|-|App Recognition is operating without a valid feature pack is_security_log : yes
 2024-06-18T12:55:38.182641-05:00 8360-Primaire arc[1234]: Event|14111|LOG_WARN|ARC|-|App Recognition is blocked due to invalid or missing feature pack is_security_log : yes
+2024-06-18T12:45:38.182641-05:00 8360-Primaire clientd[1234]: Event|14301|LOG_INFO|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 successfully on-boarded on VLAN 100. Client on-boarding started at 2024-06-18T12:00:00; L2 complete at 2024-06-18T12:01:00; L3 complete at 2024-06-18T12:02:00 is_security_log : no
+2024-06-18T12:46:38.182641-05:00 8360-Primaire clientd[1234]: Event|14302|LOG_WARN|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 partial success while on-boarding on VLAN 100. L2 status:success L3 status:partial. Client on-boarding started at 2024-06-18T12:00:00;L2 complete at 2024-06-18T12:01:00; L3 complete at 2024-06-18T12:02:00. is_security_log : no
+2024-06-18T12:47:38.182641-05:00 8360-Primaire clientd[1234]: Event|14303|LOG_ERR|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 failed to on-board with status: failed reason_code: 404 is_security_log : no
+2024-06-18T12:48:38.182641-05:00 8360-Primaire clientd[1234]: Event|14304|LOG_ERR|CLIENTINSIGHT|-|Maximum system wide client limit 1000 reached. throttle_time : 15 throttle_count : 1 is_security_log: no
+2024-06-18T12:49:38.182641-05:00 8360-Primaire clientd[1234]: Event|14305|LOG_INFO|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 successfully on-boarded on VLAN 100; Client on-boarding started at 2024-06-18T12:00:00; L2 complete at 2024-06-18T12:01:00; L3 complete at 2024-06-18T12:02:00; ARP to GW response received at 2024-06-18T12:03:00; DNS on-boarding to 192.168.1.1 completed at 2024-06-18T12:04:00 is_security_log : no
+2024-06-18T12:50:38.182641-05:00 8360-Primaire clientd[1234]: Event|14306|LOG_WARN|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 on-boarded on VLANs 100 and failed on VLANs 200; Client on-boarding started at 2024-06-18T12:00:00; L2 complete at 2024-06-18T12:01:00; L3 complete at 2024-06-18T12:02:00; ARP to GW response received at 2024-06-18T12:03:00; DNS on-boarding to 192.168.1.1 completed at 2024-06-18T12:04:00; L2 status success failure_reason_code - none; L3 status partial failure_reason_code - timeout; DNS on-boarding status failed failure_reason_code - dns_error
+2024-06-18T12:45:38.182641-05:00 8360-Primaire clientd[1234]: Event|14307|LOG_ERR|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 failed to on-board with status: failed in failure phase: 1 with reason: timeout is_security_log : no
+2024-06-18T12:46:38.182641-05:00 8360-Primaire clientd[1234]: Event|14308|LOG_INFO|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 on-boarded on VLAN 100 and failed on VLANs 200 Port eth0 auth-status success auth-type dot1x auth-latency 100ms dot1x-auth-failure-reason none mac-auth-failure-reason none radius-server 192.168.1.1 assigned-role user assigned-role-type dynamic
+2024-06-18T12:47:38.182641-05:00 8360-Primaire clientd[1234]: Event|14309|LOG_INFO|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 on-boarded on VLAN 100 Port eth0 dhcpv4-status success dhcpv4-failure-reason none dhcpv4-server 192.168.1.1 dhcpv4-client 00:11:22:33:44:55 dhcpv4-latency 50ms
+2024-06-18T12:48:38.182641-05:00 8360-Primaire clientd[1234]: Event|14310|LOG_INFO|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 on-boarded on VLAN 100 Port eth0 dhcpv6-status success dhcpv6-failure-reason none dhcpv6-server 2001:db8::1 dhcpv6-client 00:11:22:33:44:55 dhcpv6-latency 60ms
+2024-06-18T12:49:38.182641-05:00 8360-Primaire clientd[1234]: Event|14311|LOG_INFO|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 on-boarded on Port eth0 dns-status success dns-failure-reason none dns-server 192.168.1.1 dns-latency 20ms
 2024-06-18T12:45:38.182641-05:00 8360-Primaire centralsource[1234]: Event|14601|LOG_INFO|CENTRALSOURCE|-|Activate server 192.168.1.1 is reachable via VRF vrf1.
 2024-06-18T12:46:38.182641-05:00 8360-Primaire centralsource[1234]: Event|14602|LOG_INFO|CENTRALSOURCE|-|Received certificate from Activate server, processing with certificate manager. Certificate length: 2048.
 2024-06-18T12:47:38.182641-05:00 8360-Primaire centralsource[1234]: Event|14603|LOG_INFO|CENTRALSOURCE|-|HPE Aruba Networking Central location central.example.com successfully fetched from DHCP via VRF vrf1

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
@@ -1073,6 +1073,18 @@
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-evpn[1234]: Event|9516|LOG_INFO|EVPN|-|EVPN RT: rt created for VRF: vrf
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-evpn[1234]: Event|9517|LOG_INFO|EVPN|-|EVPN RT: rt deleted for VRF: vrf
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-evpn[1234]: Event|9518|LOG_INFO|EVPN|-|EVPN RT: rt updated for VRF: vrf
+2024-06-18T12:45:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9519|LOG_INFO|EVPN|-|EVPN dynamic vxlan tunnel bridging mode ibgp-ebgp enabled
+2024-06-18T12:46:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9520|LOG_INFO|EVPN|-|EVPN dynamic vxlan tunnel bridging mode ibgp-ebgp disabled
+2024-06-18T12:47:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9521|LOG_INFO|EVPN|-|EVPN VLAN Aware Bundle : example_bundle created.
+2024-06-18T12:48:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9522|LOG_INFO|EVPN|-|EVPN VLAN Aware Bundle : example_bundle deleted.
+2024-06-18T12:49:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9523|LOG_INFO|EVPN|-|EVPN VLAN Aware Bundle : example_bundle disabled.
+2024-06-18T12:50:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9524|LOG_INFO|EVPN|-|EVPN VLAN Aware Bundle : example_bundle enabled.
+2024-06-18T12:51:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9525|LOG_INFO|EVPN|-|EVPN EVI : example_evi updated with ethernet-tag : example_eth_tag.
+2024-06-18T12:52:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9526|LOG_INFO|EVPN|-|EVPN duplicate IP dampening action, MAC: 00:11:22:33:44:55, IP address: 192.168.1.1, VTEP: 192.168.1.2
+2024-06-18T12:53:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9527|LOG_INFO|EVPN|-|EVPN EVI: RT example_rtt example_rt updated for EVI: example_evi
+2024-06-18T12:54:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9528|LOG_INFO|EVPN|-|A route-map exists with broadcast group config, please unconfigure it
+2024-06-18T12:55:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9529|LOG_INFO|EVPN|-|EVPN Ethernet Segment with ESI example_esi is created.
+2024-06-18T12:56:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9530|LOG_INFO|EVPN|-|EVPN Ethernet Segment with ESI example_esi is deleted.
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9601|LOG_ERR|IPTUNNEL|-|Tunnel Creation Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9602|LOG_INFO|IPTUNNEL|-|Tunnel Created - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-tunnel[1234]: Event|9603|LOG_ERR|IPTUNNEL|-|Tunnel Deletion Failed - Name (Tunnel1) Type (GRE) VRF (VRF1) Local IP (192.168.1.1) Remote IP (192.168.2.1)
@@ -1241,6 +1253,7 @@
 2024-06-18T12:54:38.182641-05:00 8360-Primaire l3pd[1234]: Event|10810|LOG_ERR|L3PD|-|HW programming failed for IPv6 prefix-priority 2001:db8::/32
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-dpsed[1234]: Event|10901|LOG_CRIT|DPSE|-|Line card module R0X39B triggered backplane sequence recovery
 2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-dpsed[1234]: Event|10904|LOG_CRIT|DPSE|-|Line card module R0X39B completed backplane sequence recovery
+2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-dpsed[1234]: Event|10906|LOG_CRIT|DPSE|-|Control Plane (operation_name_mock) failure during (plugin_name_mock) configuration
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|11001|LOG_INFO|MACCONFIG|-|The MAC Address configured mode changed from static to dynamic
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|11002|LOG_INFO|MACCONFIG|-|The MAC Address operational mode changed from static to dynamic
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|11003|LOG_WARN|MACCONFIG|-|Station MAC add failure due to hardware full, mac=00:1A:2B:3C:4D:5E vlan=10
@@ -1287,6 +1300,10 @@
 2024-06-18T12:52:38.182641-05:00 8360-Primaire containerd[1234]: Event|11811|LOG_WARN|CONTAINER|-|Container my_container image is unsigned and not allowed by the user configuration
 2024-06-18T12:45:38.182641-05:00 8360-Primaire ufd[1234]: Event|12001|LOG_ERR|UFD|-|Uplink Failure Detection session-id 12345, state changed from UP to DOWN.
 2024-06-18T12:46:38.182641-05:00 8360-Primaire ufd[1234]: Event|12002|LOG_INFO|UFD|-|Uplink Failure Detection session-id 12345, state changed from DOWN to UP.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire dot1x[1234]: Event|12301|LOG_INFO|Dot1x|-|802.1X supplicant has blocked the interface eth0.
+2024-06-18T12:46:38.182641-05:00 8360-Primaire dot1x[1234]: Event|12302|LOG_INFO|Dot1x|-|802.1X supplicant has unblocked the interface eth0.
+2024-06-18T12:47:38.182641-05:00 8360-Primaire dot1x[1234]: Event|12303|LOG_INFO|Dot1x|-|802.1X supplicant PAE restarted on interface eth0 due to change in policy new_policy.
+2024-06-18T12:48:38.182641-05:00 8360-Primaire dot1x[1234]: Event|12304|LOG_INFO|Dot1x|-|802.1X supplicant is not supported on the port 1/1/1.
 2024-06-18T12:45:38.182641-05:00 8360-Primaire vxlan[1234]: Event|12401|LOG_WARN|DEVICEF|-|Reached the maximum number of clients limit on the switch for device fingerprinting.
 2024-06-18T12:45:38.182641-05:00 8360-Primaire vxlan[1234]: Event|12402|LOG_WARN|DEVICEF|-|Reached the maximum clients limit of 1 on the interface eth0 for device fingerprinting.
 2024-06-18T12:45:38.182641-05:00 8360-Primaire vxlan[1234]: Event|12501|LOG_ERR|VXLANAGENT|-|Netvp add failed for vni_id: 1001, tunnel_id: 2001, vlan: 3001.
@@ -1313,6 +1330,9 @@
 2024-06-18T12:46:38.182641-05:00 8360-Primaire tpm-daemon[1234]: Event|13602|LOG_ERR|TPM|-|TPM_Sign requested by process2 failed with code error_code1
 2024-06-18T12:47:38.182641-05:00 8360-Primaire tpm-daemon[1234]: Event|13603|LOG_ERR|TPM|-|TPM selftest errors occurred on the current boot
 2024-06-18T12:48:38.182641-05:00 8360-Primaire tpm-daemon[1234]: Event|13604|LOG_ERR|TPM|-|Rebooted 3 times to retry TPM selftests
+2024-06-18T12:45:38.182641-05:00 8360-Primaire sysd[1234]: Event|13901|LOG_WARN|DISTRIBUTEDSERVICE|-|Chassis Reboot Requested: power_failure
+2024-06-18T12:46:38.182641-05:00 8360-Primaire sysd[1234]: Event|13902|LOG_WARN|DISTRIBUTEDSERVICE|-|Distributed Services Admission Rejected. Reason: insufficient_resources
+2024-06-18T12:47:38.182641-05:00 8360-Primaire sysd[1234]: Event|13903|LOG_WARN|DISTRIBUTEDSERVICE|-|PSM coordinates mismatch. Active coordinates: 10.0.0.1, Configured coordinates: 10.0.0.2
 2024-06-18T12:45:38.182641-05:00 8360-Primaire traffic-insight[1234]: Event|14001|LOG_INFO|TRAFFICINSIGHT|-|Instance instance1 created
 2024-06-18T12:46:38.182641-05:00 8360-Primaire traffic-insight[1234]: Event|14002|LOG_INFO|TRAFFICINSIGHT|-|Instance instance1 deleted
 2024-06-18T12:47:38.182641-05:00 8360-Primaire traffic-insight[1234]: Event|14003|LOG_INFO|TRAFFICINSIGHT|-|Top-N flows running-statistics cleared for the monitor monitor1 and instance instance1
@@ -1343,6 +1363,16 @@
 2024-06-18T12:47:38.182641-05:00 8360-Primaire clientd[1234]: Event|14309|LOG_INFO|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 on-boarded on VLAN 100 Port eth0 dhcpv4-status success dhcpv4-failure-reason none dhcpv4-server 192.168.1.1 dhcpv4-client 00:11:22:33:44:55 dhcpv4-latency 50ms
 2024-06-18T12:48:38.182641-05:00 8360-Primaire clientd[1234]: Event|14310|LOG_INFO|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 on-boarded on VLAN 100 Port eth0 dhcpv6-status success dhcpv6-failure-reason none dhcpv6-server 2001:db8::1 dhcpv6-client 00:11:22:33:44:55 dhcpv6-latency 60ms
 2024-06-18T12:49:38.182641-05:00 8360-Primaire clientd[1234]: Event|14311|LOG_INFO|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 on-boarded on Port eth0 dns-status success dns-failure-reason none dns-server 192.168.1.1 dns-latency 20ms
+2024-06-18T12:45:38.182641-05:00 8360-Primaire dnld[1234]: Event|14501|LOG_INFO|DNLD|-|File download started from http://example.com/file1
+2024-06-18T12:46:38.182641-05:00 8360-Primaire dnld[1234]: Event|14502|LOG_INFO|DNLD|-|File download complete from http://example.com/file1
+2024-06-18T12:47:38.182641-05:00 8360-Primaire dnld[1234]: Event|14503|LOG_WARN|DNLD|-|File download aborted from http://example.com/file1
+2024-06-18T12:48:38.182641-05:00 8360-Primaire dnld[1234]: Event|14504|LOG_ERR|DNLD|-|File download failed from http://example.com/file1 with error code: 404, Not Found
+2024-06-18T12:49:38.182641-05:00 8360-Primaire dnld[1234]: Event|14505|LOG_INFO|DNLD|-|File upload started to http://example.com/upload1
+2024-06-18T12:50:38.182641-05:00 8360-Primaire dnld[1234]: Event|14506|LOG_INFO|DNLD|-|File upload complete to http://example.com/upload1
+2024-06-18T12:51:38.182641-05:00 8360-Primaire dnld[1234]: Event|14507|LOG_WARN|DNLD|-|File upload aborted to http://example.com/upload1
+2024-06-18T12:52:38.182641-05:00 8360-Primaire dnld[1234]: Event|14508|LOG_ERR|DNLD|-|File upload failed to http://example.com/upload1 with error code: 500, Internal Server Error
+2024-06-18T12:53:38.182641-05:00 8360-Primaire dnld[1234]: Event|14509|LOG_INFO|DNLD|-|File download retrying from http://example.com/file1
+2024-06-18T12:54:38.182641-05:00 8360-Primaire dnld[1234]: Event|14510|LOG_INFO|DNLD|-|File upload retrying from http://example.com/upload1
 2024-06-18T12:45:38.182641-05:00 8360-Primaire centralsource[1234]: Event|14601|LOG_INFO|CENTRALSOURCE|-|Activate server 192.168.1.1 is reachable via VRF vrf1.
 2024-06-18T12:46:38.182641-05:00 8360-Primaire centralsource[1234]: Event|14602|LOG_INFO|CENTRALSOURCE|-|Received certificate from Activate server, processing with certificate manager. Certificate length: 2048.
 2024-06-18T12:47:38.182641-05:00 8360-Primaire centralsource[1234]: Event|14603|LOG_INFO|CENTRALSOURCE|-|HPE Aruba Networking Central location central.example.com successfully fetched from DHCP via VRF vrf1

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -31314,6 +31314,42 @@
             ]
         },
         {
+            "@timestamp": "2024-08-01T15:15:35.145388-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "sequence": "1/1",
+                "throttle_count": 100
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7708",
+                "original": "2024-08-01T15:15:35.145388-05:00 8360-Primaire hpe-restd[1956]: Event|7708|LOG_INFO|AMM|1/1|Throttled 100 Messages",
+                "sequence": 1
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "hpe-restd",
+                    "procid": "1956"
+                }
+            },
+            "message": "Throttled 100 Messages",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-06-12T14:00:38.324517-05:00",
             "aruba": {
                 "cm": {
@@ -31346,6 +31382,40 @@
                 }
             },
             "message": "Certificate devices-v2.arubanetworks.com rejected due to verification failure (mock error message)",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-12T14:00:38.324517-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "throttle_count": 100
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7709",
+                "original": "2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7709|LOG_WARN|AMM|-|Throttled 100 Messages"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-config",
+                    "procid": "1989034"
+                }
+            },
+            "message": "Throttled 100 Messages",
             "tags": [
                 "preserve_original_event"
             ]
@@ -31491,6 +31561,40 @@
                 }
             },
             "message": "Certificate devices-v2.arubanetworks.com failed OCSP verification (mock status), but was accepted because OCSP enforcement is set to optional.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-12T14:00:38.324517-05:00",
+            "aruba": {
+                "component": {
+                    "category": "AMM"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "throttle_count": 100
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "7713",
+                "original": "2024-06-12T14:00:38.324517-05:00 8360-Primaire hpe-config[1989034]: Event|7713|LOG_WARN|AMM|-|Throttled 100 Messages"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "hpe-config",
+                    "procid": "1989034"
+                }
+            },
+            "message": "Throttled 100 Messages",
             "tags": [
                 "preserve_original_event"
             ]
@@ -34959,6 +35063,416 @@
             ]
         },
         {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DHCP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8217",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire dhcpv4snoopd[1234]: Event|8217|LOG_ERR|DHCP|-|Failed to import dynamic ip binding entries from local storage. filepath: /var/lib/dhcp/dhcpd.leases"
+            },
+            "file": {
+                "path": "/var/lib/dhcp/dhcpd"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "dhcpv4snoopd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to import dynamic ip binding entries from local storage. filepath: /var/lib/dhcp/dhcpd.leases",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DHCP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8218",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire dhcpv4snoopd[1234]: Event|8218|LOG_WARN|DHCP|-|Flash-storage is active for DHCPv4-Snooping."
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "dhcpv4snoopd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Flash-storage is active for DHCPv4-Snooping.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DHCP"
+                },
+                "dhcp": {
+                    "bindings_imported": "100",
+                    "volume_name": "vol1"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8219",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire dhcpv4snoopd[1234]: Event|8219|LOG_INFO|DHCP|-|Successfully imported 100 dynamic ip binding entries from external storage. volume: vol1, filename: dhcpd.leases."
+            },
+            "file": {
+                "name": "dhcpd.leases"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dhcpv4snoopd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Successfully imported 100 dynamic ip binding entries from external storage. volume: vol1, filename: dhcpd.leases.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DHCP"
+                },
+                "dhcp": {
+                    "bindings_imported": "100"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8220",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire dhcpv4snoopd[1234]: Event|8220|LOG_INFO|DHCP|-|Successfully imported 100 dynamic ip binding entries from local storage."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dhcpv4snoopd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Successfully imported 100 dynamic ip binding entries from local storage.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DHCP"
+                },
+                "dhcp": {
+                    "gateway_ip": "192.168.1.254",
+                    "lease": "3600",
+                    "nameserver_ip": "192.168.1.10"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0"
+            },
+            "client": {
+                "ip": "192.168.1.10",
+                "mac": "00-11-22-33-44-55"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8221",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire dhcpv4snoopd[1234]: Event|8221|LOG_INFO|DHCP|-|Client 00:11:22:33:44:55 on vlan 100, port eth0 received 192.168.1.10 from server 192.168.1.1 with lease 3600. Nameserver:192.168.1.10, Gateway:192.168.1.254."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dhcpv4snoopd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Client 00:11:22:33:44:55 on vlan 100, port eth0 received 192.168.1.10 from server 192.168.1.1 with lease 3600. Nameserver:192.168.1.10, Gateway:192.168.1.254.",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "server": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DHCP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0"
+            },
+            "client": {
+                "ip": "192.168.1.10",
+                "mac": "00-11-22-33-44-55"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8222",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire dhcpv4snoopd[1234]: Event|8222|LOG_INFO|DHCP|-|Client 00:11:22:33:44:55 on vlan 100, port eth0 released 192.168.1.10."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dhcpv4snoopd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Client 00:11:22:33:44:55 on vlan 100, port eth0 released 192.168.1.10.",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DHCP"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0"
+            },
+            "client": {
+                "ip": "192.168.1.10",
+                "mac": "00-11-22-33-44-55"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8223",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire dhcpv4snoopd[1234]: Event|8223|LOG_INFO|DHCP|-|Client 00:11:22:33:44:55 on vlan 100, port eth0 lease period expired for 192.168.1.10."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dhcpv4snoopd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Client 00:11:22:33:44:55 on vlan 100, port eth0 lease period expired for 192.168.1.10.",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DHCP"
+                },
+                "dhcp": {
+                    "gateway_ip": "192.168.1.254",
+                    "lease": "3600",
+                    "nameserver_ip": "192.168.1.10"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0"
+            },
+            "client": {
+                "ip": "192.168.1.10",
+                "mac": "00-11-22-33-44-55"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8224",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire dhcpv4snoopd[1234]: Event|8224|LOG_INFO|DHCP|-|Client 00:11:22:33:44:55 on vlan 100, port eth0 with 192.168.1.10. Client attributes updated: Gateway 192.168.1.254, Nameserver 192.168.1.10, Lease period 3600."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dhcpv4snoopd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Client 00:11:22:33:44:55 on vlan 100, port eth0 with 192.168.1.10. Client attributes updated: Gateway 192.168.1.254, Nameserver 192.168.1.10, Lease period 3600.",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DHCP"
+                },
+                "dhcp": {
+                    "message_type": "DISCOVER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8225",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire dhcpv4snoopd[1234]: Event|8225|LOG_WARN|DHCP|-|DHCPv4-Snooping dropped DHCP DISCOVER packet received on untrusted port eth0 from 192.168.1.1"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "dhcpv4snoopd",
+                    "procid": "1234"
+                }
+            },
+            "message": "DHCPv4-Snooping dropped DHCP DISCOVER packet received on untrusted port eth0 from 192.168.1.1",
+            "server": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DHCP"
+                },
+                "dhcp": {
+                    "message_type": "OFFER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8226",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire dhcpv4snoopd[1234]: Event|8226|LOG_WARN|DHCP|-|DHCPv4-Snooping dropped DHCP OFFER packet received from unauthorized server 192.168.1.1 on trusted port eth0"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "dhcpv4snoopd",
+                    "procid": "1234"
+                }
+            },
+            "message": "DHCPv4-Snooping dropped DHCP OFFER packet received from unauthorized server 192.168.1.1 on trusted port eth0",
+            "server": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-06-18T13:01:38.182641-05:00",
             "aruba": {
                 "component": {
@@ -35436,6 +35950,410 @@
                 }
             },
             "message": "Failed to import dynamic ip binding entries from external storage. volume: myVolume, filename: myFile.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DHCPv6"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8314",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8314|LOG_ERR|DHCPv6|-|Failed to import dynamic ip binding entries from local storage. filepath: /var/lib/dhcp/dhcpd6.leases"
+            },
+            "file": {
+                "path": "/var/lib/dhcp/dhcpd6"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "dhcpv6snoopd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Failed to import dynamic ip binding entries from local storage. filepath: /var/lib/dhcp/dhcpd6.leases",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DHCPv6"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8315",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8315|LOG_WARN|DHCPv6|-|Flash-storage is active for DHCPv6-Snooping."
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "dhcpv6snoopd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Flash-storage is active for DHCPv6-Snooping.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DHCPv6"
+                },
+                "dhcp": {
+                    "bindings_imported": "50",
+                    "volume_name": "vol1"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8316",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8316|LOG_INFO|DHCPv6|-|Successfully imported 50 dynamic ip binding entries from external storage. volume: vol1, filename: dhcpd6.leases"
+            },
+            "file": {
+                "name": "dhcpd6.lease"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dhcpv6snoopd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Successfully imported 50 dynamic ip binding entries from external storage. volume: vol1, filename: dhcpd6.leases",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DHCPv6"
+                },
+                "dhcp": {
+                    "bindings_imported": "50"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8317",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8317|LOG_INFO|DHCPv6|-|Successfully imported 50 dynamic ip binding entries from local storage."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dhcpv6snoopd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Successfully imported 50 dynamic ip binding entries from local storage.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DHCPv6"
+                },
+                "dhcp": {
+                    "lease": "3600",
+                    "nameserver_ip": "fd00:db8::3"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0"
+            },
+            "client": {
+                "ip": "fd00:db8::3",
+                "mac": "00-11-22-33-44-55"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8318",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8318|LOG_INFO|DHCPv6|-|Client 00:11:22:33:44:55 on vlan 100, port eth0 received fd00:db8::3 from server fd00:db8::3 with lease 3600. Nameserver:fd00:db8::3."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dhcpv6snoopd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Client 00:11:22:33:44:55 on vlan 100, port eth0 received fd00:db8::3 from server fd00:db8::3 with lease 3600. Nameserver:fd00:db8::3.",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "server": {
+                "ip": "fd00:db8::3"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DHCPv6"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0"
+            },
+            "client": {
+                "ip": "fd00:db8::3",
+                "mac": "00-11-22-33-44-55"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8319",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8319|LOG_INFO|DHCPv6|-|Client 00:11:22:33:44:55 on vlan 100, port eth0 released fd00:db8::3."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dhcpv6snoopd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Client 00:11:22:33:44:55 on vlan 100, port eth0 released fd00:db8::3.",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DHCPv6"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0"
+            },
+            "client": {
+                "ip": "fd00:db8::3",
+                "mac": "00-11-22-33-44-55"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8320",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8320|LOG_INFO|DHCPv6|-|Client 00:11:22:33:44:55 on vlan 100, port eth0 lease period expired for fd00:db8::3."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dhcpv6snoopd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Client 00:11:22:33:44:55 on vlan 100, port eth0 lease period expired for fd00:db8::3.",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DHCPv6"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0"
+            },
+            "client": {
+                "ip": "fd00:db8::3",
+                "mac": "00-11-22-33-44-55"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8321",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8321|LOG_INFO|DHCPv6|-|Client 00:11:22:33:44:55 on vlan 100, port eth0 with fd00:db8::3. Client attributes updated: Nameserver fd00:db8::3, Lease period 3600."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dhcpv6snoopd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Client 00:11:22:33:44:55 on vlan 100, port eth0 with fd00:db8::3. Client attributes updated: Nameserver fd00:db8::3, Lease period 3600.",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DHCPv6"
+                },
+                "dhcp": {
+                    "message_type": "SOLICIT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8322",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8322|LOG_WARN|DHCPv6|-|DHCPv6-Snooping dropped DHCP SOLICIT packet received on untrusted port eth0 from fd00:db8::3"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "dhcpv6snoopd",
+                    "procid": "1234"
+                }
+            },
+            "message": "DHCPv6-Snooping dropped DHCP SOLICIT packet received on untrusted port eth0 from fd00:db8::3",
+            "server": {
+                "ip": "fd00:db8::3"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DHCPv6"
+                },
+                "dhcp": {
+                    "message_type": "ADVERTISE"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "eth0"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "8323",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire dhcpv6snoopd[1234]: Event|8323|LOG_WARN|DHCPv6|-|DHCPv6-Snooping dropped DHCP ADVERTISE packet received from unauthorized server fd00:db8::3 on trusted port eth0"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "dhcpv6snoopd",
+                    "procid": "1234"
+                }
+            },
+            "message": "DHCPv6-Snooping dropped DHCP ADVERTISE packet received from unauthorized server fd00:db8::3 on trusted port eth0",
+            "server": {
+                "ip": "fd00:db8::3"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -38234,12 +39152,12 @@
                 "component": {
                     "category": "DCBx"
                 },
-                "dcbx": {
-                    "intf_name": "eth0"
-                },
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
                 }
             },
             "ecs": {
@@ -38270,12 +39188,12 @@
                 "component": {
                     "category": "DCBx"
                 },
-                "dcbx": {
-                    "intf_name": "eth1"
-                },
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth1"
                 }
             },
             "ecs": {
@@ -38306,12 +39224,12 @@
                 "component": {
                     "category": "DCBx"
                 },
-                "dcbx": {
-                    "intf_name": "eth1"
-                },
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth1"
                 }
             },
             "ecs": {
@@ -38342,12 +39260,12 @@
                 "component": {
                     "category": "DCBx"
                 },
-                "dcbx": {
-                    "intf_name": "eth2"
-                },
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth2"
                 }
             },
             "ecs": {
@@ -38378,12 +39296,12 @@
                 "component": {
                     "category": "DCBx"
                 },
-                "dcbx": {
-                    "intf_name": "eth1"
-                },
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth1"
                 }
             },
             "ecs": {
@@ -38414,12 +39332,12 @@
                 "component": {
                     "category": "DCBx"
                 },
-                "dcbx": {
-                    "intf_name": "eth1"
-                },
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth1"
                 }
             },
             "ecs": {
@@ -38450,12 +39368,12 @@
                 "component": {
                     "category": "DCBx"
                 },
-                "dcbx": {
-                    "intf_name": "eth1"
-                },
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth1"
                 }
             },
             "ecs": {
@@ -46496,16 +47414,18 @@
         {
             "@timestamp": "2024-06-20T13:54:38.182641-05:00",
             "aruba": {
-                "cfm": {
-                    "id": "myEndpointId",
-                    "interface": "eth0"
-                },
                 "component": {
                     "category": "CFM"
                 },
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "myEndpointId"
+                },
+                "interface": {
+                    "id": "eth0"
                 }
             },
             "ecs": {
@@ -46533,16 +47453,18 @@
         {
             "@timestamp": "2024-06-20T13:55:38.182641-05:00",
             "aruba": {
-                "cfm": {
-                    "id": "myEndpointId",
-                    "interface": "eth0"
-                },
                 "component": {
                     "category": "CFM"
                 },
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "myEndpointId"
+                },
+                "interface": {
+                    "id": "eth0"
                 }
             },
             "ecs": {
@@ -47072,6 +47994,297 @@
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",
             "aruba": {
                 "component": {
+                    "category": "CONTAINER"
+                },
+                "container": {
+                    "params": "param1,param2"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "container": {
+                "name": "my_container"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11804",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire containerd[1234]: Event|11804|LOG_INFO|CONTAINER|-|Endpoint has been executed for container my_container with parameters: param1,param2"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "containerd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Endpoint has been executed for container my_container with parameters: param1,param2",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "CONTAINER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "container": {
+                "name": "my_container"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11805",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire containerd[1234]: Event|11805|LOG_INFO|CONTAINER|-|Endpoint has been executed for container my_container with no parameters."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "containerd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Endpoint has been executed for container my_container with no parameters.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "CONTAINER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "container": {
+                "name": "my_container"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11806",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire containerd[1234]: Event|11806|LOG_INFO|CONTAINER|-|Container my_container stopped"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "containerd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Container my_container stopped",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "CONTAINER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "container": {
+                "name": "my_container"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11807",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire containerd[1234]: Event|11807|LOG_INFO|CONTAINER|-|Container my_container image signature verified and accepted"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "containerd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Container my_container image signature verified and accepted",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "CONTAINER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "container": {
+                "name": "my_container"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11808",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire containerd[1234]: Event|11808|LOG_INFO|CONTAINER|-|Container my_container image failed signature verification"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "containerd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Container my_container image failed signature verification",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "CONTAINER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "container": {
+                "name": "my_container"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11809",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire containerd[1234]: Event|11809|LOG_ERR|CONTAINER|-|Container my_container image is unsigned and not allowed in enhanced secure mode"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "containerd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Container my_container image is unsigned and not allowed in enhanced secure mode",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "CONTAINER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "container": {
+                "name": "my_container"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11810",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire containerd[1234]: Event|11810|LOG_WARN|CONTAINER|-|Container my_container image is unsigned and allowed by the user configuration"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "containerd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Container my_container image is unsigned and allowed by the user configuration",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "CONTAINER"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "container": {
+                "name": "my_container"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11811",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire containerd[1234]: Event|11811|LOG_WARN|CONTAINER|-|Container my_container image is unsigned and not allowed by the user configuration"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "containerd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Container my_container image is unsigned and not allowed by the user configuration",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
                     "category": "UFD"
                 },
                 "event_type": "Event",
@@ -47144,6 +48357,78 @@
                 }
             },
             "message": "Uplink Failure Detection session-id 12345, state changed from DOWN to UP.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DEVICEF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "12401",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire vxlan[1234]: Event|12401|LOG_WARN|DEVICEF|-|Reached the maximum number of clients limit on the switch for device fingerprinting."
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Reached the maximum number of clients limit on the switch for device fingerprinting.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DEVICEF"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                },
+                "limit": {
+                    "threshold": "1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "12402",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire vxlan[1234]: Event|12402|LOG_WARN|DEVICEF|-|Reached the maximum clients limit of 1 on the interface eth0 for device fingerprinting."
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "vxlan",
+                    "procid": "1234"
+                }
+            },
+            "message": "Reached the maximum clients limit of 1 on the interface eth0 for device fingerprinting.",
             "tags": [
                 "preserve_original_event"
             ]
@@ -47612,6 +48897,201 @@
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",
             "aruba": {
                 "component": {
+                    "category": "Console"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "13001",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire consoled[1234]: Event|13001|LOG_INFO|Console|-|User admin logged in from 192.168.1.1 through CONSOLE session."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "consoled",
+                    "procid": "1234"
+                }
+            },
+            "message": "User admin logged in from 192.168.1.1 through CONSOLE session.",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Console"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "13002",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire consoled[1234]: Event|13002|LOG_ERR|Console|-|User admin login from 192.168.1.1 for CONSOLE session has failed."
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "consoled",
+                    "procid": "1234"
+                }
+            },
+            "message": "User admin login from 192.168.1.1 for CONSOLE session has failed.",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Console"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "13003",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire consoled[1234]: Event|13003|LOG_INFO|Console|-|User admin logged out of CONSOLE session from 192.168.1.1."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "consoled",
+                    "procid": "1234"
+                }
+            },
+            "message": "User admin logged out of CONSOLE session from 192.168.1.1.",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Console"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "13004",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire consoled[1234]: Event|13004|LOG_WARN|Console|-|CONSOLE session from User admin is closed because maximum number of sessions per user is reached."
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "consoled",
+                    "procid": "1234"
+                }
+            },
+            "message": "CONSOLE session from User admin is closed because maximum number of sessions per user is reached.",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Console"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "mgmt_intf1"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "13005",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire consoled[1234]: Event|13005|LOG_WARN|Console|-|User admin login from 192.168.1.1 for CONSOLE session has failed since the user is trying to login through an interface which is not allowed. Allowed interfaces are: mgmt_intf1"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "consoled",
+                    "procid": "1234"
+                }
+            },
+            "message": "User admin login from 192.168.1.1 for CONSOLE session has failed since the user is trying to login through an interface which is not allowed. Allowed interfaces are: mgmt_intf1",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
                     "category": "Accounting"
                 },
                 "event_type": "Event",
@@ -47724,6 +49204,43 @@
             "user": {
                 "name": "admin"
             }
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "CONFIG_VALIDATOR"
+                },
+                "config": {
+                    "name": "mock_config_name"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "13401",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire consoled[1234]: Event|13401|LOG_ERR|CONFIG_VALIDATOR|-|Config mock_config_name failed to validate. Reason mock_config_reason",
+                "reason": "mock_config_reason"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "consoled",
+                    "procid": "1234"
+                }
+            },
+            "message": "Config mock_config_name failed to validate. Reason mock_config_reason",
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "@timestamp": "2024-06-18T12:46:38.182641-05:00",
@@ -48513,6 +50030,512 @@
                 }
             },
             "message": "App Recognition is blocked due to invalid or missing feature pack is_security_log : yes",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "CLIENTINSIGHT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "insight": {
+                    "l2_end_ts": "2024-06-18T12:01:00",
+                    "l3_end_ts": "2024-06-18T12:02:00",
+                    "ob_start_ts": "2024-06-18T12:00:00"
+                }
+            },
+            "client": {
+                "mac": "00-11-22-33-44-55"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14301",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire clientd[1234]: Event|14301|LOG_INFO|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 successfully on-boarded on VLAN 100. Client on-boarding started at 2024-06-18T12:00:00; L2 complete at 2024-06-18T12:01:00; L3 complete at 2024-06-18T12:02:00 is_security_log : no"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "clientd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Client 00:11:22:33:44:55 successfully on-boarded on VLAN 100. Client on-boarding started at 2024-06-18T12:00:00; L2 complete at 2024-06-18T12:01:00; L3 complete at 2024-06-18T12:02:00 is_security_log : no",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "CLIENTINSIGHT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "insight": {
+                    "l2_end_ts": "2024-06-18T12:01:00",
+                    "l2_ob_state": "success",
+                    "l3_end_ts": "2024-06-18T12:02:00",
+                    "l3_ob_state": "partial",
+                    "ob_start_ts": "2024-06-18T12:00:00"
+                }
+            },
+            "client": {
+                "mac": "00-11-22-33-44-55"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14302",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire clientd[1234]: Event|14302|LOG_WARN|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 partial success while on-boarding on VLAN 100. L2 status:success L3 status:partial. Client on-boarding started at 2024-06-18T12:00:00;L2 complete at 2024-06-18T12:01:00; L3 complete at 2024-06-18T12:02:00. is_security_log : no"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "clientd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Client 00:11:22:33:44:55 partial success while on-boarding on VLAN 100. L2 status:success L3 status:partial. Client on-boarding started at 2024-06-18T12:00:00;L2 complete at 2024-06-18T12:01:00; L3 complete at 2024-06-18T12:02:00. is_security_log : no",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "CLIENTINSIGHT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "insight": {
+                    "failure_phase_id": "404"
+                },
+                "status": "failed"
+            },
+            "client": {
+                "mac": "00-11-22-33-44-55"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14303",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire clientd[1234]: Event|14303|LOG_ERR|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 failed to on-board with status: failed reason_code: 404 is_security_log : no"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "clientd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Client 00:11:22:33:44:55 failed to on-board with status: failed reason_code: 404 is_security_log : no",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "CLIENTINSIGHT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "limit": {
+                    "threshold": "1000"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14304",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire clientd[1234]: Event|14304|LOG_ERR|CLIENTINSIGHT|-|Maximum system wide client limit 1000 reached. throttle_time : 15 throttle_count : 1 is_security_log: no"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "clientd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Maximum system wide client limit 1000 reached. throttle_time : 15 throttle_count : 1 is_security_log: no",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "CLIENTINSIGHT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "insight": {
+                    "arp_end_ts": "2024-06-18T12:03:00",
+                    "dns_end_ts": "2024-06-18T12:04:00",
+                    "l2_end_ts": "2024-06-18T12:01:00",
+                    "l3_end_ts": "2024-06-18T12:02:00",
+                    "ob_start_ts": "2024-06-18T12:00:00"
+                }
+            },
+            "client": {
+                "mac": "00-11-22-33-44-55"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14305",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire clientd[1234]: Event|14305|LOG_INFO|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 successfully on-boarded on VLAN 100; Client on-boarding started at 2024-06-18T12:00:00; L2 complete at 2024-06-18T12:01:00; L3 complete at 2024-06-18T12:02:00; ARP to GW response received at 2024-06-18T12:03:00; DNS on-boarding to 192.168.1.1 completed at 2024-06-18T12:04:00 is_security_log : no"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "clientd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Client 00:11:22:33:44:55 successfully on-boarded on VLAN 100; Client on-boarding started at 2024-06-18T12:00:00; L2 complete at 2024-06-18T12:01:00; L3 complete at 2024-06-18T12:02:00; ARP to GW response received at 2024-06-18T12:03:00; DNS on-boarding to 192.168.1.1 completed at 2024-06-18T12:04:00 is_security_log : no",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "server": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "CLIENTINSIGHT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "insight": {
+                    "arp_end_ts": "2024-06-18T12:03:00",
+                    "dns_end_ts": "2024-06-18T12:04:00",
+                    "failed_vlans": "200",
+                    "l2_end_ts": "2024-06-18T12:01:00",
+                    "l2_failure_reason": "none",
+                    "l2_ob_state": "success",
+                    "l3_end_ts": "2024-06-18T12:02:00",
+                    "l3_failure_reason": "timeout",
+                    "l3_ob_state": "partial",
+                    "ob_start_ts": "2024-06-18T12:00:00"
+                },
+                "status": "failed"
+            },
+            "client": {
+                "mac": "00-11-22-33-44-55"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14306",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire clientd[1234]: Event|14306|LOG_WARN|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 on-boarded on VLANs 100 and failed on VLANs 200; Client on-boarding started at 2024-06-18T12:00:00; L2 complete at 2024-06-18T12:01:00; L3 complete at 2024-06-18T12:02:00; ARP to GW response received at 2024-06-18T12:03:00; DNS on-boarding to 192.168.1.1 completed at 2024-06-18T12:04:00; L2 status success failure_reason_code - none; L3 status partial failure_reason_code - timeout; DNS on-boarding status failed failure_reason_code - dns_error",
+                "reason": "dns_error"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "clientd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Client 00:11:22:33:44:55 on-boarded on VLANs 100 and failed on VLANs 200; Client on-boarding started at 2024-06-18T12:00:00; L2 complete at 2024-06-18T12:01:00; L3 complete at 2024-06-18T12:02:00; ARP to GW response received at 2024-06-18T12:03:00; DNS on-boarding to 192.168.1.1 completed at 2024-06-18T12:04:00; L2 status success failure_reason_code - none; L3 status partial failure_reason_code - timeout; DNS on-boarding status failed failure_reason_code - dns_error",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "server": {
+                "ip": "192.168.1.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "CLIENTINSIGHT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "insight": {
+                    "failure_phase_id": "1"
+                },
+                "status": "failed"
+            },
+            "client": {
+                "mac": "00-11-22-33-44-55"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14307",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire clientd[1234]: Event|14307|LOG_ERR|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 failed to on-board with status: failed in failure phase: 1 with reason: timeout is_security_log : no",
+                "reason": "timeout"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "clientd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Client 00:11:22:33:44:55 failed to on-board with status: failed in failure phase: 1 with reason: timeout is_security_log : no",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "CLIENTINSIGHT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "insight": {
+                    "auth_latency": "100ms",
+                    "auth_type": "dot1x",
+                    "dot1x_auth_failure_reason": "none",
+                    "failed_vlans": "200",
+                    "mac_auth_failure_reason": "none",
+                    "radius_server": "192.168.1.1",
+                    "role_type": "dynamic"
+                },
+                "port": "eth0",
+                "role": "user",
+                "status": "success"
+            },
+            "client": {
+                "mac": "00-11-22-33-44-55"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14308",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire clientd[1234]: Event|14308|LOG_INFO|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 on-boarded on VLAN 100 and failed on VLANs 200 Port eth0 auth-status success auth-type dot1x auth-latency 100ms dot1x-auth-failure-reason none mac-auth-failure-reason none radius-server 192.168.1.1 assigned-role user assigned-role-type dynamic"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "clientd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Client 00:11:22:33:44:55 on-boarded on VLAN 100 and failed on VLANs 200 Port eth0 auth-status success auth-type dot1x auth-latency 100ms dot1x-auth-failure-reason none mac-auth-failure-reason none radius-server 192.168.1.1 assigned-role user assigned-role-type dynamic",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "CLIENTINSIGHT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "insight": {
+                    "dhcp_client": "00:11:22:33:44:55",
+                    "dhcp_latency": "50ms",
+                    "dhcp_server": " 192.168.1.1",
+                    "successfulvlan": "100"
+                },
+                "port": "eth0",
+                "status": "success"
+            },
+            "client": {
+                "mac": "00-11-22-33-44-55"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14309",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire clientd[1234]: Event|14309|LOG_INFO|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 on-boarded on VLAN 100 Port eth0 dhcpv4-status success dhcpv4-failure-reason none dhcpv4-server 192.168.1.1 dhcpv4-client 00:11:22:33:44:55 dhcpv4-latency 50ms",
+                "reason": "none"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "clientd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Client 00:11:22:33:44:55 on-boarded on VLAN 100 Port eth0 dhcpv4-status success dhcpv4-failure-reason none dhcpv4-server 192.168.1.1 dhcpv4-client 00:11:22:33:44:55 dhcpv4-latency 50ms",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "CLIENTINSIGHT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "insight": {
+                    "dhcp_client": "00:11:22:33:44:55",
+                    "dhcp_latency": "60ms",
+                    "dhcp_server": " 2001:db8::1",
+                    "successfulvlan": "100"
+                },
+                "port": "eth0",
+                "status": "success"
+            },
+            "client": {
+                "mac": "00-11-22-33-44-55"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14310",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire clientd[1234]: Event|14310|LOG_INFO|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 on-boarded on VLAN 100 Port eth0 dhcpv6-status success dhcpv6-failure-reason none dhcpv6-server 2001:db8::1 dhcpv6-client 00:11:22:33:44:55 dhcpv6-latency 60ms",
+                "reason": "none"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "clientd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Client 00:11:22:33:44:55 on-boarded on VLAN 100 Port eth0 dhcpv6-status success dhcpv6-failure-reason none dhcpv6-server 2001:db8::1 dhcpv6-client 00:11:22:33:44:55 dhcpv6-latency 60ms",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "CLIENTINSIGHT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "insight": {
+                    "dns_latency": "20ms",
+                    "dns_server": "192.168.1.1"
+                },
+                "port": "eth0",
+                "status": "success"
+            },
+            "client": {
+                "mac": "00-11-22-33-44-55"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14311",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire clientd[1234]: Event|14311|LOG_INFO|CLIENTINSIGHT|-|Client 00:11:22:33:44:55 on-boarded on Port eth0 dns-status success dns-failure-reason none dns-server 192.168.1.1 dns-latency 20ms",
+                "reason": "none"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "clientd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Client 00:11:22:33:44:55 on-boarded on Port eth0 dns-status success dns-failure-reason none dns-server 192.168.1.1 dns-latency 20ms",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -36563,6 +36563,9 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "aruba_interface_id"
                 }
             },
             "ecs": {
@@ -36586,13 +36589,6 @@
             "network": {
                 "vlan": {
                     "id": "aruba_vlan"
-                }
-            },
-            "observer": {
-                "ingress": {
-                    "interface": {
-                        "id": "aruba_interface_id"
-                    }
                 }
             },
             "tags": [
@@ -36692,6 +36688,9 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "aruba_interface_name"
                 }
             },
             "ecs": {
@@ -36712,13 +36711,6 @@
                 }
             },
             "message": "aruba_interface_name is not an L2 port",
-            "observer": {
-                "ingress": {
-                    "interface": {
-                        "name": "aruba_interface_name"
-                    }
-                }
-            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -36730,13 +36722,16 @@
                     "category": "ERPS"
                 },
                 "erps": {
-                    "port_name": "some_port_name",
                     "ring_id": "aruba_ring_id"
                 },
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
-                }
+                },
+                "interface": {
+                    "name": "aruba_interface_name"
+                },
+                "port": "some_port_name"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -36756,13 +36751,6 @@
                 }
             },
             "message": "aruba_interface_name is already associated with some_port_name of ERPS ring aruba_ring_id",
-            "observer": {
-                "ingress": {
-                    "interface": {
-                        "name": "aruba_interface_name"
-                    }
-                }
-            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -36979,16 +36967,14 @@
                 "component": {
                     "category": "ERPS"
                 },
-                "erps": {
-                    "port_name": "some_port_name"
-                },
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
                 },
                 "instance": {
                     "id": "some_instance_id"
-                }
+                },
+                "port": "some_port_name"
             },
             "ecs": {
                 "version": "8.11.0"
@@ -37021,6 +37007,9 @@
                 "event_type": "Event",
                 "hardware": {
                     "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "some_interface_name"
                 }
             },
             "ecs": {
@@ -37041,13 +37030,6 @@
                 }
             },
             "message": "RPL configuration is not allowed on ISL port some_interface_name",
-            "observer": {
-                "ingress": {
-                    "interface": {
-                        "name": "some_interface_name"
-                    }
-                }
-            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -40301,6 +40283,445 @@
                 }
             },
             "message": "EVPN RT: rt updated for VRF: vrf",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "EVPN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9519",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9519|LOG_INFO|EVPN|-|EVPN dynamic vxlan tunnel bridging mode ibgp-ebgp enabled"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "evpnd",
+                    "procid": "1234"
+                }
+            },
+            "message": "EVPN dynamic vxlan tunnel bridging mode ibgp-ebgp enabled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "EVPN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9520",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9520|LOG_INFO|EVPN|-|EVPN dynamic vxlan tunnel bridging mode ibgp-ebgp disabled"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "evpnd",
+                    "procid": "1234"
+                }
+            },
+            "message": "EVPN dynamic vxlan tunnel bridging mode ibgp-ebgp disabled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "EVPN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9521",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9521|LOG_INFO|EVPN|-|EVPN VLAN Aware Bundle : example_bundle created."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "evpnd",
+                    "procid": "1234"
+                }
+            },
+            "message": "EVPN VLAN Aware Bundle : example_bundle created.",
+            "package": {
+                "name": "example_bundle"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "EVPN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9522",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9522|LOG_INFO|EVPN|-|EVPN VLAN Aware Bundle : example_bundle deleted."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "evpnd",
+                    "procid": "1234"
+                }
+            },
+            "message": "EVPN VLAN Aware Bundle : example_bundle deleted.",
+            "package": {
+                "name": "example_bundle"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "EVPN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9523",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9523|LOG_INFO|EVPN|-|EVPN VLAN Aware Bundle : example_bundle disabled."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "evpnd",
+                    "procid": "1234"
+                }
+            },
+            "message": "EVPN VLAN Aware Bundle : example_bundle disabled.",
+            "package": {
+                "name": "example_bundle"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "EVPN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9524",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9524|LOG_INFO|EVPN|-|EVPN VLAN Aware Bundle : example_bundle enabled."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "evpnd",
+                    "procid": "1234"
+                }
+            },
+            "message": "EVPN VLAN Aware Bundle : example_bundle enabled.",
+            "package": {
+                "name": "example_bundle"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "EVPN"
+                },
+                "event_type": "Event",
+                "evpn": {
+                    "eth_tag": "example_eth_tag"
+                },
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9525",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9525|LOG_INFO|EVPN|-|EVPN EVI : example_evi updated with ethernet-tag : example_eth_tag."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "evpnd",
+                    "procid": "1234"
+                }
+            },
+            "message": "EVPN EVI : example_evi updated with ethernet-tag : example_eth_tag.",
+            "network": {
+                "vlan": {
+                    "id": "example_evi"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "EVPN"
+                },
+                "event_type": "Event",
+                "evpn": {
+                    "vtep_ip": "192.168.1.2"
+                },
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "192.168.1.1",
+                "mac": "00-11-22-33-44-55"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "action",
+                "category": [
+                    "network"
+                ],
+                "code": "9526",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9526|LOG_INFO|EVPN|-|EVPN duplicate IP dampening action, MAC: 00:11:22:33:44:55, IP address: 192.168.1.1, VTEP: 192.168.1.2"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "evpnd",
+                    "procid": "1234"
+                }
+            },
+            "message": "EVPN duplicate IP dampening action, MAC: 00:11:22:33:44:55, IP address: 192.168.1.1, VTEP: 192.168.1.2",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "EVPN"
+                },
+                "event_type": "Event",
+                "evpn": {
+                    "rt": "example_rt",
+                    "rtt": "example_rtt"
+                },
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9527",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9527|LOG_INFO|EVPN|-|EVPN EVI: RT example_rtt example_rt updated for EVI: example_evi"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "evpnd",
+                    "procid": "1234"
+                }
+            },
+            "message": "EVPN EVI: RT example_rtt example_rt updated for EVI: example_evi",
+            "network": {
+                "vlan": {
+                    "id": "example_evi"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "EVPN"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9528",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9528|LOG_INFO|EVPN|-|A route-map exists with broadcast group config, please unconfigure it"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "evpnd",
+                    "procid": "1234"
+                }
+            },
+            "message": "A route-map exists with broadcast group config, please unconfigure it",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:55:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "EVPN"
+                },
+                "event_type": "Event",
+                "evpn": {
+                    "esi": "example_esi"
+                },
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9529",
+                "original": "2024-06-18T12:55:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9529|LOG_INFO|EVPN|-|EVPN Ethernet Segment with ESI example_esi is created."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "evpnd",
+                    "procid": "1234"
+                }
+            },
+            "message": "EVPN Ethernet Segment with ESI example_esi is created.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:56:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "EVPN"
+                },
+                "event_type": "Event",
+                "evpn": {
+                    "esi": "example_esi"
+                },
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "9530",
+                "original": "2024-06-18T12:56:38.182641-05:00 8360-Primaire evpnd[1234]: Event|9530|LOG_INFO|EVPN|-|EVPN Ethernet Segment with ESI example_esi is deleted."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "evpnd",
+                    "procid": "1234"
+                }
+            },
+            "message": "EVPN Ethernet Segment with ESI example_esi is deleted.",
             "tags": [
                 "preserve_original_event"
             ]
@@ -46638,6 +47059,43 @@
             ]
         },
         {
+            "@timestamp": "2024-06-19T13:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DPSE"
+                },
+                "dpse": {
+                    "operation_name": "operation_name_mock",
+                    "plugin_name": "plugin_name_mock"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "10906",
+                "original": "2024-06-19T13:53:38.182641-05:00 8360-Primaire hpe-dpsed[1234]: Event|10906|LOG_CRIT|DPSE|-|Control Plane (operation_name_mock) failure during (plugin_name_mock) configuration"
+            },
+            "log": {
+                "level": "LOG_CRIT",
+                "syslog": {
+                    "appname": "hpe-dpsed",
+                    "procid": "1234"
+                }
+            },
+            "message": "Control Plane (operation_name_mock) failure during (plugin_name_mock) configuration",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",
             "aruba": {
                 "component": {
@@ -48365,6 +48823,151 @@
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",
             "aruba": {
                 "component": {
+                    "category": "Dot1x"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "12301",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire dot1x[1234]: Event|12301|LOG_INFO|Dot1x|-|802.1X supplicant has blocked the interface eth0."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dot1x",
+                    "procid": "1234"
+                }
+            },
+            "message": "802.1X supplicant has blocked the interface eth0.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Dot1x"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "12302",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire dot1x[1234]: Event|12302|LOG_INFO|Dot1x|-|802.1X supplicant has unblocked the interface eth0."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dot1x",
+                    "procid": "1234"
+                }
+            },
+            "message": "802.1X supplicant has unblocked the interface eth0.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Dot1x"
+                },
+                "dot1x": {
+                    "policy": "new_policy"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "id": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "12303",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire dot1x[1234]: Event|12303|LOG_INFO|Dot1x|-|802.1X supplicant PAE restarted on interface eth0 due to change in policy new_policy."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dot1x",
+                    "procid": "1234"
+                }
+            },
+            "message": "802.1X supplicant PAE restarted on interface eth0 due to change in policy new_policy.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Dot1x"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "port": "1/1/1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "12304",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire dot1x[1234]: Event|12304|LOG_INFO|Dot1x|-|802.1X supplicant is not supported on the port 1/1/1."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dot1x",
+                    "procid": "1234"
+                }
+            },
+            "message": "802.1X supplicant is not supported on the port 1/1/1.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
                     "category": "DEVICEF"
                 },
                 "event_type": "Event",
@@ -49344,6 +49947,111 @@
                 }
             },
             "message": "Rebooted 3 times to retry TPM selftests",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DISTRIBUTEDSERVICE"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "13901",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire sysd[1234]: Event|13901|LOG_WARN|DISTRIBUTEDSERVICE|-|Chassis Reboot Requested: power_failure",
+                "reason": "power_failure"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "sysd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Chassis Reboot Requested: power_failure",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DISTRIBUTEDSERVICE"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "13902",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire sysd[1234]: Event|13902|LOG_WARN|DISTRIBUTEDSERVICE|-|Distributed Services Admission Rejected. Reason: insufficient_resources",
+                "reason": "insufficient_resources"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "sysd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Distributed Services Admission Rejected. Reason: insufficient_resources",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DISTRIBUTEDSERVICE"
+                },
+                "distributed": {
+                    "active_coordinates": "10.0.0.1",
+                    "configured_coordinates": "10"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "13903",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire sysd[1234]: Event|13903|LOG_WARN|DISTRIBUTEDSERVICE|-|PSM coordinates mismatch. Active coordinates: 10.0.0.1, Configured coordinates: 10.0.0.2"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "sysd",
+                    "procid": "1234"
+                }
+            },
+            "message": "PSM coordinates mismatch. Active coordinates: 10.0.0.1, Configured coordinates: 10.0.0.2",
             "tags": [
                 "preserve_original_event"
             ]
@@ -50539,6 +51247,378 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DNLD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14501",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire dnld[1234]: Event|14501|LOG_INFO|DNLD|-|File download started from http://example.com/file1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dnld",
+                    "procid": "1234"
+                }
+            },
+            "message": "File download started from http://example.com/file1",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "original": "http://example.com/file1"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DNLD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14502",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire dnld[1234]: Event|14502|LOG_INFO|DNLD|-|File download complete from http://example.com/file1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dnld",
+                    "procid": "1234"
+                }
+            },
+            "message": "File download complete from http://example.com/file1",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "original": "http://example.com/file1"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DNLD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14503",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire dnld[1234]: Event|14503|LOG_WARN|DNLD|-|File download aborted from http://example.com/file1"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "dnld",
+                    "procid": "1234"
+                }
+            },
+            "message": "File download aborted from http://example.com/file1",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "original": "http://example.com/file1"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DNLD"
+                },
+                "error": {
+                    "description": "Not Found"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "error": {
+                "code": "404"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14504",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire dnld[1234]: Event|14504|LOG_ERR|DNLD|-|File download failed from http://example.com/file1 with error code: 404, Not Found"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "dnld",
+                    "procid": "1234"
+                }
+            },
+            "message": "File download failed from http://example.com/file1 with error code: 404, Not Found",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "original": "http://example.com/file1"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DNLD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14505",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire dnld[1234]: Event|14505|LOG_INFO|DNLD|-|File upload started to http://example.com/upload1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dnld",
+                    "procid": "1234"
+                }
+            },
+            "message": "File upload started to http://example.com/upload1",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "original": "http://example.com/upload1"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DNLD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14506",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire dnld[1234]: Event|14506|LOG_INFO|DNLD|-|File upload complete to http://example.com/upload1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dnld",
+                    "procid": "1234"
+                }
+            },
+            "message": "File upload complete to http://example.com/upload1",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "original": "http://example.com/upload1"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DNLD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14507",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire dnld[1234]: Event|14507|LOG_WARN|DNLD|-|File upload aborted to http://example.com/upload1"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "dnld",
+                    "procid": "1234"
+                }
+            },
+            "message": "File upload aborted to http://example.com/upload1",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "original": "http://example.com/upload1"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DNLD"
+                },
+                "error": {
+                    "description": "Internal Server Error"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "error": {
+                "code": "500"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14508",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire dnld[1234]: Event|14508|LOG_ERR|DNLD|-|File upload failed to http://example.com/upload1 with error code: 500, Internal Server Error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "dnld",
+                    "procid": "1234"
+                }
+            },
+            "message": "File upload failed to http://example.com/upload1 with error code: 500, Internal Server Error",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "original": "http://example.com/upload1"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DNLD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14509",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire dnld[1234]: Event|14509|LOG_INFO|DNLD|-|File download retrying from http://example.com/file1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dnld",
+                    "procid": "1234"
+                }
+            },
+            "message": "File download retrying from http://example.com/file1",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "original": "http://example.com/file1"
+            }
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "DNLD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "14510",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire dnld[1234]: Event|14510|LOG_INFO|DNLD|-|File upload retrying from http://example.com/upload1"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "dnld",
+                    "procid": "1234"
+                }
+            },
+            "message": "File upload retrying from http://example.com/upload1",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "original": "http://example.com/upload1"
+            }
         },
         {
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -860,7 +860,7 @@ processors:
         INTERFACE: "(I|i)nterface %{DATA:aruba.interface.id}"
 
   # ECMP Events (18xx)
-  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ECMP.htm
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ECMP.htm
   - grok:
       field: message
       tag: ecmp_event_1801
@@ -3400,13 +3400,13 @@ processors:
         - "^ND packet of type=%{DATA:aruba.nd.type} received on port:%{DATA:aruba.port} vlan:%{DATA:network.vlan.id} with src_mac:%{MAC:source.mac} is %{DATA:aruba.status}. count=%{NUMBER:aruba.count:long}"
 
   # ERPS Events (85xx)
-  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ERPS.htm
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ERPS.htm
   - dissect:
       field: message
       tag: erps_event_8501
       description: "Log event when RAPS messages are not received for a certain time interval"
       if: "ctx.event?.code == '8501'"
-      pattern: "Expected R-APS packets not received on %{observer.ingress.interface.id} in ring %{aruba.erps.ring_id} with control VLAN %{network.vlan.id}"
+      pattern: "Expected R-APS packets not received on %{aruba.interface.id} in ring %{aruba.erps.ring_id} with control VLAN %{network.vlan.id}"
   - grok:
       field: message
       tag: erps_event_8502
@@ -3425,13 +3425,13 @@ processors:
       tag: erps_event_8504
       description: "Log event when ring is configured with a non-L2 port"
       if: "ctx.event?.code == '8504'"
-      pattern: "%{observer.ingress.interface.name} is not an L2 port"
+      pattern: "%{aruba.interface.name} is not an L2 port"
   - dissect:
       field: message
       tag: erps_event_8505
       description: "Log event when an interface which is already associated to a ring port is getting mapped to other ring port as well"
       if: "ctx.event?.code == '8505'"
-      pattern: "%{observer.ingress.interface.name} is already associated with %{aruba.erps.port_name} of ERPS ring %{aruba.erps.ring_id}"
+      pattern: "%{aruba.interface.name} is already associated with %{aruba.port} of ERPS ring %{aruba.erps.ring_id}"
   - dissect:
       field: message
       tag: erps_event_8506
@@ -3467,13 +3467,13 @@ processors:
       tag: erps_event_8512
       description: "Log event if the same ring port is configured as RPL port for more than one instance"
       if: "ctx.event?.code == '8512'"
-      pattern: "%{aruba.erps.port_name} is already configured as RPL port for instance %{aruba.instance.id}"
+      pattern: "%{aruba.port} is already configured as RPL port for instance %{aruba.instance.id}"
   - dissect:
       field: message
       tag: erps_event_8513
       description: "Log event if ring port which is also an ISL is being configured as RPL"
       if: "ctx.event?.code == '8513'"
-      pattern: "RPL configuration is not allowed on ISL port %{observer.ingress.interface.name}"
+      pattern: "RPL configuration is not allowed on ISL port %{aruba.interface.name}"
   - dissect:
       field: message
       tag: erps_event_8515
@@ -3673,12 +3673,12 @@ processors:
         - "^Port security sticky client move violation triggered on port %{DATA:aruba.port} for client with MAC address %{MAC:client.mac}"
 
   # EVPN Events (95xx)
-  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/EVPN.htm
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/EVPN.htm
   - grok:
       field: message
       tag: evpn_event_9501_9502
       description: "Logs EVPN EVI create|delete event."
-      if: "['9501', '9502'].contains(ctx.event?.code)"
+      if: "['9501','9502'].contains(ctx.event?.code)"
       patterns:
           - "^EVPN EVI: %{DATA:network.vlan.id} (created|deleted)"
   - dissect:
@@ -3697,14 +3697,14 @@ processors:
       field: message
       tag: evpn_event_9505_9506_9507
       description: "Logs EVPN RT create|delete|update event for an EVI."
-      if: "['9505', '9506', '9507'].contains(ctx.event?.code)"
+      if: "['9505','9506','9507'].contains(ctx.event?.code)"
       patterns:
           - "^EVPN RT: %{DATA:aruba.evpn.rt} (created|deleted|updated) for EVI: %{DATA:network.vlan.id}$"
   - grok:
       field: message
       tag: evpn_event_9508_9509
       description: "Logs EVPN VTEP VNI add|delete event."
-      if: "['9508', '9509'].contains(ctx.event?.code)"
+      if: "['9508','9509'].contains(ctx.event?.code)"
       patterns:
           - "^VNI: %{DATA:aruba.evpn.vni} is (added|deleted) for EVPN Peer VTEP: %{DATA:aruba.evpn.vtep_ip}$"
   - grok:
@@ -3732,7 +3732,7 @@ processors:
       field: message
       tag: evpn_event_9513_9514
       description: "Logs EVPN VRF create|delete event."
-      if: "['9513', '9514'].contains(ctx.event?.code)"
+      if: "['9513','9514'].contains(ctx.event?.code)"
       patterns:
           - "^EVPN VRF: %{DATA:aruba.vrf.id} (created|deleted)"
   - dissect:
@@ -3745,9 +3745,41 @@ processors:
       field: message
       tag: evpn_event_9516_9517_9518
       description: "Logs EVPN VRF RT create|delete|update event."
-      if: "['9516', '9517', '9518'].contains(ctx.event?.code)"
+      if: "['9516','9517','9518'].contains(ctx.event?.code)"
       patterns:
           - "^EVPN RT: %{DATA:aruba.evpn.rt} (created|deleted|updated) for VRF: %{DATA:aruba.vrf.id}$"
+  - grok:
+      field: message
+      tag: evpn_event_9521_9522_9523_9524
+      description: "Log event when EVPN VLAN Aware bundle created | bundle deleted | bundle disabled | bundle enabled"
+      if: "['9521','9522','9523','9524'].contains(ctx.event?.code)"
+      patterns:
+        - "^EVPN VLAN Aware Bundle : %{DATA:package.name} (created|deleted|disable|enabled)"
+  - dissect:
+      field: message
+      tag: evpn_event_9525
+      description: "Log event when VLAN ethernet-tag is updated"
+      if: "ctx.event?.code == '9525'"
+      pattern: "EVPN EVI : %{network.vlan.id} updated with ethernet-tag : %{aruba.evpn.eth_tag}."
+  - dissect:
+      field: message
+      tag: evpn_event_9526
+      description: "Logs EVPN duplicate IP dampening event"
+      if: "ctx.event?.code == '9526'"
+      pattern: "EVPN duplicate IP dampening %{event.action}, MAC: %{client.mac}, IP address: %{client.ip}, VTEP: %{aruba.evpn.vtep_ip}"
+  - dissect:
+      field: message
+      tag: evpn_event_9527
+      description: "Logs EVPN RT update event for an EVI"
+      if: "ctx.event?.code == '9527'"
+      pattern: "EVPN EVI: RT %{aruba.evpn.rtt} %{aruba.evpn.rt} updated for EVI: %{network.vlan.id}"
+  - grok:
+      field: message
+      tag: evpn_event_9529_9530
+      description: "Log event when EVPN Ethernet Segment created | deleted"
+      if: "['9529','9530'].contains(ctx.event?.code)"
+      patterns:
+        - "^EVPN Ethernet Segment with ESI %{DATA:aruba.evpn.esi} is (created|deleted)"
 
   # IP tunnels events (96xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/IP_TUNNEL.htm
@@ -4238,8 +4270,8 @@ processors:
       patterns:
         - "^HW programming failed for (IPv4|IPv6) prefix-priority %{GREEDYDATA:aruba.asic.route_prefix}"
 
-  # DPSE Events (109xx)
-  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DPSE.htm
+  # DPSE daemon events (109xx)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DPSE.htm
   - dissect:
       field: message
       tag: dpse_event_10901
@@ -4252,6 +4284,12 @@ processors:
       description: "The system completed backplane sequence recovery triggered by line card error"
       if: "ctx.event?.code == '10904'"
       pattern: "Line card module %{aruba.dpse.linecard_name} completed backplane sequence recovery"
+  - dissect:
+      field: message
+      tag: dpse_event_10906
+      description: "An ops-switchd plugin failed executing an operation"
+      if: "ctx.event?.code == '10906'"
+      pattern: 'Control Plane (%{aruba.dpse.operation_name}) failure during (%{aruba.dpse.plugin_name}) configuration'
 
   # MAC Address mode configuration events (1100x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/FAULT_MONITOR.htm
@@ -4423,24 +4461,36 @@ processors:
         - "^Container %{DATA:container.name} (stopped|image)"
 
   # DNS Client Events (119xx)
-  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DNS_CLIENT.htm
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DNS_CLIENT.htm
   - grok:
       field: message
       tag: dns_client_event_11901
       description: "Event reported when DNS event triggered"
-      if: "['11901'].contains(ctx.event?.code)"
+      if: "ctx.event?.code == '11901'"
       patterns:
-        - "%{DATA:aruba.dns.type} event for VRF %{DATA:aruba.dns.vrf_name}$"
+        - "%{DATA:aruba.dns.type} event for VRF %{DATA:aruba.vrf.name}$"
 
   # UFD events (1200x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/UFD.htm
   - grok:
       field: message
-      tag: ufd_event_12001
-      description: ""
+      tag: ufd_event_12001_12002
+      description: "Event reported when Links-to-Disable go down | Event reported when Links-to-Disable ports are restored"
       if: "['12001','12002'].contains(ctx.event?.code)"
       patterns:
         - "^Uplink Failure Detection session-id %{DATA:aruba.instance.id}, state changed from %{DATA:aruba.ufd.from_state} to %{GREEDYDATA:aruba.state}."
+
+  # Dot1x supplicant events (1230x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DOT1X_SUPPLICANT.htm
+  - grok:
+      field: message
+      tag: dot1x_event_12301_12302_12303_12304
+      description: ""
+      if: "['12301','12302','12303','12304'].contains(ctx.event?.code)"
+      patterns:
+        - "^802.1X supplicant has (blocked|unblocked) the interface %{GREEDYDATA:aruba.interface.id}."
+        - "^802.1X supplicant PAE restarted on interface %{GREEDYDATA:aruba.interface.id} due to change in policy %{GREEDYDATA:aruba.dot1x.policy}."
+        - "^802.1X supplicant is not supported on the port %{GREEDYDATA:aruba.port}."
 
   # Device fingerprinting events (1240x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DFP.htm
@@ -4558,6 +4608,27 @@ processors:
       description: "Indicates the system was rebooted some number of time to recovery from a TPM selftest error"
       if: "ctx.event?.code == '13604'"
       pattern: "Rebooted %{aruba.tpm.reboot_num} times to retry TPM selftests"
+
+  # Distributed services events (1390X)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DIST-SERV.htm
+  - dissect:
+      field: message
+      tag: dist_service_event_13901
+      description: "Log event that indicates the chassis requires a reboot."
+      if: "ctx.event?.code == '13901'"
+      pattern: "Chassis Reboot Requested: %{event.reason}"
+  - dissect:
+      field: message
+      tag: dist_service_event_13902
+      description: "Log event that indicates admission to PSM was rejected.' event_description_template"
+      if: "ctx.event?.code == '13902'"
+      pattern: "Distributed Services Admission Rejected. Reason: %{event.reason}"
+  - dissect:
+      field: message
+      tag: dist_service_event_13903
+      description: "Log event that indicates mismatch of PSM coordinates."
+      if: "ctx.event?.code == '13903'"
+      pattern: "PSM coordinates mismatch. Active coordinates: %{aruba.distributed.active_coordinates}, Configured coordinates: %{aruba.distributed.configured_coordinates}."      
 
   # Traffic Insight events (1400x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/TRAFFIC_INSIGHT.htm
@@ -4684,6 +4755,30 @@ processors:
       description: "Client DNS on-boarding details"
       if: "ctx.event?.code == '14311'"
       pattern: "Client %{client.mac} on-boarded on Port %{aruba.port} dns-status %{aruba.status} dns-failure-reason %{event.reason} dns-server %{aruba.insight.dns_server} dns-latency %{aruba.insight.dns_latency}"
+
+  # Download events (145xx)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DOWNLOAD.htm
+  - grok:
+      field: message
+      tag: download_event_14501_14502_14503_14509_14510
+      description: "Indicates that a file download has been started | file has been successfully downloaded | file download has been aborted | file download has been retried | file upload has been retried"
+      if: "['14501','14502','14503','14509','14510'].contains(ctx.event?.code)"
+      patterns:
+        - "from %{GREEDYDATA:url.original}"
+  - grok:
+      field: message
+      tag: download_event_14505_14506_14507
+      description: "Indicates that a file upload has been started | file has been successfully uploaded | file upload has been aborted"
+      if: "['14505','14506','14507'].contains(ctx.event?.code)"
+      patterns:
+        - "to %{GREEDYDATA:url.original}"
+  - grok:
+      field: message
+      tag: download_event_14504_14508
+      description: "Indicates that a file download has been retried | file upload has been retried"
+      if: "['14504','14508'].contains(ctx.event?.code)"
+      patterns:
+        - "^File (upload|download) failed (to|from) %{DATA:url.original} with error code: %{DATA:error.code}, %{GREEDYDATA:aruba.error.description}"
 
   # Central Source events (1460x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CENTRAL_SOURCE.htm

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -737,13 +737,7 @@ processors:
         UNIT: "unit %{DATA:aruba.unit}"
 
     # CoPP Events (15xx)
-    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/COPP.htm
-    # The following Event IDs do not need further processing
-    # * 1501
-    # * 1502
-    # * 1503
-    # * 1504
-    # * 1505
+    # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/COPP.htm
   - dissect:
       field: message
       tag: copp_event_1506
@@ -903,12 +897,12 @@ processors:
         - "ECMP error: %{DATA:aruba.ecmp.err}$"
 
   # DHCP Server events (19xx)
-  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DHCP-SERVER.htm
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DHCP-SERVER.htm
   - grok:
       field: message
-      tag: dhcp_server_event_1901_through_1906
+      tag: dhcp_server_event_1901_1902_1903_1904_1905_1906
       description: "Logs DHCP lease addition, deletion, or update"
-      if: "['1901', '1902', '1903', '1904', '1905', '1906'].contains(ctx.event?.code)"
+      if: "['1901','1902','1903','1904','1905','1906'].contains(ctx.event?.code)"
       patterns:
         - "^DHCP Lease (added|addition|deleted|deletion|update|updated)( failed)? %{DHCP_EXPIRE_TIME_FMT:event.end} %{MAC:host.mac} %{IP:host.ip} %{HOSTNAME:host.name} %{DATA:user.id}$"
       pattern_definitions:
@@ -917,7 +911,7 @@ processors:
       field: message
       tag: dhcp_server_event_1907_1908
       description: "Logs enable or disable of DHCP server on a VRF"
-      if: "['1907', '1908'].contains(ctx.event?.code)"
+      if: "['1907','1908'].contains(ctx.event?.code)"
       patterns:
         - "^DHCP server (en|dis)abled on VRF %{DATA:aruba.vrf.name}$"
   - dissect:
@@ -930,7 +924,7 @@ processors:
       field: message
       tag: dhcp_server_event_1910_1911
       description: "Event raised when DHCP or DHCPv6 Server Lease on the VRF is cleared"
-      if: "['1910', '1911'].contains(ctx.event?.code)"
+      if: "['1910','1911'].contains(ctx.event?.code)"
       patterns:
         - "^(DHCP|DHCPv6) Server Lease cleared on vrf %{DATA:aruba.vrf.name}\\.$"
 
@@ -2526,13 +2520,7 @@ processors:
         - "VRF with vrf name %{DATA:aruba.vrf.name} "
 
   # Credential Manager events (65xx)
-  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CREDMGR.htm
-  #
-  # The following event IDs do not need further processing:
-  # * 6501
-  # * 6502
-  # * 6504
-  # * 6505
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CREDMGR.htm
   - dissect:
       if: "ctx.event.code == '6506'"
       tag: credmgr_event_6506
@@ -2580,7 +2568,7 @@ processors:
         - "session %{GREEDYDATA:aruba.session.id}"
 
   # Config Management events (68xx)
-  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CONFIG_MGMT.htm
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CONFIG_MGMT.htm
   - dissect:
       if: "ctx.event.code == '6801'"
       tag: config_event_6801
@@ -2833,7 +2821,7 @@ processors:
         IP_SLA_SESSION_NAME: "IP-SLA (session:)?%{DATA:aruba.ip_sla.name}"
 
   # CPU_RX Events (75xx)
-  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CPU_RX.htm
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CPU_RX.htm
   - dissect:
       field: message
       tag: cpu_rx_event_7501
@@ -2858,7 +2846,7 @@ processors:
         - "(error|update|persistence): %{GREEDYDATA:aruba.instance.id}"
 
   # Certificate management events (77xx)
-  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CERTMGR.htm
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CERTMGR.htm
   - grok:
       if: "['7701', '7702', '7703', '7704'].contains(ctx.event?.code)"
       tag: cm_event_7701_7702_7703_7704
@@ -2882,12 +2870,15 @@ processors:
         - "^Certificate %{DATA:aruba.cm.cert_name} has not yet reached its start date"
         - "^Certificate %{DATA:aruba.cm.cert_name} has expired and can no longer be used"
         - "^Certificate %{DATA:aruba.cm.cert_name} verified and accepted"
-  - dissect:
+        - "^Throttled %{NUMBER:aruba.throttle_count:long} Messages"
+  - grok:
       if: "ctx.event.code == '7709'"
       tag: cm_event_7709
       field: "message"
       description: "Event raised when a certificate chain is rejected"
-      pattern: "Certificate %{aruba.cm.cert_name} rejected due to verification failure (%{event.reason})"
+      patterns: 
+        - "^Certificate %{DATA:aruba.cm.cert_name} rejected due to verification failure \\(%{GREEDYDATA:event.reason}\\)"
+        - "^Throttled %{NUMBER:aruba.throttle_count:long} Messages"
   - grok:
       if: "['7710', '7711', '7712'].contains(ctx.event?.code)"
       tag: cm_event_7710_7711_7712
@@ -2896,12 +2887,14 @@ processors:
       patterns:
         - "^(Certificate signing request|Self-signed certificate) %{DATA:aruba.cm.cert_name} created"
         - "^Application association with the %{DATA:aruba.cm.cert_name} certificate is not permitted"
-  - dissect:
+  - grok:
       if: "ctx.event.code == '7713'"
       tag: cm_event_7713
       field: "message"
       description: "Event raised when a certificate is verified due to optional OCSP enforcement"
-      pattern: "Certificate %{aruba.cm.cert_name} failed OCSP verification (%{aruba.status}), but was accepted because OCSP enforcement is set to optional."
+      patterns: 
+        - "^Certificate %{DATA:aruba.cm.cert_name} failed OCSP verification \\(%{DATA:aruba.status}\\), but was accepted because OCSP enforcement is set to optional."
+        - "^Throttled %{NUMBER:aruba.throttle_count:long} Messages"
   - grok:
       if: "['7714', '7715'].contains(ctx.event?.code)"
       tag: cm_event_7714_7715
@@ -3142,11 +3135,7 @@ processors:
       pattern: "Unsupported underlay port %{aruba.port} configured for tunnel %{aruba.vxlan.vtep_peer}"
 
   # DHCPv4 Snooping events (82xx)
-  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DHCPv4-SNOOPING.htm
-  #
-  # The following event ID does not need further processing:
-  # * 8212
-  #
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DHCPv4-SNOOPING.htm
   - grok:
       field: message
       tag: dhcpv4_snoop_event_8201
@@ -3252,13 +3241,38 @@ processors:
       if: "ctx.event?.code == '8216'"
       patterns:
         - "^Failed to import dynamic ip binding entries from external storage. volume: %{DATA:aruba.dhcp.volume_name}, filename: %{DATA:file.name}.$"
+  - dissect:
+      field: message
+      tag: dhcpv4_snoop_event_8217
+      description: "Log event when failed to import dynamic ip binding entries from local storage."
+      if: "ctx.event?.code == '8217'"
+      pattern: "Failed to import dynamic ip binding entries from local storage. filepath: %{file.path}."
+  - grok:
+      field: message
+      tag: dhcpv4_snoop_event_8219_8220
+      description: "Log event when dynamic ip binding entries from external storage are successfully imported | from local storage are successfully imported"
+      if: "['8219','8220'].contains(ctx.event?.code)"
+      patterns:
+        - "^Successfully imported %{DATA:aruba.dhcp.bindings_imported} dynamic ip binding entries from (external|local) storage.( volume: %{DATA:aruba.dhcp.volume_name}, filename: %{GREEDYDATA:file.name}.)?"
+  - grok:
+      field: message
+      tag: dhcpv4_snoop_event_8221_8222_8223_8224
+      description: "Log event when a client receives IP from DHCP server along with static attributes. | when a client releases | when a client's lease period expires | when a client's static attributes are updated"
+      if: "['8221','8222','8223','8224'].contains(ctx.event?.code)"
+      patterns:
+        - "^Client %{MAC:client.mac} on vlan %{DATA:network.vlan.id}, port %{DATA:aruba.port} received %{IP:client.ip} from server %{IP:server.ip} with lease %{DATA:aruba.dhcp.lease}. Nameserver:%{IP:aruba.dhcp.nameserver_ip}, Gateway:%{IP:aruba.dhcp.gateway_ip}."
+        - "^Client %{MAC:client.mac} on vlan %{DATA:network.vlan.id}, port %{DATA:aruba.port} (released|lease period expired for|with) %{IP:client.ip}.( Client attributes updated: Gateway %{IP:aruba.dhcp.gateway_ip}, Nameserver %{IP:aruba.dhcp.nameserver_ip}, Lease period %{GREEDYDATA:aruba.dhcp.lease}.)?"
+  - grok:
+      field: message
+      tag: dhcpv4_snoop_event_8225_8226
+      description: "DHCP server packet received on an untrusted port | An unauthorized server detected on a trusted port"
+      if: "['8225','8226'].contains(ctx.event?.code)"
+      patterns:
+        - "^DHCPv4-Snooping dropped DHCP %{DATA:aruba.dhcp.message_type} packet received on untrusted port %{DATA:aruba.port} from %{IP:server.ip}"
+        - "^DHCPv4-Snooping dropped DHCP %{DATA:aruba.dhcp.message_type} packet received from unauthorized server %{IP:server.ip} on trusted port %{GREEDYDATA:aruba.port}"
 
   # DHCPv6 snooping events (83xx)
-  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DHCPV6_SNOOPING.htm
-  #
-  # The following event ID does not need further processing:
-  # * 8309
-  #
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DHCPv6-SNOOPING.htm
   - grok:
       field: message
       tag: dhcpv6_snooping_event_8301
@@ -3343,6 +3357,35 @@ processors:
       if: "ctx.event?.code == '8313'"
       patterns:
         - "^Failed to import dynamic ip binding entries from external storage. volume: %{DATA:aruba.dhcp.volume_name}, filename: %{DATA:file.name}.$"
+  - dissect:
+      field: message
+      tag: dhcpv6_snooping_event_8314
+      description: "Log event when import of dynamic binding entries from local storage is failed."
+      if: "ctx.event?.code == '8314'"
+      pattern: "Failed to import dynamic ip binding entries from local storage. filepath: %{file.path}."
+  - grok:
+      field: message
+      tag: dhcpv6_snoop_event_8316_8317
+      description: "Log event when dynamic ip binding entries from external storage are successfully imported | from local storage are successfully imported"
+      if: "['8316','8317'].contains(ctx.event?.code)"
+      patterns:
+        - "^Successfully imported %{DATA:aruba.dhcp.bindings_imported} dynamic ip binding entries from (external|local) storage.( volume: %{DATA:aruba.dhcp.volume_name}, filename: %{GREEDYDATA:file.name}.)?"
+  - grok:
+      field: message
+      tag: dhcpv6_snoop_event_8318_8319_8320_8321
+      description: "Log event when a client receives IPv6 address from DHCP server along with static attributes | when a client releases IPv6 address | when a client's lease period expires | when a client's static attributes are updated"
+      if: "['8318','8319','8320','8321'].contains(ctx.event?.code)"
+      patterns:
+        - "^Client %{MAC:client.mac} on vlan %{DATA:network.vlan.id}, port %{DATA:aruba.port} received %{IP:client.ip} from server %{IP:server.ip} with lease %{DATA:aruba.dhcp.lease}. Nameserver:%{IP:aruba.dhcp.nameserver_ip}."
+        - "^Client %{MAC:client.mac} on vlan %{DATA:network.vlan.id}, port %{DATA:aruba.port} (released|lease period expired for|with) %{IP:client.ip}.( Client attributes updated: Gateway %{IP:aruba.dhcp.gateway_ip}, Nameserver %{IP:aruba.dhcp.nameserver_ip}, Lease period %{GREEDYDATA:aruba.dhcp.lease}.)?"
+  - grok:
+      field: message
+      tag: dhcpv6_snoop_event_8322_8323
+      description: "Packet dropped on an untrusted port | An unauthorized server detected on port"
+      if: "['8322','8323'].contains(ctx.event?.code)"
+      patterns:
+        - "^DHCPv6-Snooping dropped DHCP %{DATA:aruba.dhcp.message_type} packet received on untrusted port %{DATA:aruba.port} from %{IP:server.ip}"
+        - "^DHCPv6-Snooping dropped DHCP %{DATA:aruba.dhcp.message_type} packet received from unauthorized server %{IP:server.ip} on trusted port %{GREEDYDATA:aruba.port}"
 
   # ND snooping events (840x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ND-SNOOPING.htm
@@ -3574,32 +3617,36 @@ processors:
         - "^Failed to report storage %{DATA:aruba.storage.name} details for module %{NUMBER:aruba.slot:long}. Error: %{GREEDYDATA:event.reason}"
         - "^Storage %{DATA:aruba.storage.name} (health alert. E|e)ndurance utilization at %{NUMBER:aruba.storage.usage:long}\\% in module %{NUMBER:aruba.slot:long}(. Failure is imminent. Please backup data)?"
 
-  # DCBX Events (92xx)
-  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DCBX.htm
+  # Discovery and Capability Exchange (DCBx) events (92xx)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DCBX.htm
   - grok:
       field: message
       tag: dcbx_event_9203_9204
-      if: "['9203', '9204'].contains(ctx.event?.code)"
+      if: "['9203','9204'].contains(ctx.event?.code)"
+      description: "Log event when DCBX is enabled on the interface | when DCBX is disabled on the interface"
       patterns:
-        - "^DCBX is (dis|en)abled on interface %{DATA:aruba.dcbx.intf_name}$"
+        - "^DCBX is (dis|en)abled on interface %{DATA:aruba.interface.name}$"
   - grok:
       field: message
       tag: dcbx_event_9205_9206
-      if: "['9205', '9206'].contains(ctx.event?.code)"
+      if: "['9205','9206'].contains(ctx.event?.code)"
+      description: "Log event when DCBX oper status is active on an interface | when DCBX oper status is inactive on an interface"
       patterns:
-        - "^DCBX status (in)?active on interface %{DATA:aruba.dcbx.intf_name}$"
+        - "^DCBX status (in)?active on interface %{DATA:aruba.interface.name}$"
   - grok:
       field: message
       tag: dcbx_event_9207_9208
-      if: "['9207', '9208'].contains(ctx.event?.code)"
+      if: "['9207','9208'].contains(ctx.event?.code)"
+      description: "Log event when PFC TLVs are active on an interface | when PFC TLVs are inactive on an interface"
       patterns:
-        - "^PFC TLV status (in)?active on interface %{DATA:aruba.dcbx.intf_name}$"
+        - "^PFC TLV status (in)?active on interface %{DATA:aruba.interface.name}$"
   - grok:
       field: message
       tag: dcbx_event_9209
-      if: "['9209'].contains(ctx.event?.code)"
+      if: "ctx.event?.code == '9209'"
+      description: "Log event when there is PFC TLV priority mismatch on an interface"
       patterns:
-        - "^PFC TLV status priority mismatch on interface %{DATA:aruba.dcbx.intf_name}$"
+        - "^PFC TLV status priority mismatch on interface %{DATA:aruba.interface.name}$"
 
   # Port access roles events (930x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ROLE.htm
@@ -4310,18 +4357,18 @@ processors:
       if: "ctx.event?.code == '11501'"
       pattern: "IPv6 route prefix %{aruba.prefix} is not supported on this platform"
 
-  # CFM Events (116xx)
-  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ETH_OAM_CFM.htm
+  # Connectivity Fault Management (CFM) events (1160x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ETH_OAM_CFM.htm
   - dissect:
       field: message
       tag: cfm_event_11601
       if: "ctx.event?.code == '11601'"
-      pattern: "Connection lost for Maintenance Endpoint %{aruba.cfm.id} on %{aruba.cfm.interface}."
+      pattern: "Connection lost for Maintenance Endpoint %{aruba.instance.id} on %{aruba.interface.id}."
   - dissect:
       field: message
       tag: cfm_event_11602
       if: "ctx.event?.code == '11602'"
-      pattern: "Connection restored for Maintenance Endpoint %{aruba.cfm.id} on %{aruba.cfm.interface}."
+      pattern: "Connection restored for Maintenance Endpoint %{aruba.instance.id} on %{aruba.interface.id}."
 
   # Alarm events (117xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ALARM.htm
@@ -4360,12 +4407,20 @@ processors:
         - "^(System|Input) alarm %{DATA:aruba.alarm.name} has activated through relay(, triggered at %{GREEDYDATA:aruba.alarm.trigger})?"
 
   # Container Manager Events (118xx)
-  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CONTAINER.htm
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CONTAINER.htm
   - dissect:
       field: message
       tag: container_manager_event_11801_11802_11803
-      if: "['11801', '11802', '11803'].contains(ctx.event?.code)"
+      if: "['11801','11802','11803'].contains(ctx.event?.code)"
       pattern: "Container %{container.name} is %{?ignore_action}"
+  - grok:
+      field: message
+      tag: container_manager_event_11804_11805_11806_11807_11808_11809_11810_11811
+      if: "['11804','11805','11806','11807','11808','11809','11810','11811'].contains(ctx.event?.code)"
+      patterns:
+        - "^Endpoint has been executed for container %{DATA:container.name} (with parameters: %{GREEDYDATA:aruba.container.params}|with no parameters.)"
+        - "^Endpoint has been executed for container %{DATA:container.name} with no parameters."
+        - "^Container %{DATA:container.name} (stopped|image)"
 
   # DNS Client Events (119xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DNS_CLIENT.htm
@@ -4386,6 +4441,15 @@ processors:
       if: "['12001','12002'].contains(ctx.event?.code)"
       patterns:
         - "^Uplink Failure Detection session-id %{DATA:aruba.instance.id}, state changed from %{DATA:aruba.ufd.from_state} to %{GREEDYDATA:aruba.state}."
+
+  # Device fingerprinting events (1240x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DFP.htm
+  - dissect:
+      field: message
+      tag: device_fingerprinting_event_12402
+      description: "Log the event when the per port clients limit for device fingerprinting is reached."
+      if: "ctx.event?.code == '12402'"
+      pattern: "Reached the maximum clients limit of %{aruba.limit.threshold} on the interface %{aruba.interface.id} for device fingerprinting"
 
   # VXLAN agent events (1250x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/VXLAN_AGENT.htm
@@ -4418,13 +4482,42 @@ processors:
         - "^TELNET session from %{IP:client.ip} is rejected because maximum number of TELNET sessions is reached."
   - grok:
       field: message
-      tag: telnet_server_event_
+      tag: telnet_server_event_12908_12909
       description: ""
       # Possible documentation error with duplicate definition of 12908, will parse 12908 and 12909 together in the same grok
       if: "['12908','12909'].contains(ctx.event?.code)"
       patterns:
         - "^TELNET session from User %{DATA:user.name} is closed because maximum number of sessions per user is reached."
         - "^User %{DATA:user.name} login from %{IP:client.ip} for TELNET session has failed since the user is trying to login through an interface which is not allowed. Allowed interfaces are: %{GREEDYDATA:aruba.interface.id}."
+
+  # Console events (1300x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CONSOLE.htm
+  - grok:
+      field: message
+      tag: console_event_13001_13002
+      description: "Logs a message when a user login is successful | Logs a message when a user login fails"
+      if: "['13001','13002'].contains(ctx.event?.code)"
+      patterns:
+        - "^User %{DATA:user.name} (logged in|login) from %{IP:client.ip} (through|for) CONSOLE"
+  - grok:
+      field: message
+      tag: console_event_13003
+      description: "Logs a message when a user logs out of a session"
+      if: "ctx.event?.code == '13003'"
+      patterns: 
+        - "^User %{DATA:user.name} logged out of CONSOLE session from %{IP:client.ip}."
+  - dissect:
+      field: message
+      tag: console_event_13004
+      description: "Logs a message when a user tries to login while maximum number of sessions per user are reached."
+      if: "ctx.event?.code == '13004'"
+      pattern: "CONSOLE session from User %{user.name} is closed because maximum number of sessions per user is reached."
+  - dissect:
+      field: message
+      tag: console_event_13005
+      description: "Logs a message when a user login fails since the access through this management interface is not allowed"
+      if: "ctx.event?.code == '13005'"
+      pattern: "User %{user.name} login from %{client.ip} for CONSOLE session has failed since the user is trying to login through an interface which is not allowed. Allowed interfaces are: %{aruba.interface.id}"
 
   # Accounting events (1310x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ACCOUNTING.htm
@@ -4435,6 +4528,15 @@ processors:
       if: "['13101','13102','13103'].contains(ctx.event?.code)"
       patterns:
         - "^(SSH|TELNET|CONSOLE) session from %{IP:client.ip} (for|with) (U|u)ser %{DATA:user.name} "
+
+  # Config validator events (1340x)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CONFIG-VALIDATOR.htm
+  - dissect:
+      field: message
+      tag: config_validator_13401
+      description: "The following are the events related to configuration validation."
+      if: "ctx.event?.code == '13401'"
+      pattern: "Config %{aruba.config.name} failed to validate. Reason %{event.reason}"
 
   # TPM events (1360x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/TPMD.htm
@@ -4518,6 +4620,70 @@ processors:
       if: "['14105','14109'].contains(ctx.event?.code)"
       patterns: 
         - "(is|been) %{DATA:aruba.status} - event_name"
+
+  # Client insight events (143xx)
+  # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CLIENT_INSIGHT.htm
+  - dissect:
+      field: message
+      tag: insight_event_14301
+      description: "Client on-boarding successful"
+      if: "ctx.event?.code == '14301'"
+      pattern: "Client %{client.mac} successfully on-boarded on VLAN %{network.vlan.id}. Client on-boarding started at %{aruba.insight.ob_start_ts}; L2 complete at %{aruba.insight.l2_end_ts}; L3 complete at %{aruba.insight.l3_end_ts} is_security_log : no"
+  - dissect:
+      field: message
+      tag: insight_event_14302
+      description: "Client on-boarding partially success"
+      if: "ctx.event?.code == '14302'"
+      pattern: "Client %{client.mac} partial success while on-boarding on VLAN %{network.vlan.id}. L2 status:%{aruba.insight.l2_ob_state} L3 status:%{aruba.insight.l3_ob_state}. Client on-boarding started at %{aruba.insight.ob_start_ts};L2 complete at %{aruba.insight.l2_end_ts}; L3 complete at %{aruba.insight.l3_end_ts}. is_security_log : no"
+  - dissect:
+      field: message
+      tag: insight_event_14303
+      description: "Client on-boarding failed"
+      if: "ctx.event?.code == '14303'"
+      pattern: "Client %{client.mac} failed to on-board with status: %{aruba.status} reason_code: %{aruba.insight.failure_phase_id} is_security_log : no"
+  - dissect:
+      field: message
+      tag: insight_event_14304
+      description: "Maximum system wide client limit reached"
+      if: "ctx.event?.code == '14304'"
+      pattern: "Maximum system wide client limit %{aruba.limit.threshold} reached. throttle_time : 15 throttle_count : 1 is_security_log: no"
+  - dissect:
+      field: message
+      tag: insight_event_14305
+      description: "Client on-boarding successful"
+      if: "ctx.event?.code == '14305'"
+      pattern: "Client %{client.mac} successfully on-boarded on VLAN %{network.vlan.id}; Client on-boarding started at %{aruba.insight.ob_start_ts}; L2 complete at %{aruba.insight.l2_end_ts}; L3 complete at %{aruba.insight.l3_end_ts}; ARP to GW response received at %{aruba.insight.arp_end_ts}; DNS on-boarding to %{server.ip} completed at %{aruba.insight.dns_end_ts} is_security_log : no"
+  - dissect:
+      field: message
+      tag: insight_event_14306
+      description: "Client on-boarding partially success"
+      if: "ctx.event?.code == '14306'"
+      pattern: "Client %{client.mac} on-boarded on VLANs %{network.vlan.id} and failed on VLANs %{aruba.insight.failed_vlans}; Client on-boarding started at %{aruba.insight.ob_start_ts}; L2 complete at %{aruba.insight.l2_end_ts}; L3 complete at %{aruba.insight.l3_end_ts}; ARP to GW response received at %{aruba.insight.arp_end_ts}; DNS on-boarding to %{server.ip} completed at %{aruba.insight.dns_end_ts}; L2 status %{aruba.insight.l2_ob_state} failure_reason_code - %{aruba.insight.l2_failure_reason}; L3 status %{aruba.insight.l3_ob_state} failure_reason_code - %{aruba.insight.l3_failure_reason}; DNS on-boarding status %{aruba.status} failure_reason_code - %{event.reason}"
+  - dissect:
+      field: message
+      tag: insight_event_14307
+      description: "Client on-boarding failed"
+      if: "ctx.event?.code == '14307'"
+      pattern: "Client %{client.mac} failed to on-board with status: %{aruba.status} in failure phase: %{aruba.insight.failure_phase_id} with reason: %{event.reason} is_security_log : no"
+  - dissect:
+      field: message
+      tag: insight_event_14308
+      description: "Client L2 on-boarding details"
+      if: "ctx.event?.code == '14308'"
+      pattern: "Client %{client.mac} on-boarded on VLAN %{network.vlan.id} and failed on VLANs %{aruba.insight.failed_vlans} Port %{aruba.port} auth-status %{aruba.status} auth-type %{aruba.insight.auth_type} auth-latency %{aruba.insight.auth_latency} dot1x-auth-failure-reason %{aruba.insight.dot1x_auth_failure_reason} mac-auth-failure-reason %{aruba.insight.mac_auth_failure_reason} radius-server %{aruba.insight.radius_server} assigned-role %{aruba.role} assigned-role-type %{aruba.insight.role_type}"
+  - grok:
+      field: message
+      tag: insight_event_14309_14310
+      description: "Client DHCPV4 on-boarding details | Client DHCPV6 on-boarding details"
+      if: "['14309','14310'].contains(ctx.event?.code)"
+      patterns:
+        - "^Client %{MAC:client.mac} on-boarded on VLAN %{DATA:aruba.insight.successfulvlan} Port %{DATA:aruba.port} (dhcpv4|dhcpv6)-status %{DATA:aruba.status} (dhcpv4|dhcpv6)-failure-reason %{DATA:event.reason} (dhcpv4|dhcpv6)-server%{DATA:aruba.insight.dhcp_server} (dhcpv4|dhcpv6)-client %{DATA:aruba.insight.dhcp_client} (dhcpv4|dhcpv6)-latency %{GREEDYDATA:aruba.insight.dhcp_latency}"
+  - dissect:
+      field: message
+      tag: insight_event_14311
+      description: "Client DNS on-boarding details"
+      if: "ctx.event?.code == '14311'"
+      pattern: "Client %{client.mac} on-boarded on Port %{aruba.port} dns-status %{aruba.status} dns-failure-reason %{event.reason} dns-server %{aruba.insight.dns_server} dns-latency %{aruba.insight.dns_latency}"
 
   # Central Source events (1460x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CENTRAL_SOURCE.htm

--- a/packages/hpe_aruba_cx/data_stream/log/fields/ecs.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/ecs.yml
@@ -45,6 +45,8 @@
 - external: ecs
   name: file.name
 - external: ecs
+  name: file.path
+- external: ecs
   name: file.type
 - external: ecs
   name: host.boot.id

--- a/packages/hpe_aruba_cx/data_stream/log/fields/ecs.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/ecs.yml
@@ -85,6 +85,8 @@
 - external: ecs
   name: package.installed
 - external: ecs
+  name: package.name
+- external: ecs
   name: package.version
 - external: ecs
   name: process.end

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -140,15 +140,6 @@
         - name: vtep_ip
           type: ip
           description: ""
-    - name: cfm
-      type: group
-      fields:
-        - name: interface
-          type: keyword
-          description: "Interface name on which CFM event occurred"
-        - name: id
-          type: keyword
-          description: "Maintenance Endpoint ID"
     - name: cm
       type: group
       fields:
@@ -185,7 +176,16 @@
         - name: from
           type: keyword
           description: ""
+        - name: name
+          type: keyword
+          description: ""
         - name: to
+          type: keyword
+          description: ""
+    - name: container
+      type: group
+      fields:
+        - name: params
           type: keyword
           description: ""
     - name: copp
@@ -203,22 +203,31 @@
         - name: filter_description
           type: keyword
           description: ""
-    - name: dcbx
-      type: group
-      fields:
-        - name: intf_name
-          type: keyword
-          description: "Interface name as reported by the system"
     - name: dhcp
       type: group
       fields:
+        - name: bindings_imported
+          type: keyword
+          description: ""
         - name: config
           type: keyword
+          description: ""
+        - name: gateway_ip
+          type: ip
           description: ""
         - name: ipv6_address
           type: keyword
           description: ""
+        - name: lease
+          type: keyword
+          description: ""
         - name: lease_ip_address
+          type: ip
+          description: ""
+        - name: message_type
+          type: keyword
+          description: ""
+        - name: nameserver_ip
           type: ip
           description: ""
         - name: new_port
@@ -459,6 +468,78 @@
           type: keyword
           description: ""
         - name: vni
+          type: keyword
+          description: ""
+    - name: insight
+      type: group
+      fields:
+        - name: arp_end_ts
+          type: keyword
+          description: ""
+        - name: role_type
+          type: keyword
+          description: ""
+        - name: auth_latency
+          type: keyword
+          description: ""
+        - name: auth_type
+          type: keyword
+          description: ""
+        - name: dhcp_client
+          type: keyword
+          description: ""
+        - name: dhcp_latency
+          type: keyword
+          description: ""
+        - name: dhcp_server
+          type: keyword
+          description: ""
+        - name: dns_end_ts
+          type: keyword
+          description: ""
+        - name: dns_latency
+          type: keyword
+          description: ""
+        - name: dns_server
+          type: keyword
+          description: ""
+        - name: dot1x_auth_failure_reason
+          type: keyword
+          description: ""
+        - name: failed_vlans
+          type: keyword
+          description: ""
+        - name: failure_phase_id
+          type: keyword
+          description: ""
+        - name: l2_end_ts
+          type: keyword
+          description: ""
+        - name: l2_failure_reason
+          type: keyword
+          description: ""
+        - name: l2_ob_state
+          type: keyword
+          description: ""
+        - name: l3_end_ts
+          type: keyword
+          description: ""
+        - name: l3_failure_reason
+          type: keyword
+          description: ""
+        - name: l3_ob_state
+          type: keyword
+          description: ""
+        - name: mac_auth_failure_reason
+          type: keyword
+          description: ""
+        - name: ob_start_ts
+          type: keyword
+          description: ""
+        - name: radius_server
+          type: keyword
+          description: ""
+        - name: successfulvlan
           type: keyword
           description: ""
     - name: instance

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -242,6 +242,15 @@
         - name: volume_name
           type: keyword
           description: ""
+    - name: distributed
+      type: group
+      fields:
+        - name: active_coordinates
+          type: keyword
+          description: ""
+        - name: configured_coordinates
+          type: keyword
+          description: ""
     - name: dns
       type: group
       fields:
@@ -251,10 +260,22 @@
         - name: vrf_name
           type: keyword
           description: ""
+    - name: dot1x
+      type: group
+      fields:
+        - name: policy
+          type: keyword
+          description: ""
     - name: dpse
       type: group
       fields:
         - name: linecard_name
+          type: keyword
+          description: ""
+        - name: operation_name
+          type: keyword
+          description: ""
+        - name: plugin_name
           type: keyword
           description: ""
     - name: ecmp
@@ -275,9 +296,6 @@
         - name: ring_id
           type: keyword
           description: ""
-        - name: port_name
-          type: keyword
-          description: ""
     - name: error
       type: group
       fields:
@@ -293,10 +311,19 @@
     - name: evpn
       type: group
       fields:
+        - name: esi
+          type: keyword
+          description: ""
+        - name: eth_tag
+          type: keyword
+          description: ""
         - name: rd
           type: keyword
           description: ""
         - name: rt
+          type: keyword
+          description: ""
+        - name: rtt
           type: keyword
           description: ""
         - name: vni

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -181,7 +181,54 @@ Note: Descriptions have not been filled out
 | `<cert_length>`     | aruba.len                    |
 | `<vrf>`             | aruba.vrf.id                 |
 
-#### [Certificate management events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CERTMGR.htm)
+#### [Client insight events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CLIENT_INSIGHT.htm)
+| Doc Fields                    | Schema Mapping                |
+|-------------------------------|-------------------------------|
+| `<arp_end_ts>`                | aruba.insight.arp_end_ts      |
+| `<assigned-role>`             | aruba.role                    |
+| `<assigned-role-type>`        | aruba.insight.role_type       |
+| `<auth-latency>`              | aruba.insight.auth_latency    |
+| `<auth-status>`               | aruba.status                  |
+| `<auth-type>`                 | aruba.insight.auth_type       |
+| `<client-number>`             | aruba.limit.threshold         |
+| `<dot1x-auth-failure-reason>` | aruba.insight.dot1x_auth_failure_reason |
+| `<dhcpv4-client>`             | aruba.insight.dhcp_client     |
+| `<dhcpv4-failure-reason>`     | event.reason                  |
+| `<dhcpv4-latency>`            | aruba.insight.dhcp_latency    |
+| `<dhcpv4-server>`             | aruba.insight.dhcp_server     |
+| `<dhcpv4-status>`             | aruba.status                  |
+| `<dhcpv6-client>`             | aruba.insight.dhcp_client     |
+| `<dhcpv6-failure-reason>`     | event.reason                  |
+| `<dhcpv6-latency>`            | aruba.insight.dhcp_latency    |
+| `<dhcpv6-server>`             | aruba.insight.dhcp_server     |
+| `<dhcpv6-status>`             | aruba.status                  |
+| `<dns_end_ts>`                | aruba.insight.dns_end_ts      |
+| `<dns_failure_reason>`        | event.reason                  |
+| `<dns-failure-reason>`        | event.reason                  |
+| `<dns-latency>`               | aruba.insight.dns_latency     |
+| `<dns_server_ip>`             | server.ip                     |
+| `<dns-server>`                | aruba.insight.dns_server      |
+| `<dns_status>`                | aruba.status                  |
+| `<dns-status>`                | aruba.status                  |
+| `<failed_vlans>`              | aruba.insight.failed_vlans    |
+| `<failure_phase_id>`          | aruba.insight.failure_phase_id|
+| `<failure_reason>`            | event.reason                  |
+| `<l2_end_ts>`                 | aruba.insight.l2_end_ts       |
+| `<l2_failure_reason>`         | aruba.insight.l2_failure_reason |
+| `<l2_ob_state>`               | aruba.insight.l2_ob_state     |
+| `<l3_end_ts>`                 | aruba.insight.l3_end_ts       |
+| `<l3_failure_reason>`         | aruba.insight.l3_failure_reason |
+| `<l3_ob_state>`               | aruba.insight.l3_ob_state     |
+| `<mac>`                       | client.mac                    |
+| `<mac-auth-failure-reason>`   | aruba.insight.mac_auth_failure_reason |
+| `<port>`                      | aruba.port                    |
+| `<ob_start_ts>`               | aruba.insight.ob_start_ts     |
+| `<onboarding_status>`         | aruba.status                  |
+| `<radius-server>`             | aruba.insight.radius_server   |
+| `<successfulvlan>`            | aruba.insight.successfulvlan  |
+| `<vlans>`                     | network.vlan.id               |
+
+#### [Certificate management events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CERTMGR.htm)
 | Doc Fields       | Schema Mapping        |
 |------------------|-----------------------|
 | `<cert_name>`    | aruba.cm.cert_name    |
@@ -191,7 +238,7 @@ Note: Descriptions have not been filled out
 | `<profile_name>` | aruba.cm.profile_name |
 | `<status>`       | aruba.status          |
 
-#### [Config Management events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CONFIG_MGMT.htm)
+#### [Config Management events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CONFIG_MGMT.htm)
 | Doc Fields     | Schema Mapping       |
 |----------------|----------------------|
 | `<error>`      | event.reason         |
@@ -201,41 +248,65 @@ Note: Descriptions have not been filled out
 | `<type>`       | aruba.config.type    |
 | `<value>`      | aruba.config.value   |
 
-#### [Connectivity Fault Management (CFM) events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ETH_OAM_CFM.htm)
+#### [Config validator events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CONFIG-VALIDATOR.htm)
+| Doc Fields     | Schema Mapping       |
+|----------------|----------------------|
+| `<name>`       | aruba.config.name    |
+| `<reason>`     | event.reason         |
+
+#### [Connectivity Fault Management (CFM) events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ETH_OAM_CFM.htm)
 | Doc Fields    | Schema Mapping      |
 |---------------|---------------------|
-| `<id>`        | aruba.cfm.id        |
-| `<interface>` | aruba.cfm.interfact |
+| `<id>`        | aruba.instance.id   |
+| `<interface>` | aruba.interface.id  |
+
+#### [Console events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CONSOLE.htm)
+| Doc Fields    | Schema Mapping      |
+|---------------|---------------------|
+| `<ip_address>`        | client.ip   |
+| `<mgmt_intf>`        | aruba.interface.id   |
+| `<user_name>` | user.name  |
 
 #### [Container manager events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CONTAINER.htm)
-| Doc Fields   | Schema Mapping   |
-|--------------|------------------|
-| `<name>`     | container.name   |
+| Doc Fields   | Schema Mapping          |
+|--------------|-------------------------|
+| `<name>`     | container.name          |
+| `<params>`   | aruba.container.params  |
 
-#### [CoPP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/COPP.htm)
+#### [CoPP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/COPP.htm)
 | Doc Field                      | Schema Mapping      |
 |--------------------------------|---------------------|
 | `<class>`                      | aruba.copp.class    |
 | `<slot>`                       | aruba.slot          |
 
-#### [CPU_RX events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CPU_RX.htm)
+#### [CPU_RX events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CPU_RX.htm)
 | Doc Field                      | Schema Mapping                  |
 |--------------------------------|---------------------------------|
 | `<action>`                     | event.action                    |
 | `<filter_description>`         | aruba.cpu_rx.filter_description |
 | `<unit>`                       | aruba.instance.id               |
 
-#### [Credential Manager events DHCP Relay events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CREDMGR.htm)
+#### [Credential Manager events DHCP Relay events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CREDMGR.htm)
 | Doc Field   | Schema Mapping |
 |-------------|----------------|
 | `<key-id>`  | user.id        |
 | `<user>`    | user.name      |
 
-#### [DHCP Relay events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DHCP-RELAY.htm)
+#### [CX LMS events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CX_LMS.htm)
 | Doc Field | Schema Mapping |
 |-----------|----------------|
 
-#### [DHCP Server events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DHCP-SERVER.htm)
+#### [Device fingerprinting events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DFP.htm)
+| Doc Field        | Schema Mapping        |
+|------------------|-----------------------|
+| `<client_limit>` | aruba.limit.threshold |
+| `<interface>`    | aruba.interface.id    |
+
+#### [DHCP Relay events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DHCP-RELAY.htm)
+| Doc Field | Schema Mapping |
+|-----------|----------------|
+
+#### [DHCP Server events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DHCP-SERVER.htm)
 | Doc Field       | Schema Mapping    |
 |-----------------|-------------------|
 | `<client_id>`   | user.id           |
@@ -247,45 +318,54 @@ Note: Descriptions have not been filled out
 | `<vfr>`         | aruba.vrf.id      |
 | `<vfr_name>`    | aruba.vrf.name    |
 
-#### [DHCPv4 Snooping events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DHCPv4-SNOOPING.htm)
-| Doc Field             | Schema Mapping      |
-|-----------------------|---------------------|
-| `<client_mac>`        | client.mac          |
-| `<existing_port>`     | server.port         |
-| `<filename>`          | file.name           |
-| `<ip_address>`        | client.ip           |
-| `<lease_ip_address>`  | client.ip           |
-| `<mac>`               | client.mac          |
-| `<new_port>`          | aruba.dhcp.new_port |
-| `<port>`              | aruba.port          |
-| `<server_ip_address>` | server.ip           |
-| `<source_mac>`        | client.mac          |
-| `<vid>`               | network.vlan.id     |
-| `<volume_name>`       | aruba.volume_name   |
+#### [DHCPv4 Snooping events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DHCPv4-SNOOPING.htm)
+| Doc Field             | Schema Mapping                |
+|-----------------------|-------------------------------|
+| `<bindings_imported>` | client.dhcp.bindings_imported |
+| `<client_mac>`        | client.mac                    |
+| `<existing_port>`     | server.port                   |
+| `<filename>`          | file.name                     |
+| `<file_path>`         | file.path                     |
+| `<gateway_ip>`        | aruba.dhcp.gateway_ip         |
+| `<ip_address>`        | client.ip                     |
+| `<lease>`             | aruba.dhcp.lease              |
+| `<lease_ip_address>`  | client.ip                     |
+| `<mac>`               | client.mac                    |
+| `<message_type>`      | aruba.dhcp.message_type       |
+| `<nameserver_ip>`     | client.mac                    |
+| `<new_port>`          | aruba.dhcp.new_port           |
+| `<port>`              | aruba.port                    |
+| `<server_ip_address>` | server.ip                     |
+| `<source_mac>`        | client.mac                    |
+| `<vid>`               | network.vlan.id               |
+| `<volume_name>`       | aruba.volume_name             |
 
-#### [DHCPv6 Relay events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DHCPv6-RELAY.htm)
-| Field | Description | Type | Common |
-|-------|-------------|------|--------|
+#### [DHCPv6 Relay events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DHCPv6-RELAY.htm)
+| Doc Field       | Schema Mapping    |
+|-----------------|-------------------|
 
+#### [DHCPv6 snooping events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DHCPv6-SNOOPING.htm)
+| Doc Fields            | Schema Mapping                |
+|-----------------------|-------------------------------|
+| `<bindings_imported>` | client.dhcp.bindings_imported |
+| `<existing_port>`     | aruba.port                    |
+| `<file_name>`         | file.name                     |
+| `<file_path>`         | file.path                     |
+| `<ip>`                | client.ip                     |
+| `<ipv6_address>`      | client.ip, server.ip          |
+| `<lease>`             | aruba.dhcp.lease              |
+| `<mac>`               | client.mac                    |
+| `<message_type>`      | aruba.dhcp.message_type       |
+| `<nameserver_ip>`     | client.mac                    |
+| `<new_port>`          | aruba.dhcp.new_port           |
+| `<port>`              | aruba.port                    |
+| `<vid>`               | network.vlan.id               |
+| `<volume_name>`       | aruba.dhcp.volume_name        |
 
-#### [DHCPv6 snooping events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DHCPv6-SNOOPING.htm)
-
-| Doc Fields                       | Schema Mapping         |
-|----------------------------------|------------------------|
-| `<ipv6_address>`                 | client.ip, server.ip   |
-| `<port>`                         | aruba.port             |
-| `<mac>`                          | client.mac             |
-| `<existing_port>`                | aruba.port             |
-| `<new_port>`                     | aruba.dhcp.new_port    |
-| `<ip>`                           | client.ip              |
-| `<vid>`                          | network.vlan.id        |
-| `<volume_name>`                  | aruba.dhcp.volume_name |
-| `<file_name>`                    | file.name              |
-
-#### [Discovery and Capability Exchange (DCBx) events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DCBX.htm)
-| Field                | Description | Type | Common                          |
-|----------------------|-------------|------|---------------------------------|
-| aruba.dcbx.intf_name | Interface name as reported by the system | keyword | |
+#### [Discovery and Capability Exchange (DCBx) events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DCBX.htm)
+| Doc Fields            | Schema Mapping                |
+|-----------------------|-------------------------------|
+| `<intf_name>` | aruba.interface.name |
 
 #### [DNS client events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DNS_CLIENT.htm)
 | Field            | Description | Type | Common           |
@@ -1495,8 +1575,6 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.bgp.peer_grp |  | keyword |
 | aruba.bgp.pg_name |  | keyword |
 | aruba.bgp.vtep_ip |  | ip |
-| aruba.cfm.id | Maintenance Endpoint ID | keyword |
-| aruba.cfm.interface | Interface name on which CFM event occurred | keyword |
 | aruba.cm.cert_name |  | keyword |
 | aruba.cm.days |  | long |
 | aruba.cm.est_name |  | keyword |
@@ -1504,16 +1582,22 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.component.category |  | keyword |
 | aruba.component.name |  | keyword |
 | aruba.config.from |  | keyword |
+| aruba.config.name |  | keyword |
 | aruba.config.to |  | keyword |
 | aruba.config.type |  | keyword |
 | aruba.config.value |  | keyword |
+| aruba.container.params |  | keyword |
 | aruba.copp.class | Control Plane Policing (CoPP) class | keyword |
 | aruba.count |  | long |
 | aruba.cpu_rx.filter_description |  | keyword |
-| aruba.dcbx.intf_name | Interface name as reported by the system | keyword |
+| aruba.dhcp.bindings_imported |  | keyword |
 | aruba.dhcp.config |  | keyword |
+| aruba.dhcp.gateway_ip |  | ip |
 | aruba.dhcp.ipv6_address |  | keyword |
+| aruba.dhcp.lease |  | keyword |
 | aruba.dhcp.lease_ip_address |  | ip |
+| aruba.dhcp.message_type |  | keyword |
+| aruba.dhcp.nameserver_ip |  | ip |
 | aruba.dhcp.new_port |  | keyword |
 | aruba.dhcp.server_ip_address |  | ip |
 | aruba.dhcp.source_mac |  | keyword |
@@ -1584,6 +1668,29 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.hardware.test_name |  | keyword |
 | aruba.hardware.type |  | keyword |
 | aruba.hardware.vni |  | keyword |
+| aruba.insight.arp_end_ts |  | keyword |
+| aruba.insight.auth_latency |  | keyword |
+| aruba.insight.auth_type |  | keyword |
+| aruba.insight.dhcp_client |  | keyword |
+| aruba.insight.dhcp_latency |  | keyword |
+| aruba.insight.dhcp_server |  | keyword |
+| aruba.insight.dns_end_ts |  | keyword |
+| aruba.insight.dns_latency |  | keyword |
+| aruba.insight.dns_server |  | keyword |
+| aruba.insight.dot1x_auth_failure_reason |  | keyword |
+| aruba.insight.failed_vlans |  | keyword |
+| aruba.insight.failure_phase_id |  | keyword |
+| aruba.insight.l2_end_ts |  | keyword |
+| aruba.insight.l2_failure_reason |  | keyword |
+| aruba.insight.l2_ob_state |  | keyword |
+| aruba.insight.l3_end_ts |  | keyword |
+| aruba.insight.l3_failure_reason |  | keyword |
+| aruba.insight.l3_ob_state |  | keyword |
+| aruba.insight.mac_auth_failure_reason |  | keyword |
+| aruba.insight.ob_start_ts |  | keyword |
+| aruba.insight.radius_server |  | keyword |
+| aruba.insight.role_type |  | keyword |
+| aruba.insight.successfulvlan |  | keyword |
 | aruba.instance.id |  | keyword |
 | aruba.interface.id |  | keyword |
 | aruba.interface.name |  | keyword |
@@ -1920,6 +2027,8 @@ The `log` dataset collects the HPE Aruba CX logs.
 | event.sequence | Sequence number of the event. The sequence number is a value published by some event sources, to make the exact ordering of events unambiguous, regardless of the timestamp precision. | long |
 | event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |
 | file.name | Name of the file including the extension, without the directory. | keyword |
+| file.path | Full path to the file, including the file name. It should include the drive letter, when appropriate. | keyword |
+| file.path.text | Multi-field of `file.path`. | match_only_text |
 | file.type | File type (file, dir, or symlink). | keyword |
 | host.boot.id | Linux boot uuid taken from /proc/sys/kernel/random/boot_id. Note the boot_id value from /proc may or may not be the same in containers as on the host. Some container runtimes will bind mount a new boot_id value onto the proc file in each container. | keyword |
 | host.ip | Host ip addresses. | ip |

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -261,11 +261,11 @@ Note: Descriptions have not been filled out
 | `<interface>` | aruba.interface.id  |
 
 #### [Console events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CONSOLE.htm)
-| Doc Fields    | Schema Mapping      |
-|---------------|---------------------|
-| `<ip_address>`        | client.ip   |
-| `<mgmt_intf>`        | aruba.interface.id   |
-| `<user_name>` | user.name  |
+| Doc Fields     | Schema Mapping        |
+|----------------|-----------------------|
+| `<ip_address>` | client.ip             |
+| `<mgmt_intf>`  | aruba.interface.id    |
+| `<user_name>`  | user.name             |
 
 #### [Container manager events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CONTAINER.htm)
 | Doc Fields   | Schema Mapping          |

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -363,9 +363,9 @@ Note: Descriptions have not been filled out
 | `<volume_name>`       | aruba.dhcp.volume_name        |
 
 #### [Discovery and Capability Exchange (DCBx) events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DCBX.htm)
-| Doc Fields            | Schema Mapping                |
-|-----------------------|-------------------------------|
-| `<intf_name>` | aruba.interface.name |
+| Doc Fields   | Schema Mapping         |
+|--------------|------------------------|
+| `<intf_name>`| aruba.interface.name   |
 
 #### [DNS client events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DNS_CLIENT.htm)
 | Field            | Description | Type | Common           |

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -267,7 +267,7 @@ Note: Descriptions have not been filled out
 | `<mgmt_intf>`  | aruba.interface.id    |
 | `<user_name>`  | user.name             |
 
-#### [Container manager events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/CONTAINER.htm)
+#### [Container manager events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CONTAINER.htm)
 | Doc Fields   | Schema Mapping          |
 |--------------|-------------------------|
 | `<name>`     | container.name          |

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -324,7 +324,7 @@ Note: Descriptions have not been filled out
 | `<bindings_imported>` | client.dhcp.bindings_imported |
 | `<client_mac>`        | client.mac                    |
 | `<existing_port>`     | server.port                   |
-| `<filename>`          | file.name                     |
+| `<file_name>`         | file.name                     |
 | `<file_path>`         | file.path                     |
 | `<gateway_ip>`        | aruba.dhcp.gateway_ip         |
 | `<ip_address>`        | client.ip                     |
@@ -335,6 +335,7 @@ Note: Descriptions have not been filled out
 | `<nameserver_ip>`     | client.mac                    |
 | `<new_port>`          | aruba.dhcp.new_port           |
 | `<port>`              | aruba.port                    |
+| `<server_ip>`         | server.ip                     |
 | `<server_ip_address>` | server.ip                     |
 | `<source_mac>`        | client.mac                    |
 | `<vid>`               | network.vlan.id               |
@@ -367,51 +368,78 @@ Note: Descriptions have not been filled out
 |--------------|------------------------|
 | `<intf_name>`| aruba.interface.name   |
 
-#### [DNS client events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DNS_CLIENT.htm)
-| Field            | Description | Type | Common           |
-|------------------|-------------|------|------------------|
-| aruba.dns.type   | DNS event type | keyword | event.type       |
-| aruba.dns.vrf_name | Virtual Routing and Forwarding name | keyword | aruba.vrf.name   |
+#### [Distributed services events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DIST-SERV.htm)
+| Doc Fields                | Schema Mapping                           |
+|---------------------------|------------------------------------------|
+| `<active_coordinates>`    | aruba.distributed.active_coordinates     |
+| `<configured_coordinates>`| aruba.distributed.configured_coordinates |
+| `<reason>`                | event.reason                             |
 
-#### [DPSE events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/DPSE.htm)
-| Field                    | Description | Type | Common                          |
-|--------------------------|-------------|------|---------------------------------|
-| aruba.dpse.linecard_name |             |      |                                 |
+#### [DNS client events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DNS_CLIENT.htm)
+| Docs Field   | Schema Mapping       |
+|--------------|----------------------|
+| `<type>`     | aruba.dns.type       |
+| `<vrf_name>` | aruba.vrf.name       |
 
-#### [ECMP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ECMP.htm)
-| Field               | Schema Mapping  |
-|---------------------|-----------------|
-| aruba.ecmp.egressid |                 |
-| aruba.ecmp.err      |                 |
-| aruba.ecmp.route    |                 |
+#### [Dot1x supplicant events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DOT1X_SUPPLICANT.htm)
+| Docs Field | Schema Mapping         |
+|------------|------------------------|
+| `<ifname>` | aruba.interface.name   |
+| `<policy>` | aruba.dot1x.policy     |
+| `<port>`   | aruba.port             |
 
-#### [ERPS events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/ERPS.htm)
+#### [Download events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DOWNLOAD.htm)
+| Docs Field | Schema Mapping             |
+|------------|----------------------------|
+| `<desc>`   | aruba.error.description    |
+| `<error>`  | error.code                 |
+| `<url>`    | aruba.port                 |
+
+#### [DPSE daemon events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/DPSE.htm)
+| Docs Field        | Schema Mapping             |
+|-------------------|----------------------------|
+| `<linecard_name>` | aruba.dpse.linecard_name   |
+| `<operation_name>`| aruba.dpse.operation_name  |
+| `<plugin_name>`   | aruba.dpse.plugin_name     |
+
+#### [ECMP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ECMP.htm)
+| Field       | Schema Mapping       |
+|-------------|----------------------|
+| `<egressid>`| aruba.ecmp.egressid  |
+| `<err>`     | aruba.ecmp.err       |
+| `<route>`   | aruba.ecmp.route     |
+
+#### [ERPS events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/ERPS.htm)
 | Field                  | Description | Type | Common                       |
 |------------------------|-------------|------|------------------------------|
 | `<ccvlan>`             |             |      | network.vlan.id              |
 | `<dataVlan>`           |             |      | network.vlan.id              |
-| `<ifID>`               |             |      | observer.ingress.interface.id|
+| `<ifID>`               |             |      | aruba.interface.id           |
 | `<instanceID>`         |             |      | aruba.instance.id            |
-| `<interfaceName>`      |             |      | observer.ingress.interface.name|
+| `<interfaceName>`      |             |      | aruba.interface.name         |
 | `<node>`               |             |      | client.mac                   |
-| `<portName>`           |             |      | aruba.erps.port_name         |
+| `<portName>`           |             |      | aruba.port                   |
 | `<reason>`             |             |      | event.reason                 |
 | `<ringID>`             |             |      | aruba.erps.ring_id           |
 | `<state>`              |             |      | aruba.status                 |
 | `<vlandID>`            |             |      | network.vlan.id              |
 
-#### [EVPN events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/EVPN.htm)
-| Doc Field   |  Schema Mapping   |
-|-------------|-------------------|
-| `<action>`  |  event.action     |
-| `<evi>`     |  network.vlan.id  |
-| `<ip_addr>` |  client.ip        |
-| `<mac_addr>`|  client.mac       |
-| `<rd>`      |  aruba.evpn.rd    |
-| `<rt>`      |  aruba.evpn.rt    |
-| `<vni>`     |  aruba.evpn.vni   |
-| `<vrf>`     |  aruba.vrf.id     |
-| `<vtep_ip>` |  aruba.evpn.vtep_ip|
+#### [EVPN events](https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/EVPN.htm)
+| Doc Field       | Schema Mapping     |
+|-----------------|--------------------|
+| `<action>`      | event.action       |
+| `<bundle_name>` | package.name       |
+| `<esi>`         | aruba.evpn.esi     |
+| `<eth_tag>`     | aruba.evpn.eth_tag |
+| `<evi>`         | network.vlan.id    |
+| `<ip_addr>`     | client.ip          |
+| `<mac_addr>`    | client.mac         |
+| `<rd>`          | aruba.evpn.rd      |
+| `<rt>`          | aruba.evpn.rt      |
+| `<rtt>`         | aruba.evpn.rtt     |
+| `<vni>`         | aruba.evpn.vni     |
+| `<vrf>`         | aruba.vrf.id       |
+| `<vtep_ip>`     | aruba.evpn.vtep_ip |
 
 #### [External Storage events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/EXTERNAL-STORAGE.htm)
 | Doc Field   | Schema Mapping              |
@@ -1602,19 +1630,26 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.dhcp.server_ip_address |  | ip |
 | aruba.dhcp.source_mac |  | keyword |
 | aruba.dhcp.volume_name |  | keyword |
+| aruba.distributed.active_coordinates |  | keyword |
+| aruba.distributed.configured_coordinates |  | keyword |
 | aruba.dns.type |  | keyword |
 | aruba.dns.vrf_name |  | keyword |
+| aruba.dot1x.policy |  | keyword |
 | aruba.dpse.linecard_name |  | keyword |
+| aruba.dpse.operation_name |  | keyword |
+| aruba.dpse.plugin_name |  | keyword |
 | aruba.ecmp.egressid |  | keyword |
 | aruba.ecmp.err |  | keyword |
 | aruba.ecmp.route |  | keyword |
-| aruba.erps.port_name |  | keyword |
 | aruba.erps.ring_id |  | keyword |
 | aruba.error.count |  | long |
 | aruba.error.description |  | keyword |
 | aruba.event_type |  | keyword |
+| aruba.evpn.esi |  | keyword |
+| aruba.evpn.eth_tag |  | keyword |
 | aruba.evpn.rd |  | keyword |
 | aruba.evpn.rt |  | keyword |
+| aruba.evpn.rtt |  | keyword |
 | aruba.evpn.vni |  | keyword |
 | aruba.evpn.vtep_ip |  | ip |
 | aruba.fan.air_flow_direction |  | keyword |
@@ -2053,6 +2088,7 @@ The `log` dataset collects the HPE Aruba CX logs.
 | observer.ingress.interface.id | Interface ID as reported by an observer (typically SNMP interface ID). | keyword |
 | observer.ingress.interface.name | Interface name as reported by the system. | keyword |
 | package.installed | Time when package was installed. | date |
+| package.name | Package name | keyword |
 | package.version | Package version | keyword |
 | process.end | The time the process ended. | date |
 | process.name | Process name. Sometimes called program name or similar. | keyword |


### PR DESCRIPTION
## Parent Ticket
https://github.com/elastic/integrations/issues/12249


## Description
- updated CoPP Events (15xx) doc link
- updated DHCP Server events (19xx) doc link
- updated Credential Manager events (65xx) doc link
- updated Config Management events (68xx) doc link
- updated CPU_RX Events (75xx) doc link
- updated Certificate management events (77xx) doc link and added throttle parsing
- updated DHCPv4 Snooping events (82xx) doc link, added new messages 8217-8226
- updated DHCPv6 snooping events (83xx) dock link, added new messages 8314-8323
- updated Discovery and Capability Exchange (DCBx) events (92xx) doc link, refactored fields
- updated Connectivity Fault Management (CFM) events (1160x) doc link, refactored fields
- updated Container Manager Events (118xx) doc link, added messages 11804-11811
- added Device fingerprinting events (1240x)
- added Console events (1300x)
- added Config validator events (1340x)
- added Client insight events (143xx)
- updated ECMP Events (18xx) to 10.15
- updated ERPS Events (85xx) to 10.15 and refactored some fields
- updated EVPN Events (95xx) to 10.15 added new events 9521-9530
- updated DPSE Events (109xx) to 10.15, added one new event: 10906
- updated DNS Client Events (119xx) to 10.15
- updated UFD events (1200x) to 10.15, added one new event:  12002
- added Dot1x supplicant events (1230x)
- added Distributed services events (1390X)
- added Download events (145xx)
