### PR TITLE
[fleet_server] Support 9.0 stack

### DIFF
--- a/packages/fleet_server/changelog.yml
+++ b/packages/fleet_server/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.0"
+  changes:
+    - description: Support for stack 9.0
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12460
 - version: "1.5.0"
   changes:
     - description: Added new output health data stream

--- a/packages/fleet_server/manifest.yml
+++ b/packages/fleet_server/manifest.yml
@@ -1,13 +1,13 @@
 name: fleet_server
 title: Fleet Server
-version: 1.5.0
+version: 1.6.0
 description: Centrally manage Elastic Agents with the Fleet Server integration.
 type: integration
-format_version: 3.0.0
+format_version: 3.0.4
 categories: ["elastic_stack"]
 conditions:
   kibana:
-    version: "^8.12.0"
+    version: "^8.12.0 || ^9.0.0"
   elastic:
     subscription: basic
 owner:


### PR DESCRIPTION
## Proposed commit message

Add support for 9.0 in fleet_server package.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] ~~I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

## Related issues

- Required by https://github.com/elastic/kibana/pull/208169. 
