### PR TITLE
Apache Tomcat made the HTTP in the log optional

### DIFF
--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.8.3"
   changes:
-    - description: Making HTTP version optional
+    - description: Make http.version field optional.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/12443
 - version: "1.8.2"

--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Making HTTP version optional
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/12145
+      link: https://github.com/elastic/integrations/pull/12443
 - version: "1.8.2"
   changes:
     - description: Update links to getting started docs

--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.3"
+  changes:
+    - description: Making HTTP version optional
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12145
 - version: "1.8.2"
   changes:
     - description: Update links to getting started docs

--- a/packages/apache_tomcat/data_stream/access/_dev/test/pipeline/test-access.log
+++ b/packages/apache_tomcat/data_stream/access/_dev/test/pipeline/test-access.log
@@ -8,3 +8,4 @@
 81.2.69.144 - admin [02/Mar/2023:19:01:17 +0530] "GET /manager/status HTTP/1.1" 200 4654 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36
 81.2.69.144 - admin [02/Mar/2023:19:02:25 +0530] "GET / HTTP/1.1" 200 11235
 81.2.69.144 - - [24/Oct/2024:14:18:49 +1100] "-" 400 - 81.2.69.145 + 0.000 "-" "-" X-Forwarded-For="-"
+10.10.10.10 - - [28/May/2024:17:20:05 +0200] "GET / " 200 17

--- a/packages/apache_tomcat/data_stream/access/_dev/test/pipeline/test-access.log-expected.json
+++ b/packages/apache_tomcat/data_stream/access/_dev/test/pipeline/test-access.log-expected.json
@@ -652,15 +652,15 @@
             "@timestamp": "2024-10-24T03:18:49.000Z",
             "apache_tomcat": {
                 "access": {
+                    "connection_status": "+",
                     "http": {
-                        "useragent": "-",
-                        "ident": "-"
+                        "ident": "-",
+                        "useragent": "-"
                     },
-                    "response_time": 0,
                     "ip": {
                         "local": "81.2.69.145"
                     },
-                    "connection_status": "+"
+                    "response_time": 0.0
                 }
             },
             "ecs": {
@@ -670,18 +670,12 @@
                 "category": [
                     "web"
                 ],
-                "type": [
-                    "access"
-                ],
                 "kind": "event",
                 "module": "apache_tomcat",
                 "original": "81.2.69.144 - - [24/Oct/2024:14:18:49 +1100] \"-\" 400 - 81.2.69.145 + 0.000 \"-\" \"-\" X-Forwarded-For=\"-\"",
-                "outcome": "failure"
-            },
-            "related": {
-                "ip": [
-                    "81.2.69.144",
-                    "81.2.69.145"
+                "outcome": "failure",
+                "type": [
+                    "access"
                 ]
             },
             "http": {
@@ -692,6 +686,12 @@
                     "status_code": 400
                 }
             },
+            "related": {
+                "ip": [
+                    "81.2.69.144",
+                    "81.2.69.145"
+                ]
+            },
             "source": {
                 "ip": "81.2.69.144"
             },
@@ -701,6 +701,51 @@
             "user_agent": {
                 "original": "-"
             }
+        },
+        {
+            "@timestamp": "2024-05-28T15:20:05.000Z",
+            "apache_tomcat": {
+                "access": {
+                    "http": {
+                        "ident": "-",
+                        "useragent": "-"
+                    }
+                }
+            },
+            "destination": {
+                "bytes": 17
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "web"
+                ],
+                "kind": "event",
+                "module": "apache_tomcat",
+                "original": "10.10.10.10 - - [28/May/2024:17:20:05 +0200] \"GET / \" 200 17",
+                "outcome": "success",
+                "type": [
+                    "access"
+                ]
+            },
+            "http": {
+                "response": {
+                    "status_code": 200
+                }
+            },
+            "related": {
+                "ip": [
+                    "10.10.10.10"
+                ]
+            },
+            "source": {
+                "ip": "10.10.10.10"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -32,7 +32,7 @@ processors:
   - dissect:
       field: _tmp.dissect_request
       pattern: '%{http.request.method} %{url.original} HTTP/%{http.version}'
-      if: ctx._tmp.dissect_request != '-'
+      if: ctx._tmp?.dissect_request != null && ctx._tmp.dissect_request != '-' && ctx._tmp.dissect_request.contains('HTTP/')
       on_failure:
         - append:
             field: error.message

--- a/packages/apache_tomcat/manifest.yml
+++ b/packages/apache_tomcat/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: apache_tomcat
 title: Apache Tomcat
-version: "1.8.2"
+version: "1.8.3"
 description: Collect and parse logs and metrics from Apache Tomcat servers with Elastic Agent.
 categories: ["web", "observability"]
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

made the `HTTP version` inside the tomcat log optional.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) ~~

## Related issues

- Closes https://github.com/elastic/integrations/issues/10450