### PR TITLE
M365 Defender: Make token endpoint configurable for Alert data stream

### DIFF
--- a/packages/m365_defender/changelog.yml
+++ b/packages/m365_defender/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "2.20.0"
   changes:
-    - description: Make token endpoint configurable for Alerts data stream.
+    - description: Make token endpoint configurable for Alert data stream.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/12401
 - version: "2.19.0"
   changes:
     - description: Add support for `IdentityInfo` advanced hunting table.

--- a/packages/m365_defender/changelog.yml
+++ b/packages/m365_defender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.20.0"
+  changes:
+    - description: Make token endpoint configurable for Alerts data stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "2.19.0"
   changes:
     - description: Add support for `IdentityInfo` advanced hunting table.

--- a/packages/m365_defender/data_stream/alert/agent/stream/httpjson.yml.hbs
+++ b/packages/m365_defender/data_stream/alert/agent/stream/httpjson.yml.hbs
@@ -6,7 +6,7 @@ request.tracer.maxbackups: 5
 {{/if}}
 auth.oauth2.client.id: {{client_id}}
 auth.oauth2.client.secret: {{client_secret}}
-auth.oauth2.token_url: {{login_url}}/{{tenant_id}}/oauth2/v2.0/token
+auth.oauth2.token_url: {{login_url}}/{{tenant_id}}/{{token_endpoint}}
 auth.oauth2.scopes: {{request_url}}/.default
 request.url: {{request_url}}/v1.0/security/alerts_v2
 {{#if http_client_timeout}}

--- a/packages/m365_defender/manifest.yml
+++ b/packages/m365_defender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: m365_defender
 title: Microsoft M365 Defender
-version: "2.19.0"
+version: "2.20.0"
 description: Collect logs from Microsoft M365 Defender with Elastic Agent.
 categories:
   - "security"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

See title.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

