### PR TITLE
#12249-6 Driving to OS 10.15 part 6

### DIFF
--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -804,22 +804,13 @@ Note: Descriptions have not been filled out
 | `<txportName>` | aruba.loop.tx_port     |
 | `<vlan>`       | network.vlan.id        |
 
-#### [Loopback events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LOOPBACK.htm)
+#### [Loopback events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/LOOPBACK.htm)
 | Docs Field    | Schema Mapping        |
 |---------------|-----------------------|
 | `<interface>` | aruba.interface.id    |
 | `<state>`     | aruba.state           |
 
-
-#### [MAC Address mode configuration events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3_MAC_ADDRESS_CONFIGURATION.htm)
-| Docs Field   | Schema Mapping       |
-|--------------|----------------------|
-| `<mac>`      | server.mac           |
-| `<new_mode>` | aruba.mac.new_mode   |
-| `<old_mode>` | aruba.mac.old_mode   |
-| `<vlan>`     | network.vlan.id      |
-
-#### [MAC Learning events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MAC-LEARN.htm)
+#### [MAC address management events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MAC-MGMT.htm)
 | Docs Field    | Schema Mapping               |
 |---------------|------------------------------|
 | `<from-intf>` | aruba.interface.prev_id      |
@@ -828,40 +819,67 @@ Note: Descriptions have not been filled out
 | `<to-intf>`   | aruba.mac.interface.id       |
 | `<vlan>`      | network.vlan.id              |
 
-#### [MACsec events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MACSEC.htm)
+#### [MAC Address mode configuration events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/L3_MAC_ADDRESS_CONFIGURATION.htm)
+| Docs Field  | Schema Mapping           |
+|-------------|--------------------------|
+| `<current>` | aruba.limit.read_value   |
+| `<mac>`     | server.mac               |
+| `<max>`     | aruba.limit.threshold    |
+| `<new_mode>`| aruba.mac.new_mode       |
+| `<old_mode>`| aruba.mac.old_mode       |
+| `<vlan>`    | network.vlan.id          |
+
+#### Deprecated for "MAC address management events" in 10.15
+#### [MAC Learning events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MAC-LEARN.htm)
+| Docs Field    | Schema Mapping               |
+|---------------|------------------------------|
+| `<from-intf>` | aruba.interface.prev_id      |
+| `<intf>`      | aruba.interface.id           |
+| `<mac>`       | server.mac                   |
+| `<to-intf>`   | aruba.mac.interface.id       |
+| `<vlan>`      | network.vlan.id              |
+
+#### [MACsec events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MACSEC.htm)
 | Docs Field     | Schema Mapping               |
 |----------------|------------------------------|
 | `<ckn>`        | aruba.mac.ckn                |
+| `<feature>`    | aruba.mac.feature            |
 | `<ifname>`     | aruba.interface.name         |
+| `<ifname>`     | aruba.instance.id            |
 | `<latest_an>`  | aruba.mac.latest_an          |
 | `<latest_kn>`  | aruba.mac.latest_kn          |
+| `<name>`       | aruba.port                   |
 | `<old_an>`     | aruba.mac.old_an             |
 | `<old_kn>`     | aruba.mac.old_kn             |
+| `<reason>`     | event.reason                 |
 | `<sci>`        | aruba.mac.sci                |
 
-#### [Management events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MGMT.htm)
+#### [Management events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MGMT.htm)
 | Docs Field                    | Schema Mapping           |
 |-------------------------------|--------------------------|
 | `<mgmt_intf_config_crit>`     | aruba.mgmt.config_crit   |
 | `<mgmt_intf_config_err>`      | aruba.mgmt.config_err    |
 | `<mgmt_intf_config_param>`    | aruba.mgmt.config_param  |
 
-#### [MDNS events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MDNS.htm)
+#### [MDNS events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MDNS.htm)
 | Docs Field                  | Schema Mapping           |
 |-----------------------------|--------------------------|
 
 
-#### [MGMD events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MGMD.htm)
+#### [MGMD events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MGMD.htm)
 | Docs Field    | Schema Mapping              |
 |---------------|-----------------------------|
+| `<acl_name>`  | aruba.acl.name              |
 | `<if_name>`   | aruba.interface.name        |
 | `<ip_address>`| client.ip                   |
 | `<l3Port>`    | aruba.mgmd.l3_port          |
 | `<mgmd_type>` | aruba.mgmd.mgmd_type        |
 | `<pkt_type>`  | aruba.mgmd.pkt_type         |
 | `<port>`      | aruba.port                  |
+| `<port_name>` | aruba.port                  |
 | `<port0>`     | aruba.port                  |
 | `<port1>`     | aruba.mgmd.port1            |
+| `<protocol>`  | aruba.mgmd.protocol         |
 | `<ring_id>`   | aruba.mgmd.ring_id          |
 | `<size_value>`| aruba.len                   |
 | `<state>`     | aruba.state                 |
@@ -870,19 +888,27 @@ Note: Descriptions have not been filled out
 | `<type>`      | aruba.mgmd.type             |
 | `<vlan>`      | network.vlan.id             |
 
-#### [Mirroring events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MIRRORING.htm)
+#### [Mirroring events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MIRRORING.htm)
 | Docs Field   | Schema Mapping       |
 |--------------|----------------------|
 | `<number>`   | aruba.session.id     |
 
-#### [Module events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MODULE.htm)
+#### [Module events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MODULE.htm)
 | Docs Field      | Schema Mapping         |
 |-----------------|------------------------|
 | `<name>`        | aruba.module.name      |
+| `<new_part>`    | aruba.module.new_part  |
+| `<old_part>`    | aruba.module.old_part  |
 | `<part_number>` | aruba.unit             |
 | `<priority>`    | aruba.priority         |
 | `<reason>`      | event.reason           |
 | `<type>`        | aruba.module.type      |
+
+#### [MPLS events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MPLS.htm)
+| Docs Field      | Schema Mapping          |
+|-----------------|-------------------------|
+| `<local_ldp_id>`| aruba.mpls.local_ldp_id |
+| `<peer_ldp_id>` | aruba.mpls.peer_ldp_id  |
 
 #### [MSDP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MSDP.htm)
 | Docs Field    | Schema Mapping               |

--- a/packages/hpe_aruba_cx/_dev/build/docs/README.md
+++ b/packages/hpe_aruba_cx/_dev/build/docs/README.md
@@ -845,7 +845,7 @@ Note: Descriptions have not been filled out
 | `<ckn>`        | aruba.mac.ckn                |
 | `<feature>`    | aruba.mac.feature            |
 | `<ifname>`     | aruba.interface.name         |
-| `<ifname>`     | aruba.instance.id            |
+| `<id>`         | aruba.instance.id            |
 | `<latest_an>`  | aruba.mac.latest_an          |
 | `<latest_kn>`  | aruba.mac.latest_kn          |
 | `<name>`       | aruba.port                   |

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log
@@ -329,6 +329,12 @@
 2024-06-18T13:04:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2620|LOG_INFO|MGMD|-|Received MLDV1 query from 192.168.1.1 when the device is configured for MLDV2.
 2024-06-18T13:05:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2621|LOG_INFO|MGMD|-|Received MLDV2 query from 192.168.1.1 when the device is configured for MLDV1.
 2024-06-18T13:06:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2622|LOG_INFO|MGMD|-|Flood mode is temporarily activated on ERPS ports eth0 and eth1 as ring state for ring id 1 changed to idle.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2623|LOG_INFO|MGMD|-|Remote IDL connection established.
