### PR TITLE
[Kubernetes][Bug-Fix] Fix kubernetes.pod.cpu.usage.nanocores unit of measure

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix kubernetes.pod.cpu.usage.nanocores unit
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/12274
+      link: https://github.com/elastic/integrations/pull/12404
 - version: 1.70.0
   changes:
     - description: Make fingerprint configurable

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -2,7 +2,7 @@
 - version: 1.70.1
   changes:
     - description: Fix kubernetes.pod.cpu.usage.nanocores unit
-      type: enhancement
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/12404
 - version: 1.70.0
   changes:

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.70.1
+  changes:
+    - description: Fix kubernetes.pod.cpu.usage.nanocores unit
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12274
 - version: 1.70.0
   changes:
     - description: Make fingerprint configurable

--- a/packages/kubernetes/data_stream/pod/fields/fields.yml
+++ b/packages/kubernetes/data_stream/pod/fields/fields.yml
@@ -46,7 +46,6 @@
           fields:
             - name: nanocores
               type: long
-              unit: byte
               metric_type: gauge
               description: |
                 CPU used nanocores

--- a/packages/kubernetes/docs/kubelet.md
+++ b/packages/kubernetes/docs/kubelet.md
@@ -649,7 +649,7 @@ An example event for `pod` looks as following:
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
 | kubernetes.node.uid | Kubernetes node UID | keyword |  |  |
 | kubernetes.pod.cpu.usage.limit.pct | CPU usage as a percentage of the defined limit for the pod containers (or total node CPU if one or more containers of the pod are unlimited) | scaled_float | percent | gauge |
-| kubernetes.pod.cpu.usage.nanocores | CPU used nanocores | long | byte | gauge |
+| kubernetes.pod.cpu.usage.nanocores | CPU used nanocores | long |  | gauge |
 | kubernetes.pod.cpu.usage.node.pct | CPU usage as a percentage of the total node CPU | scaled_float | percent | gauge |
 | kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
 | kubernetes.pod.memory.available.bytes | Total memory available | long |  | gauge |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: kubernetes
 title: Kubernetes
-version: 1.70.0
+version: 1.70.1
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Fix kubernetes.pod.cpu.usage.nanocores unit of measure

Currently, the field kubernetes.pod.cpu.usage.nanocores uses bytes as its unit of measurement. In contrast, other similar fields, such as kubernetes.container.cpu.usage.nanocores, do not specify a unit of measurement.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist


## How to test this PR locally

Start collecting data with the K8S integration (the `kubernetes.pod` dataset is enough):

1. Upload the integration v 1.70.1
2. Perform a rollover
3. Verify that the mapping of the field does not contain the unit of measure

```
GET .ds-metrics-kubernetes.pod-default*/_mapping/kubernetes.pod.cpu.usage.nanocores
```

## Related issues

- Similar to: https://github.com/elastic/integrations/pull/9780 


## Screenshots

