### PR TITLE
Missing vulnerability management category

### DIFF
--- a/packages/tenable_io/changelog.yml
+++ b/packages/tenable_io/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.6.1"
+  changes:
+    - description: Add "vulnerability_management" category.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12438
 - version: "3.6.0"
   changes:
     - description: Include `serial_number` field for Asset events.

--- a/packages/tenable_io/manifest.yml
+++ b/packages/tenable_io/manifest.yml
@@ -1,11 +1,12 @@
 format_version: "3.0.2"
 name: tenable_io
 title: Tenable Vulnerability Management
-version: "3.6.0"
+version: "3.6.1"
 description: Collect logs from Tenable Vulnerability Management with Elastic Agent.
 type: integration
 categories:
   - security
+  - vulnerability_management
 conditions:
   kibana:
     version: "^8.13.0"

--- a/packages/tenable_sc/changelog.yml
+++ b/packages/tenable_sc/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.28.1"
+  changes:
+    - description: Add "vulnerability_management" category.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12438
 - version: "1.28.0"
   changes:
     - description: Update lastSeen parameter format in vulnerablity data-stream.

--- a/packages/tenable_sc/manifest.yml
+++ b/packages/tenable_sc/manifest.yml
@@ -2,12 +2,13 @@ format_version: "3.0.2"
 name: tenable_sc
 title: Tenable Security Center
 # The version must be updated in the input configuration templates as well, in order to set the correct User-Agent header. Until elastic/kibana#121310 is implemented we will have to manually sync these.
-version: "1.28.0"
+version: "1.28.1"
 description: |
   Collect data from Tenable Security Center with Elastic Agent.
 type: integration
 categories:
   - security
+  - vulnerability_management
 conditions:
   kibana:
     version: "^8.13.0"


### PR DESCRIPTION
The Tenable Vulnerability Management and Security Center integrations are not being presented when a user selects the Vulnerability Management category within the Security section of integrations, it is a very simple fix adding the below to the categories section:

`  - vulnerability_management`

This would help new users find this integration easier when browsing via categories