### PR TITLE
google_workspace.chrome: Increase CEL resource.tracer.maxsize limit

### DIFF
--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Increase CEL resource.tracer.maxsize to prevent loss of trace responses.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/12491
 - version: "2.29.0"
   changes:
     - description: Add support of Chrome Audit Events.

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.30.0"
+  changes:
+    - description: Increase CEL resource.tracer.maxsize to prevent loss of trace responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.29.0"
   changes:
     - description: Add support of Chrome Audit Events.

--- a/packages/google_workspace/data_stream/chrome/agent/stream/cel.yml.hbs
+++ b/packages/google_workspace/data_stream/chrome/agent/stream/cel.yml.hbs
@@ -3,6 +3,7 @@ interval: {{interval}}
 {{#if enable_request_tracer}}
 resource.tracer.filename: "../../logs/cel/http-request-trace-*.ndjson"
 resource.tracer.maxbackups: 5
+resource.tracer.maxsize: 5
 {{/if}}
 {{#if proxy_url}}
 resource.proxy_url: {{proxy_url}}

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: "2.29.0"
+version: "2.30.0"
 source:
   license: Elastic-2.0
 description: Collect logs from Google Workspace with Elastic Agent.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
The default limit in the Filebeat input is 1MiB which is too small for some responses, resulting in loss of visibility in debugging issues in the integration, so increase to 5MiB.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
