### PR TITLE
[microsoft_exchange_online_message_trace] Remove event.start/end

### DIFF
--- a/packages/microsoft_exchange_online_message_trace/changelog.yml
+++ b/packages/microsoft_exchange_online_message_trace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.25.3"
+  changes:
+    - description: Remove incorrect use of `event.start`, `event.end`.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12446
 - version: "1.25.2"
   changes:
     - description: Fix handling of SenderAddress where the value is '<>'.

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
@@ -58,10 +58,8 @@
                 "category": [
                     "email"
                 ],
-                "end": "2022-09-05T21:46:46.420Z",
                 "original": "{\"EndDate\":\"2022-09-05T21:46:46.4206759Z\",\"FromIP\":\"81.2.69.144\",\"Index\":0,\"MessageId\":\"\\u003ca210cf91-4f2e-484c-8ada-3b27064ee5e3@az.uksouth.production.microsoft.com\\u003e\",\"MessageTraceId\":\"cf7a249a-5edd-4350-130a-08da8f69e0f6\",\"Organization\":\"contoso.com\",\"Received\":\"2022-09-05T18:10:13.4907658\",\"RecipientAddress\":\"linus@contoso.com\",\"SenderAddress\":\"azure-noreply@azure.microsoft.com\",\"Size\":87891,\"StartDate\":\"2022-09-03T21:46:46.4206759Z\",\"Status\":\"Delivered\",\"Subject\":\"PIM: A privileged directory role was assigned outside of PIM\",\"ToIP\":\"216.160.83.56\"}",
                 "outcome": "success",
-                "start": "2022-09-03T21:46:46.420Z",
                 "type": [
                     "info"
                 ]
@@ -168,10 +166,8 @@
                 "category": [
                     "email"
                 ],
-                "end": "2022-10-22T09:40:10.000Z",
                 "original": "{\"Organization\":\"contoso.com\",\"MessageId\":\"\\u003cGVAP278MB037518E76F4082DFE9B607B3DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM\\u003e\",\"Received\":\"2022-10-21T17:25:30.6006882Z\",\"SenderAddress\":\"noreply@azure.microsoft.com\",\"RecipientAddress\":\"linus@contoso.com\",\"Subject\":\"testmail 1\",\"Status\":\"Delivered\",\"ToIP\":null,\"FromIP\":\"81.2.69.144\",\"Size\":22704,\"MessageTraceId\":\"a6f62809-5cda-4454-0962-08dab38940d6\",\"StartDate\":\"2022-10-21T09:40:10Z\",\"EndDate\":\"2022-10-22T09:40:10Z\",\"Index\":1}",
                 "outcome": "success",
-                "start": "2022-10-21T09:40:10.000Z",
                 "type": [
                     "info"
                 ]
@@ -277,10 +273,8 @@
                 "category": [
                     "email"
                 ],
-                "end": "2022-10-22T09:40:10.000Z",
                 "original": "{\"Organization\":\"contoso.com\",\"MessageId\":\"\\u003cGVAP278MB037586A65EF1FB2F844B0258DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM\\u003e\",\"Received\":\"2022-10-21T17:25:36.969376Z\",\"SenderAddress\":\"noreply@azure.microsoft.com\",\"RecipientAddress\":\"linus@contoso.com\",\"Subject\":\"testmail 2\",\"Status\":\"Delivered\",\"ToIP\":null,\"FromIP\":\"81.2.69.144\",\"Size\":22761,\"MessageTraceId\":\"a5e6dc0f-23df-4b20-d240-08dab38944a1\",\"StartDate\":\"2022-10-21T09:40:10Z\",\"EndDate\":\"2022-10-22T09:40:10Z\",\"Index\":0}",
                 "outcome": "success",
-                "start": "2022-10-21T09:40:10.000Z",
                 "type": [
                     "info"
                 ]
@@ -386,10 +380,8 @@
                 "category": [
                     "email"
                 ],
