### PR TITLE
[cisco_duo] Avoid obsolete cursor data in activity, telephony_v2

### DIFF
--- a/packages/cisco_duo/changelog.yml
+++ b/packages/cisco_duo/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.2"
+  changes:
+    - description: Avoid obsolete cursor data in activity, telephony_v2.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12492
 - version: "2.3.1"
   changes:
     - description: Fix broken links in Security Service integrations packages.

--- a/packages/cisco_duo/data_stream/activity/agent/stream/cel.yml.hbs
+++ b/packages/cisco_duo/data_stream/activity/agent/stream/cel.yml.hbs
@@ -38,7 +38,7 @@ program: |
         :
             state.with({
                 "mintime": string(1000 * int(
-                    state.?cursor.last_published.optMap(t,
+                    state.?cursor.last_ts.optMap(t,
                         t.parse_time(time_layout.RFC3339Nano)
                     ).orValue(
                         now - duration(state.initial_interval)
@@ -109,19 +109,19 @@ program: |
                         :
                             optional.none(),
                         "cursor": {
-                            ?"last_published": (has(body.?response.items) && size(body.response.items) > 0) ?
+                            ?"last_ts": (has(body.?response.items) && size(body.response.items) > 0) ?
                                 optional.of(
                                     body.response.items.map(i, i.ts).max().as(last_timestamp,
-                                        !has(dyn(state).?cursor.last_published) ?
+                                        !has(dyn(state).?cursor.last_ts) ?
                                             last_timestamp
-                                        : (last_timestamp < dyn(state).cursor.last_published) ?
-                                            dyn(state).cursor.last_published
+                                        : (last_timestamp < dyn(state).cursor.last_ts) ?
+                                            dyn(state).cursor.last_ts
                                         :
                                             last_timestamp
                                     )
                                 )
                             :
-                                dyn(state).?cursor.last_published,
+                                dyn(state).?cursor.last_ts,
                         }
                     }
                 :

--- a/packages/cisco_duo/data_stream/activity/agent/stream/cel.yml.hbs
+++ b/packages/cisco_duo/data_stream/activity/agent/stream/cel.yml.hbs
@@ -38,7 +38,7 @@ program: |
         :
             state.with({
                 "mintime": string(1000 * int(
-                    state.?cursor.last_ts.optMap(t,
+                    state.?cursor.last_response_ts.optMap(t,
                         t.parse_time(time_layout.RFC3339Nano)
                     ).orValue(
                         now - duration(state.initial_interval)
@@ -109,19 +109,19 @@ program: |
                         :
                             optional.none(),
                         "cursor": {
-                            ?"last_ts": (has(body.?response.items) && size(body.response.items) > 0) ?
+                            ?"last_response_ts": (has(body.?response.items) && size(body.response.items) > 0) ?
                                 optional.of(
                                     body.response.items.map(i, i.ts).max().as(last_timestamp,
-                                        !has(dyn(state).?cursor.last_ts) ?
+                                        !has(dyn(state).?cursor.last_response_ts) ?
                                             last_timestamp
-                                        : (last_timestamp < dyn(state).cursor.last_ts) ?
-                                            dyn(state).cursor.last_ts
+                                        : (last_timestamp < dyn(state).cursor.last_response_ts) ?
+                                            dyn(state).cursor.last_response_ts
                                         :
                                             last_timestamp
                                     )
                                 )
                             :
-                                dyn(state).?cursor.last_ts,
+                                dyn(state).?cursor.last_response_ts,
                         }
                     }
                 :

--- a/packages/cisco_duo/data_stream/telephony_v2/agent/stream/cel.yml.hbs
+++ b/packages/cisco_duo/data_stream/telephony_v2/agent/stream/cel.yml.hbs
@@ -38,7 +38,7 @@ program: |
         :
             state.with({
                 "mintime": string(1000 * int(
-                    state.?cursor.last_published.optMap(t,
+                    state.?cursor.last_ts.optMap(t,
                         t.parse_time(time_layout.RFC3339Nano)
                     ).orValue(
                         now - duration(state.initial_interval)
@@ -106,19 +106,19 @@ program: |
                         :
                             optional.none(),
                         "cursor": {
-                            ?"last_published": (has(body.?response.items) && size(body.response.items) > 0) ?
+                            ?"last_ts": (has(body.?response.items) && size(body.response.items) > 0) ?
                                 optional.of(
                                     body.response.items.map(i, i.ts).max().as(last_timestamp,
-                                        !has(dyn(state).?cursor.last_published) ?
+                                        !has(dyn(state).?cursor.last_ts) ?
                                             last_timestamp
-                                        : (last_timestamp < dyn(state).cursor.last_published) ?
-                                            dyn(state).cursor.last_published
+                                        : (last_timestamp < dyn(state).cursor.last_ts) ?
+                                            dyn(state).cursor.last_ts
                                         :
                                             last_timestamp
                                     )
                                 )
                             :
-                                dyn(state).?cursor.last_published,
+                                dyn(state).?cursor.last_ts,
                         }
                     }
                 :

--- a/packages/cisco_duo/data_stream/telephony_v2/agent/stream/cel.yml.hbs
+++ b/packages/cisco_duo/data_stream/telephony_v2/agent/stream/cel.yml.hbs
@@ -38,7 +38,7 @@ program: |
         :
             state.with({
                 "mintime": string(1000 * int(
-                    state.?cursor.last_ts.optMap(t,
+                    state.?cursor.last_response_ts.optMap(t,
                         t.parse_time(time_layout.RFC3339Nano)
                     ).orValue(
                         now - duration(state.initial_interval)
@@ -106,19 +106,19 @@ program: |
                         :
                             optional.none(),
                         "cursor": {
-                            ?"last_ts": (has(body.?response.items) && size(body.response.items) > 0) ?
+                            ?"last_response_ts": (has(body.?response.items) && size(body.response.items) > 0) ?
                                 optional.of(
                                     body.response.items.map(i, i.ts).max().as(last_timestamp,
-                                        !has(dyn(state).?cursor.last_ts) ?
+                                        !has(dyn(state).?cursor.last_response_ts) ?
                                             last_timestamp
-                                        : (last_timestamp < dyn(state).cursor.last_ts) ?
-                                            dyn(state).cursor.last_ts
+                                        : (last_timestamp < dyn(state).cursor.last_response_ts) ?
+                                            dyn(state).cursor.last_response_ts
                                         :
                                             last_timestamp
                                     )
                                 )
                             :
-                                dyn(state).?cursor.last_ts,
+                                dyn(state).?cursor.last_response_ts,
                         }
                     }
                 :

--- a/packages/cisco_duo/manifest.yml
+++ b/packages/cisco_duo/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cisco_duo
 title: Cisco Duo
-version: "2.3.1"
+version: "2.3.2"
 description: Collect logs from Cisco Duo with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[cisco_duo] Avoid obsolete cursor data in activity, telephony_v2

In an earlier version of the CEL code for `activity`[1] and
`telephony_v2`[2], `cursor.last_published` was set to a UNIX timestamp
value. This was changed to use RFC3339 formatted times in later
PRs[3][4] (with the corresponding read-time parsing added in [5]).

Users who didn't create a new policy may have the current parsing logic
fail when it encounters an old UNIX timestamp value in
`cursor.last_published`.

This PR addresses that issue by renaming `cursor.last_published` to 
`cursor.last_response_ts`. That effectively clears the cursor so that
obsolete values will not be seen.

[1]: https://github.com/elastic/integrations/blob/2ea993/packages/cisco_duo/data_stream/activity/agent/stream/cel.yml.hbs#L111-L114
[2]: https://github.com/elastic/integrations/blob/2ea993/packages/cisco_duo/data_stream/telephony_v2/agent/stream/cel.yml.hbs#L112-L115
[3]: https://github.com/elastic/integrations/pull/11640
[4]: https://github.com/elastic/integrations/pull/11670
[5]: https://github.com/elastic/integrations/pull/11772
```

## Discussion

The [API documentation](https://duo.com/docs/adminapi#activity-logs)'s description of the `ts` field remains consistent with https://github.com/elastic/integrations/pull/11772.

An alternative to this PR would be to parse both legacy and new data, as follows:

<details>

```diff
diff --git a/packages/cisco_duo/data_stream/activity/agent/stream/cel.yml.hbs b/packages/cisco_duo/data_stream/activity/agent/stream/cel.yml.hbs
index c03f4a1ed3..ffea8d42de 100644
--- a/packages/cisco_duo/data_stream/activity/agent/stream/cel.yml.hbs
+++ b/packages/cisco_duo/data_stream/activity/agent/stream/cel.yml.hbs
@@ -39,7 +39,10 @@ program: |
             state.with({
                 "mintime": string(1000 * int(
                     state.?cursor.last_published.optMap(t,
-                        t.parse_time(time_layout.RFC3339Nano)
+                        !is_error(int(t)) ?
+                          timestamp(int(t)/1000)+duration(string(int(t)%1000)+"ms")
+                        :
+                          t.parse_time(time_layout.RFC3339Nano)
                     ).orValue(
                         now - duration(state.initial_interval)
                     )
diff --git a/packages/cisco_duo/data_stream/telephony_v2/agent/stream/cel.yml.hbs b/packages/cisco_duo/data_stream/telephony_v2/agent/stream/cel.yml.hbs
index 553258248b..000c160d67 100644
--- a/packages/cisco_duo/data_stream/telephony_v2/agent/stream/cel.yml.hbs
+++ b/packages/cisco_duo/data_stream/telephony_v2/agent/stream/cel.yml.hbs
@@ -39,7 +39,10 @@ program: |
             state.with({
                 "mintime": string(1000 * int(
                     state.?cursor.last_published.optMap(t,
-                        t.parse_time(time_layout.RFC3339Nano)
+                        !is_error(int(t)) ?
+                          timestamp(int(t)/1000)+duration(string(int(t)%1000)+"ms")
+                        :
+                          t.parse_time(time_layout.RFC3339Nano)
                     ).orValue(
                         now - duration(state.initial_interval)
                     )
```

</details>

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Relates #11640
- Relates #11670
- Relates #11772