### PR TITLE
Adding escape_string helper to ensure connector_name field is escaped properly

### DIFF
--- a/packages/elastic_connectors/agent/input/amazon_s3.yml.hbs
+++ b/packages/elastic_connectors/agent/input/amazon_s3.yml.hbs
@@ -3,5 +3,5 @@ service_type: s3
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/azure_blob_storage.yml.hbs
+++ b/packages/elastic_connectors/agent/input/azure_blob_storage.yml.hbs
@@ -3,5 +3,5 @@ service_type: azure_blob_storage
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/box.yml.hbs
+++ b/packages/elastic_connectors/agent/input/box.yml.hbs
@@ -3,5 +3,5 @@ service_type: box
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/confluence.yml.hbs
+++ b/packages/elastic_connectors/agent/input/confluence.yml.hbs
@@ -3,5 +3,5 @@ service_type: confluence
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/dropbox.yml.hbs
+++ b/packages/elastic_connectors/agent/input/dropbox.yml.hbs
@@ -3,5 +3,5 @@ service_type: dropbox
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/github.yml.hbs
+++ b/packages/elastic_connectors/agent/input/github.yml.hbs
@@ -3,5 +3,5 @@ service_type: github
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/gmail.yml.hbs
+++ b/packages/elastic_connectors/agent/input/gmail.yml.hbs
@@ -3,5 +3,5 @@ service_type: gmail
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/google_cloud_storage.yml.hbs
+++ b/packages/elastic_connectors/agent/input/google_cloud_storage.yml.hbs
@@ -3,5 +3,5 @@ service_type: google_cloud_storage
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/google_drive.yml.hbs
+++ b/packages/elastic_connectors/agent/input/google_drive.yml.hbs
@@ -3,5 +3,5 @@ service_type: google_drive
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/jira.yml.hbs
+++ b/packages/elastic_connectors/agent/input/jira.yml.hbs
@@ -3,5 +3,5 @@ service_type: jira
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/microsoft_sql.yml.hbs
+++ b/packages/elastic_connectors/agent/input/microsoft_sql.yml.hbs
@@ -3,5 +3,5 @@ service_type: mssql
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/mongodb.yml.hbs
+++ b/packages/elastic_connectors/agent/input/mongodb.yml.hbs
@@ -3,5 +3,5 @@ service_type: mongodb
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/mysql.yml.hbs
+++ b/packages/elastic_connectors/agent/input/mysql.yml.hbs
@@ -3,5 +3,5 @@ service_type: mysql
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/network_drive.yml.hbs
+++ b/packages/elastic_connectors/agent/input/network_drive.yml.hbs
@@ -3,5 +3,5 @@ service_type: network_drive
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/notion.yml.hbs
+++ b/packages/elastic_connectors/agent/input/notion.yml.hbs
@@ -3,5 +3,5 @@ service_type: notion
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/onedrive.yml.hbs
+++ b/packages/elastic_connectors/agent/input/onedrive.yml.hbs
@@ -3,5 +3,5 @@ service_type: onedrive
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/oracle.yml.hbs
+++ b/packages/elastic_connectors/agent/input/oracle.yml.hbs
@@ -3,5 +3,5 @@ service_type: oracle
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/outlook.yml.hbs
+++ b/packages/elastic_connectors/agent/input/outlook.yml.hbs
@@ -3,5 +3,5 @@ service_type: outlook
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/postgresql.yml.hbs
+++ b/packages/elastic_connectors/agent/input/postgresql.yml.hbs
@@ -3,5 +3,5 @@ service_type: postgresql
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/salesforce.yml.hbs
+++ b/packages/elastic_connectors/agent/input/salesforce.yml.hbs
@@ -3,5 +3,5 @@ service_type: salesforce
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/servicenow.yml.hbs
+++ b/packages/elastic_connectors/agent/input/servicenow.yml.hbs
@@ -3,5 +3,5 @@ service_type: servicenow
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/sharepoint_online.yml.hbs
+++ b/packages/elastic_connectors/agent/input/sharepoint_online.yml.hbs
@@ -3,5 +3,5 @@ service_type: sharepoint_online
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/sharepoint_server.yml.hbs
+++ b/packages/elastic_connectors/agent/input/sharepoint_server.yml.hbs
@@ -3,5 +3,5 @@ service_type: sharepoint_server
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/slack.yml.hbs
+++ b/packages/elastic_connectors/agent/input/slack.yml.hbs
@@ -3,5 +3,5 @@ service_type: slack
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/teams.yml.hbs
+++ b/packages/elastic_connectors/agent/input/teams.yml.hbs
@@ -3,5 +3,5 @@ service_type: microsoft_teams
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/agent/input/zoom.yml.hbs
+++ b/packages/elastic_connectors/agent/input/zoom.yml.hbs
@@ -3,5 +3,5 @@ service_type: zoom
 connector_id: {{connector_id}}
 {{/if}}
 {{#if connector_name}}
-connector_name: {{connector_name}}
+connector_name: {{escape_string connector_name}}
 {{/if}}

--- a/packages/elastic_connectors/changelog.yml
+++ b/packages/elastic_connectors/changelog.yml
@@ -2,7 +2,7 @@
 - version: 1.0.1
   changes:
     - description: Add escape_string halper to connector_name field
-      type: bug
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/12444
 - version: 1.0.0
   changes:

--- a/packages/elastic_connectors/changelog.yml
+++ b/packages/elastic_connectors/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.0.1
+  changes:
+    - description: Add escape_string halper to connector_name field
+      type: bug
+      link: https://github.com/elastic/integrations/pull/12444
 - version: 1.0.0
   changes:
     - description: Remove links to all connectors in README

--- a/packages/elastic_connectors/manifest.yml
+++ b/packages/elastic_connectors/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.1
 name: elastic_connectors
 title: "Elastic Connectors"
-version: 1.0.0
+version: 1.0.1
 source:
   license: "Elastic-2.0"
 description: "Sync data from source to the Elasticsearch index."


### PR DESCRIPTION
## Proposed commit message
This PR adds the escape_string helper to the connector_name field under elastic_connectors to ensure that the field is escaped correctly.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally
1. Create an agentless cloud deployment with image override for connectors, see these instructions on uploading the built package to Kibana: https://github.com/elastic/search-team/issues/8918#issuecomment-2554307174
2. Create an integration for Github from Integrations page entering a name into it that will not be a valid string in yaml, if not escaped - for example [Elastic-managed] github connector qlnF
3. Agentless connector should be deployed successfully

(To reproduce this error on an existing 9.0 agentless cloud deployment with image override for connectors, simply perform the above steps and watch the connector fail to deploy - see the Related Issues for more details)

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
https://github.com/elastic/search-team/issues/9158