-                "end": "2022-10-22T09:40:10.000Z",
                 "original": "{\"Organization\":\"contoso.com\",\"MessageId\":\"\\u003cGVAP278MB037586A65EF1FB2F844B0258DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM\\u003e\",\"Received\":\"2022-10-21T17:25:36.969376Z\",\"SenderAddress\":\"noreply@contoso.com\",\"RecipientAddress\":\"linus@contoso.com\",\"Subject\":\"testmail 2\",\"Status\":\"Delivered\",\"ToIP\":null,\"FromIP\":\"81.2.69.144\",\"Size\":22761,\"MessageTraceId\":\"a5e6dc0f-23df-4b20-d240-08dab38944a1\",\"StartDate\":\"2022-10-21T09:40:10Z\",\"EndDate\":\"2022-10-22T09:40:10Z\",\"Index\":0}",
                 "outcome": "success",
-                "start": "2022-10-21T09:40:10.000Z",
                 "type": [
                     "info"
                 ]
@@ -498,10 +490,8 @@
                 "category": [
                     "email"
                 ],
-                "end": "2025-01-09T20:37:51.000Z",
                 "original": "{\"EndDate\":\"2025-01-09T20:37:51Z\",\"FromIP\":null,\"Index\":52,\"MessageId\":\"<J.P@foo-7-v>\",\"MessageTraceId\":\"2405b572-b741-49b3-a189-00c01bf8bdec\",\"Organization\":\"example.com\",\"Received\":\"2025-01-09T20:36:20.4601289\",\"RecipientAddress\":\"foo@example.com\",\"SenderAddress\":\"<>\",\"Size\":0,\"StartDate\":\"2025-01-08T18:53:13Z\",\"Status\":\"Delivered\",\"Subject\":null,\"ToIP\":null}",
                 "outcome": "success",
-                "start": "2025-01-08T18:53:13.000Z",
                 "type": [
                     "info"
                 ]

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -105,20 +105,6 @@ processors:
       formats:
         - "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSZ"
         - "ISO8601"
-  - date:
-      if: "ctx.microsoft?.online_message_trace?.StartDate != null"
-      field: "microsoft.online_message_trace.StartDate"
-      target_field: "event.start"
-      formats:
-        - "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSZ"
-        - "ISO8601"
-  - date:
-      if: "ctx.microsoft?.online_message_trace?.EndDate != null"
-      field: "microsoft.online_message_trace.EndDate"
-      target_field: "event.end"
-      formats:
-        - "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSZ"
-        - "ISO8601"
   # IP Geolocation Lookup
   - geoip:
       field: source.ip

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/sample_event.json
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/sample_event.json
@@ -59,11 +59,9 @@
         ],
         "created": "2024-11-04T20:39:54.654Z",
         "dataset": "microsoft_exchange_online_message_trace.log",
-        "end": "2022-10-22T09:40:10.000Z",
         "ingested": "2024-11-04T20:39:57Z",
         "original": "{\"EndDate\":\"2022-10-22T09:40:10Z\",\"FromIP\":\"40.107.23.81\",\"Index\":1,\"MessageId\":\"\\u003cGVAP278MB037518E76F4082DFE9B607B3DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM\\u003e\",\"MessageTraceId\":\"a6f62809-5cda-4454-0962-08dab38940d6\",\"Organization\":\"contoso.com\",\"Received\":\"2022-10-21T17:25:30.6006882Z\",\"RecipientAddress\":\"linus@contoso.com\",\"SenderAddress\":\"noreply@azure.microsoft.com\",\"Size\":22704,\"StartDate\":\"2022-10-21T09:40:10Z\",\"Status\":\"Delivered\",\"Subject\":\"testmail 1\",\"ToIP\":null}",
         "outcome": "success",
-        "start": "2022-10-21T09:40:10.000Z",
         "type": [
             "info"
         ]

--- a/packages/microsoft_exchange_online_message_trace/docs/README.md
+++ b/packages/microsoft_exchange_online_message_trace/docs/README.md
@@ -203,11 +203,9 @@ An example event for `log` looks as following:
         ],
         "created": "2024-11-04T20:39:54.654Z",
         "dataset": "microsoft_exchange_online_message_trace.log",
