### PR TITLE
[GCP VertexAI] Remove zone filter and fix regions

### DIFF
--- a/packages/gcp_vertexai/changelog.yml
+++ b/packages/gcp_vertexai/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove zone and fix default value in regions filter.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/12420
+      link: https://github.com/elastic/integrations/pull/12421
 - version: "0.3.0"
   changes:
     - description: Add support for regions and zone.

--- a/packages/gcp_vertexai/changelog.yml
+++ b/packages/gcp_vertexai/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Add support for regions and zone.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.3.0"
   changes:
     - description: Add support for regions and zone.

--- a/packages/gcp_vertexai/changelog.yml
+++ b/packages/gcp_vertexai/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "0.3.1"
   changes:
-    - description: Add support for regions and zone.
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+    - description: Remove zone and fix default value in regions filter.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12420
 - version: "0.3.0"
   changes:
     - description: Add support for regions and zone.

--- a/packages/gcp_vertexai/data_stream/metrics/agent/stream/stream.yml.hbs
+++ b/packages/gcp_vertexai/data_stream/metrics/agent/stream/stream.yml.hbs
@@ -7,9 +7,6 @@ credentials_file_path: {{credentials_file}}
 {{#if credentials_json}}
 credentials_json: '{{credentials_json}}'
 {{/if}}
-{{#if zone}}
-zone: {{zone}}
-{{/if}}
 {{#if regions}}
 regions:
 {{#each regions as |region i|}}

--- a/packages/gcp_vertexai/data_stream/metrics/manifest.yml
+++ b/packages/gcp_vertexai/data_stream/metrics/manifest.yml
@@ -17,13 +17,6 @@ streams:
         multi: false
         required: false
         show_user: true
-      - name: zone
-        type: text
-        title: GCP Zone
-        multi: false
-        required: false
-        show_user: true
-        default: us-central1-a
       - name: regions
         type: text
         title: GCP Regions
@@ -31,4 +24,5 @@ streams:
         multi: true
         required: false
         show_user: true
-        default: us-central1
+        default:
+          - us-central1

--- a/packages/gcp_vertexai/manifest.yml
+++ b/packages/gcp_vertexai/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.3
 name: gcp_vertexai
 title: "GCP Vertex AI"
-version: 0.3.0
+version: 0.3.1
 source:
   license: "Elastic-2.0"
 description: "Collect GCP Vertex AI metrics with Elastic Agent"


### PR DESCRIPTION
This PR removes the zone filter and fixes the regions filter default value.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<img width="1714" alt="Screenshot 2025-01-22 at 12 40 58 PM" src="https://github.com/user-attachments/assets/2851112b-07e9-4fe1-98a7-a5af025b80e8" />

<img width="1714" alt="Screenshot 2025-01-22 at 12 40 43 PM" src="https://github.com/user-attachments/assets/3a51132b-21d9-4627-a4d7-627b3852525f" />