### PR TITLE
[apache] Support stack 9.0

### DIFF
--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Support stack 9.0
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/12145
+      link: https://github.com/elastic/integrations/pull/12504
 - version: "1.26.0"
   changes:
     - description: "Deprecate third-party REST API import option."

--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.27.0"
+  changes:
+    - description: Support stack 9.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/12145
 - version: "1.26.0"
   changes:
     - description: "Deprecate third-party REST API import option."

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.1.4
+format_version: 3.1.5
 name: apache
 title: Apache HTTP Server
-version: "1.26.0"
+version: "1.27.0"
 source:
   license: Elastic-2.0
 description: Collect logs and metrics from Apache servers with Elastic Agent.
@@ -11,7 +11,7 @@ categories:
   - observability
 conditions:
   kibana:
-    version: "^8.13.0"
+    version: "^8.13.0 || ^9.0.0"
   elastic:
     subscription: basic
 screenshots:


### PR DESCRIPTION
Prepare apache package for 9.0.

The apache package is used in Kibana test suites and we need to have it before enabling constraints in https://github.com/elastic/kibana/pull/208169.