-        "end": "2022-10-22T09:40:10.000Z",
         "ingested": "2024-11-04T20:39:57Z",
         "original": "{\"EndDate\":\"2022-10-22T09:40:10Z\",\"FromIP\":\"40.107.23.81\",\"Index\":1,\"MessageId\":\"\\u003cGVAP278MB037518E76F4082DFE9B607B3DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM\\u003e\",\"MessageTraceId\":\"a6f62809-5cda-4454-0962-08dab38940d6\",\"Organization\":\"contoso.com\",\"Received\":\"2022-10-21T17:25:30.6006882Z\",\"RecipientAddress\":\"linus@contoso.com\",\"SenderAddress\":\"noreply@azure.microsoft.com\",\"Size\":22704,\"StartDate\":\"2022-10-21T09:40:10Z\",\"Status\":\"Delivered\",\"Subject\":\"testmail 1\",\"ToIP\":null}",
         "outcome": "success",
-        "start": "2022-10-21T09:40:10.000Z",
         "type": [
             "info"
         ]

--- a/packages/microsoft_exchange_online_message_trace/manifest.yml
+++ b/packages/microsoft_exchange_online_message_trace/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: microsoft_exchange_online_message_trace
 title: "Microsoft Exchange Online Message Trace"
-version: "1.25.2"
+version: "1.25.3"
 description: "Microsoft Exchange Online Message Trace Integration"
 type: integration
 categories:

--- a/packages/microsoft_exchange_online_message_trace/manifest.yml
+++ b/packages/microsoft_exchange_online_message_trace/manifest.yml
@@ -147,7 +147,7 @@ policy_templates:
           - name: additional_look_back
             type: text
             title: Additional Look-back Time
-            description: Adds time to the interval to prevent missed events. Supported units for this parameter are h/m/s.
+            description: Adds time to the interval to prevent missed events. Up to 24h may be required. Supported units for this parameter are h/m/s.
             default: 1h
             multi: false
             required: true


### PR DESCRIPTION
## Proposed commit message

```
[microsoft_exchange_online_message_trace] Remove event.start/end

Don't set `event.start` and `event.end` to `StartDate` and `EndDate`,
because those are query parameters, not properties of the event itself.

Also, extend the description of the `additional_look_back` setting to
note that up to 24h may be necessary (according to the API
documentation[1]).

[1]: https://learn.microsoft.com/en-us/previous-versions/office/developer/o365-enterprise-developers/jj984335%28v%3doffice.15%29
```

## Discussion

Elsewhere I suggested standard solutions for pagination when there is:
1. a delay between data creation and data availability, and/or
2. an unstable a period after initial creation of the data.

<details>

![image](https://github.com/user-attachments/assets/54d67dc5-6fff-4b49-aada-5549b9c238fa)

</details>

I suggested switching from the look-back strategy (introduced in https://github.com/elastic/integrations/pull/8717) to the standard solutions, in order to reduce fetching of the same data multiple times (and reduce indexing failures due to duplicate `_id` values).

However, the standard solution for delayed data availability isn't possible, because there is no creation or update time associated with the log entries we receive. `StartDate` and `EndDate` are query parameters. In the [API documentation](https://learn.microsoft.com/en-us/previous-versions/office/developer/o365-enterprise-developers/jj984335%28v%3doffice.15%29) these fields are marked "[In]" rather than "[In/Out]" (input parameters and report output columns). We just see them echoed back in the response.

This PR cleans up incorrect population of ECS fields with `StartDate` and `EndDate`.

Shall we drop `microsoft.online_message_trace.StartDate` and `microsoft.online_message_trace.EndDate` as well?

The standard solution for an unstable period is complicated by the fact that this period can be quite long. In https://github.com/elastic/integrations/pull/8717 it was reported to usually be less than an hour, but some users on the Internet report delays of multiple hours and the API documentation says up to 24 hours.

So, regarding pagination and duplicate `_id` values, the choice is between:

* a long (up to 24h) delay for all data (by only fetching data once it's known to be there), or
* indexing rejections due to duplicate `_id` values (using the look-back strategy).

In this case I think the look-back strategy is not a bad one.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Relates #11911