+2024-06-18T12:46:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2624|LOG_INFO|MGMD|-|Querier functionality offloaded to VSX peer.
+2024-06-18T12:47:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2625|LOG_INFO|MGMD|-|IGMPv2 packet received for group address 239.255.255.250 in SSM range which is not part of SSM map.
+2024-06-18T12:48:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2626|LOG_INFO|MGMD|-|MLDv1 packet received for group address ff02::1 in SSM range which is not part of SSM map.
+2024-06-18T12:49:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2627|LOG_INFO|MGMD|-|SSM-map example_acl applied to IGMP interface eth0
+2024-06-18T12:50:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2628|LOG_ERR|MGMD|-|IGMP/MLD internal queue limit exceeded. Needs admin intervention.
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-replication[1234]: Event|2701|LOG_WARN|REPLICATIONMGR|-|All bitmaps have been allocated
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-replication[1234]: Event|2702|LOG_WARN|REPLICATIONMGR|-|Over 80 percent of bitmaps have been allocated
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-replication[1234]: Event|2705|LOG_WARN|REPLICATIONMGR|-|Multicast L3 Bridge Control Forwarding entry with uuid 123e4567-e89b-12d3-a456-426614174000 has no reference to a VLAN
@@ -437,6 +443,12 @@
 2024-06-18T13:02:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3238|LOG_INFO|Module|-|Ethernet module eth0 enabling front-end power
 2024-06-18T13:03:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3239|LOG_WARN|Module|-|Ethernet module eth0 disabling front-end power: power failure
 2024-06-18T13:04:38.182641-05:00 8360-Primaire hpe-module[1234]: Event|3240|LOG_ERR|Module|-|Ethernet module eth0 has persistent hardware error
+2024-06-18T12:45:38.182641-05:00 8360-Primaire module[1234]: Event|3241|LOG_INFO|Module|-|ExampleModule is starting zeroization and setting enhanced secure mode
+2024-06-18T12:46:38.182641-05:00 8360-Primaire module[1234]: Event|3242|LOG_INFO|Module|-|ExampleModule zeroization completed and enhanced secure mode set.
+2024-06-18T12:47:38.182641-05:00 8360-Primaire module[1234]: Event|3243|LOG_ERR|Module|-|ExampleModule zeroization failed.
+2024-06-18T12:48:38.182641-05:00 8360-Primaire module[1234]: Event|3244|LOG_INFO|Module|-|ExampleModule Front-panel factory-reset is now enabled
+2024-06-18T12:49:38.182641-05:00 8360-Primaire module[1234]: Event|3245|LOG_ERR|Module|-|ExampleModule Front-panel factory-reset is NOT supported with current system recipe.
+2024-06-18T12:50:38.182641-05:00 8360-Primaire module[1234]: Event|3246|LOG_INFO|Module|-|Config compatibility allowed between modules old_part1 and new_part2
 2024-06-21T18:32:07.025548-05:00 8360-Primaire dhcpd[999]: Event|3301|LOG_INFO|DHCPv6|-|DHCPv6 Relay Enabled
 2024-06-21T18:32:07.025548-05:00 8360-Primaire dhcpd[999]: Event|3302|LOG_INFO|DHCPv6|-|DHCPv6 Relay Disabled
 2024-06-21T18:32:07.025548-05:00 8360-Primaire dhcpd[999]: Event|3401|LOG_INFO|DHCPD|-|DHCP Relay Enabled
@@ -594,11 +606,15 @@
 2024-06-18T12:49:38.182641-05:00 8360-Primaire usermgmt[1234]: Event|4705|LOG_INFO|USERMGMT|-|User admin set export password
 2024-06-18T12:50:38.182641-05:00 8360-Primaire usermgmt[1234]: Event|4706|LOG_INFO|USERMGMT|-|User admin restored default export password
 2024-06-18T12:51:38.182641-05:00 8360-Primaire usermgmt[1234]: Event|4707|LOG_INFO|USERMGMT|-|User admin locked out from session 12345
-2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4801|LOG_INFO|MACLEARN|-|MAC 00:1A:2B:3C:4D:5E moved from port eth0 to port eth1 on VLAN 10
-2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4802|LOG_INFO|MACLEARN|-|All dynamic MAC addresses on VLAN 10 were flushed
-2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4803|LOG_INFO|MACLEARN|-|All dynamic MAC addresses on port eth0 were flushed
-2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4804|LOG_INFO|MACLEARN|-|All dynamic MAC addresses on port eth1 were flushed
-2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4805|LOG_INFO|MACLEARN|-|All dynamic MAC addresses on VLAN 20 were flushed
+2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4801|LOG_INFO|MACADDRESSMGMT|-|MAC 00:1A:2B:3C:4D:5E moved from port eth0 to port eth1 on VLAN 10
+2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4802|LOG_INFO|MACADDRESSMGMT|-|All dynamic MAC addresses on VLAN 10 were flushed
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4803|LOG_INFO|MACADDRESSMGMT|-|All dynamic MAC addresses on port eth0 were flushed
+2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4804|LOG_INFO|MACADDRESSMGMT|-|All dynamic MAC addresses on port eth1 were flushed
+2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4805|LOG_INFO|MACADDRESSMGMT|-|All dynamic MAC addresses on VLAN 20 were flushed
+2024-06-18T12:50:38.182641-05:00 8360-Primaire macd[1234]: Event|4806|LOG_WARN|MACADDRESSMGMT|-|L2X thread not running. Attempting to recover
+2024-06-18T12:51:38.182641-05:00 8360-Primaire macd[1234]: Event|4807|LOG_WARN|MACADDRESSMGMT|-|L2X thread recovered
+2024-06-18T12:52:38.182641-05:00 8360-Primaire macd[1234]: Event|4808|LOG_ERR|MACADDRESSMGMT|-|L2X thread recovery failed
+2024-06-18T12:53:38.182641-05:00 8360-Primaire macd[1234]: Event|4809|LOG_ERR|MACADDRESSMGMT|-|MAC hash collision occurred for MAC 00:11:22:33:44:55 on VLAN 100
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-ospfv3[1234]: Event|4901|LOG_ERR|OSPFv3|-|Failed to install rule error: No space left on device
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-ospfv3[1234]: Event|4902|LOG_INFO|OSPFv3|-|OSPF3 all routers field entry added: group_id=1 fp_id=2 stat_id=3
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-ospfv3[1234]: Event|4903|LOG_INFO|OSPFv3|-|OSPF3 designated routers field entry added: group_id=1 fp_id=2 stat_id=3
@@ -1287,6 +1303,7 @@
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|11001|LOG_INFO|MACCONFIG|-|The MAC Address configured mode changed from static to dynamic
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|11002|LOG_INFO|MACCONFIG|-|The MAC Address operational mode changed from static to dynamic
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|11003|LOG_WARN|MACCONFIG|-|Station MAC add failure due to hardware full, mac=00:1A:2B:3C:4D:5E vlan=10
+2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|11004|LOG_ERR|MACCONFIG|-|The MAC Address operational mode changed from static to dynamic due to reaching SVI threshold. Current=1 Max=2
 2024-06-19T13:57:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|11101|LOG_WARN|AMM|-|Interface eth0: link fault detected
 2024-06-19T13:58:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|11102|LOG_WARN|AMM|-|Interface eth1: link fault detected and port disabled
 2024-06-19T13:59:38.182641-05:00 8360-Primaire hpe-faultmon[1234]: Event|11103|LOG_INFO|AMM|-|Interface eth2: link fault re-enable time expired, port enabled
