### PR TITLE
akamai - fingerprint event.original instead of requestId

### DIFF
--- a/packages/akamai/changelog.yml
+++ b/packages/akamai/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.27.2"
+  changes:
+    - description: Events with the same requestId are now properly indexed. Previously, multiple records with the same requestId could conflict (and be dropped) due to variations in other fields like httpMessage.bytes or httpMessage.responseHeaders.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12393
 - version: "2.27.1"
   changes:
     - description: Fix pipeline error when converting an empty numerical field.

--- a/packages/akamai/data_stream/siem/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/akamai/data_stream/siem/elasticsearch/ingest_pipeline/default.yml
@@ -57,10 +57,22 @@ processors:
       copy_from: http.request.id
       ignore_empty_value: true
   - fingerprint:
+      description: >
+        Fingerprint the event.original value in attempt to prevent the same
+        event from being indexed more than once under connection failures or
+        other agent related issues.
+      if: ctx.event?.original != null
       fields:
-        - http.request.id
-      target_field: "_id"
-      ignore_missing: true
+        - event.original
+      target_field: _id
+  - set:
+      description: >
+        Prefix the _id with the start time because identifiers that generally
+        increase over time based on sorting order generally result in better
+        indexing performance than completely random identifiers.
+      if: ctx.json?.httpMessage?.start != null && ctx._id != null
+      field: _id
+      value: '{{{json.httpMessage.start}}}-{{{_id}}}'
   - rename:
       field: json.httpMessage.method
       target_field: http.request.method

--- a/packages/akamai/manifest.yml
+++ b/packages/akamai/manifest.yml
@@ -1,6 +1,6 @@
 name: akamai
 title: Akamai
-version: "2.27.1"
+version: "2.27.2"
 description: Collect logs from Akamai with Elastic Agent.
 type: integration
 format_version: "3.0.2"


### PR DESCRIPTION
## Proposed commit message

```
Fix the document _id calculation to allow events with the same requestId
to be indexed.

The httpMessage.requestId field in Akamai SIEM events is not unique to all
events based on observations of the data. It was observed that a given request
ID could have multiple records. Among three records with the same requestId,
one variant had httpMessage.bytes=0 and another had a different
httpMessage.responseHeaders with "Server: Akamai Image Server...".

I prefixed the document _id value with the timestamp based on recommendations
from the "Efficient Duplicate Prevention for Event-Based Data in Elasticsearch"
blog post.

References

- https://www.elastic.co/blog/efficient-duplicate-prevention-for-event-based-data-in-elasticsearch.
- https://github.com/akamai/akamai-apis/blob/b106ff167cb582efdaf4aa185c962ab33d3d6dee/apis/siem/v1/schemas/siem-event-200.yaml#L260-L263
```