### PR TITLE
Add the new browser-monitoring osquery pack

### DIFF
--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.1"
+  changes:
+    - description: Add the browser-monitoring osquery pack
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12513
 - version: "1.15.0"
   changes:
     - description: Add mappings for ECS email fields

--- a/packages/osquery_manager/kibana/osquery_pack_asset/osquery_manager-15e85d01-713d-483a-a928-e7a373d21f6c.json
+++ b/packages/osquery_manager/kibana/osquery_pack_asset/osquery_manager-15e85d01-713d-483a-a928-e7a373d21f6c.json
@@ -1,0 +1,133 @@
+{
+    "attributes": {
+        "description": "Collect installed browser extension information for all users",
+        "name": "browser-monitoring",
+        "version": 1,
+        "queries": [
+            {
+                "ecs_mapping": [
+                    {
+                        "key": "file.path",
+                        "value": {
+                            "field": "path"
+                        }
+                    },
+                    {
+                        "key": "user.name",
+                        "value": {
+                            "field": "username"
+                        }
+                    },
+                    {
+                        "key": "file.name",
+                        "value": {
+                            "field": "name"
+                        }
+                    }
+                ],
+                "id": "chrome_extensions",
+                "interval": 21600,
+                "query": "SELECT * FROM users JOIN chrome_extensions USING (uid)",
+                "version": "1.4.5"
+            },
+            {
+                "ecs_mapping": [
+                    {
+                        "key": "user.name",
+                        "value": {
+                            "field": "username"
+                        }
+                    },
+                    {
+                        "key": "file.path",
+                        "value": {
+                            "field": "path"
+                        }
+                    },
+                    {
+                        "key": "user.full_name",
+                        "value": {
+                            "field": "description"
+                        }
+                    }
+                ],
+                "id": "chrome_extension_content_scripts",
+                "interval": 21600,
+                "query": "SELECT * FROM users JOIN chrome_extension_content_scripts USING (uid)",
+                "version": "1.4.5"
+            },
+            {
+                "id": "safari_extensions",
+                "interval": 21600,
+                "platform": "darwin",
+                "query": "SELECT * FROM users JOIN safari_extensions USING (uid)",
+                "version": "1.4.5"
+            },
+            {
+                "ecs_mapping": [
+                    {
+                        "key": "user.name",
+                        "value": {
+                            "field": "username"
+                        }
+                    },
+                    {
+                        "key": "file.path",
+                        "value": {
+                            "field": "path"
+                        }
+                    }
+                ],
+                "id": "firefox_addons",
+                "interval": 21600,
+                "query": "SELECT * FROM users JOIN firefox_addons USING (uid)",
+                "version": "1.4.5"
+            },
+            {
+                "ecs_mapping": [
+                    {
+                        "key": "file.path",
+                        "value": {
+                            "field": "path"
+                        }
+                    },
+                    {
+                        "key": "registry.path",
+                        "value": {
+                            "field": "registry_path"
+                        }
+                    }
+                ],
+                "id": "ie_extensions",
+                "interval": 21600,
+                "platform": "windows",
+                "query": "SELECT * FROM ie_extensions;",
+                "version": "1.4.5"
+            },
+            {
+                "ecs_mapping": [
+                    {
+                        "key": "user.name",
+                        "value": {
+                            "field": "username"
+                        }
+                    },
+                    {
+                        "key": "file.path",
+                        "value": {
+                            "field": "path"
+                        }
+                    }
+                ],
+                "id": "browser_plugins",
+                "interval": 21600,
+                "platform": "darwin",
+                "query": "SELECT * FROM users JOIN browser_plugins USING (uid)",
+                "version": "1.4.5"
+            }
+        ]
+    },
+    "coreMigrationVersion": "8.8.0",
+    "id": "osquery_manager-15e85d01-713d-483a-a928-e7a373d21f6c",
+    "type": "osquery-pack-asset"
+}

--- a/packages/osquery_manager/kibana/osquery_pack_asset/osquery_manager-15e85d01-713d-483a-a928-e7a373d21f6c.json
+++ b/packages/osquery_manager/kibana/osquery_pack_asset/osquery_manager-15e85d01-713d-483a-a928-e7a373d21f6c.json
@@ -1,8 +1,9 @@
 {
     "attributes": {
-        "description": "Collect installed browser extension information for all users",
+        "created_at": "2025-01-29T09:47:21.585Z",
+        "created_by": "system",
+        "description": "This pack collects information about browser extensions installed on workstations",
         "name": "browser-monitoring",
-        "version": 1,
         "queries": [
             {
                 "ecs_mapping": [
@@ -125,9 +126,17 @@
                 "query": "SELECT * FROM users JOIN browser_plugins USING (uid)",
                 "version": "1.4.5"
             }
-        ]
+        ],
+        "shards": [],
+        "updated_at": "2025-01-29T09:47:21.585Z",
+        "updated_by": "elastic"
     },
     "coreMigrationVersion": "8.8.0",
     "id": "osquery_manager-15e85d01-713d-483a-a928-e7a373d21f6c",
-    "type": "osquery-pack-asset"
+    "managed": false,
+    "references": [],
+    "type": "osquery-pack-asset",
+    "typeMigrationVersion": "10.1.0",
+    "updated_at": "2025-01-29T09:47:21.585Z",
+    "version": "WzI0NTQwNSw2MF0="
 }

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: osquery_manager
 title: Osquery Manager
-version: 1.15.0
+version: 1.15.1
 description: Deploy Osquery with Elastic Agent, then run and schedule queries in Kibana
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

This commit adds the browser-monitoring osquery pack asset to the osquery_manager integration. This pack collects information about browser extensions installed on workstations.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

To test this PR the `browser-monitoring` pack should be loaded into the list of preloaded osquery packs added by Elastic. 

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Screenshots

When loaded the pack should look like this: 
![image](https://github.com/user-attachments/assets/4caadaa7-97a7-4c92-9918-4bdbe20ed174)