@@ -1304,6 +1321,16 @@
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-macsec[1234]: Event|11202|LOG_INFO|MACsec|-|MKA session secured for Connectivity Association 1234 on interface eth0.
 2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-macsec[1234]: Event|11203|LOG_INFO|MACsec|-|Secure Association key updated for Connectivity Association 1234 on interface eth0 - Latest AN/KN 1/2, Old AN/KN 3/4.
 2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-macsec[1234]: Event|11204|LOG_INFO|MACsec|-|Possible replay attempt detected on the Secure Channel 00:11:22:33:44:55.
+2024-06-18T12:45:38.182641-05:00 8360-Primaire macsecd[1234]: Event|11205|LOG_INFO|MACsec|-|The data traffic on interface eth0 is now secured by MACsec.
+2024-06-18T12:46:38.182641-05:00 8360-Primaire macsecd[1234]: Event|11206|LOG_INFO|MACsec|-|The data traffic on interface eth0 is no longer secured by MACsec.
+2024-06-18T12:47:38.182641-05:00 8360-Primaire macsecd[1234]: Event|11207|LOG_ERR|MACsec|-|Interface eth0 MACsec selftest failed - hardware_error.
+2024-06-18T12:48:38.182641-05:00 8360-Primaire macsecd[1234]: Event|11208|LOG_INFO|MACsec|-|MACsec frame with an unknown SCI detected on MACsec entity running on interface eth0 with port ID 1.
+2024-06-18T12:49:38.182641-05:00 8360-Primaire macsecd[1234]: Event|11209|LOG_INFO|MACsec|-|Suspending data delay protection for Connectivity Association 1234 on interface eth0 during ISSU.
+2024-06-18T12:50:38.182641-05:00 8360-Primaire macsecd[1234]: Event|11210|LOG_INFO|MACsec|-|Resuming data delay protection for Connectivity Association 1234 on interface eth0 post ISSU.
+2024-06-18T12:51:38.182641-05:00 8360-Primaire macsecd[1234]: Event|11211|LOG_INFO|MACsec|-|ISSU aborted by MACsec. Reason - configuration_error.
+2024-06-18T12:52:38.182641-05:00 8360-Primaire macsecd[1234]: Event|11212|LOG_ERR|MACsec|-|Interface eth0 blocked by MACsec due to a misconfiguration. Reason - configuration_error.
+2024-06-18T12:53:38.182641-05:00 8360-Primaire macsecd[1234]: Event|11213|LOG_ERR|MACsec|-|MACsec is disabled on port eth0. Additional licenses are needed to enable the encryption functionality on the port.
+2024-06-18T12:54:38.182641-05:00 8360-Primaire macsecd[1234]: Event|11214|LOG_INFO|MACsec|-|MACsec is operational on port eth0 without a valid license for encryption.
 2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-smartlink[1234]: Event|11301|LOG_INFO|Smartlink|-|Flush message received on eth0 with control VLAN 100
 2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-smartlink[1234]: Event|11302|LOG_INFO|Smartlink|-|Active link of the smartlink group 1 changed to eth1
 2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-smartlink[1234]: Event|11303|LOG_INFO|Smartlink|-|Backup link of the smartlink group 1 changed to eth2
@@ -1389,6 +1416,10 @@
 2024-06-18T13:08:38.182641-05:00 8360-Primaire hotpatchd[1234]: Event|13224|LOG_ERR|HOTPATCH|-|Hot-patch patch24 failed to download.
 2024-06-18T13:09:38.182641-05:00 8360-Primaire hotpatchd[1234]: Event|13225|LOG_INFO|HOTPATCH|-|Hot-patch patch25 downloaded successfully.
 2024-06-18T13:10:38.182641-05:00 8360-Primaire hotpatchd[1234]: Event|13226|LOG_INFO|HOTPATCH|-|Attempt to Hot-Patch patch26 on ss_type_ss_name at boot: "success".
+2024-06-18T12:45:38.182641-05:00 8360-Primaire mplsldpd[1234]: Event|13301|LOG_INFO|MPLS|-|MPLS LDP session with local identifier 192.168.1.1 and peer identifier 192.168.1.2 has come up.
+2024-06-18T12:46:38.182641-05:00 8360-Primaire mplsldpd[1234]: Event|13302|LOG_INFO|MPLS|-|MPLS LDP session with local identifier 192.168.1.1 and peer identifier 192.168.1.2 has gone down.
+2024-06-18T12:47:38.182641-05:00 8360-Primaire mplsldpd[1234]: Event|13303|LOG_INFO|MPLS|-|MPLS Graceful Restart process started.
+2024-06-18T12:48:38.182641-05:00 8360-Primaire mplsldpd[1234]: Event|13304|LOG_ERR|MPLS|-|MPLS Graceful Restart process is complete.
 2024-06-18T12:47:38.182641-05:00 8360-Primaire consoled[1234]: Event|13401|LOG_ERR|CONFIG_VALIDATOR|-|Config mock_config_name failed to validate. Reason mock_config_reason
 2024-06-18T12:45:38.182641-05:00 8360-Primaire issud[1234]: Event|13501|LOG_INFO|ISSU|-|Started in-service software upgrade to location1 operating system image v1.0
 2024-06-18T12:46:38.182641-05:00 8360-Primaire issud[1234]: Event|13502|LOG_INFO|ISSU|-|In-service software upgrade started operation upgrade_operation

--- a/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
+++ b/packages/hpe_aruba_cx/data_stream/log/_dev/test/pipeline/test-aruba-fabricated.log-expected.json
@@ -12339,6 +12339,217 @@
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",
             "aruba": {
                 "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2623",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2623|LOG_INFO|MGMD|-|Remote IDL connection established."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Remote IDL connection established.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2624",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2624|LOG_INFO|MGMD|-|Querier functionality offloaded to VSX peer."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Querier functionality offloaded to VSX peer.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "239.255.255.250"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2625",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2625|LOG_INFO|MGMD|-|IGMPv2 packet received for group address 239.255.255.250 in SSM range which is not part of SSM map."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "IGMPv2 packet received for group address 239.255.255.250 in SSM range which is not part of SSM map.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "client": {
+                "ip": "ff02::1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2626",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2626|LOG_INFO|MGMD|-|MLDv1 packet received for group address ff02::1 in SSM range which is not part of SSM map."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "MLDv1 packet received for group address ff02::1 in SSM range which is not part of SSM map.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "acl": {
+                    "name": "example_acl"
+                },
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mgmd": {
+                    "protocol": "IGMP"
+                },
+                "port": "eth0"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2627",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2627|LOG_INFO|MGMD|-|SSM-map example_acl applied to IGMP interface eth0"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "SSM-map example_acl applied to IGMP interface eth0",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MGMD"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "2628",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire mgmd[1234]: Event|2628|LOG_ERR|MGMD|-|IGMP/MLD internal queue limit exceeded. Needs admin intervention."
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "mgmd",
+                    "procid": "1234"
+                }
+            },
+            "message": "IGMP/MLD internal queue limit exceeded. Needs admin intervention.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
                     "category": "REPLICATIONMGR"
                 },
                 "event_type": "Event",
