### PR TITLE
[Azure Billing] Fix billing subscription scope in doc

### DIFF
--- a/packages/azure_billing/_dev/build/docs/README.md
+++ b/packages/azure_billing/_dev/build/docs/README.md
@@ -120,7 +120,7 @@ Take note of the following values, which you will use later when specifying sett
 * `Tenant ID`: use the "Tenant ID" from your Microsoft Entra ID.
 * `Subscription ID`: use the "Subscription Id" to access Azure APIs.
 
-* Only one of the following(Optional):
+* Only one of the following (Optional):
     * `Department ID`: use the "Department Id" content if you decide to collect metrics from a department.
     * `Billing account ID`: use the "Billing account ID" content if you decide to collect metrics from a billing account.
 

--- a/packages/azure_billing/_dev/build/docs/README.md
+++ b/packages/azure_billing/_dev/build/docs/README.md
@@ -118,10 +118,11 @@ To collect billing metrics from a billing account (instead of a subscription):
 Take note of the following values, which you will use later when specifying settings.
 
 * `Tenant ID`: use the "Tenant ID" from your Microsoft Entra ID.
-* Only one of the following:
-	* `Subscription ID`: use the "Subscription Id" content if you decide to collect metrics from a subscription.
-	* `Department Id`: use the "Department Id" content if you decide to collect metrics from a department.
-	* `Billing account ID`: use the "Billing account ID" content if you decide to collect metrics from a billing account.
+* `Subscription ID`: use the "Subscription Id" to access Azure APIs.
+
+* Only one of the following(Optional):
+    * `Department ID`: use the "Department Id" content if you decide to collect metrics from a department.
+    * `Billing account ID`: use the "Billing account ID" content if you decide to collect metrics from a billing account.
 
 Your App Registration is now ready for the Elastic Agent.
 
@@ -208,7 +209,7 @@ There are three supported scopes for this integration:
 * Department
 * Billing Account
 
-The integration uses the Subscription ID as the default scope for the billing data.
+>Note: The integration uses the Subscription ID as the default scope for the billing data.
 
 To change the scope, expand the data stream section named **Collect Azure Billing metrics** in the integration settings and set one of the two available options (if you set both, the billing account scope take precedence over the department):
 

--- a/packages/azure_billing/changelog.yml
+++ b/packages/azure_billing/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.7.4"
+  changes:
+    - description: Fix billing scope for subscription id in Readme.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.7.3"
   changes:
     - description: Update links to getting started docs

--- a/packages/azure_billing/changelog.yml
+++ b/packages/azure_billing/changelog.yml
@@ -1,6 +1,6 @@
 - version: "1.7.4"
   changes:
-    - description: Fix billing scope for subscription id in Readme.
+    - description: Fix billing scope for Subscription ID in Readme.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/12432
 - version: "1.7.3"

--- a/packages/azure_billing/changelog.yml
+++ b/packages/azure_billing/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Fix billing scope for subscription id in Readme.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/12432
 - version: "1.7.3"
   changes:
     - description: Update links to getting started docs

--- a/packages/azure_billing/changelog.yml
+++ b/packages/azure_billing/changelog.yml
@@ -1,6 +1,6 @@
 - version: "1.7.4"
   changes:
-    - description: Fix billing scope for Subscription ID in Readme.
+    - description: Fix billing scope for Subscription ID in documentation.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/12432
 - version: "1.7.3"

--- a/packages/azure_billing/docs/README.md
+++ b/packages/azure_billing/docs/README.md
@@ -120,7 +120,7 @@ Take note of the following values, which you will use later when specifying sett
 * `Tenant ID`: use the "Tenant ID" from your Microsoft Entra ID.
 * `Subscription ID`: use the "Subscription Id" to access Azure APIs.
 
-* Only one of the following(Optional):
+* Only one of the following (Optional):
     * `Department ID`: use the "Department Id" content if you decide to collect metrics from a department.
     * `Billing account ID`: use the "Billing account ID" content if you decide to collect metrics from a billing account.
 

--- a/packages/azure_billing/docs/README.md
+++ b/packages/azure_billing/docs/README.md
@@ -118,10 +118,11 @@ To collect billing metrics from a billing account (instead of a subscription):
 Take note of the following values, which you will use later when specifying settings.
 
 * `Tenant ID`: use the "Tenant ID" from your Microsoft Entra ID.
-* Only one of the following:
-	* `Subscription ID`: use the "Subscription Id" content if you decide to collect metrics from a subscription.
-	* `Department Id`: use the "Department Id" content if you decide to collect metrics from a department.
-	* `Billing account ID`: use the "Billing account ID" content if you decide to collect metrics from a billing account.
+* `Subscription ID`: use the "Subscription Id" to access Azure APIs.
+
+* Only one of the following(Optional):
+    * `Department ID`: use the "Department Id" content if you decide to collect metrics from a department.
+    * `Billing account ID`: use the "Billing account ID" content if you decide to collect metrics from a billing account.
 
 Your App Registration is now ready for the Elastic Agent.
 
@@ -208,7 +209,7 @@ There are three supported scopes for this integration:
 * Department
 * Billing Account
 
-The integration uses the Subscription ID as the default scope for the billing data.
+>Note: The integration uses the Subscription ID as the default scope for the billing data.
 
 To change the scope, expand the data stream section named **Collect Azure Billing metrics** in the integration settings and set one of the two available options (if you set both, the billing account scope take precedence over the department):
 

--- a/packages/azure_billing/manifest.yml
+++ b/packages/azure_billing/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_billing
 title: Azure Billing Metrics
-version: "1.7.3"
+version: "1.7.4"
 description: Collect billing metrics with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION

## Proposed commit message

This PR brings the subscription id from the either of the three billing scope. As the subscription id is default which is also used to establish API connection.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

- Verify the README for scope changes.
