### PR TITLE
Switch container logs input to /var/log/pod/* path

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.81.0
+  changes:
+    - description: Switch k8s input paths to /var/log/pods/* to ingest rotated container logs
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12500
 - version: 1.80.0
   changes:
     - description: Add support for Kibana `9.0.0` 

--- a/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
@@ -1,15 +1,4 @@
-{{!
-  Because we use `${kubernetes.container.id}` in the ID, an instance
-  of this input will be generated for every container, so `paths` must
-  always be unique per container otherwise there will be data
-  duplication, at the extreme this will overload Filebeat and cause
-  data ingestion issues.
-
-  This ID is also mentioned in the `README.md, so if it is changed, it
-  needs to be updated there as well.
-}}
-
-id: kubernetes-container-logs-${kubernetes.pod.name}-${kubernetes.container.id}
+id: kubernetes-container-logs-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.id}
 paths:
 {{#each paths}}
   - {{this}}

--- a/packages/kubernetes/data_stream/container_logs/manifest.yml
+++ b/packages/kubernetes/data_stream/container_logs/manifest.yml
@@ -12,14 +12,7 @@ streams:
         title: Kubernetes container log path
         multi: true
         default:
-          - /var/log/containers/*${kubernetes.container.id}.log
-        description: >-
-          For every container the Elastic-Agent can see (usually every
-          container on the node) an instance of the input will be
-          created harvesting all paths defined here, even if 
-          the paths contain no variable! Refer to the [integration
-          documentation](https://www.elastic.co/guide/en/integrations/current/kubernetes.html)
-          for more details.
+          - /var/log/pods/${kubernetes.namespace}_${kubernetes.pod.name}_${kubernetes.pod.uid}/${kubernetes.container.name}/*.log
       - name: symlinks
         type: bool
         title: Use Symlinks

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: kubernetes
 title: Kubernetes
-version: 1.80.0
+version: 1.81.0
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

This PR changes the input definition for ingesting k8s container logs from /var/log/containers/* to /var/log/pods/* which contains all available logs (including rotated ones) for pods running on the k8s node.

Before this change the integration would configure the elastic-agent input using the currently running container id and locating the corresponding log file under /var/log/containers/* which would point to the current log file, ignoring previously rotated log files for the container.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/elastic-agent/issues/5164
- Relates https://github.com/elastic/elastic-agent/pull/6583

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