@@ -16485,6 +16696,224 @@
                 }
             },
             "message": "Ethernet module eth0 has persistent hardware error",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "ExampleModule"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3241",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire module[1234]: Event|3241|LOG_INFO|Module|-|ExampleModule is starting zeroization and setting enhanced secure mode"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "module",
+                    "procid": "1234"
+                }
+            },
+            "message": "ExampleModule is starting zeroization and setting enhanced secure mode",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "ExampleModule"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3242",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire module[1234]: Event|3242|LOG_INFO|Module|-|ExampleModule zeroization completed and enhanced secure mode set."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "module",
+                    "procid": "1234"
+                }
+            },
+            "message": "ExampleModule zeroization completed and enhanced secure mode set.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "ExampleModule"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3243",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire module[1234]: Event|3243|LOG_ERR|Module|-|ExampleModule zeroization failed."
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "module",
+                    "procid": "1234"
+                }
+            },
+            "message": "ExampleModule zeroization failed.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "ExampleModule"
+                },
+                "status": "enabled"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3244",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire module[1234]: Event|3244|LOG_INFO|Module|-|ExampleModule Front-panel factory-reset is now enabled"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "module",
+                    "procid": "1234"
+                }
+            },
+            "message": "ExampleModule Front-panel factory-reset is now enabled",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "name": "ExampleModule"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3245",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire module[1234]: Event|3245|LOG_ERR|Module|-|ExampleModule Front-panel factory-reset is NOT supported with current system recipe."
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "module",
+                    "procid": "1234"
+                }
+            },
+            "message": "ExampleModule Front-panel factory-reset is NOT supported with current system recipe.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "Module"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "module": {
+                    "new_part": "new_part2",
+                    "old_part": "old_part1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "3246",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire module[1234]: Event|3246|LOG_INFO|Module|-|Config compatibility allowed between modules old_part1 and new_part2"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "module",
+                    "procid": "1234"
+                }
+            },
+            "message": "Config compatibility allowed between modules old_part1 and new_part2",
             "tags": [
                 "preserve_original_event"
             ]
@@ -22489,7 +22918,7 @@
             "@timestamp": "2024-06-18T12:45:38.182641-05:00",
             "aruba": {
                 "component": {
-                    "category": "MACLEARN"
+                    "category": "MACADDRESSMGMT"
                 },
                 "event_type": "Event",
                 "hardware": {
@@ -22508,7 +22937,7 @@
                     "network"
                 ],
                 "code": "4801",
-                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4801|LOG_INFO|MACLEARN|-|MAC 00:1A:2B:3C:4D:5E moved from port eth0 to port eth1 on VLAN 10"
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4801|LOG_INFO|MACADDRESSMGMT|-|MAC 00:1A:2B:3C:4D:5E moved from port eth0 to port eth1 on VLAN 10"
             },
             "log": {
                 "level": "LOG_INFO",
@@ -22534,7 +22963,7 @@
             "@timestamp": "2024-06-18T12:46:38.182641-05:00",
             "aruba": {
                 "component": {
-                    "category": "MACLEARN"
+                    "category": "MACADDRESSMGMT"
                 },
                 "event_type": "Event",
                 "hardware": {
@@ -22549,7 +22978,7 @@
                     "network"
                 ],
                 "code": "4802",
-                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4802|LOG_INFO|MACLEARN|-|All dynamic MAC addresses on VLAN 10 were flushed"
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4802|LOG_INFO|MACADDRESSMGMT|-|All dynamic MAC addresses on VLAN 10 were flushed"
             },
             "log": {
                 "level": "LOG_INFO",
@@ -22572,7 +23001,7 @@
             "@timestamp": "2024-06-18T12:47:38.182641-05:00",
             "aruba": {
                 "component": {
-                    "category": "MACLEARN"
+                    "category": "MACADDRESSMGMT"
                 },
                 "event_type": "Event",
                 "hardware": {
@@ -22590,7 +23019,7 @@
                     "network"
                 ],
                 "code": "4803",
-                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4803|LOG_INFO|MACLEARN|-|All dynamic MAC addresses on port eth0 were flushed"
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4803|LOG_INFO|MACADDRESSMGMT|-|All dynamic MAC addresses on port eth0 were flushed"
             },
             "log": {
                 "level": "LOG_INFO",
@@ -22608,7 +23037,7 @@
             "@timestamp": "2024-06-18T12:48:38.182641-05:00",
             "aruba": {
                 "component": {
-                    "category": "MACLEARN"
+                    "category": "MACADDRESSMGMT"
                 },
                 "event_type": "Event",
                 "hardware": {
@@ -22626,7 +23055,7 @@
                     "network"
                 ],
                 "code": "4804",
-                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4804|LOG_INFO|MACLEARN|-|All dynamic MAC addresses on port eth1 were flushed"
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4804|LOG_INFO|MACADDRESSMGMT|-|All dynamic MAC addresses on port eth1 were flushed"
             },
             "log": {
                 "level": "LOG_INFO",
@@ -22644,7 +23073,7 @@
             "@timestamp": "2024-06-18T12:49:38.182641-05:00",
             "aruba": {
                 "component": {
-                    "category": "MACLEARN"
+                    "category": "MACADDRESSMGMT"
                 },
                 "event_type": "Event",
                 "hardware": {
@@ -22659,7 +23088,7 @@
                     "network"
                 ],
                 "code": "4805",
-                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4805|LOG_INFO|MACLEARN|-|All dynamic MAC addresses on VLAN 20 were flushed"
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|4805|LOG_INFO|MACADDRESSMGMT|-|All dynamic MAC addresses on VLAN 20 were flushed"
             },
             "log": {
                 "level": "LOG_INFO",
@@ -22673,6 +23102,146 @@
                 "vlan": {
                     "id": "20"
                 }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACADDRESSMGMT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4806",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire macd[1234]: Event|4806|LOG_WARN|MACADDRESSMGMT|-|L2X thread not running. Attempting to recover"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "macd",
+                    "procid": "1234"
+                }
+            },
+            "message": "L2X thread not running. Attempting to recover",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACADDRESSMGMT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4807",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire macd[1234]: Event|4807|LOG_WARN|MACADDRESSMGMT|-|L2X thread recovered"
+            },
+            "log": {
+                "level": "LOG_WARN",
+                "syslog": {
+                    "appname": "macd",
+                    "procid": "1234"
+                }
+            },
+            "message": "L2X thread recovered",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACADDRESSMGMT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4808",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire macd[1234]: Event|4808|LOG_ERR|MACADDRESSMGMT|-|L2X thread recovery failed"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "macd",
+                    "procid": "1234"
+                }
+            },
+            "message": "L2X thread recovery failed",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACADDRESSMGMT"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "4809",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire macd[1234]: Event|4809|LOG_ERR|MACADDRESSMGMT|-|MAC hash collision occurred for MAC 00:11:22:33:44:55 on VLAN 100"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "macd",
+                    "procid": "1234"
+                }
+            },
+            "message": "MAC hash collision occurred for MAC 00:11:22:33:44:55 on VLAN 100",
+            "network": {
+                "vlan": {
+                    "id": "100"
+                }
+            },
+            "server": {
+                "mac": "00-11-22-33-44-55"
             },
             "tags": [
                 "preserve_original_event"
@@ -48350,6 +48919,47 @@
             ]
         },
         {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACCONFIG"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "limit": {
+                    "read_value": 1,
+                    "threshold": "2"
+                },
+                "mac": {
+                    "new_mode": "dynamic",
+                    "old_mode": "static"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11004",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire hpe-mac[1234]: Event|11004|LOG_ERR|MACCONFIG|-|The MAC Address operational mode changed from static to dynamic due to reaching SVI threshold. Current=1 Max=2"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "hpe-mac",
+                    "procid": "1234"
+                }
+            },
+            "message": "The MAC Address operational mode changed from static to dynamic due to reaching SVI threshold. Current=1 Max=2",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-06-19T13:57:38.182641-05:00",
             "aruba": {
                 "component": {
@@ -49003,6 +49613,377 @@
                 }
             },
             "message": "Possible replay attempt detected on the Secure Channel 00:11:22:33:44:55.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACsec"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11205",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire macsecd[1234]: Event|11205|LOG_INFO|MACsec|-|The data traffic on interface eth0 is now secured by MACsec."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "macsecd",
