### PR TITLE
[imperva_cloud_waf] Tolerate no separator in log files

### DIFF
--- a/packages/imperva_cloud_waf/changelog.yml
+++ b/packages/imperva_cloud_waf/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.1"
+  changes:
+    - description: Tolerate no separator in log files.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12497
 - version: "1.5.0"
   changes:
     - description: Add support for Access Point ARN when collecting logs via the AWS S3 Bucket.

--- a/packages/imperva_cloud_waf/data_stream/event/agent/stream/cel.yml.hbs
+++ b/packages/imperva_cloud_waf/data_stream/event/agent/stream/cel.yml.hbs
@@ -45,7 +45,7 @@ program: |
           "Authorization": ["Basic "+string(base64(state.user + ":" + state.password))],
         }
       }).do_request().as(resp, bytes(resp.Body).as(body, {
-        "events": string(body).split("|==|")[1].split("\n").filter(x,x!="").map(x,{"message":x}),
+        "events": (string(body)+"|==|").split("|==|")[1].split("\n").filter(x,x!="").map(x,{"message":x}),
         "cursor": {
           "log_file": (
             has(state.cursor) && has(state.cursor.log_file) && state.cursor.log_file != null

--- a/packages/imperva_cloud_waf/manifest.yml
+++ b/packages/imperva_cloud_waf/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: imperva_cloud_waf
 title: Imperva Cloud WAF
-version: "1.5.0"
+version: "1.5.1"
 description: Collect logs from Imperva Cloud WAF with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[imperva_cloud_waf] Tolerate no separator in log files

Make the CEL program tolerate log files that don't contain a
header/events separator (`|==|`).

The existing CEL program can fail with the error:

    failed evaluation: failed eval: ERROR: <input>:19:35: index out of
    bounds: 1 | ).as(v, v.next < size(v.worklist) ? |.................
    .................^

With this change, it will not fail, but no events will be returned.
```

## Discussion

The observed error is for the index `1`. The use of `v.worklist[v.next]` will never cause that, because those uses are all surrounded by the condition `v.next < size(v.worklist)`, so it must be the access following `split("|==|")`.

[Log file structure documentation](https://docs.imperva.com/bundle/cloud-application-security/page/more/log-file-structure.htm).

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Screenshots

Here's a screenshot showing the problem:

![image](https://github.com/user-attachments/assets/a7ad3705-de10-45e5-ac7b-d639c27797ea)