+                    "procid": "1234"
+                }
+            },
+            "message": "The data traffic on interface eth0 is now secured by MACsec.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACsec"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11206",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire macsecd[1234]: Event|11206|LOG_INFO|MACsec|-|The data traffic on interface eth0 is no longer secured by MACsec."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "macsecd",
+                    "procid": "1234"
+                }
+            },
+            "message": "The data traffic on interface eth0 is no longer secured by MACsec.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACsec"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11207",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire macsecd[1234]: Event|11207|LOG_ERR|MACsec|-|Interface eth0 MACsec selftest failed - hardware_error.",
+                "reason": "hardware_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "macsecd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface eth0 MACsec selftest failed - hardware_error.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACsec"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "instance": {
+                    "id": "1"
+                },
+                "interface": {
+                    "name": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11208",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire macsecd[1234]: Event|11208|LOG_INFO|MACsec|-|MACsec frame with an unknown SCI detected on MACsec entity running on interface eth0 with port ID 1."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "macsecd",
+                    "procid": "1234"
+                }
+            },
+            "message": "MACsec frame with an unknown SCI detected on MACsec entity running on interface eth0 with port ID 1.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:49:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACsec"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                },
+                "mac": {
+                    "ckn": "1234"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11209",
+                "original": "2024-06-18T12:49:38.182641-05:00 8360-Primaire macsecd[1234]: Event|11209|LOG_INFO|MACsec|-|Suspending data delay protection for Connectivity Association 1234 on interface eth0 during ISSU."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "macsecd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Suspending data delay protection for Connectivity Association 1234 on interface eth0 during ISSU.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:50:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACsec"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                },
+                "mac": {
+                    "ckn": "1234"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11210",
+                "original": "2024-06-18T12:50:38.182641-05:00 8360-Primaire macsecd[1234]: Event|11210|LOG_INFO|MACsec|-|Resuming data delay protection for Connectivity Association 1234 on interface eth0 post ISSU."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "macsecd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Resuming data delay protection for Connectivity Association 1234 on interface eth0 post ISSU.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:51:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACsec"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11211",
+                "original": "2024-06-18T12:51:38.182641-05:00 8360-Primaire macsecd[1234]: Event|11211|LOG_INFO|MACsec|-|ISSU aborted by MACsec. Reason - configuration_error.",
+                "reason": "configuration_error"
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "macsecd",
+                    "procid": "1234"
+                }
+            },
+            "message": "ISSU aborted by MACsec. Reason - configuration_error.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:52:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACsec"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "interface": {
+                    "name": "eth0"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11212",
+                "original": "2024-06-18T12:52:38.182641-05:00 8360-Primaire macsecd[1234]: Event|11212|LOG_ERR|MACsec|-|Interface eth0 blocked by MACsec due to a misconfiguration. Reason - configuration_error.",
+                "reason": "configuration_error"
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "macsecd",
+                    "procid": "1234"
+                }
+            },
+            "message": "Interface eth0 blocked by MACsec due to a misconfiguration. Reason - configuration_error.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:53:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACsec"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mac": {
+                    "feature": "encryption"
+                },
+                "port": "eth0"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11213",
+                "original": "2024-06-18T12:53:38.182641-05:00 8360-Primaire macsecd[1234]: Event|11213|LOG_ERR|MACsec|-|MACsec is disabled on port eth0. Additional licenses are needed to enable the encryption functionality on the port."
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "macsecd",
+                    "procid": "1234"
+                }
+            },
+            "message": "MACsec is disabled on port eth0. Additional licenses are needed to enable the encryption functionality on the port.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:54:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MACsec"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mac": {
+                    "feature": "encryption"
+                },
+                "port": "eth0"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "11214",
+                "original": "2024-06-18T12:54:38.182641-05:00 8360-Primaire macsecd[1234]: Event|11214|LOG_INFO|MACsec|-|MACsec is operational on port eth0 without a valid license for encryption."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "macsecd",
+                    "procid": "1234"
+                }
+            },
+            "message": "MACsec is operational on port eth0 without a valid license for encryption.",
             "tags": [
                 "preserve_original_event"
             ]
@@ -52149,6 +53130,146 @@
             "package": {
                 "name": "patch26"
             },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:45:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MPLS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mpls": {
+                    "local_ldp_id": "192.168.1.1",
+                    "peer_ldp_id": "192.168.1.2"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "13301",
+                "original": "2024-06-18T12:45:38.182641-05:00 8360-Primaire mplsldpd[1234]: Event|13301|LOG_INFO|MPLS|-|MPLS LDP session with local identifier 192.168.1.1 and peer identifier 192.168.1.2 has come up."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mplsldpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "MPLS LDP session with local identifier 192.168.1.1 and peer identifier 192.168.1.2 has come up.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:46:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MPLS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                },
+                "mpls": {
+                    "local_ldp_id": "192.168.1.1",
+                    "peer_ldp_id": "192.168.1.2"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "13302",
+                "original": "2024-06-18T12:46:38.182641-05:00 8360-Primaire mplsldpd[1234]: Event|13302|LOG_INFO|MPLS|-|MPLS LDP session with local identifier 192.168.1.1 and peer identifier 192.168.1.2 has gone down."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mplsldpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "MPLS LDP session with local identifier 192.168.1.1 and peer identifier 192.168.1.2 has gone down.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:47:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MPLS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "13303",
+                "original": "2024-06-18T12:47:38.182641-05:00 8360-Primaire mplsldpd[1234]: Event|13303|LOG_INFO|MPLS|-|MPLS Graceful Restart process started."
+            },
+            "log": {
+                "level": "LOG_INFO",
+                "syslog": {
+                    "appname": "mplsldpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "MPLS Graceful Restart process started.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-18T12:48:38.182641-05:00",
+            "aruba": {
+                "component": {
+                    "category": "MPLS"
+                },
+                "event_type": "Event",
+                "hardware": {
+                    "device": "8360-Primaire"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "13304",
+                "original": "2024-06-18T12:48:38.182641-05:00 8360-Primaire mplsldpd[1234]: Event|13304|LOG_ERR|MPLS|-|MPLS Graceful Restart process is complete."
+            },
+            "log": {
+                "level": "LOG_ERR",
+                "syslog": {
+                    "appname": "mplsldpd",
+                    "procid": "1234"
+                }
+            },
+            "message": "MPLS Graceful Restart process is complete.",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -448,7 +448,7 @@ processors:
         - "^Module %{DATA:aruba.temp.module} shutdown initiated for sensor %{DATA:aruba.temp.name} with low critical temperature, %{NUMBER:aruba.temp.celsius:long} degC"
 
     # Loopback events (90x)
-    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LOOPBACK.htm
+    # https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/LOOPBACK.htm
   - grok:
       field: message
       tag: loop_901_902_903
@@ -1198,7 +1198,7 @@ processors:
         - "^OSPF (all|designated) routers field entry added: group_id=%{DATA:group.id} fp_id=%{DATA:aruba.ospf.fp_id} stat_id=%{GREEDYDATA:aruba.ospf.stats_id}"
 
     # MGMD events (26xx)
-    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MGMD.htm
+    # https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MGMD.htm
   - grok:
       field: message
       tag: mgmd_event_2601_through_2622
@@ -1232,6 +1232,14 @@ processors:
       patterns:
         - "^%{DATA:aruba.mgmd.mgmd_type} is not operational on interface %{DATA:aruba.mgmd.l3_port} due to resource unavailability"
         - "^%{DATA:aruba.mgmd.mgmd_type} snooping is %{DATA:aruba.status} on VLAN %{GREEDYDATA:network.vlan.id}."
+  - grok:
+      field: message
+      tag: mgmd_event_2625_2626_2627
+      description: "This log event is used to identify IGMPv2 packet in ssm-range but not in ssm-map | identify MLDv1 packet in ssm-range but not in ssm-map | identify that ssm-map ACL is applied to particular interface"
+      if: "['2625','2626','2627'].contains(ctx.event?.code)"
+      patterns:
+        - "^(IGMPv2|MLDv1) packet received for group address %{IP:client.ip} in SSM range which is not part of SSM map."
+        - "^SSM-map %{DATA:aruba.acl.name} applied to %{DATA:aruba.mgmd.protocol} interface %{GREEDYDATA:aruba.port}"
 
     # Replication Manager events (270x)
     # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/REPLD.htm
@@ -1461,7 +1469,7 @@ processors:
         3105_PATTERN: "%{DATA:aruba.port} ports"
 
     # Module events (32xx)
-    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MODULE.htm
+    # https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MODULE.htm
   - grok:
       field: message
       tag: module_event_3201_through_3240_common
@@ -1483,6 +1491,28 @@ processors:
         - "^%{DATA:aruba.module.type} module %{DATA:aruba.module.name} is requesting to power on with priority %{GREEDYDATA:aruba.priority}"
         - "^%{DATA:aruba.module.name} is starting zeroization"
         - "^%{DATA:aruba.module.name} zeroization (completed|failed)"
+  - grok:
+      field: message
+      tag: module_event_3241_3242_3243
+      description: "Indicates that the module is about to start zeroization and setting enhanced secure mode | module zeroization has completed and enhanced secure modes | module zeroization failed to complete"
+      if: "['3241','3242','3243'].contains(ctx.event?.code)"
+      patterns:
+        - "^%{DATA:aruba.module.name}( is starting)? zeroization"
+  - grok:
+      field: message
+      tag: module_event_3244_3245
+      description: "Indicates that the module front-panel factory-reset configuration has been changed | module does not support front-panel factory-reset with current system recipe"
+      if: "['3244','3245'].contains(ctx.event?.code)"
+      patterns:
+        - "^%{DATA:aruba.module.name} Front-panel factory-reset is (now %{GREEDYDATA:aruba.status}|NOT supported with current system recipe)"
+  - grok:
+      field: message
+      tag: module_event_3246
+      description: "Indicates that config was kept between part number changes"
+      if: "ctx.event?.code == '3246'"
+      patterns: 
+        # Accounting for the spelling error in the documentation for `compatability`
+        - "^Config (compatability|compatibility) allowed between modules %{DATA:aruba.module.old_part} and %{GREEDYDATA:aruba.module.new_part}"
 
   # IRDP events (350x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/IRDP.htm
@@ -1712,7 +1742,7 @@ processors:
         - "^Failed to (enable|disable) local proxy ARP for port %{DATA:aruba.port} on vrf %{GREEDYDATA:aruba.vrf.id}"
 
     # Management events (430x)
-    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MGMT.htm
+    # https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MGMT.htm
   - grok:
       field: message
       tag: mgmt_event_4301
@@ -1971,17 +2001,23 @@ processors:
       patterns:
         - "^User %{DATA:user.name} "
 
-    # MAC Learning events (480x)
-    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MAC-LEARN.htm
+    # MAC address management events (480x)
+    # https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MAC-MGMT.htm
   - grok:
       field: message
-      tag: mac_learn_event_4801_through_4805
-      description: "The following are the events related to MAC learning."
+      tag: mac_address_mgmt_event_4801_4802_4803_4804_4805
+      description: "Event raised when L2 mac move | when L2 MAC table is flushed with [vlan|port] [delete|down|move] event or clear mac-address command from vtysh"
       if: "['4801','4802','4803','4804','4805'].contains(ctx.event?.code)"
       patterns:
         - "^MAC %{MAC:server.mac} moved from port %{DATA:aruba.interface.prev_id} to port %{DATA:aruba.interface.id} on VLAN %{GREEDYDATA:network.vlan.id}"
         - "^All dynamic MAC addresses on VLAN %{DATA:network.vlan.id} were flushed"
         - "^All dynamic MAC addresses on port %{DATA:aruba.interface.id} were flushed"
+  - dissect:
+      field: message
+      tag: mac_address_mgmt_event_4809
+      description: "Logs warning that MAC hit a hash collision in SDK."
+      if: "ctx.event?.code == '4809'"
+      pattern: "MAC hash collision occurred for MAC %{server.mac} on VLAN %{network.vlan.id}"
 
     # OSPFv3 events (490x)
     # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/OSPFv3.htm
@@ -2598,7 +2634,7 @@ processors:
         - "^Failed to create layer 3 (IPv4|IPv6) (RX|TX) statistic for port:%{GREEDYDATA:aruba.port}"
 
     # Mirroring events (670x)
-    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MIRRORING.htm
+    # https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MIRRORING.htm
   - grok:
       field: message
       tag: mirror_event_6701_through_6706
@@ -4333,15 +4369,22 @@ processors:
       pattern: 'Control Plane (%{aruba.dpse.operation_name}) failure during (%{aruba.dpse.plugin_name}) configuration'
 
   # MAC Address mode configuration events (1100x)
-  # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/FAULT_MONITOR.htm
+  # https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/L3_MAC_ADDRESS_CONFIGURATION.htm
   - grok:
       field: message
       tag: mac_event_11001_11002_11003
-      description: "The following are the events related to MAC Address mode configuration"
+      description: "Log event when the MAC Address [configured|operational] mode is changed | event when a local station MAC address cannot be added because the table is full"
       if: "['11001','11002','11003'].contains(ctx.event?.code)"
       patterns:
         - "^The MAC Address (configured|operational) mode changed from %{DATA:aruba.mac.old_mode} to %{GREEDYDATA:aruba.mac.new_mode}"
         - "^Station MAC add failure due to hardware full, mac=%{MAC:server.mac} vlan=%{GREEDYDATA:network.vlan.id}"
+  - grok:
+      field: message
+      tag: mac_event_11004
+      description: "Log event when the MAC Address operational mode is changed due to out of resources"
+      if: "ctx.event?.code == '11004'"
+      patterns:
+        - "^The MAC Address operational mode changed from %{DATA:aruba.mac.old_mode} to %{DATA:aruba.mac.new_mode} due to reaching SVI threshold. Current=%{NUMBER:aruba.limit.read_value:long} Max=%{GREEDYDATA:aruba.limit.threshold}"
 
   # Fault Monitor Events (111xx)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/FAULT_MONITOR.htm
@@ -4414,10 +4457,10 @@ processors:
           - "^MAC Lockout packet drop detected for %{MAC:client.mac} as source & destination address with source packet count: %{NUMBER:aruba.fault.sa_diff_count:long} and destination packet count: %{NUMBER:aruba.fault.da_diff_count:long}"
 
     # MACsec events (1120x)
-    # https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MACSEC.htm
+    # https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MACSEC.htm
   - grok:
       field: message
-      tag: macsec_event_11201_through_11204
+      tag: macsec_event_11201_11202_11203_11204
       description: "The following are the events related to MACsec"
       if: "['11201','11202','11203','11204'].contains(ctx.event?.code)"
       patterns:
@@ -4425,6 +4468,43 @@ processors:
         - "^MKA session secured for Connectivity Association %{DATA:aruba.mac.ckn} on interface %{GREEDYDATA:aruba.interface.name}"
         - "^Secure Association key updated for Connectivity Association %{DATA:aruba.mac.ckn} on interface %{DATA:aruba.interface.name} - Latest AN/KN %{DATA:aruba.mac.latest_an}/%{DATA:aruba.mac.latest_kn}, Old AN/KN %{DATA:aruba.mac.old_an}/%{GREEDYDATA:aruba.mac.old_kn}"
         - "^Possible replay attempt detected on the Secure Channel %{GREEDYDATA:aruba.mac.sci}."
+  - grok:
+      field: message
+      tag: macsec_event_11205_11206_11207
+      description: "The data plane traffic on an interface is (not)? secured by MACsec | selftest failed for the specified interface"
+      if: "['11205','11206','11207'].contains(ctx.event?.code)"
+      patterns:
+        - "^The data traffic on interface %{DATA:aruba.interface.name} is "
+        - "^Interface %{DATA:aruba.interface.name} MACsec selftest failed - %{GREEDYDATA:event.reason}."
+  - dissect:
+      field: message
+      tag: macsec_event_11208
+      description: "Detected a MACsec frame with unknown SCI on an interface with the specified port ID"
+      if: "ctx.event?.code == '11208'"
+      pattern: "MACsec frame with an unknown SCI detected on MACsec entity running on interface %{aruba.interface.name} with port ID %{aruba.instance.id}."
+  - grok:
+      field: message
+      tag: macsec_event_11209_11210
+      description: "Data delay protection is suspended for the specified CKN on interface during ISSU | Data delay protection is resumed for the given CKN post ISSU"
+      if: "['11209','11210'].contains(ctx.event?.code)"
+      patterns:
+        - "^(Suspending|Resuming) data delay protection for Connectivity Association %{DATA:aruba.mac.ckn} on interface %{DATA:aruba.interface.name} (during|post) ISSU"
+  - grok:
+      field: message
+      tag: macsec_event_11211_11212
+      description: "ISSU aborted by MACsec | MACsec daemon blocked an interface due to a configuration error"
+      if: "['11211','11212'].contains(ctx.event?.code)"
+      patterns:
+        - "^ISSU aborted by MACsec. Reason - %{GREEDYDATA:event.reason}."
+        - "^Interface %{DATA:aruba.interface.name} blocked by MACsec due to a misconfiguration. Reason - %{GREEDYDATA:event.reason}."
+  - grok:
+      field: message
+      tag: macsec_event_11213_11214
+      description: "The port will remain blocked for both ingress and egress traffic till a valid license is not installed | MACsec is operational on the port in honor mode"
+      if: "['11213','11214'].contains(ctx.event?.code)"
+      patterns:
+        - "^MACsec is disabled on port %{DATA:aruba.port}. Additional licenses are needed to enable the %{DATA:aruba.mac.feature} functionality on the port."
+        - "^MACsec is operational on port %{DATA:aruba.port} without a valid license for %{GREEDYDATA:aruba.mac.feature}."
 
   # Smartlink events (1130x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/SMARTLINK.htm
@@ -4680,6 +4760,16 @@ processors:
       description: "Status of the Hot-patch attempted to be applied at boot"
       if: "ctx.event?.code == '13226'"
       pattern: 'Attempt to Hot-Patch %{package.name} on %{aruba.hotpatch.ss} at boot: "%{aruba.status}".'
+
+  # MPLS events (1330x)
+  # https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MPLS.htm
+  - grok:
+      field: message
+      tag: mpls_event_13401_13302
+      description: ""
+      if: "['13301','13302'].contains(ctx.event?.code)"
+      patterns:
+        - "^MPLS LDP session with local identifier %{DATA:aruba.mpls.local_ldp_id} and peer identifier %{DATA:aruba.mpls.peer_ldp_id} has (come up|gone down)"
 
   # Config validator events (1340x)
   # https://www.arubanetworks.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/CONFIG-VALIDATOR.htm

--- a/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
+++ b/packages/hpe_aruba_cx/data_stream/log/fields/fields.yml
@@ -828,6 +828,9 @@
         - name: ckn
           type: keyword
           description: ""
+        - name: feature
+          type: keyword
+          description: ""
         - name: latest_an
           type: keyword
           description: ""
@@ -870,6 +873,9 @@
         - name: port1
           type: keyword
           description: ""
+        - name: protocol
+          type: keyword
+          description: ""
         - name: ring_id
           type: keyword
           description: ""
@@ -894,7 +900,22 @@
         - name: name
           type: keyword
           description: ""
+        - name: new_part
+          type: keyword
+          description: ""
+        - name: old_part
+          type: keyword
+          description: ""
         - name: type
+          type: keyword
+          description: ""
+    - name: mpls
+      type: group
+      fields:
+        - name: local_ldp_id
+          type: keyword
+          description: ""
+        - name: peer_ldp_id
           type: keyword
           description: ""
     - name: msdp

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -804,22 +804,13 @@ Note: Descriptions have not been filled out
 | `<txportName>` | aruba.loop.tx_port     |
 | `<vlan>`       | network.vlan.id        |
 
-#### [Loopback events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/LOOPBACK.htm)
+#### [Loopback events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/LOOPBACK.htm)
 | Docs Field    | Schema Mapping        |
 |---------------|-----------------------|
 | `<interface>` | aruba.interface.id    |
 | `<state>`     | aruba.state           |
 
-
-#### [MAC Address mode configuration events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/L3_MAC_ADDRESS_CONFIGURATION.htm)
-| Docs Field   | Schema Mapping       |
-|--------------|----------------------|
-| `<mac>`      | server.mac           |
-| `<new_mode>` | aruba.mac.new_mode   |
-| `<old_mode>` | aruba.mac.old_mode   |
-| `<vlan>`     | network.vlan.id      |
-
-#### [MAC Learning events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MAC-LEARN.htm)
+#### [MAC address management events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MAC-MGMT.htm)
 | Docs Field    | Schema Mapping               |
 |---------------|------------------------------|
 | `<from-intf>` | aruba.interface.prev_id      |
@@ -828,40 +819,67 @@ Note: Descriptions have not been filled out
 | `<to-intf>`   | aruba.mac.interface.id       |
 | `<vlan>`      | network.vlan.id              |
 
-#### [MACsec events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MACSEC.htm)
+#### [MAC Address mode configuration events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/L3_MAC_ADDRESS_CONFIGURATION.htm)
+| Docs Field  | Schema Mapping           |
+|-------------|--------------------------|
+| `<current>` | aruba.limit.read_value   |
+| `<mac>`     | server.mac               |
+| `<max>`     | aruba.limit.threshold    |
+| `<new_mode>`| aruba.mac.new_mode       |
+| `<old_mode>`| aruba.mac.old_mode       |
+| `<vlan>`    | network.vlan.id          |
+
+#### Deprecated for "MAC address management events" in 10.15
+#### [MAC Learning events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MAC-LEARN.htm)
+| Docs Field    | Schema Mapping               |
+|---------------|------------------------------|
+| `<from-intf>` | aruba.interface.prev_id      |
+| `<intf>`      | aruba.interface.id           |
+| `<mac>`       | server.mac                   |
+| `<to-intf>`   | aruba.mac.interface.id       |
+| `<vlan>`      | network.vlan.id              |
+
+#### [MACsec events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MACSEC.htm)
 | Docs Field     | Schema Mapping               |
 |----------------|------------------------------|
 | `<ckn>`        | aruba.mac.ckn                |
+| `<feature>`    | aruba.mac.feature            |
 | `<ifname>`     | aruba.interface.name         |
+| `<ifname>`     | aruba.instance.id            |
 | `<latest_an>`  | aruba.mac.latest_an          |
 | `<latest_kn>`  | aruba.mac.latest_kn          |
+| `<name>`       | aruba.port                   |
 | `<old_an>`     | aruba.mac.old_an             |
 | `<old_kn>`     | aruba.mac.old_kn             |
+| `<reason>`     | event.reason                 |
 | `<sci>`        | aruba.mac.sci                |
 
-#### [Management events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MGMT.htm)
+#### [Management events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MGMT.htm)
 | Docs Field                    | Schema Mapping           |
 |-------------------------------|--------------------------|
 | `<mgmt_intf_config_crit>`     | aruba.mgmt.config_crit   |
 | `<mgmt_intf_config_err>`      | aruba.mgmt.config_err    |
 | `<mgmt_intf_config_param>`    | aruba.mgmt.config_param  |
 
-#### [MDNS events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MDNS.htm)
+#### [MDNS events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MDNS.htm)
 | Docs Field                  | Schema Mapping           |
 |-----------------------------|--------------------------|
 
 
-#### [MGMD events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MGMD.htm)
+#### [MGMD events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MGMD.htm)
 | Docs Field    | Schema Mapping              |
 |---------------|-----------------------------|
+| `<acl_name>`  | aruba.acl.name              |
 | `<if_name>`   | aruba.interface.name        |
 | `<ip_address>`| client.ip                   |
 | `<l3Port>`    | aruba.mgmd.l3_port          |
 | `<mgmd_type>` | aruba.mgmd.mgmd_type        |
 | `<pkt_type>`  | aruba.mgmd.pkt_type         |
 | `<port>`      | aruba.port                  |
+| `<port_name>` | aruba.port                  |
 | `<port0>`     | aruba.port                  |
 | `<port1>`     | aruba.mgmd.port1            |
+| `<protocol>`  | aruba.mgmd.protocol         |
 | `<ring_id>`   | aruba.mgmd.ring_id          |
 | `<size_value>`| aruba.len                   |
 | `<state>`     | aruba.state                 |
@@ -870,19 +888,27 @@ Note: Descriptions have not been filled out
 | `<type>`      | aruba.mgmd.type             |
 | `<vlan>`      | network.vlan.id             |
 
-#### [Mirroring events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MIRRORING.htm)
+#### [Mirroring events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MIRRORING.htm)
 | Docs Field   | Schema Mapping       |
 |--------------|----------------------|
 | `<number>`   | aruba.session.id     |
 
-#### [Module events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MODULE.htm)
+#### [Module events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MODULE.htm)
 | Docs Field      | Schema Mapping         |
 |-----------------|------------------------|
 | `<name>`        | aruba.module.name      |
+| `<new_part>`    | aruba.module.new_part  |
+| `<old_part>`    | aruba.module.old_part  |
 | `<part_number>` | aruba.unit             |
 | `<priority>`    | aruba.priority         |
 | `<reason>`      | event.reason           |
 | `<type>`        | aruba.module.type      |
+
+#### [MPLS events](https://arubanetworking.hpe.com/techdocs/AOS-CX/10.15/HTML/elmrg/Content/events/MPLS.htm)
+| Docs Field      | Schema Mapping          |
+|-----------------|-------------------------|
+| `<local_ldp_id>`| aruba.mpls.local_ldp_id |
+| `<peer_ldp_id>` | aruba.mpls.peer_ldp_id  |
 
 #### [MSDP events](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-8214/Content/events/MSDP.htm)
 | Docs Field    | Schema Mapping               |
@@ -1891,6 +1917,7 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.loop.rx_port |  | keyword |
 | aruba.loop.tx_port |  | keyword |
 | aruba.mac.ckn |  | keyword |
+| aruba.mac.feature |  | keyword |
 | aruba.mac.latest_an |  | keyword |
 | aruba.mac.latest_kn |  | keyword |
 | aruba.mac.new_mode |  | keyword |
@@ -1903,13 +1930,18 @@ The `log` dataset collects the HPE Aruba CX logs.
 | aruba.mgmd.mgmd_type |  | keyword |
 | aruba.mgmd.pkt_type |  | keyword |
 | aruba.mgmd.port1 |  | keyword |
+| aruba.mgmd.protocol |  | keyword |
 | aruba.mgmd.ring_id |  | keyword |
 | aruba.mgmd.type |  | keyword |
 | aruba.mgmt.config_crit |  | object |
 | aruba.mgmt.config_err |  | object |
 | aruba.mgmt.config_param |  | object |
 | aruba.module.name |  | keyword |
+| aruba.module.new_part |  | keyword |
+| aruba.module.old_part |  | keyword |
 | aruba.module.type |  | keyword |
+| aruba.mpls.local_ldp_id |  | keyword |
+| aruba.mpls.peer_ldp_id |  | keyword |
 | aruba.msdp.grp_ip |  | ip |
 | aruba.msdp.rp_ip |  | ip |
 | aruba.msdp.tcp_entity |  | keyword |

--- a/packages/hpe_aruba_cx/docs/README.md
+++ b/packages/hpe_aruba_cx/docs/README.md
@@ -845,7 +845,7 @@ Note: Descriptions have not been filled out
 | `<ckn>`        | aruba.mac.ckn                |
 | `<feature>`    | aruba.mac.feature            |
 | `<ifname>`     | aruba.interface.name         |
-| `<ifname>`     | aruba.instance.id            |
+| `<id>`         | aruba.instance.id            |
 | `<latest_an>`  | aruba.mac.latest_an          |
 | `<latest_kn>`  | aruba.mac.latest_kn          |
 | `<name>`       | aruba.port                   |


### PR DESCRIPTION
## Parent Ticket
https://github.com/elastic/integrations/issues/12249

## Description
- updated link to Loopback events (90x)
- updated MGMD events (26xx), added events 2625-2627
- update Module events (32xx), added 3241-3246
- updated Management events (430x)
- Mac Learn events were deprecated, moved to MAC address management events (480x)
- updated Mirroring events (670x)
- updated MAC Address mode configuration events (1100x), added event 11004
- updated MACsec events (1120x), added event 11205-11214
- added new event MPLS events (1330x)
