### PR TITLE
[PANW] Remove leftover message field after parse

### DIFF
--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "4.3.0"
+- version: "5.0.0"
   changes:
     - description: Remove leftover message field after parse
       type: breaking-change

--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove leftover message field after parse
       type: breaking-change
-      link: https://github.com/elastic/integrations/pull/XXXXX #TODO
+      link: https://github.com/elastic/integrations/pull/12517
 - version: "4.2.0"
   changes:
     - description: Parse URL in threat logs with 'domain-edl' threat category

--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.3.0"
+  changes:
+    - description: Remove leftover message field after parse
+      type: breaking-change
+      link: https://github.com/elastic/integrations/pull/XXXXX #TODO
 - version: "4.2.0"
   changes:
     - description: Parse URL in threat logs with 'domain-edl' threat category

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-audit-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-audit-sample.log-expected.json
@@ -54,7 +54,6 @@
                 "outcome": "success",
                 "timezone": "-04:00"
             },
-            "message": "2561,gui-op,Mustang,\"<show><config-locks><vsys>all</vsys></config-locks></show>\",success",
             "observer": {
                 "hostname": "10.1.1.1",
                 "product": "PAN-OS",
@@ -96,7 +95,6 @@
                 "outcome": "success",
                 "timezone": "-04:00"
             },
-            "message": "2561,gui-op,Mustang,\"<show><config-locks><vsys>all</vsys></config-locks></show>\",success",
             "observer": {
                 "hostname": "test-hostname",
                 "product": "PAN-OS",
@@ -138,7 +136,6 @@
                 "outcome": "success",
                 "timezone": "-04:00"
             },
-            "message": "2561,gui-op,Mustang,\"<show><config-locks><vsys>all</vsys></config-locks></show>\",success",
             "observer": {
                 "hostname": "test-hostname.test.intra",
                 "product": "PAN-OS",
@@ -180,7 +177,6 @@
                 "outcome": "success",
                 "timezone": "-04:00"
             },
-            "message": "2561,gui-op,redact,\"<debug><dataplane><packet-diag><show><setting/></show></packet-diag></dataplane></debug>\",success",
             "observer": {
                 "hostname": "10.1.1.1",
                 "product": "PAN-OS",
@@ -222,7 +218,6 @@
                 "outcome": "success",
                 "timezone": "-04:00"
             },
-            "message": "2561,gui-op,redact,\"<debug><dataplane><packet-diag><show><setting/></show></packet-diag></dataplane></debug>\",success",
             "observer": {
                 "hostname": "10.1.1.1",
                 "product": "PAN-OS",

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-audit-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-audit-sample.log-expected.json
@@ -13,7 +13,6 @@
                 "outcome": "success",
                 "timezone": "-04:00"
             },
-            "message": "2561,gui-op,suser,\"<debug><dataplane><packet-diag><show><setting/></show></packet-diag></dataplane></debug>\",success",
             "observer": {
                 "hostname": "192.168.0.1",
                 "product": "PAN-OS",

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-authentication-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-authentication-sample.log-expected.json
@@ -14,7 +14,6 @@
                 "outcome": "success",
                 "timezone": "-04:30"
             },
-            "message": "vsys1,fe80::4e7:1ab2:f6aa:82fa,user,normalize-user,object,auth-policy,12345,auth-id,vendor,log-action,server-profile,description,client-type,event-type,10,20,action-flag,0,0,0,0,vsys-name,device-name,vsys-id,auth-protocol,uuid,2021-11-23T01:03:05.498-08:00,src-category,src-profile,src-model,src-vendor,src-os-family,src-os-version,src-hostname,aa:aa:aa:aa:aa:aa,region,,\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36\",session-id",
             "network": {
                 "type": "ipv6"
             },

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-authentication-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-authentication-sample.log-expected.json
@@ -152,7 +152,6 @@
                 "outcome": "success",
                 "timezone": "-04:30"
             },
-            "message": "vsys1,10.20.30.40,,,AD-LDAP-MFA,MFA-Policy,1,123456789,,log-action,,No user activity after prompted for credentials from AUTH-PORTAL.,Authentication Portal,Authentication Timeout,1,9876543210,action-flag,1,0,0,0,,PA-850,1,,rule-uuid,2024-08-27T11:03:10.861+02:00,,,,,,,,,,,,0,",
             "network": {
                 "type": "ipv4"
             },

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-config-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-config-sample.log-expected.json
@@ -82,7 +82,6 @@
                     "81.2.69.193"
                 ]
             },
-            "message": "81.2.69.193,,set,admin,Web,Succeeded, config shared log-settings globalprotect match-list  globalProtect,,\"globalprotect { match-list { globalProtect  { send-syslog [ SYSLOG-1 ]; filter \"\"All Logs\"\"; } } } \",1234567890,0x0,0,0,0,0,,PA-VM,0,",
             "observer": {
                 "hostname": "PA-VM",
                 "product": "PAN-OS",
@@ -145,7 +144,6 @@
                     "81.2.69.193"
                 ]
             },
-            "message": "81.2.69.193,,set,admin,Web,Succeeded, vsys  vsys1 rulebase security rules  reset-adult,,reset-adult 73a06abf-75ca-436f-9319-1a15b27fa692 { to [ public ]; from [ private ]; source [ any ]; destination [ any ]; source-user [ any ]; category [ adult ]; application [ any ]; service [ application-default ]; source-hip [ any ]; destination-hip [ any ]; action reset-client; icmp-unreachable yes; log-start yes; rule-type interzone; } ,7286123782408765488,0x0,0,0,0,0,,PA-VM,0,",
             "observer": {
                 "hostname": "PA-VM",
                 "product": "PAN-OS",
@@ -209,7 +207,6 @@
                     "81.2.69.193"
                 ]
             },
-            "message": "81.2.69.193,,move,admin,Web,Succeeded, vsys  vsys1 rulebase security rules  block-1.1.1.1,,,7286123782408765487,0x0,0,0,0,0,,PA-VM,0,",
             "observer": {
                 "hostname": "PA-VM",
                 "product": "PAN-OS",
@@ -271,7 +268,6 @@
                     "81.2.69.193"
                 ]
             },
-            "message": "81.2.69.193,,override,admin,Web,Failed, deviceconfig system device-telemetry,,,7286123782408765440,0x0,0,0,0,0,,PA-VM,0,",
             "observer": {
                 "hostname": "PA-VM",
                 "product": "PAN-OS",
@@ -334,7 +330,6 @@
                     "81.2.69.193"
                 ]
             },
-            "message": "81.2.69.193,,edit,admin,Web,Succeeded, vsys vsys1 address test123,\"test123 { description \"\"this, is a test. with, three comma, x4\"\"; } \",\"test123 { description \"\"this, is a test. with, three comma, x5\"\"; } \",7304387121517691189,0x0,0,0,0,0,,PA-VM,0,,0,2024-02-29T16:59:40.421+01:00",
             "observer": {
                 "hostname": "PA-VM",
                 "product": "PAN-OS",

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-config-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-config-sample.log-expected.json
@@ -20,7 +20,6 @@
                     "81.2.69.193"
                 ]
             },
-            "message": "81.2.69.193,,set,admin,Web,Succeeded, config shared log-settings iptag match-list  ip-tag,,\"iptag { match-list { ip-tag  { send-syslog [ SYSLOG-1 ]; filter \"\"All Logs\"\"; } } } \",1234567890,0x0,0,0,0,0,,PA-VM,0,",
             "observer": {
                 "hostname": "PA-VM",
                 "product": "PAN-OS",

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-correlated-events-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-correlated-events-sample.log-expected.json
@@ -17,7 +17,6 @@
             "log": {
                 "level": "4"
             },
-            "message": "81.2.69.142,src-user,vsys,cat,4,0,0,0,0,vsys-name,d-name,vsys-id,o-name,o-id,evidence",
             "network": {
                 "type": "ipv4"
             },

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-decryption-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-decryption-sample.log-expected.json
@@ -41,7 +41,6 @@
                 "nat_translated": true,
                 "ssl_decrypted": true
             },
-            "message": "81.2.69.145,81.2.69.144,81.2.69.145,81.2.69.144,intrazone-default,,,incomplete,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,,2021/11/11 15:42:44,33288,1,49908,443,49908,20077,0x1400000,tcp,allow,N/A,,,,,731a6a1a-9a62-4a92-a49a-0876025a9436,Server_Hello,Client_Hello,TLS1.2,ECDHE,AES_256_GCM,SHA384,,,Certificate,trusted,Trusted,GlobalProtect,ba67e84495b59512,a6a13e87221733b712ddbd0978da1ffdd69503dfd1f0a86f73d86bf90b743b85,2021/11/11 15:21:28,2022/11/11 15:21:28,V3,2048,9,9,0,0,:::::RSA,com.example.com,com.example.com,,,Received fatal alert CertificateUnknown from client,,,,,,,,2021-11-11T15:42:44.845-08:00,,,,,,,,,,,,,,,,,7028724914890736000,0x0,0,0,0,0,,PA-VM,1,unknown,unknown,unknown,1,,,incomplete,no",
             "network": {
                 "application": "incomplete",
                 "community_id": [

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-decryption-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-decryption-sample.log-expected.json
@@ -240,7 +240,6 @@
                 "nat_translated": true,
                 "ssl_decrypted": true
             },
-            "message": "81.2.69.145,81.2.69.144,81.2.69.145,81.2.69.144,intrazone-default,,,incomplete,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,,2021/11/11 15:42:44,33288,1,49908,443,49908,20077,0x1400000,tcp,allow,N/A,,,,,731a6a1a-9a62-4a92-a49a-0876025a9436,Server_Hello,Client_Hello,TLS1.2,ECDHE,AES_256_GCM,SHA384,,,Certificate,trusted,Trusted,GlobalProtect,ba67e84495b59512,a6a13e87221733b712ddbd0978da1ffdd69503dfd1f0a86f73d86bf90b743b85,2021/11/11 15:21:28,2022/11/11 15:21:28,V3,Unknown,9,9,0,0,:::::RSA,com.example.com,com.example.com,,,Received fatal alert CertificateUnknown from client,,,,,,,,2021-11-11T15:42:44.845-08:00,,,,,,,,,,,,,,,,,7028724914890736000,0x0,0,0,0,0,,PA-VM,1,unknown,unknown,unknown,1,,,incomplete,no",
             "network": {
                 "application": "incomplete",
                 "community_id": [
@@ -439,7 +438,6 @@
             "labels": {
                 "decrypted_traffic": true
             },
-            "message": "81.2.69.145,81.2.69.144,81.2.69.145,81.2.69.144,intrazone-default,,,ssl,vsys1,LAN,PROXY,ae1,ethernet1/5,TEST-Log,2024/05/30 15:46:50,35508943,1,60312,9400,0,0,0x400,tcp,allow,N/A,,,,,731a6a1a-9a62-4a92-a49a-0876025a9436,Unknown,Unknown,TLS1.3,ECDHE,AES_256_GCM,SHA384,SSL Exception Destination Hosts,,None,uninspected,Uninspected,No Decrypt,,,,,V1,0,0,0,0,0,:::::NONE,,,,,,,,,,,,,2024-05-27T15:46:51.539+02:00,,,,,,,,,,,,,,,,,7335860982980205586,0x8000000000000000,12,0,0,0,,TESTFW01,1,encrypted-tunnel,networking,browser-based,4,\\\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\\\",,ssl,no,no",
             "network": {
                 "application": "ssl",
                 "community_id": "1:qCIgD9m/NwEUSR7fxRwieKZtcc8=",
@@ -596,7 +594,6 @@
             "labels": {
                 "ssl_decrypted": true
             },
-            "message": "10.46.249.76,10.68.15.198,0.0.0.0,0.0.0.0,SectorProxy Browsing lko-user,,,incomplete,vsys1,interconnect,proxy,ethernet1/2,ethernet1/3,HOST-LOGCOLLECTOR,2024/08/19 13:58:18,886968,1,14620,8098,0,0,0x1000000,tcp,allow,N/A,,,,,89bec869-072f-4d78-9691-ed67ebc08749,Unknown,Unknown,TLS1.3,,,,Decrypt - SOC - my-user,,Protocol,uninspected,Uninspected,Forward,,,,,V1,0,0,0,0,13,:::::NONE,,,,www2.example.com,TLS Handshake Failure. Received fatal alert HandshakeFailure from server,,,,,,,,2024-08-19T13:58:18.289+00:00,,,,,,,,,,,,,,,,,7395705320301543310,0x8000000000000000,850,852,0,0,,fw1034,1,unknown,unknown,unknown,1,,,incomplete,no,no",
             "network": {
                 "application": "incomplete",
                 "community_id": "1:v6CpC7JhBowT3JTASj/bcaOVqw0=",

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-globalprotect-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-globalprotect-sample.log-expected.json
@@ -26,7 +26,6 @@
                     "full": "OS 10 Pro , 64-bit"
                 }
             },
-            "message": "vsys1,portal-prelogin,before-login,,,,BE,,216.160.83.57,0.0.0.0,81.2.69.193,0.0.0.0,09300aaa-23-4900-8aa9-32695452aa,,5.2.4,OS,\"OS 10 Pro , 64-bit\",1,,,\"\",success,,0,,0,GlobalProtect Portal,69200719497738,0x0",
             "network": {
                 "type": "ipv4"
             },

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-globalprotect-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-globalprotect-sample.log-expected.json
@@ -110,7 +110,6 @@
                     "full": "OS 10 Pro , 64-bit"
                 }
             },
-            "message": "vsys1,gateway-config-release,configuration,,,domain\\user,BE,CP935,89.160.20.112,0.0.0.0,10.20.13.217,0.0.0.0,e0957c11-93-437a-9e23-9f0c24059898,5J9VN53,5.2.4,OS,\"OS 10 Pro , 64-bit\",1,,,\"\",success,,0,,0,GlobalProtect_GW,6919501582016786,0x0",
             "network": {
                 "type": "ipv4"
             },
@@ -209,7 +208,6 @@
                 ],
                 "name": "host82878"
             },
-            "message": "vsys1,gateway-hip-check,host-info,,,domain\\user1,,HOST82878,1.128.3.4,0.0.0.0,67.43.156.14,0.0.0.0,523e8b-7efa-4397-a4d5-824dfa4d8a,F1SM2,5.2.4,,\"\",1,,,\"HIP report is not needed\",success,,0,,0,GlobalProtect_GW,6920071768563516860,0x0",
             "network": {
                 "type": "ipv4"
             },
@@ -306,7 +304,6 @@
                     "full": "OS 10 Pro , 64-bit"
                 }
             },
-            "message": "vsys1,gateway-getconfig,configuration,,IPSec,pre-logon,BE,HOST73486,81.2.69.193,0.0.0.0,89.160.20.112,0.0.0.0,7d01b5-f538-4fa3-a2a2-83980d1325,5C261FNR,5.2.4,OS,\"OS 10 Pro , 64-bit\",1,,,\"Config name: , Client region: BE.\",success,,0,,0,GlobalProtect_GW,6944137135219737,0x0",
             "network": {
                 "type": "ipv4"
             },
@@ -405,7 +402,6 @@
                 ],
                 "name": "hostp92413"
             },
-            "message": "vsys1,gateway-tunnel-latency,tunnel,,,,userlterso,HOSTP92413,81.2.69.143,0.0.0.0,0.0.0.0,0.0.0.0,2ba9f01-b83b-4902-a1fb-1748c0365,GJG98Y2,5.2.4,,\"\",1,,,\"Pre-tunnel latency: 67ms, Post-tunnel latency: 47ms\",success,,0,,0,GlobalProtect_GW,6920071768563516847,0x0",
             "network": {
                 "type": "ipv4"
             },
@@ -492,7 +488,6 @@
                     "full": "OS 10 Enterprise, 64-bit"
                 }
             },
-            "message": "vsys1,gateway-auth,login,Other,,maxmustermann,10.0.0.0-10.255.255.255,PC1234,10.20.30.40,0.0.0.0,0.0.0.0,0.0.0.0,985e865f-7da3-43b4-89a9-299b1bb0c975,SERIALNR,5.1.1,OS,\"OS 10 Enterprise, 64-bit\",1,,,,success,,0,pre-logon,0,GP GW intern,6894571632887748064,0x8000000000000000,1970-01-01T01:00:00.000+01:00,,0,manual only,,",
             "network": {
                 "type": "ipv4"
             },
@@ -581,7 +576,6 @@
                     "full": "OS 10 Enterprise, 64-bit"
                 }
             },
-            "message": "vsys1,gateway-setup-ipsec,tunnel,,IPSec,domain\\musterman,DE,Rechner123,175.16.199.1,0.0.0.0,10.20.30.40,0.0.0.0,96c43d47-8bb5-4f78-8dfc-413a189a29e0,SERIALNR,5.1.1,OS,\"OS 10 Enterprise, 64-bit\",1,,,,success,,0,,0,GPGateway,6894571632887761989,0x8000000000000000,1970-01-01T01:00:00.000+01:00,,0,manual only,,",
             "network": {
                 "type": "ipv4"
             },
@@ -680,7 +674,6 @@
                     "full": "OS 10 Enterprise, 64-bit"
                 }
             },
-            "message": "vsys1,portal-prelogin,before-login,,,Max.Mustermann@domain.de,10.0.0.0-10.255.255.255,,10.20.30.40,0.0.0.0,0.0.0.0,0.0.0.0,0183d851-7ea2-4a0d-80de-fde1e04ce12f,,5.1.1,OS,\"OS 10 Enterprise, 64-bit\",1,,,,success,,0,,0,GP Portal,6894571632887745099,0x8000000000000000,1970-01-01T01:00:00.000+01:00,,0,manual only,,",
             "network": {
                 "type": "ipv4"
             },
@@ -765,7 +758,6 @@
                     "full": "OS 10 Enterprise, 64-bit"
                 }
             },
-            "message": "vsys1,portal-getconfig,configuration,,,domain\\maxmustermann,10.0.0.0-10.255.255.255,PC12345,10.20.30.40,0.0.0.0,0.0.0.0,0.0.0.0,8cbc136b-e262-4cf8-912c-95ea132d9fef,SERIENNR,5.1.1,OS,\"OS 10 Enterprise, 64-bit\",1,,,\"Config name: GP Clients, Machine Certificate CN : (null)\",success,,0,pre-logon,0,GP Portal,6894571632887746544,0x8000000000000000,1970-01-01T01:00:00.000+01:00,,0,manual only,,",
             "network": {
                 "type": "ipv4"
             },
@@ -852,7 +844,6 @@
                 ],
                 "name": "hostname"
             },
-            "message": "vsys1,gateway-hip-check,host-info,,,host\\\\user,,HOSTNAME,10.1.1.1,,10.2.2.2,fc00::1,8cbc136b-e262-4cf8-912c-95ea132d9fef,SERIALNR,5.2.6,,,1,,,HIP report is not needed,success,,0,,0,GlobalProtect_External_Gateway,1305925,true",
             "network": {
                 "type": "ipv4"
             },
@@ -933,7 +924,6 @@
                 ],
                 "name": "hostname"
             },
-            "message": "vsys1,gateway-tunnel-latency,tunnel,,,user,,HOSTNAME,10.3.3.3,,10.4.4.4,,8cbc136b-e262-4cf8-912c-95ea132d9fef,SERIALNR,5.2.8,,,1,,,\"Pre-tunnel latency: 35ms, Post-tunnel latency: 16ms\",success,,0,,0,GlobalProtect_External_Gateway,1041590,true",
             "network": {
                 "type": "ipv4"
             },
@@ -1012,7 +1002,6 @@
                 ],
                 "name": "hostname"
             },
-            "message": "vsys1,gateway-tunnel-latency,tunnel,,,user,,HOSTNAME,,fc00::1234,,fc00::abcd,8cbc136b-e262-4cf8-912c-95ea132d9fef,SERIALNR,5.2.8,,,1,,,\"Pre-tunnel latency: 35ms, Post-tunnel latency: 16ms\",success,,0,,0,GlobalProtect_External_Gateway,1041590,true",
             "network": {
                 "type": "ipv6"
             },

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-gtp-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-gtp-sample.log-expected.json
@@ -37,7 +37,6 @@
             "log": {
                 "level": "4"
             },
-            "message": "81.2.69.142,81.2.69.144,,,rule-name,,,app,v-system,s-zone,d-zone,inbound-int,outbound-int,log-action,,1212121,,9550,9551,,,,tcp,action,gtp-event,msisdn,apn,rat,gtp-msg-type,81.2.69.142,TE-Ide-1,TE-Ide-2,GTP-interface,GTP-cause,4,mcc,mnc,1010,100,GTP-event-code,,,src-loc,dst-loc,,,,,,,,imsi,imei,,,,,,,,,,,,,,,,,2021/10/26 15:35:42,9999,TI-Rule,81.2.69.142,remote-user-id,uuid,pcap-id,1970-01-01T01:00:00.000+01:00,ASST,ASD,app-sub-cat,app-cat,app-tech,4,app-char,app-container,no,no",
             "network": {
                 "application": "app",
                 "community_id": "1:Lg7reiz4N7t4w/tC1zo+4I0ysCs=",

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-hipmatch-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-hipmatch-sample.log-expected.json
@@ -94,7 +94,6 @@
                     "full": "Mac"
                 }
             },
-            "message": "ira,vsys1,oh-C02ABCDEFGH4,Mac,89.160.20.112,GP-HIP-PROFILE,1,profile,0,0,0123456789,0x0,0,0,0,0,,SumoRedfw01a,1,0.0.0.0,gh:85:90:99:5a:40,C02ABCDEFGH",
             "network": {
                 "type": "ipv4"
             },

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-hipmatch-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-hipmatch-sample.log-expected.json
@@ -17,7 +17,6 @@
                 "id": "d275bcbe-3a07-4e69-85c5-3ad9192c212e",
                 "name": "pc12345"
             },
-            "message": "domain\\mustermanm,vsys1,PC12345,,10.20.30.40,GlobalProtect 5.1.1,1,object,0,0,6894571641485024543,0x8000000000000000,267,24,19,0,,de-firewall,1,0.0.0.0,d275bcbe-3a07-4e69-85c5-3ad9192c212e,F0S48Y2,,1970-01-01T01:00:00.000+01:00",
             "network": {
                 "type": "ipv4"
             },

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-other-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-other-sample.log-expected.json
@@ -20,7 +20,6 @@
                     "192.168.0.2"
                 ]
             },
-            "message": "192.168.0.2,,set,admin,Web,Succeeded, config shared local-user-database user  badguy,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "1606001116",

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-other-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-other-sample.log-expected.json
@@ -73,7 +73,6 @@
                     "192.168.0.2"
                 ]
             },
-            "message": "192.168.0.2,,set,admin,Web,Succeeded, config mgt-config users  badguy,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "1606001116",
@@ -127,7 +126,6 @@
                     "192.168.0.2"
                 ]
             },
-            "message": "192.168.0.2,,commit,admin,Web,Submitted,,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "1606001116",
@@ -178,7 +176,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",routed-config-p1-success,,0,0,general,informational,Route daemon configuration load phase-1 succeeded.,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "1606001116",
@@ -219,7 +216,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",ike-config-p1-success,,0,0,general,informational,IKE daemon configuration load phase-1 succeeded.,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "1606001116",
@@ -260,7 +256,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",routed-config-p2-success,,0,0,general,informational,Route daemon configuration load phase-2 succeeded.,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "1606001116",
@@ -301,7 +296,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",rasmgr-config-p2-success,,0,0,general,informational,RASMGR daemon configuration load phase-2 succeeded.,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "1606001116",
@@ -344,7 +338,6 @@
                     "192.168.0.2"
                 ]
             },
-            "message": "192.168.0.2,,edit,badguy,Web,Succeeded, vsys  vsys1 profiles url-filtering  monzyspolicy,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "1606001116",
@@ -398,7 +391,6 @@
                     "192.168.0.2"
                 ]
             },
-            "message": "192.168.0.2,,commit,badguy,Web,Submitted,,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "1606001116",
@@ -449,7 +441,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",routed-config-p1-success,,0,0,general,informational,Route daemon configuration load phase-1 succeeded.,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "1606001116",
@@ -490,7 +481,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",ike-config-p1-success,,0,0,general,informational,IKE daemon configuration load phase-1 succeeded.,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "1606001116",
@@ -531,7 +521,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",routed-config-p2-success,,0,0,general,informational,Route daemon configuration load phase-2 succeeded.,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "1606001116",
@@ -572,7 +561,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",ike-config-p2-success,,0,0,general,informational,IKE daemon configuration load phase-2 succeeded.,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "1606001116",
@@ -613,7 +601,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",rasmgr-config-p2-success,,0,0,general,informational,RASMGR daemon configuration load phase-2 succeeded.,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "1606001116",
@@ -654,7 +641,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",unknown,,0,0,general,informational,Config installed,909,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "1606001116",
@@ -695,7 +681,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",general,,0,0,general,informational,Log type config cleared by user badguy ,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "1606001116",
@@ -736,7 +721,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",unknown,,0,0,general,informational,Config installed,884,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "01606001116",
@@ -777,7 +761,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",rasmgr-config-p2-success,,0,0,general,informational,RASMGR daemon configuration load phase-2 succeeded.,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "01606001116",
@@ -818,7 +801,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",ike-config-p2-success,,0,0,general,informational,IKE daemon configuration load phase-2 succeeded.,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "01606001116",
@@ -859,7 +841,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",routed-config-p2-success,,0,0,general,informational,Route daemon configuration load phase-2 succeeded.,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "01606001116",
@@ -900,7 +881,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",rasmgr-config-p1-success,,0,0,general,informational,RASMGR daemon configuration load phase-1 succeeded.,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "01606001116",
@@ -941,7 +921,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",routed-config-p1-success,,0,0,general,informational,Route daemon configuration load phase-1 succeeded.,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "01606001116",
@@ -982,7 +961,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",unknown,,0,0,general,informational,Config installed,840,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "01606001116",
@@ -1023,7 +1001,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",rasmgr-config-p2-success,,0,0,general,informational,RASMGR daemon configuration load phase-2 succeeded.,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "01606001116",
@@ -1064,7 +1041,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",ike-config-p2-success,,0,0,general,informational,IKE daemon configuration load phase-2 succeeded.,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "01606001116",
@@ -1105,7 +1081,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",routed-config-p2-success,,0,0,general,informational,Route daemon configuration load phase-2 succeeded.,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "01606001116",
@@ -1146,7 +1121,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",rasmgr-config-p1-success,,0,0,general,informational,RASMGR daemon configuration load phase-1 succeeded.,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "01606001116",
@@ -1187,7 +1161,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",ike-config-p1-success,,0,0,general,informational,IKE daemon configuration load phase-1 succeeded.,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "01606001116",
@@ -1230,7 +1203,6 @@
                     "192.168.0.2"
                 ]
             },
-            "message": "192.168.0.2,,commit,admin,Web,Submitted,,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "01606001116",
@@ -1283,7 +1255,6 @@
                     "192.168.0.2"
                 ]
             },
-            "message": "192.168.0.2,,edit,admin,Web,Succeeded, vsys  vsys1 profiles data-objects  PII,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "01606001116",
@@ -1335,7 +1306,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",unknown,,0,0,general,informational,Config installed,821,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "01606001116",
@@ -1376,7 +1346,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",rasmgr-config-p2-success,,0,0,general,informational,RASMGR daemon configuration load phase-2 succeeded.,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "01606001116",
@@ -1417,7 +1386,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",ike-config-p2-success,,0,0,general,informational,IKE daemon configuration load phase-2 succeeded.,0,0x0",
             "observer": {
                 "product": "PAN-OS",
                 "serial_number": "01606001116",
@@ -1485,7 +1453,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:57,25149,1,59309,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:56,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -1596,7 +1563,6 @@
                     "connection"
                 ]
             },
-            "message": "10.1.0.12,192.168.0.2,,,block-1.1.1.1,,,not-applicable,vsys1,private,public,ethernet1/2,,elastic,2023/10/04 09:52:23,0,1,35906,80,0,0,0x4000,tcp,drop,0,0,0,1,2023/10/04 09:52:21,0,any,,7286123782408766774,0x0,10.0.0.0-10.255.255.255,United States,,1,0,policy-deny,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2023-10-04T09:52:23.437-07:00",
             "network": {
                 "application": "not-applicable",
                 "bytes": 0,

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-threat-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-threat-sample.log-expected.json
@@ -46,7 +46,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:58,25149,1,59309,80,0,0,0x208000,tcp,alert,\"lorexx.cn/loader.exe\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:CpnxxiYk2GolQXL1AiyOIq2jeIE=",

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-threat-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-threat-sample.log-expected.json
@@ -211,7 +211,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:58,26067,1,59313,80,0,0,0x208000,tcp,alert,\"lsiu.info/evo/count.php?o=2\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:lB9VWdNEHqna/swiak+4X1dqv1k=",
@@ -378,7 +377,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:58,26522,1,59314,80,0,0,0x208000,tcp,alert,\"lsiu.info/evo/count.php?o=5\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:3be4rO6jMOmXDKYhNViDYESR4pg=",
@@ -545,7 +543,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:58,25112,1,59315,80,0,0,0x208000,tcp,alert,\"lsiu.info/evo/count.php?o=7\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:CvgumdBliLFimUvrE/1C91M3lrQ=",
@@ -712,7 +709,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:58,25179,1,59316,80,0,0,0x208000,tcp,alert,\"lsiu.info/evo/exploits/x18.php?o=2&t=1241403746&i=1365814122\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:6fDJsdstw4iPHg4mtYfqCIw/9W8=",
@@ -879,7 +875,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:58,25848,1,59317,80,0,0,0x208000,tcp,alert,\"lsiu.info/evo/exploits/x19.php?o=2&t=1241403746&i=1365814122\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:36riPo5QLmTmjShd1xO6omV9lbg=",
@@ -1046,7 +1041,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:56,24910,1,59302,80,0,0,0x208000,tcp,alert,\"liteautobestguide.cn/load.php\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:GY8jhTkAcplSQMn+CC7/azIV2gs=",
@@ -1212,7 +1206,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:56,26862,1,59301,80,0,0,0x208000,tcp,alert,\"liteautobestguide.cn/index.php\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:5JhT/ZcbuwDQS34hGqhKf01RQ34=",
@@ -1378,7 +1371,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:57,22860,1,59303,80,0,0,0x208000,tcp,alert,\"litetopdetect.cn/index.php\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:JLt9t3wJPT2YYVwyev/DS8HhBiQ=",
@@ -1544,7 +1536,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:57,26360,1,59304,80,0,0,0x208000,tcp,alert,\"lkmpmlm.com/fff9999.php?aid=0&uid=6cbbc5081e7548e276611ff5059df6ed30c8f8f1&os=513\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:AYXyX5+VIkDGOJnqe2YBg9tVR5g=",
@@ -1711,7 +1702,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:54,25543,1,59297,80,0,0,0x208000,tcp,alert,\"girlteenxxxfreemov.com/\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:045bWPQTN726UkmixpDOZJC9Yi4=",
@@ -1876,7 +1866,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:55,25437,1,59299,80,0,0,0x208000,tcp,alert,\"imagesrepository.com/resolution.php\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:H2dYyEhLqvaoBzgcR4r/ZZbNhd0=",
@@ -2042,7 +2031,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:55,26338,1,59298,80,0,0,0x208000,tcp,alert,\"hottestfiles.com/search/search.php?q=xxx\",(9999),search-engines,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:Khx1n7BSHDnacX/jmUf9qzaA43E=",
@@ -2208,7 +2196,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:55,25713,1,59300,80,0,0,0x200000,tcp,block-url,\"infodist1.com/in.cgi?11&parameter=404\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:jTZdxPnMPc+sLaxgXFcrsz+OuvQ=",
@@ -2374,7 +2361,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:53,25451,1,59295,80,0,0,0x208000,tcp,alert,\"cls-softwares.com/suc.php\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:vCMdT6zPx0277mqoTE2FybOH35w=",
@@ -2540,7 +2526,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:53,26414,1,59291,80,0,0,0x208000,tcp,alert,\"cls-softwares.com/softwarefortubeview.40013.exe\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:koetsWC4zZQTKrn1+nSjU/gkrDc=",
@@ -2705,7 +2690,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:53,26927,1,59296,80,0,0,0x200000,tcp,block-url,\"findmorepill.com/klik/search.php?q=xxx\",(9999),online-gambling,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,Germany,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:oDY9jf8hdgOlTemZLRLtdPEwuRY=",
@@ -2871,7 +2855,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:51,26127,1,59280,80,0,0,0x208000,tcp,alert,\"allowedwebsurfing.com/\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:qI6GZCcTdUKaf6uoJvk4RiEYMoc=",
@@ -3036,7 +3019,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:51,25306,1,59281,80,0,0,0x208000,tcp,alert,\"antivirus-remote.com/\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:euxf4A6kWeWGJu6MuGDs2l85ugI=",
@@ -3201,7 +3183,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:52,24561,1,59282,80,0,0,0x208000,tcp,alert,\"bklinkov.ru/hi/start.cfg\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:SdTb469tRCABgoEEDDEw1DSQQHs=",
@@ -3367,7 +3348,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:52,15099,1,59290,80,0,0,0x208000,tcp,alert,\"blogsexnakedgirlxxx.com/\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:77gDm3uChN5sMPF96tsLJjK6Bc4=",
@@ -3532,7 +3512,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:52,24955,1,59286,80,0,0,0x208000,tcp,alert,\"bklinkov.ru/hi/start.exe\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:MRL6gXI2+bPHjOwl6jUcT9qzDE4=",
@@ -3698,7 +3677,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:49,25398,1,59275,80,0,0,0x208000,tcp,alert,\"-/\",(9999),private-ip-addresses,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:g+OW2rFxOQFbjQiQ/fw145Cfric=",
@@ -3863,7 +3841,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:49,25945,1,59277,80,0,0,0x208000,tcp,alert,\"-/\",(9999),private-ip-addresses,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:6PzwuKfF+39cTFyZytdFAhD4w44=",
@@ -4028,7 +4005,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:49,27111,1,59276,80,0,0,0x208000,tcp,alert,\"-/\",(9999),private-ip-addresses,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:vRVo2Gp1oNRBcvj5NtWtblslqFk=",
@@ -4193,7 +4169,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:50,25871,1,59278,80,0,0,0x208000,tcp,alert,\"-/\",(9999),private-ip-addresses,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:06OCvk6jDtgpNZu7X72+H8dLeQ8=",
@@ -4358,7 +4333,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:50,26251,1,59279,80,0,0,0x208000,tcp,alert,\"-/\",(9999),private-ip-addresses,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:zCXr7ZHueb4XQvihT/RtgRKe8VI=",
@@ -4523,7 +4497,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:47,24816,1,59271,80,0,0,0x208000,tcp,alert,\"-/\",(9999),private-ip-addresses,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:1lzsBSPnoPJeEUEveEgV+jZ1xOA=",
@@ -4688,7 +4661,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:47,25062,1,59269,80,0,0,0x208000,tcp,alert,\"-/\",(9999),private-ip-addresses,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:SXzPelGxF8TuDIbRbwKvR0ebxPA=",
@@ -4853,7 +4825,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:47,26266,1,59270,80,0,0,0x208000,tcp,alert,\"-/\",(9999),private-ip-addresses,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:susDkHpBXaMVE4YOqEBbFKp9r00=",
@@ -5018,7 +4989,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:48,23898,1,59274,80,0,0,0x208000,tcp,alert,\"-/\",(9999),private-ip-addresses,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:iXmhRxdINxEmOXTjxHfTv8gVn1o=",
@@ -5183,7 +5153,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:48,25259,1,59273,80,0,0,0x208000,tcp,alert,\"-/\",(9999),private-ip-addresses,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:B6oxpQQYa0rsyW55IuJO81SLmqQ=",
@@ -5348,7 +5317,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:48,26466,1,59272,80,0,0,0x208000,tcp,alert,\"-/\",(9999),private-ip-addresses,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:i77fJfEDsnltkr5Ib1/ISaydfdg=",
@@ -5512,7 +5480,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:44,4086,1,59261,80,0,0,0x200000,tcp,block-url,\"wantfinest.com/tds/in.cgi?default\",(9999),unknown,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:IJvQ8uQdf8IMfv+pa7ougp18GvM=",
@@ -5677,7 +5644,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:39,26534,1,59248,80,0,0,0x200000,tcp,block-url,\"sameshitasiteverwas.com/traf/tds/in.cgi?2\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,Korea Republic Of,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:q2pcfpZcAPG71w/ewi9qWbP1iPo=",
@@ -5842,7 +5808,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:40,26965,1,59251,80,0,0,0x200000,tcp,block-url,\"svarkon.ru/update.exe\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,Russian Federation,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:nE+H7Z778BIW5nL9ViBz57RhPQI=",
@@ -6006,7 +5971,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:37,26076,1,59244,80,0,0,0x200000,tcp,block-url,\"onlinescanxpp.com/land/eurl/1.php?code=\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:g3JhDl3Gkv1JmUHYgub2bB0hWK4=",
@@ -6171,7 +6135,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:35,26198,1,59237,80,0,0,0x200000,tcp,block-url,\"nolagtime.com/conn/?JKV_1RWbUUdIfRUWUaITfdIfbREdYEYdfTTRI-6XBB_1WQR-6GF5_1AU-6LC6_1Y-gW-gEUQQ-gE-tsDF6K5D_rpX51_rR-t-66FC_1Q_fQ_fQ_fQ_fQ_fQ_fQ_fQ-62BG_1Q-672V_1YOR-6N8J_1Q-6252_1WQRR-69LV_1-65GZ_1W-6\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:46UstfGPWeZVxrzoO9FBbSk5buo=",
@@ -6335,7 +6298,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:36,26056,1,59238,80,0,0,0x200000,tcp,block-url,\"nolagtime.com/gwc.txt\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:fEjmFv/r7P1mfCuztp/sNazEdmg=",
@@ -6499,7 +6461,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:38:20,25465,1,59010,80,0,0,0x200000,tcp,block-url,\"karavan.us/bon/index.php\",(9999),unknown,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:Itoh3MIE1ST0EL8MzzvZn6JtmTQ=",
@@ -6663,7 +6624,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:38:15,24316,1,58969,80,0,0,0x200000,tcp,block-url,\"findnolimits.com/go.php?sid=1\",(9999),dead-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:Ys9Ml4mGCmU2eiSE7dR++eJlyOA=",
@@ -6828,7 +6788,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:38:13,17258,1,58941,80,0,0,0x200000,tcp,block-url,\"bizoplata.ru/moun.html\",(9999),parked-domains,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,Russian Federation,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:zO0hayGDH/CHTey82VssD6lNSiU=",
@@ -6992,7 +6951,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:38:13,24735,1,58942,80,0,0,0x200000,tcp,block-url,\"bizoplata.ru/palast.html\",(9999),parked-domains,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,Russian Federation,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:u3SLWX+WInAjEpFvbgZJ7ppjDRY=",
@@ -7145,7 +7103,6 @@
             "log": {
                 "level": "critical"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,crusher,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:37:33,23497,1,80,58849,0,0,0x200000,tcp,drop-all-packets,\"controller.php\",Bredolab.Gen Command and Control Traffic(13024),any,critical,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:1QAo/7Uu2ZnQ3tX0xM16HUiNjrs=",
@@ -7307,7 +7264,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:37:32,23711,1,58856,80,0,0,0x200000,tcp,block-url,\"www.15min.it/\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,Canada,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:fAZZS4QiYR9HRv2mpevkcTa8bEI=",
@@ -7470,7 +7426,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:37:27,23659,1,58847,80,0,0,0x200000,tcp,block-url,\"tubemov.com/\",(9999),adult-and-pornography,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:xI/vHpVryFpDr9TeLpa+sn06lIg=",
@@ -7633,7 +7588,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:37:25,23782,1,58841,80,0,0,0x200000,tcp,block-url,\"pagesinxt.com/?dn=teenstube.us&flrdr=yes&nxte=js\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,Virgin Islands British,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:UYDmWKyJJKqYep7xR0rD4zO6+ME=",
@@ -7797,7 +7751,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:37:06,23239,1,58795,80,0,0,0x200000,tcp,block-url,\"movfree.com/\",(9999),spyware-and-adware,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:Q4nvWFoSeEki/rbya7cqvARiQi8=",
@@ -7960,7 +7913,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:36:52,22479,1,58753,80,0,0,0x200000,tcp,block-url,\"gometascan.com/\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:6ovStyNF6gHrKTo/Q05+3qFBMNM=",
@@ -8123,7 +8075,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:36:40,21458,1,58708,80,0,0,0x200000,tcp,block-url,\"antivirus-powerful-scannerv2.com/download/Install_11-1.exe\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:Xm3NWlcLQMLGItqDbcIMdKH+qek=",
@@ -8287,7 +8238,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:36:39,21577,1,58707,80,0,0,0x200000,tcp,block-url,\"antivirus-powerful-scannerv2.com/1/?id=11-1&back==TQzyDTyMUQNMI=N\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:d7zW/Z+qbkM84EVWHsgcDUV40MY=",
@@ -8451,7 +8401,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:36:28,21487,1,58603,80,0,0,0x200000,tcp,block-url,\"basdzsdas.com/poker/config.bin\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:G7F7gp4Vd2RQ5kRfwVmq8efOZL0=",
@@ -8615,7 +8564,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:36:28,21487,1,58603,80,0,0,0x200000,tcp,block-url,\"basdzsdas.com/poker/config.bin\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:G7F7gp4Vd2RQ5kRfwVmq8efOZL0=",
@@ -8774,7 +8722,6 @@
             "log": {
                 "level": "low"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,crusher,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:20:05,64856,1,80,54431,0,0,0x200000,tcp,deny,\"uLLGRaXP.exe\",Windows Executable (EXE)(52020),any,low,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:dd+2RtCBMUfATx7W9zSc0ZBYnK0=",
@@ -8936,7 +8883,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:36:28,21487,1,58603,80,0,0,0x200000,tcp,block-url,\"basdzsdas.com/poker/config.bin\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:G7F7gp4Vd2RQ5kRfwVmq8efOZL0=",
@@ -9095,7 +9041,6 @@
             "log": {
                 "level": "low"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,crusher,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:51:34,37983,1,80,61220,0,0,0x200000,tcp,deny,\"FunkyEmoticons_setup.exe\",Windows Executable (EXE)(52020),any,low,server-to-client,0,0x0,European Union,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:hh9v5OE+zszAvwG3xMpfjtFz8B0=",
@@ -9252,7 +9197,6 @@
             "log": {
                 "level": "low"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,crusher,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:54:38,41989,1,80,61726,0,0,0x200000,tcp,deny,\"52hxw.exe\",Windows Executable (EXE)(52020),any,low,server-to-client,0,0x0,China,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:vpiRKKCil4wbkrh++9kb1un4Ymo=",
@@ -9414,7 +9358,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 05:01:00,49238,1,63007,80,0,0,0x200000,tcp,block-url,\"softsellfast.com/test/config.bin\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:6b7FIfvAunGzr85o0MLQFvp0BQM=",
@@ -9573,7 +9516,6 @@
             "log": {
                 "level": "low"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,crusher,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:45:23,21592,1,80,60212,0,0,0x200000,tcp,deny,\"setup.exe\",Windows Executable (EXE)(52020),any,low,server-to-client,0,0x0,Netherlands,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:BQ/dUPZO8/mW0sp66fiTYAhPyE4=",
@@ -9730,7 +9672,6 @@
             "log": {
                 "level": "low"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,crusher,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:46:22,33760,1,80,60392,0,0,0x200000,tcp,deny,\"Live-Player_setup.exe\",Windows Executable (EXE)(52020),any,low,server-to-client,0,0x0,European Union,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:/mjoSXhsxmOmj+1KojpmihUMtnQ=",
@@ -9892,7 +9833,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:42:39,28723,1,59709,80,0,0,0x200000,tcp,block-url,\"boialex.narod.ru/config.txt\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,Russian Federation,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:ZithDSqahEs9YBK9Uwr8ubWPM7w=",
@@ -10056,7 +9996,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:42:42,28932,1,59721,80,0,0,0x200000,tcp,block-url,\"edw-melon.narod.ru/config.txt\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,Russian Federation,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:DHVwop+oDb6b+fXFJcQe+63vKqI=",
@@ -10220,7 +10159,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:42:51,28953,1,59752,80,0,0,0x200000,tcp,block-url,\"maximtushin.narod.ru/config.txt\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,Russian Federation,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:aNSYU1I4qtaV4fuGe9HTFru7eDc=",
@@ -10379,7 +10317,6 @@
             "log": {
                 "level": "low"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,crusher,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:20:05,64856,1,80,54431,0,0,0x200000,tcp,deny,\"uLLGRaXP.exe\",Windows Executable (EXE)(52020),any,low,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:dd+2RtCBMUfATx7W9zSc0ZBYnK0=",
@@ -10541,7 +10478,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:09:01,55402,1,63183,80,0,0,0x200000,tcp,block-url,\"marketingsoluchion.biz/fkn/config.bin\",(9999),unknown,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:2rgAHkgQA6DrgtjSmjlvvertGQQ=",
@@ -10704,7 +10640,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.6,175.16.199.1,0.0.0.0,0.0.0.0,rule1,jordy,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 08:18:32,25217,1,1047,80,0,0,0x200000,tcp,alert,\"default.aspx\",PII(60000),any,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:6aQBn5QchBNL0ZBo/IVt9BBsYB0=",
@@ -10854,7 +10789,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.6,0.0.0.0,0.0.0.0,rule1,,jordy,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 08:18:34,25653,1,80,1039,0,0,0x200000,tcp,alert,\"sck.aspx\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:5SoLZizmsszANiI7xjGLSw7GJbQ=",
@@ -11008,7 +10942,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.6,0.0.0.0,0.0.0.0,rule1,,jordy,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 08:18:37,25717,3,80,1064,0,0,0x200000,tcp,alert,\"ADSAdClient31.dll\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:YwIjUf5XmZ40QrFQbjqLanySfdw=",
@@ -11169,7 +11102,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.6,175.16.199.1,0.0.0.0,0.0.0.0,rule1,jordy,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 08:18:38,25290,1,1048,80,0,0,0x200000,tcp,alert,\"c.gif\",PII(60000),any,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:XYAoUgct4Qp84w3QO5r+XC/xzUE=",
@@ -11319,7 +11251,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.6,0.0.0.0,0.0.0.0,rule1,,jordy,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 08:18:42,25932,1,80,1071,0,0,0x200000,tcp,alert,\"csi\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:G3mrQpxPg+ppF9n+9Uc40LS+KX0=",
@@ -11480,7 +11411,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,picard,,pandora,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 08:50:17,28264,1,57502,80,0,0,0x200000,tcp,alert,\"internal-tuner.pandora.com\",PII(60000),any,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "pandora",
                 "community_id": "1:ej0sWBrryoi/pHYI/R8rvOEHNQc=",
@@ -11630,7 +11560,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 08:58:22,29312,1,80,57876,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "google-maps",
                 "community_id": "1:lX77aiJ1H3y+5//PYYCh3tYdAyc=",
@@ -11787,7 +11716,6 @@
             "log": {
                 "level": "low"
             },
-            "message": "175.16.199.1,192.168.0.6,0.0.0.0,0.0.0.0,rule1,,jordy,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 08:22:31,26747,1,80,1082,0,0,0x200000,tcp,deny,\"about.exe\",Windows Executable (EXE)(52020),any,low,server-to-client,0,0x0,Ukraine,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:TrrVRDnZdCQgLAGLHO4GHt2+qw4=",
@@ -11941,7 +11869,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 07:11:48,19205,1,80,50986,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "google-maps",
                 "community_id": "1:dbOGjR1aWV8DyP4vLGz1QsZ0ny0=",
@@ -12095,7 +12022,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 07:14:07,19360,1,80,51716,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "google-maps",
                 "community_id": "1:mtzOFl1R3JVEIPm0akw/TS3ROok=",
@@ -12249,7 +12175,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 07:14:44,19696,1,80,52119,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "google-maps",
                 "community_id": "1:/n7j8c8MKf35yw9cDwEnJ7VUlqI=",
@@ -12403,7 +12328,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 07:16:08,19679,1,80,52411,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "google-maps",
                 "community_id": "1:gPWVl9L6vD63Bmbr0WIBMb7WLdc=",
@@ -12564,7 +12488,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,picard,,google-analytics,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 07:18:19,19448,1,52366,80,0,0,0x200000,tcp,alert,\"__utm.gif\",PII(60000),any,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "google-analytics",
                 "community_id": "1:ALFdhF5T8C5nvWPkG0y4cS0/5QM=",
@@ -12714,7 +12637,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 07:25:09,20422,1,80,53026,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "google-maps",
                 "community_id": "1:e4r6wJ1eOAxh+oapONp3HAqGoiw=",
@@ -12868,7 +12790,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 07:36:09,21267,1,80,53809,0,0,0x200000,tcp,alert,\"nav_logo107.png\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:qFLy3+Xm+Yir6ObFGBuWtDh9Ryo=",
@@ -13022,7 +12943,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 08:08:13,24567,1,80,55912,0,0,0x200000,tcp,alert,\"Eadweard_Muybridge\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:VnAH7uRc/1Fo96KeI+gR6FdX/+4=",
@@ -13176,7 +13096,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 08:08:49,24646,1,80,55916,0,0,0x200000,tcp,alert,\"load.php\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:mDb1jYB7jLdLjgofpLkOZVSAbQo=",
@@ -13330,7 +13249,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.6,0.0.0.0,0.0.0.0,rule1,,jordy,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 08:17:01,25874,1,80,1046,0,0,0x200000,tcp,reset-both,\"8fe44cb728c0f40750c64ee906eb72.css\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:rI+JtLN1tgRFWLwW5eO/dAik6SY=",
@@ -13484,7 +13402,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,jordy,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 04:06:46,2175,1,80,61734,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "google-maps",
                 "community_id": "1:h4FhwHd9ztu4jpl3xgOaiB011a4=",
@@ -13638,7 +13555,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,jordy,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 04:12:57,3046,1,80,62292,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "google-maps",
                 "community_id": "1:GSknwPhD0cMXgRXsuLSg5w0bq98=",
@@ -13792,7 +13708,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,jordy,rss,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 06:07:54,1560,1,80,64669,0,0,0x200000,tcp,alert,\"appcast.xml\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "rss",
                 "community_id": "1:QRX5cQgXoEh4jqvb7ZLpI4VOhLc=",
@@ -13946,7 +13861,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 06:48:48,16852,1,80,65265,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "google-maps",
                 "community_id": "1:nDUNBR/xYCMP799BdvaOhbJMzn0=",
@@ -14100,7 +14014,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 06:49:05,15948,1,80,64979,0,0,0x200000,tcp,alert,\"csi\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:/XRD8fjQCZ2reh0gJyQK2rfs+Wc=",
@@ -14254,7 +14167,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 06:50:19,17028,1,80,49432,0,0,0x200000,tcp,alert,\"index.php\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:ur+hejcekimZ+EBsduNmTAfLAKk=",
@@ -14408,7 +14320,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 06:51:39,15878,1,80,49722,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "google-maps",
                 "community_id": "1:iVCt7y8n4xY4lxHpFzTmtUtGbGw=",
@@ -14569,7 +14480,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,picard,,google-analytics,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 06:53:47,16602,1,49681,80,0,0,0x200000,tcp,alert,\"__utm.gif\",PII(60000),any,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "google-analytics",
                 "community_id": "1:CSr3gOfGhxc2481kFidqrVh2b1o=",
@@ -14719,7 +14629,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 06:54:41,17433,1,80,50108,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "google-maps",
                 "community_id": "1:y8Rri5paZwSUjfuP8OCSj7AGTaw=",
@@ -14873,7 +14782,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 06:55:00,17104,1,80,50387,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "google-maps",
                 "community_id": "1:VbV334KW3Is9ozPo/GT616Kmfs8=",
@@ -15034,7 +14942,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,jordy,,pandora,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 03:44:55,63706,1,59781,80,0,0,0x200000,tcp,alert,\"internal-tuner.pandora.com\",PII(60000),any,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
             "network": {
                 "application": "pandora",
                 "community_id": "1:hWRgBF3xOOzQR0p2sUrnCEIRsLc=",
@@ -15184,7 +15091,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,jordy,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 03:45:50,65257,1,80,60005,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "google-maps",
                 "community_id": "1:5goyhqr2B6bgLWsDzxl1OgXk8mQ=",
@@ -15338,7 +15244,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,jordy,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 03:49:22,537,1,80,60443,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "google-maps",
                 "community_id": "1:y4JV3O9OSznWA8cTxHb1krRrj2U=",
@@ -15492,7 +15397,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,jordy,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 03:53:45,914,1,80,60822,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "google-maps",
                 "community_id": "1:Aa48sm/4uPjGhcG+b/Uf7cDELks=",
@@ -15646,7 +15550,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,jordy,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 03:55:28,1475,1,80,61105,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "google-maps",
                 "community_id": "1:+Fw7pXGMYsoIHJl6XCvpSnc+ktw=",
@@ -15800,7 +15703,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,jordy,google-analytics,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 03:55:57,883,1,80,60782,0,0,0x200000,tcp,alert,\"ga.js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "google-analytics",
                 "community_id": "1:1Gs2F0v1jt3hXj1u3g2EOeRAzcQ=",
@@ -15954,7 +15856,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,jordy,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 04:04:00,1965,1,80,61470,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "google-maps",
                 "community_id": "1:JXDqxOKk8OSmF1oSccqMIKzY9uk=",
@@ -16112,7 +16013,6 @@
             "log": {
                 "level": "low"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,crusher,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:20:05,64856,1,80,54431,0,0,0x200000,tcp,deny,\"C:\\path\\to\\uLLGRaXP.exe\",Windows Executable (EXE)(52020),any,low,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:dd+2RtCBMUfATx7W9zSc0ZBYnK0=",
@@ -16270,7 +16170,6 @@
             "log": {
                 "level": "low"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,crusher,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:20:05,64856,1,80,54431,0,0,0x200000,tcp,deny,\"/path/to/uLLGRaXP.exe\",Windows Executable (EXE)(52020),any,low,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:dd+2RtCBMUfATx7W9zSc0ZBYnK0=",
@@ -16429,7 +16328,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,intranet\\\\schmidtdo,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:42:51,28953,1,59752,80,0,0,0x200000,tcp,alert,\"portal.azure.com/api/Telemetry\",(9999),computer-and-internet-info,informational,client-to-server,0,0x8000000000000000,192.168.0.0-192.168.255.255,United States,,text/plain,0,,,1,\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36\",,,\"https://portal.azure.com/\",,,,0,267,24,19,0,,de-fwpm1-spelle,,,,post,0,,0,2022/11/29 12:59:46,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,,\"computer-and-internet-info,low-risk\",9d9738ea-f704-4b0f-90cf-a62bcbad0236,542331861,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2022-11-29T13:00:01.051+01:00,,,,general-business,saas,browser-based,1,\"pervasive-use,is-saas,is-fedramp,is-hipaa,is-soc1,is-soc2,is-ip-based-restrictions\",windows-azure,windows-azure-base,yes,no",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:yc9H3qlXvXQQ9zip1/LX5C4Q5sM=",
@@ -16666,7 +16564,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,intranet\\\\schmidtdo,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:42:51,28953,1,59752,80,0,0,0x200000,tcp,alert,\"portal.azure.com/api/Telemetry\",(9999),computer-and-internet-info,informational,client-to-server,0,0x8000000000000000,192.168.0.0-192.168.255.255,United States,,text/plain,0,,,1,\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36\",,,\"https://portal.azure.com/\",,,,0,267,24,19,0,,de-fwpm1-spelle,,,,post,0,,0,2022/11/29 12:59:46,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,,\" ADFS Servers,computer-and-internet-info,low-risk\",9d9738ea-f704-4b0f-90cf-a62bcbad0236,542331861,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2022-11-29T13:00:01.051+01:00,,,,general-business,saas,browser-based,1,\"pervasive-use,is-saas,is-fedramp,is-hipaa,is-soc1,is-soc2,is-ip-based-restrictions\",windows-azure,windows-azure-base,yes,no",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:yc9H3qlXvXQQ9zip1/LX5C4Q5sM=",

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-traffic-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-traffic-sample.log-expected.json
@@ -164,7 +164,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:59,25572,1,54448,53,0,0,0x200000,udp,allow,76,76,0,1,2012/04/10 04:39:58,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 76,
@@ -285,7 +284,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:59,26208,1,53121,53,0,0,0x200000,udp,allow,76,76,0,1,2012/04/10 04:39:58,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 76,
@@ -406,7 +404,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:59,14931,1,59323,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:58,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -527,7 +524,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:59,25544,1,59322,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:58,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -648,7 +644,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:59,25308,1,55766,53,0,0,0x200000,udp,allow,74,74,0,1,2012/04/10 04:39:58,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 74,
@@ -769,7 +764,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:59,26376,1,55072,53,0,0,0x200000,udp,allow,74,74,0,1,2012/04/10 04:39:58,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 74,
@@ -890,7 +884,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:58,25118,1,59207,80,0,0,0x200000,tcp,allow,1355,549,806,10,2012/04/10 04:39:27,1,private-ip-addresses,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,6,4",
             "network": {
                 "application": "web-browsing",
                 "bytes": 1355,
@@ -1011,7 +1004,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:58,26146,1,59209,80,0,0,0x200000,tcp,allow,1355,549,806,10,2012/04/10 04:39:28,0,private-ip-addresses,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,6,4",
             "network": {
                 "application": "web-browsing",
                 "bytes": 1355,
@@ -1132,7 +1124,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:58,25272,1,59208,80,0,0,0x200000,tcp,allow,1355,549,806,10,2012/04/10 04:39:27,1,private-ip-addresses,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,6,4",
             "network": {
                 "application": "web-browsing",
                 "bytes": 1355,
@@ -1253,7 +1244,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:58,24069,1,59318,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:58,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -1374,7 +1364,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:58,25848,1,59317,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:57,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -1495,7 +1484,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:58,25179,1,59316,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:57,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -1616,7 +1604,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:58,25112,1,59315,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:57,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -1737,7 +1724,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:57,26161,1,59206,80,0,0,0x200000,tcp,allow,1355,549,806,10,2012/04/10 04:39:27,0,private-ip-addresses,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,6,4",
             "network": {
                 "application": "web-browsing",
                 "bytes": 1355,
@@ -1858,7 +1844,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:57,26000,1,59205,80,0,0,0x200000,tcp,allow,1355,549,806,10,2012/04/10 04:39:26,1,private-ip-addresses,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,6,4",
             "network": {
                 "application": "web-browsing",
                 "bytes": 1355,
@@ -1979,7 +1964,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:57,65184,1,56858,80,0,0,0x200000,tcp,allow,1910,1359,551,21,2012/04/10 04:29:54,512,malware-sites,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,18,3",
             "network": {
                 "application": "web-browsing",
                 "bytes": 1910,
@@ -2100,7 +2084,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:57,26522,1,59314,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:56,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -2221,7 +2204,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:57,26067,1,59313,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:56,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -2342,7 +2324,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:57,26573,1,52139,53,0,0,0x200000,udp,allow,69,69,0,1,2012/04/10 04:39:56,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 69,
@@ -2463,7 +2444,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:57,26894,1,60592,53,0,0,0x200000,udp,allow,69,69,0,1,2012/04/10 04:39:56,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 69,
@@ -2584,7 +2564,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:57,25149,1,59309,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:56,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -2705,7 +2684,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:56,25258,1,57322,53,0,0,0x200000,udp,allow,164,66,98,2,2012/04/10 04:39:26,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,1",
             "network": {
                 "application": "dns",
                 "bytes": 164,
@@ -2826,7 +2804,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:56,25025,1,59204,80,0,0,0x200000,tcp,allow,1355,549,806,10,2012/04/10 04:39:26,0,private-ip-addresses,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,6,4",
             "network": {
                 "application": "web-browsing",
                 "bytes": 1355,
@@ -2947,7 +2924,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:56,26138,1,59203,80,0,0,0x200000,tcp,allow,1355,549,806,10,2012/04/10 04:39:26,0,private-ip-addresses,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,6,4",
             "network": {
                 "application": "web-browsing",
                 "bytes": 1355,
@@ -3068,7 +3044,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:56,27175,1,59305,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:56,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -3189,7 +3164,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:56,26261,1,64005,53,0,0,0x200000,udp,allow,69,69,0,1,2012/04/10 04:39:55,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 69,
@@ -3310,7 +3284,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:56,25022,1,58768,53,0,0,0x200000,udp,allow,69,69,0,1,2012/04/10 04:39:55,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 69,
@@ -3431,7 +3404,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,skype,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:56,24027,1,47752,13069,0,0,0x200000,udp,allow,1008,504,504,16,2012/04/10 04:37:50,125,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,8,8",
             "network": {
                 "application": "skype",
                 "bytes": 1008,
@@ -3552,7 +3524,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:56,26360,1,59304,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:55,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -3673,7 +3644,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:56,26394,1,54533,53,0,0,0x200000,udp,allow,71,71,0,1,2012/04/10 04:39:55,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 71,
@@ -3794,7 +3764,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:55,24917,1,59201,80,0,0,0x200000,tcp,allow,9967,837,9130,20,2012/04/10 04:39:24,1,search-engines,0,0,0x0,192.168.0.0-192.168.255.255,Italy,0,10,10",
             "network": {
                 "application": "web-browsing",
                 "bytes": 9967,
@@ -3915,7 +3884,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:55,22860,1,59303,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:55,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -4036,7 +4004,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:55,14146,1,50876,53,0,0,0x200000,udp,allow,76,76,0,1,2012/04/10 04:39:54,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 76,
@@ -4157,7 +4124,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:55,25876,1,57657,53,0,0,0x200000,udp,allow,76,76,0,1,2012/04/10 04:39:54,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 76,
@@ -4278,7 +4244,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:55,24910,1,59302,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:54,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -4399,7 +4364,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:55,26862,1,59301,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:54,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -4520,7 +4484,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:55,26222,1,64844,53,0,0,0x200000,udp,allow,80,80,0,1,2012/04/10 04:39:54,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 80,
@@ -4641,7 +4604,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:55,26329,1,52257,53,0,0,0x200000,udp,allow,80,80,0,1,2012/04/10 04:39:54,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 80,
@@ -4759,7 +4721,6 @@
                     "connection"
                 ]
             },
-            "message": "192.168.0.100,175.16.199.1,0.0.0.0,0.0.0.0,rule1,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:54,25142,1,38796,53,0,0,0x0,udp,allow,206,95,111,2,2012/04/10 04:39:24,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,1",
             "network": {
                 "application": "dns",
                 "bytes": 206,
@@ -4871,7 +4832,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:54,25095,1,59200,80,0,0,0x200000,tcp,allow,1503,597,906,13,2012/04/10 04:39:23,1,entertainment-and-arts,0,0,0x0,192.168.0.0-192.168.255.255,Italy,0,6,7",
             "network": {
                 "application": "web-browsing",
                 "bytes": 1503,
@@ -4989,7 +4949,6 @@
                     "connection"
                 ]
             },
-            "message": "192.168.0.100,175.16.199.1,0.0.0.0,0.0.0.0,rule1,,,paloalto-wildfire-cloud,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:54,24787,1,48412,443,0,0,0x0,tcp,allow,5817,804,5013,17,2012/04/10 04:39:24,0,computer-and-internet-security,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,10,7",
             "network": {
                 "application": "paloalto-wildfire-cloud",
                 "bytes": 5817,
@@ -5101,7 +5060,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,skype-probe,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:54,25948,1,47752,40026,0,0,0x200000,udp,allow,286,187,99,2,2012/04/10 04:39:24,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,1",
             "network": {
                 "application": "skype-probe",
                 "bytes": 286,
@@ -5222,7 +5180,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,skype-probe,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:54,25444,1,47752,40029,0,0,0x200000,udp,allow,978,76,902,2,2012/04/10 04:39:24,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,1",
             "network": {
                 "application": "skype-probe",
                 "bytes": 978,
@@ -5340,7 +5297,6 @@
                     "connection"
                 ]
             },
-            "message": "192.168.0.100,175.16.199.1,0.0.0.0,0.0.0.0,rule1,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:54,25349,1,52189,53,0,0,0x0,udp,allow,227,86,141,2,2012/04/10 04:39:24,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,1",
             "network": {
                 "application": "dns",
                 "bytes": 227,
@@ -5452,7 +5408,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:54,25713,1,59300,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:54,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -5573,7 +5528,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:54,26499,1,54414,53,0,0,0x200000,udp,allow,73,73,0,1,2012/04/10 04:39:53,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 73,
@@ -5694,7 +5648,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:53,25437,1,59299,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:53,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -5815,7 +5768,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:53,24848,1,60399,53,0,0,0x200000,udp,allow,80,80,0,1,2012/04/10 04:39:53,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 80,
@@ -5936,7 +5888,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:53,24924,1,59626,53,0,0,0x200000,udp,allow,482,166,316,4,2012/04/10 04:39:22,1,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,2,2",
             "network": {
                 "application": "dns",
                 "bytes": 482,
@@ -6057,7 +6008,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:53,25899,1,51542,53,0,0,0x200000,udp,allow,196,75,121,2,2012/04/10 04:39:23,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,1",
             "network": {
                 "application": "dns",
                 "bytes": 196,
@@ -6178,7 +6128,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:53,26066,1,54182,53,0,0,0x200000,udp,allow,244,75,169,2,2012/04/10 04:39:23,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,1",
             "network": {
                 "application": "dns",
                 "bytes": 244,
@@ -6299,7 +6248,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:53,24908,1,59199,80,0,0,0x200000,tcp,allow,1548,594,954,13,2012/04/10 04:39:23,0,business-and-economy,0,0,0x0,192.168.0.0-192.168.255.255,Italy,0,6,7",
             "network": {
                 "application": "web-browsing",
                 "bytes": 1548,
@@ -6420,7 +6368,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:53,25105,1,59198,80,0,0,0x200000,tcp,allow,10135,1005,9130,22,2012/04/10 04:39:21,2,search-engines,0,0,0x0,192.168.0.0-192.168.255.255,Italy,0,12,10",
             "network": {
                 "application": "web-browsing",
                 "bytes": 10135,
@@ -6541,7 +6488,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:53,11964,1,56856,80,0,0,0x200000,tcp,allow,1918,1363,555,21,2012/04/10 04:29:51,512,malware-sites,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,18,3",
             "network": {
                 "application": "web-browsing",
                 "bytes": 1918,
@@ -6662,7 +6608,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:53,26502,1,52489,53,0,0,0x200000,udp,allow,80,80,0,1,2012/04/10 04:39:53,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 80,
@@ -6783,7 +6728,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:53,26338,1,59298,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:53,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -6904,7 +6848,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:53,24919,1,60185,53,0,0,0x200000,udp,allow,76,76,0,1,2012/04/10 04:39:52,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 76,
@@ -7025,7 +6968,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:53,26731,1,51817,53,0,0,0x200000,udp,allow,76,76,0,1,2012/04/10 04:39:52,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 76,
@@ -7146,7 +7088,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,skype-probe,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:53,26504,1,47752,40043,0,0,0x200000,udp,allow,186,186,0,1,2012/04/10 04:39:52,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "skype-probe",
                 "bytes": 186,
@@ -7267,7 +7208,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:53,25543,1,59297,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:52,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -7388,7 +7328,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:53,21948,1,52537,53,0,0,0x200000,udp,allow,82,82,0,1,2012/04/10 04:39:52,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 82,
@@ -7509,7 +7448,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:52,26279,1,53155,53,0,0,0x200000,udp,allow,82,82,0,1,2012/04/10 04:39:52,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 82,
@@ -7630,7 +7568,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:52,24894,1,59197,80,0,0,0x200000,tcp,allow,1487,581,906,13,2012/04/10 04:39:21,1,entertainment-and-arts,0,0,0x0,192.168.0.0-192.168.255.255,Italy,0,6,7",
             "network": {
                 "application": "web-browsing",
                 "bytes": 1487,
@@ -7751,7 +7688,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:52,24985,1,56995,53,0,0,0x200000,udp,allow,251,88,163,2,2012/04/10 04:39:22,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,1",
             "network": {
                 "application": "dns",
                 "bytes": 251,
@@ -7872,7 +7808,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:52,25380,1,59069,53,0,0,0x200000,udp,allow,76,76,0,1,2012/04/10 04:39:51,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 76,
@@ -7993,7 +7928,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:52,24994,1,55697,53,0,0,0x200000,udp,allow,76,76,0,1,2012/04/10 04:39:51,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 76,
@@ -8114,7 +8048,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:52,25451,1,59295,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:51,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -8235,7 +8168,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:51,24866,1,59196,80,0,0,0x200000,tcp,allow,1500,578,922,13,2012/04/10 04:39:20,1,business-and-economy,0,0,0x0,192.168.0.0-192.168.255.255,Italy,0,6,7",
             "network": {
                 "application": "web-browsing",
                 "bytes": 1500,
@@ -8356,7 +8288,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:51,26414,1,59291,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:51,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -8477,7 +8408,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:51,26131,1,52858,53,0,0,0x200000,udp,allow,77,77,0,1,2012/04/10 04:39:50,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 77,
@@ -8598,7 +8528,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:51,26555,1,61383,53,0,0,0x200000,udp,allow,77,77,0,1,2012/04/10 04:39:50,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 77,
@@ -8719,7 +8648,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:50,15099,1,59290,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:50,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -8840,7 +8768,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:50,24980,1,59195,80,0,0,0x200000,tcp,allow,28096,1310,26786,39,2012/04/10 04:39:20,0,not-resolved,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,17,22",
             "network": {
                 "application": "web-browsing",
                 "bytes": 28096,
@@ -8961,7 +8888,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:50,26215,1,49812,53,0,0,0x200000,udp,allow,83,83,0,1,2012/04/10 04:39:50,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 83,
@@ -9082,7 +9008,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:50,25881,1,50185,53,0,0,0x200000,udp,allow,83,83,0,1,2012/04/10 04:39:50,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 83,
@@ -9203,7 +9128,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:50,24955,1,59286,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:50,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -9314,7 +9238,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,192.168.0.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:50,24961,1,52531,53,0,0,0x200000,udp,allow,244,75,169,2,2012/04/10 04:39:20,0,any,0,0,0x0,192.168.0.0-192.168.255.255,192.168.0.0-192.168.255.255,0,1,1",
             "network": {
                 "application": "dns",
                 "bytes": 244,
@@ -9435,7 +9358,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:50,24226,1,59194,80,0,0,0x200000,tcp,allow,10097,1033,9064,21,2012/04/10 04:39:17,3,search-engines,0,0,0x0,192.168.0.0-192.168.255.255,Italy,0,12,9",
             "network": {
                 "application": "web-browsing",
                 "bytes": 10097,
@@ -9556,7 +9478,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:50,25129,1,59192,80,0,0,0x200000,tcp,allow,10105,981,9124,22,2012/04/10 04:39:13,7,search-engines,0,0,0x0,192.168.0.0-192.168.255.255,Italy,0,12,10",
             "network": {
                 "application": "web-browsing",
                 "bytes": 10105,
@@ -9667,7 +9588,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,192.168.0.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:50,25194,1,56463,53,0,0,0x200000,udp,allow,214,77,137,2,2012/04/10 04:39:20,0,any,0,0,0x0,192.168.0.0-192.168.255.255,192.168.0.0-192.168.255.255,0,1,1",
             "network": {
                 "application": "dns",
                 "bytes": 214,
@@ -9778,7 +9698,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,192.168.0.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:50,26257,1,55849,53,0,0,0x200000,udp,allow,170,77,93,2,2012/04/10 04:39:20,0,any,0,0,0x0,192.168.0.0-192.168.255.255,192.168.0.0-192.168.255.255,0,1,1",
             "network": {
                 "application": "dns",
                 "bytes": 170,
@@ -9899,7 +9818,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:50,24561,1,59282,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:49,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -10020,7 +9938,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:50,26150,1,57846,53,0,0,0x200000,udp,allow,71,71,0,1,2012/04/10 04:39:49,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 71,
@@ -10141,7 +10058,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:50,25676,1,51008,53,0,0,0x200000,udp,allow,71,71,0,1,2012/04/10 04:39:49,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 71,
@@ -10262,7 +10178,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:50,25306,1,59281,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:49,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -10383,7 +10298,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:50,26411,1,55252,53,0,0,0x200000,udp,allow,80,80,0,1,2012/04/10 04:39:49,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 80,
@@ -10494,7 +10408,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,192.168.0.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:50,24844,1,56995,53,0,0,0x200000,udp,allow,176,176,0,2,2012/04/10 04:39:18,1,any,0,0,0x0,192.168.0.0-192.168.255.255,192.168.0.0-192.168.255.255,0,2,0",
             "network": {
                 "application": "dns",
                 "bytes": 176,
@@ -10615,7 +10528,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:49,26335,1,60989,53,0,0,0x200000,udp,allow,80,80,0,1,2012/04/10 04:39:49,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 80,
@@ -10736,7 +10648,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:49,26127,1,59280,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:48,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -10857,7 +10768,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:49,25488,1,53766,53,0,0,0x200000,udp,allow,81,81,0,1,2012/04/10 04:39:48,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 81,
@@ -10978,7 +10888,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:49,25269,1,56032,53,0,0,0x200000,udp,allow,81,81,0,1,2012/04/10 04:39:48,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "dns",
                 "bytes": 81,
@@ -11099,7 +11008,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:48,25715,1,59193,80,0,0,0x200000,tcp,allow,1487,581,906,13,2012/04/10 04:39:17,1,entertainment-and-arts,0,0,0x0,192.168.0.0-192.168.255.255,Italy,0,6,7",
             "network": {
                 "application": "web-browsing",
                 "bytes": 1487,
@@ -11220,7 +11128,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:48,26251,1,59279,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:48,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -11341,7 +11248,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:48,25871,1,59278,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:48,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -11462,7 +11368,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:48,25945,1,59277,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:47,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -11573,7 +11478,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,192.168.0.1,0.0.0.0,0.0.0.0,rule1,crusher,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:48,25310,1,60026,53,0,0,0x200000,udp,allow,166,166,0,2,2012/04/10 04:39:16,1,any,0,0,0x0,192.168.0.0-192.168.255.255,192.168.0.0-192.168.255.255,0,2,0",
             "network": {
                 "application": "dns",
                 "bytes": 166,
@@ -11694,7 +11598,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:47,27111,1,59276,80,0,0,0x200000,tcp,allow,429,351,78,4,2012/04/10 04:39:47,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,3,1",
             "network": {
                 "application": "web-browsing",
                 "bytes": 429,
@@ -11815,7 +11718,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:47,25398,1,59275,80,0,0,0x200000,tcp,allow,429,351,78,4,2012/04/10 04:39:47,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,3,1",
             "network": {
                 "application": "web-browsing",
                 "bytes": 429,
@@ -11936,7 +11838,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:47,23898,1,59274,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:46,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-traffic-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-traffic-sample.log-expected.json
@@ -44,7 +44,6 @@
             "labels": {
                 "captive_portal": true
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:59,11449,1,59324,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:59,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-traffic.json-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-traffic.json-expected.json
@@ -51,7 +51,6 @@
                 },
                 "offset": 0
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:59,11449,1,59324,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:59,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-traffic.json-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-traffic.json-expected.json
@@ -222,7 +222,6 @@
                 },
                 "offset": 0
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:59,11449,1,59324,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:59,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,
@@ -396,7 +395,6 @@
                 },
                 "offset": 0
             },
-            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:59,11449,1,59324,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:59,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 78,

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-ip-tag-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-ip-tag-sample.log-expected.json
@@ -14,7 +14,6 @@
                 "original": "1,2019/11/23 00:44:44,01234567890,IPTAG,login,2561,2019/11/23 00:44:44,vsys,81.2.69.142,tag-name,1000,1000,100,Data Source Name, Data Source Type,Data Source Subtype,1000,0x0,0,0,0,0,vsys-name,d-name,vsys-id,1970-01-01T01:00:00.000+01:00",
                 "timezone": "+01:00"
             },
-            "message": "vsys,81.2.69.142,tag-name,1000,1000,100,Data Source Name, Data Source Type,Data Source Subtype,1000,0x0,0,0,0,0,vsys-name,d-name,vsys-id,1970-01-01T01:00:00.000+01:00",
             "network": {
                 "type": "ipv4"
             },

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-sctp-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-sctp-sample.log-expected.json
@@ -33,7 +33,6 @@
             "log": {
                 "level": "4"
             },
-            "message": "81.2.69.142,81.2.69.144,,,rule-name,,,,vsys,src-zone,dst-zone,inbound-int,outbound-int,log-action,,1000,1000,9550,9551,,,,,tcp,action,0,0,0,0,vsys-name,device-name,1000,,2000,payload-protocol-id,4,chunk-type,,tag-1,tag-2,100,dia-app-id,dia-cmd-code,dia-avp-code,sctp-stream-id,end-reason,100,SSN,SGT,filter,1,2,3,11,12,13,3000,1970-01-01T01:00:00.000+01:00",
             "network": {
                 "community_id": "1:Lg7reiz4N7t4w/tC1zo+4I0ysCs=",
                 "packets": 11,

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-system-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-system-sample.log-expected.json
@@ -68,7 +68,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",general,,0,0,general,informational,\"Connection to Update server closed: updates.paloaltonetworks.com, source: 81.2.69.193\",1234567890,0x0,0,0,0,0,,PA-VM,0,0,2021-10-26T14:49:03.776-07:00",
             "observer": {
                 "hostname": "PA-VM",
                 "product": "PAN-OS",
@@ -119,7 +118,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",general,,0,0,general,informational,\"Connection to Update server: updates.paloaltonetworks.com completed successfully, initiated by 192.168.0.15\",7286123782408765862,0x0,0,0,0,0,,PA-VM,0,0,2023-10-04T09:51:21.211-07:00",
             "observer": {
                 "hostname": "PA-VM",
                 "product": "PAN-OS",
@@ -171,7 +169,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",rasmgr-config-p2-success,,0,0,general,informational,\"RASMGR daemon configuration load phase-2 succeeded.\",7286123782408765849,0x0,0,0,0,0,,PA-VM,0,0,2023-10-04T09:49:31.372-07:00",
             "observer": {
                 "hostname": "PA-VM",
                 "product": "PAN-OS",
@@ -223,7 +220,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",ike-config-p2-success,,0,0,general,informational,\"IKE daemon configuration load phase-2 succeeded.\",7286123782408765846,0x0,0,0,0,0,,PA-VM,0,0,2023-10-04T09:49:31.363-07:00",
             "observer": {
                 "hostname": "PA-VM",
                 "product": "PAN-OS",

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-system-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-system-sample.log-expected.json
@@ -18,7 +18,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": ",general,,0,0,general,informational,\"Connection to Update server closed: updates.paloaltonetworks.com, source: 81.2.69.193\",1234567890,0x0,0,0,0,0,,PA-VM,0,0,2021-10-26T15:05:03.440-07:00",
             "observer": {
                 "hostname": "PA-VM",
                 "product": "PAN-OS",

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-threat-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-threat-sample.log-expected.json
@@ -210,7 +210,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28219,1,52983,443,28249,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7727,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -371,7 +370,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,27723,1,52986,443,63898,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7728,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -532,7 +530,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28172,1,52985,443,7515,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7729,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -693,7 +690,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28151,1,52987,443,3225,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7730,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -854,7 +850,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28076,1,52988,443,60449,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7731,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -1015,7 +1010,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28173,1,52990,443,60559,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7732,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -1176,7 +1170,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28186,1,52989,443,47414,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7733,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -1337,7 +1330,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28192,1,52992,443,37673,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7734,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -1498,7 +1490,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,27011,1,52991,443,8232,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7735,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -1659,7 +1650,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28240,1,52994,443,32982,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7736,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -1820,7 +1810,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28143,1,52993,443,10473,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7737,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -1981,7 +1970,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28272,1,52995,443,20446,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7738,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -2142,7 +2130,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28146,1,52996,443,34699,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7739,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -2303,7 +2290,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28278,1,52997,443,22820,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7740,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -2464,7 +2450,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:37,28185,1,52998,443,41060,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7741,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -2625,7 +2610,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:37,28201,1,52999,443,9058,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7742,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -2786,7 +2770,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:37,28148,1,53001,443,54846,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7743,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -2947,7 +2930,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:37,28121,1,53002,443,52731,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7744,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -3108,7 +3090,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:38,28228,1,53003,443,15165,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7745,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -3269,7 +3250,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:38,28196,1,53004,443,53918,443,0x403000,tcp,block-url,\"b.scorecardresearch.com/\",(9999),business-and-economy,informational,client-to-server,7746,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -3430,7 +3410,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:38,28007,1,53000,443,40792,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7747,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -3591,7 +3570,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28117,1,53006,443,54044,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7748,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -3752,7 +3730,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28109,1,53007,443,19544,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7749,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -3913,7 +3890,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28260,1,53008,443,13462,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7750,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -4074,7 +4050,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28275,1,53010,443,44892,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7752,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -4235,7 +4210,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28266,1,53011,443,16487,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7753,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -4396,7 +4370,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28294,1,53012,443,23952,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7754,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -4557,7 +4530,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28248,1,53013,443,2810,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7755,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -4718,7 +4690,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28274,1,53014,443,13272,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7756,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -4879,7 +4850,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28285,1,53022,443,8663,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7762,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -5040,7 +5010,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28306,1,53023,443,55738,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7763,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -5201,7 +5170,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28116,1,53024,443,10650,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7764,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -5362,7 +5330,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28214,1,53025,443,44087,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7765,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -5523,7 +5490,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28080,1,53026,443,15915,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7766,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -5684,7 +5650,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:53,28318,1,53041,443,41165,443,0x403000,tcp,block-url,\"cdn.taboola.com/\",(9999),business-and-economy,informational,client-to-server,7768,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -5845,7 +5810,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:54,28300,1,53040,443,54133,443,0x403000,tcp,block-url,\"rules.quantcount.com/\",(9999),business-and-economy,informational,client-to-server,7769,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -6006,7 +5970,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:58,28339,1,53093,443,8485,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7770,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -6167,7 +6130,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:58,28299,1,53094,443,12496,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7771,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -6328,7 +6290,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:58,28303,1,53095,443,17029,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7772,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -6489,7 +6450,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:58,28390,1,53096,443,23696,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7773,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -6650,7 +6610,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:59,28433,1,53097,443,34769,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7774,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -6811,7 +6770,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:59,28380,1,53099,443,22486,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7775,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -6972,7 +6930,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:59,28363,1,53100,443,12894,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7776,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -7133,7 +7090,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:00,28349,1,53101,443,62348,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7777,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -7294,7 +7250,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:00,28411,1,53104,443,6224,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7778,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -7455,7 +7410,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:00,28397,1,53107,443,44120,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7779,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -7616,7 +7570,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:00,28347,1,53108,443,44228,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7780,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -7777,7 +7730,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:00,28443,1,53109,443,31322,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7781,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -7938,7 +7890,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:13,28439,1,53118,443,1672,443,0x403000,tcp,block-url,\"www.googleadservices.com/\",(9999),business-and-economy,informational,client-to-server,7782,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -8099,7 +8050,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:15,25958,1,53126,443,20801,443,0x403000,tcp,block-url,\"service.maxymiser.net/\",(9999),business-and-economy,informational,client-to-server,7783,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -8260,7 +8210,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:15,28429,1,53127,443,24533,443,0x403000,tcp,block-url,\"service.maxymiser.net/\",(9999),business-and-economy,informational,client-to-server,7784,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -8421,7 +8370,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:15,28465,1,53128,443,30150,443,0x403000,tcp,block-url,\"service.maxymiser.net/\",(9999),business-and-economy,informational,client-to-server,7785,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -8582,7 +8530,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:15,28504,1,53129,443,36305,443,0x403000,tcp,block-url,\"service.maxymiser.net/\",(9999),business-and-economy,informational,client-to-server,7786,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -8743,7 +8690,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:16,28458,1,53130,443,42682,443,0x403000,tcp,block-url,\"service.maxymiser.net/\",(9999),business-and-economy,informational,client-to-server,7787,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -8904,7 +8850,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:16,28491,1,53131,443,22530,443,0x403000,tcp,block-url,\"service.maxymiser.net/\",(9999),business-and-economy,informational,client-to-server,7788,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -9065,7 +9010,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:16,28520,1,53132,443,43713,443,0x403000,tcp,block-url,\"service.maxymiser.net/\",(9999),business-and-economy,informational,client-to-server,7789,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -9226,7 +9170,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:16,28335,1,53133,443,60608,443,0x403000,tcp,block-url,\"service.maxymiser.net/\",(9999),business-and-economy,informational,client-to-server,7790,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -9387,7 +9330,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:16,28414,1,53134,443,9302,443,0x403000,tcp,block-url,\"service.maxymiser.net/\",(9999),business-and-economy,informational,client-to-server,7791,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -9548,7 +9490,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:16,28488,1,53135,443,11634,443,0x403000,tcp,block-url,\"service.maxymiser.net/\",(9999),business-and-economy,informational,client-to-server,7792,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -9709,7 +9650,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:26,28469,1,53152,443,30818,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7793,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -9870,7 +9810,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:26,28556,1,53155,443,64260,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7794,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -10031,7 +9970,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:26,28558,1,53158,443,7071,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7795,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -10192,7 +10130,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:26,28531,1,53160,443,4512,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7796,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -10353,7 +10290,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:26,28580,1,53161,443,3422,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7797,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -10514,7 +10450,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:27,28477,1,53162,443,4651,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7798,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -10675,7 +10610,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:27,28484,1,53163,443,19068,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7799,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -10836,7 +10770,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:27,28609,1,53164,443,5831,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7800,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -10997,7 +10930,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:27,28564,1,53165,443,7084,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7801,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -11158,7 +11090,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:27,28542,1,53166,443,18633,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7802,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -11319,7 +11250,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:27,28590,1,53167,443,25557,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7803,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -11480,7 +11410,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:27,28455,1,53150,443,20661,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7804,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -11641,7 +11570,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:28,28585,1,53185,443,65438,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7805,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -11802,7 +11730,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:28,28462,1,53187,443,53101,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7806,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -11963,7 +11890,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:28,28839,1,53188,443,35463,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7807,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -12124,7 +12050,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:29,28400,1,53178,443,45769,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7808,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -12285,7 +12210,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:29,28400,1,53178,443,45769,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7808,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,\"Some-Header:\"\"eg1.com, eg2.com\"\";\",",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -12447,7 +12371,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:29,28400,1,53178,443,45769,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7808,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,\"Some-Header:\"\"eg1.com, eg2.com\"\"; Another-Header:\"\"eg3.com, eg4.com\"\";\",",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -12609,7 +12532,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:29,28400,1,53178,443,45769,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7808,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,\"Header-As-Last-Field:\"\"eg1.com, eg2.com\"\";\"",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -12774,7 +12696,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.12,81.2.69.193,67.43.156.12,LAn-TO-WAn,,,web-browsing,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 16:24:30,1450,2,51360,36524,37704,36524,0x502000,tcp,reset-both,\"browser\",Virus/Linux.example(419149938),medium-risk,medium,server-to-client,7031297127854637094,0x0,United States,China,,,0,,,1,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,elf,Antivirus-3901-4412,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T16:24:30.762-08:00,,,,internet-utility,general-internet,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,web-browsing,no,no",
             "network": {
                 "application": "web-browsing",
                 "community_id": [
@@ -12963,7 +12884,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.12,81.2.69.193,67.43.156.12,LAn-TO-WAn,,,web-browsing,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 16:24:05,1451,1,51361,36524,24986,36524,0x502000,tcp,reset-both,\"browser\",Virus/Linux.example(419149938),medium-risk,medium,server-to-client,7031297127854637092,0x0,United States,China,,,0,,,1,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,elf,Antivirus-3901-4412,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T16:24:05.837-08:00,,,,internet-utility,general-internet,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,web-browsing,no,no",
             "network": {
                 "application": "web-browsing",
                 "community_id": [
@@ -13148,7 +13068,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 16:23:55,1448,1,59738,53,4993,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637090,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T16:23:55.782-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -13330,7 +13249,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 16:19:45,1401,1,59189,53,53300,53,0x403000,udp,drop-packet,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637088,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T16:19:45.724-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -13515,7 +13433,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 16:13:19,1290,1,59141,53,11524,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637082,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T16:13:19.974-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -13700,7 +13617,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 16:12:04,1275,1,59707,53,8970,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637081,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T16:12:05.774-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -13885,7 +13801,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 16:11:24,1263,1,57732,53,4137,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637080,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T16:11:25.659-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -14070,7 +13985,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 16:11:04,1257,1,58456,53,3450,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637079,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T16:11:05.657-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -14252,7 +14166,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 16:10:44,1245,1,57998,53,16281,53,0x403000,udp,drop-packet,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637078,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T16:10:45.653-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -14434,7 +14347,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 15:40:32,972,1,59108,53,8224,53,0x403000,udp,drop-packet,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637069,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T15:40:32.221-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -14616,7 +14528,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 15:30:17,881,1,59495,53,8571,53,0x403000,udp,drop-packet,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637066,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T15:30:17.132-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -14801,7 +14712,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 15:25:06,827,1,59091,53,43821,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637063,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T15:25:07.057-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -14986,7 +14896,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 15:23:56,810,1,59200,53,50584,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637058,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T15:23:57.037-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -15171,7 +15080,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 15:23:11,799,1,58689,53,16219,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637057,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T15:23:12.026-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -15353,7 +15261,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 15:22:56,789,1,59276,53,32921,53,0x403000,udp,drop-packet,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637056,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T15:22:57.024-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -15542,7 +15449,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:29:34,49252,1,58941,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104735140,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:29:34.357-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:5LaQfwYZGux7FW+Sn+fmszK4nng=",
@@ -15717,7 +15623,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:29:34,49251,1,58941,53,39925,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104735139,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:29:34.356-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -15906,7 +15811,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:29:29,49250,1,59424,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104735138,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:29:29.356-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:MK9ac9vzzyBcJ3dG1CISlhCabZY=",
@@ -16078,7 +15982,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:29:24,49248,1,59424,53,47554,53,0x403000,udp,drop-packet,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104735137,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:29:24.620-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -16267,7 +16170,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:17:58,48952,1,57439,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104735054,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:17:58.973-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:zrPVGDQLvFgdSeTyJ8qQ1gCM3B4=",
@@ -16442,7 +16344,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:17:53,48947,1,57439,53,16531,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104735053,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:17:53.974-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -16631,7 +16532,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:17:43,48919,2,58744,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104735044,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:17:43.973-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:umFBqidhVAsqzbsvSZpKw4GbTJU=",
@@ -16806,7 +16706,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:17:38,48918,2,58744,53,24963,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104735038,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:17:38.972-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -16995,7 +16894,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:17:38,48917,1,57421,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104735031,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:17:38.971-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:FlR9eL7v6gq909kzbmhuKPLEepQ=",
@@ -17170,7 +17068,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:17:33,48916,1,57421,53,62251,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104735030,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:17:34.473-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -17359,7 +17256,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:15:08,48826,1,57689,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734979,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:15:08.911-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:Mrai2bjPCBmR0D+7XIxeLUm7B78=",
@@ -17534,7 +17430,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:15:08,48823,1,57689,53,49041,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734977,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:15:08.910-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -17723,7 +17618,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:14:58,48816,2,59499,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734973,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:14:58.908-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:1SK5PB9zwbzjkjaElO+9TUtFeBc=",
@@ -17898,7 +17792,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:14:53,48808,2,59499,53,8453,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734970,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:14:53.909-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -18087,7 +17980,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:14:48,48804,1,58167,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734965,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:14:49.372-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:rxSfplGAp2rbamZygTKBdsXYLYQ=",
@@ -18266,7 +18158,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:14:13,48794,1,57362,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734964,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:14:13.900-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:690Qg7aiVOzqjNrXeuatJsnPQ/8=",
@@ -18441,7 +18332,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:14:08,48793,1,57362,53,8723,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734963,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:14:08.899-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -18630,7 +18520,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:14:03,48792,1,59250,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734962,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:14:04.367-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:mfP9do6k7Nh8JLvLfufHBFE8+X8=",
@@ -18805,7 +18694,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:14:03,48789,1,59250,53,61084,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734961,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:14:04.366-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -18994,7 +18882,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:13:48,48786,1,58572,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734960,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:13:48.897-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:DH0O1fshue8AMfewCM4o3uZ8iX4=",
@@ -19169,7 +19056,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:13:43,48776,1,58572,53,38616,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734959,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:13:43.900-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -19358,7 +19244,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:13:43,48775,1,57763,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734954,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:13:43.900-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:jqTgkFapGz3qBNGRGvG+yryVEj0=",
@@ -19530,7 +19415,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:13:38,48773,1,57763,53,39403,53,0x403000,udp,drop-packet,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734953,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:13:39.364-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -19719,7 +19603,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:08:38,48682,1,59303,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734926,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:08:38.865-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:N9TLS+xuG3C64OMFvh5/E+yunaM=",
@@ -19894,7 +19777,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:08:33,48681,1,59303,53,38104,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734925,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:08:33.864-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -20083,7 +19965,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:08:28,48680,1,59271,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734924,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:08:28.863-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:cX2ubbO5L76SSBrNkfXvfmmhzww=",
@@ -20258,7 +20139,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:08:23,48679,1,59271,53,51838,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734923,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:08:24.296-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -20447,7 +20327,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:07:23,48657,1,58570,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734917,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:07:23.829-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:nQ+Fc0zhA5S3AVPdcqz8c06RR/0=",
@@ -20622,7 +20501,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:07:23,48656,1,58570,53,9367,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734916,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:07:23.829-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -20811,7 +20689,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:07:18,48655,1,59762,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734915,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:07:18.829-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:F5ayf/2zeTa8NDIYC5PuiaS4eNk=",
@@ -20986,7 +20863,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:07:13,48651,1,59762,53,26416,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734914,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:07:14.287-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -21171,7 +21047,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:06:48,48636,1,58503,53,62409,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734908,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:06:48.825-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -21360,7 +21235,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:06:43,48634,2,58503,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734906,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:06:43.825-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:o7k6TSO7n8/jRdEtlfUrqYd6kpc=",
@@ -21539,7 +21413,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:06:38,48630,2,58477,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734903,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:06:38.824-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:AViiwJCVNr7w6fSKkc4ryG5pOt0=",
@@ -21714,7 +21587,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:06:33,48629,2,58477,53,39559,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734902,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:06:33.823-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -21903,7 +21775,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:06:28,48627,1,57709,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734901,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:06:28.823-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:whlKSV/VtzwVAUXJem8BQaOqRis=",
@@ -22078,7 +21949,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:06:23,48626,1,57709,53,2447,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734899,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:06:23.822-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -22267,7 +22137,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:06:13,48617,2,58762,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734898,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:06:13.823-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:/LfmYuVOR357fnNCn3TchapkRw0=",
@@ -22442,7 +22311,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:06:13,48612,2,58762,53,3404,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734897,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:06:13.821-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -22631,7 +22499,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:06:08,48608,1,58258,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734896,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:06:09.281-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:WlEMsmKveqT7Mji2XsBbwvZsZiE=",
@@ -22803,7 +22670,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:06:08,48598,1,58258,53,36779,53,0x403000,udp,drop-packet,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734893,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:06:09.279-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -22992,7 +22858,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:46:50,32207,2,58714,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104719000,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:46:50.451-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:CYyxeQ5bLAzk9Jveu00zO63Y8Sc=",
@@ -23167,7 +23032,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:46:45,32203,2,58714,53,44895,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718999,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:46:45.424-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -23352,7 +23216,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:46:30,32192,2,59157,53,43210,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718998,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:46:31.371-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -23541,7 +23404,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:46:30,32191,3,58392,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718997,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:46:31.370-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:oJ2mFGDTfaSO+v/7GmJmGNfzt44=",
@@ -23720,7 +23582,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:46:20,32187,1,58839,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718996,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:46:20.318-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:GihEELz7Y4h9lSjvSZ2MjdVGYk4=",
@@ -23895,7 +23756,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:46:20,32184,2,58839,53,49708,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718995,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:46:20.317-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -24084,7 +23944,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:45:55,32175,1,57493,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718994,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:55.090-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:/8T2wb7d5XTZ9W1clZ8MHwy5KJY=",
@@ -24259,7 +24118,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:45:55,32174,1,57493,53,23766,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718993,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:55.089-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -24444,7 +24302,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:45:45,32170,2,57937,53,33499,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718992,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:45.088-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -24633,7 +24490,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:45:45,32169,2,57937,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718991,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:45.088-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:8jY5laToxj8V2+zWbE7r/4mlOBs=",
@@ -24812,7 +24668,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:45:35,32165,2,58434,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718990,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:35.028-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:X9o9zyc/73K41ABVnPQ+Lcdxhqc=",
@@ -24987,7 +24842,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:45:30,32164,2,58434,53,7540,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718989,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:30.028-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -25176,7 +25030,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:45:25,32158,2,57951,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718988,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:25.027-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:psbNQtiLfNcfYUxpq+KpHANhnuQ=",
@@ -25355,7 +25208,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:45:20,32157,1,58516,53,0,0,0x3000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718987,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:20.048-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:l9nsTcMXGA7xky/iyBFxm/5pTRM=",
@@ -25530,7 +25382,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:45:20,32156,2,57951,53,26691,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718986,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:20.048-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -25715,7 +25566,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:45:20,32155,1,58516,53,38731,53,0x403000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718985,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:20.047-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -25904,7 +25754,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:45:15,32152,1,59591,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718984,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:15.022-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:090FPjCg3OVgERhiCHcjX3IiY2o=",
@@ -26083,7 +25932,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:45:15,32150,1,58733,53,0,0,0x3000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718983,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:15.021-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:uBPtDcBNdfPuOj9LesXDpkQ4z4s=",
@@ -26255,7 +26103,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:45:15,32141,1,59591,53,59026,53,0x403000,udp,drop-packet,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718982,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:15.021-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -26437,7 +26284,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:45:10,32137,1,58733,53,24928,53,0x403000,udp,drop-packet,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718981,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:10.136-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -26626,7 +26472,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:41:24,32055,1,59535,53,0,0,0x3000,udp,drop,\"www.xiaz.xyz\",generic:www.xiaz.xyz(421497696),any,medium,client-to-server,7029847907104718980,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:41:24.982-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:TW1+cpa/XSFepxsksAzxtRHdBR0=",
@@ -26801,7 +26646,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:41:19,32053,1,59535,53,16245,53,0x403000,udp,drop,\"www.xiaz.xyz\",generic:www.xiaz.xyz(421497696),any,medium,client-to-server,7029847907104718979,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:41:19.983-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -26990,7 +26834,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:41:19,32052,1,57359,53,0,0,0x3000,udp,drop,\"www.xiaz.xyz\",generic:www.xiaz.xyz(421497696),any,medium,client-to-server,7029847907104718978,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:41:19.982-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:ifAPXGJ6/rLobL3l2IWWSCMrwKk=",
@@ -27162,7 +27005,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:41:14,32045,1,57359,53,28021,53,0x403000,udp,drop-packet,\"www.xiaz.xyz\",generic:www.xiaz.xyz(421497696),any,medium,client-to-server,7029847907104718977,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:41:14.992-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -27347,7 +27189,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:28:44,31811,1,58771,53,48581,53,0x403000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718976,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:28:44.802-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -27536,7 +27377,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:28:39,31804,1,58771,53,0,0,0x3000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718975,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:28:39.801-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:vc1USS+Gs67N7p8OakTYPldpdkA=",
@@ -27715,7 +27555,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:28:34,31801,2,57508,53,0,0,0x3000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718974,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:28:34.801-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:kifO4hqIDzPxrQmax3cQgYZrmUk=",
@@ -27890,7 +27729,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:28:29,31800,2,57508,53,43363,53,0x403000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718973,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:28:29.800-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -28079,7 +27917,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:28:24,31799,1,59397,53,0,0,0x3000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718972,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:28:25.768-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:0h+d+dXOeikBvCdSUs+bBP4tezA=",
@@ -28254,7 +28091,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:28:24,31798,1,59397,53,34018,53,0x403000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718971,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:28:25.767-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -28443,7 +28279,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:27:49,31787,1,59777,53,0,0,0x3000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718970,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:27:49.795-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:Ka34N/zEZP+Pg35L7u6s+L5MleM=",
@@ -28618,7 +28453,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:27:44,31781,2,59148,53,41708,53,0x403000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718969,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:27:45.763-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -28807,7 +28641,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:27:44,31779,1,59148,53,0,0,0x3000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718968,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:27:45.762-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:zbWfidUBoKFeCgIaY0r1f6dqI/Q=",
@@ -28982,7 +28815,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:27:34,31777,1,58514,53,34803,53,0x403000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718967,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:27:34.757-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -29171,7 +29003,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:27:29,31775,2,58993,53,0,0,0x3000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718966,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:27:29.758-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:/TgXJ7fK80cSza6fOUwGpJ1wMik=",
@@ -29346,7 +29177,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:27:24,31774,1,58993,53,14335,53,0x403000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718965,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:27:24.756-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -29535,7 +29365,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:27:19,31770,2,59215,53,0,0,0x3000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718964,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:27:19.756-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:N0xodL3//Wz7NeI6T0EetECLDIQ=",
@@ -29710,7 +29539,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:27:14,31766,2,59215,53,58034,53,0x403000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718963,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:27:14.755-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -29895,7 +29723,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:27:04,31762,1,57615,53,65092,53,0x403000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718962,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:27:04.776-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -30084,7 +29911,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:27:04,31761,2,58004,53,0,0,0x3000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718961,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:27:04.776-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:zm5DkK8OlGya/iybuN9H/rY2wUs=",
@@ -30256,7 +30082,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:26:59,31760,1,58004,53,50075,53,0x403000,udp,drop-packet,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718960,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:26:59.749-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -30445,7 +30270,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:12:09,31425,2,58480,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718955,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:12:09.249-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:mpLb3549rHG8d+hK4kGZxbsmElI=",
@@ -30620,7 +30444,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:12:04,31424,2,58480,53,28628,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718954,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:12:04.291-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -30805,7 +30628,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:11:34,31415,1,59487,53,17390,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718953,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:11:34.244-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -30994,7 +30816,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:11:29,31412,2,58329,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718952,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:11:29.243-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:qwBEAQ2qzPkbDrR8gHIc5fGmbuk=",
@@ -31169,7 +30990,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:11:24,31411,1,58329,53,39886,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718951,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:11:24.243-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -31358,7 +31178,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:11:14,31409,1,57978,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718950,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:11:14.242-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:IeCiryr2DsUo0eJ9BmsY+iOsf5Y=",
@@ -31533,7 +31352,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:11:09,31402,3,59191,53,1563,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718949,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:11:09.241-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -31722,7 +31540,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:11:04,31401,2,59191,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718948,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:11:04.241-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:fUjOAhlB6xRdp1c+OfiVKtsVq/U=",
@@ -31901,7 +31718,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:10:54,31397,2,59725,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718947,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:10:54.240-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:FTEVrZQEb9DVFbp+kySgnf+JRIA=",
@@ -32076,7 +31892,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:10:54,31390,2,59725,53,30685,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718946,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:10:54.239-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -32265,7 +32080,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:10:44,31381,2,57339,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718945,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:10:44.233-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:reLVOecvGsXTNQ7pqK8fMMo2YIQ=",
@@ -32440,7 +32254,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:10:39,31380,2,57339,53,64069,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718944,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:10:39.233-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -32629,7 +32442,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:10:39,31379,1,58903,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718943,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:10:39.233-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": "1:S1TfyAhYrv9wy0t3EO1ctVLhZgg=",
@@ -32801,7 +32613,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:10:34,31373,1,58903,53,26180,53,0x403000,udp,drop-packet,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718942,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:10:35.294-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
             "network": {
                 "application": "dns",
                 "community_id": [
@@ -32978,7 +32789,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "10.1.0.12,192.168.15.224,10.138.0.44,192.168.15.224,reset-adult,,,ssl,vsys1,private,public,ethernet1/2,ethernet1/1,,2023/10/04 09:40:58,763,1,50462,443,15048,443,0x407400,tcp,block-url,\"adult.com/\",(9999),adult,informational,client-to-server,7286123782408765451,0x0,10.0.0.0-10.255.255.255,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,N/A,AppThreat-0-0,0x0,0,4294967295,,\"adult,low-risk\",73a06abf-75ca-436f-9319-1a15b27fa692,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2023-10-04T09:40:58.388-07:00,,,,encrypted-tunnel,networking,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,ssl,no,no,,,NonProxyTraffic",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -33151,7 +32961,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "10.1.0.12,192.168.15.224,10.138.0.44,192.168.15.224,block-sports,,,web-browsing,vsys1,private,public,ethernet1/2,ethernet1/1,elastic,2023/10/04 09:40:43,730,1,54344,80,1618,80,0x407000,tcp,block-url,\"www.espn.com/\",(9999),sports,informational,client-to-server,7286123782408765449,0x0,10.0.0.0-10.255.255.255,United States,,,0,,,1,,,,,,,,0,0,0,0,0,,PA-VM,,,,get,0,,0,,N/A,N/A,AppThreat-0-0,0x0,0,4294967295,,\"sports,low-risk\",eb5b9cd9-716b-4729-a5de-9033f4c5aa4f,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2023-10-04T09:40:43.387-07:00,,,,internet-utility,general-internet,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,web-browsing,no,no,,,NonProxyTraffic",
             "network": {
                 "application": "web-browsing",
                 "community_id": [
@@ -33334,7 +33143,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,src-domainname\\src_username,dst-domainname\\dst_username,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28191,1,52984,443,37679,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7726,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -33511,7 +33319,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,nt-autorit..t\\src_username,nt-autorit..t\\dst_username,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28191,1,52984,443,37679,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7726,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -33688,7 +33495,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,.\\src_username,.\\dst_username,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28191,1,52984,443,37679,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7726,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -33865,7 +33671,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,src-domainname\\\\src_username,dst-domainname\\\\dst_username,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28191,1,52984,443,37679,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7726,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -34042,7 +33847,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,src_username@src-domainname,dst_username@dst-domainname,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28191,1,52984,443,37679,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7726,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -34218,7 +34022,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,src_username,dst_username,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28191,1,52984,443,37679,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7726,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -34389,7 +34192,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,x-fwd-for: 10.10.10.50,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28191,1,52984,443,37679,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7726,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -34563,7 +34365,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,src_domainname\\\\src-user#name,dst_domainname\\\\dst-user#name,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28191,1,52984,443,37679,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7726,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -34740,7 +34541,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,src_domain..name\\\\src-user#name,dst_domain..name\\\\dst-user#name,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28191,1,52984,443,37679,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7726,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -34904,7 +34704,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "10.84.12.242,192.168.236.67,192.168.26.150,192.168.236.67,A_SRC_L7D_Kassasystemen-2-Internet,,,ssl,vsys1,IOT,Internet,ae1.1324,ae2.497,Panorama-Elastic,2024/04/09 16:57:36,33874993,1,54421,443,29394,443,0x403400,tcp,block-url,\"keyvalueservice.icloud.com\",(9999),online-storage-and-backup,informational,client-to-server,7341108846123879261,0x8000000000000000,10.0.0.0-10.255.255.255,United States,,,0,,,0,,,,,,,,0,0,0,0,0,Core,AC-PA5250,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,,\" CUC_Apple,online-storage-and-backup,low-risk\",608460e0-3b24-4bef-a676-96027545ae7d,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2024-04-09T16:57:37.089+02:00,,,,encrypted-tunnel,networking,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,ssl,no,no,_reportid",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -35078,7 +34877,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "10.84.12.242,192.168.236.67,192.168.26.150,192.168.236.67,A_SRC_L7D_Kassasystemen-2-Internet,,,ssl,vsys1,IOT,Internet,ae1.1324,ae2.497,Panorama-Elastic,2024/04/09 16:57:36,33874993,1,54421,443,29394,443,0x403400,tcp,block-url,\"keyvalueservice.icloud.com?q=30\",(9999),online-storage-and-backup,informational,client-to-server,7341108846123879261,0x8000000000000000,10.0.0.0-10.255.255.255,United States,,,0,,,0,,,,,,,,0,0,0,0,0,Core,AC-PA5250,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,,\" CUC_Apple,online-storage-and-backup,low-risk\",608460e0-3b24-4bef-a676-96027545ae7d,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2024-04-09T16:57:37.089+02:00,,,,encrypted-tunnel,networking,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,ssl,no,no,_reportid",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -35252,7 +35050,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "10.84.12.242,192.168.236.67,192.168.26.150,192.168.236.67,A_SRC_L7D_Kassasystemen-2-Internet,,,ssl,vsys1,IOT,Internet,ae1.1324,ae2.497,Panorama-Elastic,2024/04/09 16:57:36,33874993,1,54421,443,29394,443,0x403400,tcp,block-url,\"keyvalueservice.icloud.com:443?q=30\",(9999),online-storage-and-backup,informational,client-to-server,7341108846123879261,0x8000000000000000,10.0.0.0-10.255.255.255,United States,,,0,,,0,,,,,,,,0,0,0,0,0,Core,AC-PA5250,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,,\" CUC_Apple,online-storage-and-backup,low-risk\",608460e0-3b24-4bef-a676-96027545ae7d,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2024-04-09T16:57:37.089+02:00,,,,encrypted-tunnel,networking,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,ssl,no,no,_reportid",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -35428,7 +35225,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "10.154.247.224,192.168.4.4,192.168.72.187,192.168.4.4,A_ANY_L7A_surf-Good internet appl PUBNET-Open Internet,,,ssl,vsys1,Open Internet,Internet-PUBNET,ae1.898,ethernet1/16.451,Panorama-Elastic,2024/04/09 11:00:29,2552174,1,57241,443,6226,443,0x403400,tcp,block-url,\"dns.google\",(9999),encrypted-dns,informational,client-to-server,7341108846081879882,0x8000000000000000,10.0.0.0-10.255.255.255,United States,,,0,,,0,,,,,,,,0,0,0,0,0,Core,AC-PA5250,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,,\"encrypted-dns,computer-and-internet-info,low-risk\",f27e631a-d0b9-4d01-bdfa-e955076d9a21,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2024-04-09T11:00:29.812+02:00,,,,encrypted-tunnel,networking,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,ssl,no,no,_reportid",
             "network": {
                 "application": "ssl",
                 "community_id": [
@@ -35602,7 +35398,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.72.187,192.168.110.104,0.0.0.0,0.0.0.0,A_SRC_ANY_DMZ-Public-to-Internet,,,google-base,vsys1,Internet,Internet,ethernet1/15.451,ae2.497,Panorama-Elastic,2024/04/09 20:43:29,3853754,1,12235,80,0,0,0xb000,tcp,alert,\"www.google.com/\",(9999),search-engines,informational,client-to-server,7341108846134004297,0x8000000000000000,Belgium,United States,,text/html,0,,,1,,,,,,,,0,0,0,0,0,Core,AC-PA5250,,,,get,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,,\" CUC_OCP4_worker-nodes,search-engines,low-risk\",a76c7b1d-5e84-48f5-9498-a9d10ffc959c,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2024-04-09T20:43:30.719+02:00,,,,internet-utility,general-internet,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,google-base,no,no,_reportid",
             "network": {
                 "application": "google-base",
                 "community_id": "1:MnImcU1JEPf3qnDIkOLE6/sgyPk=",
@@ -35764,7 +35559,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.72.187,192.168.110.104,0.0.0.0,0.0.0.0,A_SRC_ANY_DMZ-Public-to-Internet,,,google-base,vsys1,Internet,Internet,ethernet1/15.451,ae2.497,Panorama-Elastic,2024/04/09 20:43:29,3853754,1,12235,80,0,0,0xb000,tcp,alert,\"www.google.com:80/\",(9999),search-engines,informational,client-to-server,7341108846134004297,0x8000000000000000,Belgium,United States,,text/html,0,,,1,,,,,,,,0,0,0,0,0,Core,AC-PA5250,,,,get,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,,\" CUC_OCP4_worker-nodes,search-engines,low-risk\",a76c7b1d-5e84-48f5-9498-a9d10ffc959c,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2024-04-09T20:43:30.719+02:00,,,,internet-utility,general-internet,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,google-base,no,no,_reportid",
             "network": {
                 "application": "google-base",
                 "community_id": "1:MnImcU1JEPf3qnDIkOLE6/sgyPk=",
@@ -35928,7 +35722,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "10.84.12.242,192.168.236.67,192.168.26.150,192.168.236.67,A_SRC_ANY_DMZ-Public-to-Internet,src_username@src-domainname,,web-browsing,vsys1,Inside,Outside,ae1.1324,ae2.497,default,2024/04/09 20:43:29,2398805,2,50833,443,14918,443,0x1402000,tcp,reset-server,\"download-cdn.jetbrains.com/resharper/dotUltimate.2023.3.4/Packages/JetBrains.ReSharper.Plugins.ReSharperTutorials.233.0.20240306.121739.nupkg\",Virus/Linux.example(419149938),computer-and-internet-info,medium,server-to-client,7332568507791862502,0x8000000000000000,United States,United States,,,0,,,1,,,,,,,,0,16,14,0,0,,AC-PA5250,,,,,0,,0,,N/A,script-av,Antivirus-4767-5285,0x0,0,4294967295,,,a76c7b1d-5e84-48f5-9498-a9d10ffc959c,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2024-04-09T20:43:29.123+01:00,,,,internet-utility,general-internet,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,web-browsing,no,no,",
             "network": {
                 "application": "web-browsing",
                 "community_id": [
@@ -36111,7 +35904,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "10.84.12.242,192.168.236.67,192.168.26.150,192.168.236.67,A_SRC_ANY_DMZ-Public-to-Internet,src_username@src-domainname,,web-browsing,vsys1,Inside,Outside,ae1.1324,ae2.497,default,2024/04/09 20:43:29,234719,1,54576,443,50192,443,0x1402000,tcp,reset-both,\"commons-digester3-3.2.jar\",Virus/Linux.example(419149938),computer-and-internet-info,medium,server-to-client,7364505737280619655,0x8000000000000000,United States,United States,,,0,,,1,,,,,,,,0,16,14,0,0,,AC-PA5250,,,,,0,,0,2024/04/09 20:43:29,N/A,script-av,Antivirus-4809-5327,0x0,0,4294967295,,,a76c7b1d-5e84-48f5-9498-a9d10ffc959c,894567,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2024-04-09T20:43:29+02:00,,,,internet-utility,general-internet,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,web-browsing,no,no,",
             "network": {
                 "application": "web-browsing",
                 "community_id": [
@@ -36286,7 +36078,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.72.187,192.168.110.104,0.0.0.0,0.0.0.0,A_SRC_ANY_DMZ-Public-to-Internet,,,google-base,vsys1,Internet,Internet,ethernet1/15.451,ae2.497,Panorama-Elastic,2024/04/09 20:43:29,3853754,1,12235,80,0,0,0xb000,tcp,alert,\"www.google.com:80/\",(9999),search-engines,Informational,client-to-server,7341108846134004297,0x8000000000000000,Belgium,United States,,text/html,0,,,1,,,,,,,,0,0,0,0,0,Core,AC-PA5250,,,,get,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,,\" CUC_OCP4_worker-nodes,search-engines,low-risk\",a76c7b1d-5e84-48f5-9498-a9d10ffc959c,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2024-04-09T20:43:30.719+02:00,,,,internet-utility,general-internet,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,google-base,no,no,_reportid",
             "network": {
                 "application": "google-base",
                 "community_id": "1:MnImcU1JEPf3qnDIkOLE6/sgyPk=",
@@ -36455,7 +36246,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "10.84.12.242,192.168.236.67,192.168.26.150,192.168.236.67,A_SRC_ANY_DMZ-Public-to-Internet,src_username@src-domainname,,web-browsing,vsys1,Inside,Outside,ae1.1324,ae2.497,default,2024/04/09 20:43:29,234719,1,54576,443,50192,443,0x1402000,tcp,reset-both,\"commons-digester3-3.2.jar\",Virus/Linux.example(419149938),computer-and-internet-info,Medium,server-to-client,7364505737280619655,0x8000000000000000,United States,United States,,,0,,,1,,,,,,,,0,16,14,0,0,,AC-PA5250,,,,,0,,0,2024/04/09 20:43:29,N/A,script-av,Antivirus-4809-5327,0x0,0,4294967295,,,a76c7b1d-5e84-48f5-9498-a9d10ffc959c,894567,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2024-04-09T20:43:29+02:00,,,,internet-utility,general-internet,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,web-browsing,no,no,",
             "network": {
                 "application": "web-browsing",
                 "community_id": [
@@ -36632,7 +36422,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "10.64.217.27,10.48.15.198,0.0.0.0,0.0.0.0,SectorProxy Browsing my-user,x-fwd-for: 10.34.32.4,,http-proxy,vsys1,interconnect,proxy,ethernet1/2,ethernet1/3,HOST-LOGCOLLECTOR,2024/08/19 13:57:32,879663,1,61736,8085,0,0,0x18b000,tcp,alert,\"dev-prod06.example.net:443/\",(9999),computer-and-internet-info,informational,client-to-server,7397686859576788886,0x8000000000000000,10.0.0.0-10.255.255.255,10.0.0.0-10.255.255.255,,,0,,,1,,,,,,,,0,850,851,0,0,,fw1027,,,,connect,0,,0,,N/A,N/A,AppThreat-0-0,0x0,0,4294967295,,\" sed-dtenv,computer-and-internet-info,low-risk\",f1b2a45a-ae42-45e6-a58e-ba899f8fc6b9,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2024-08-19T13:57:32.686+00:00,,,,proxy,networking,browser-based,5,\"evasive-behavior,used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,prone-to-misuse,pervasive-use\",,http-proxy,no,no,",
             "network": {
                 "application": "http-proxy",
                 "community_id": "1:5kSYuTH8t3MEcUR5izvM9+O9gVs=",
@@ -36793,7 +36582,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "10.52.238.102,10.68.15.198,0.0.0.0,0.0.0.0,SectorProxy Browsing my2-user,x-fwd-for: 10.52.212.124,,http-proxy,vsys1,interconnect,proxy,ethernet1/2,ethernet1/3,HOST-LOGCOLLECTOR,2024/08/19 13:59:20,741453,1,56805,8084,0,0,0x18b000,tcp,alert,\"graph.example.com:443/\",(9999),ua-generic,informational,client-to-server,7395699350516548098,0x8000000000000000,10.0.0.0-10.255.255.255,10.0.0.0-10.255.255.255,,,0,,,1,,,,,,,,0,850,852,0,0,,fw1031,,,,connect,0,,0,,N/A,N/A,AppThreat-0-0,0x0,0,4294967295,,\" sed-bd,computer-and-internet-info,low-risk\",14491db3-57cf-4694-8c9c-ec7635e770e2,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2024-08-19T13:59:20.760+00:00,,,,proxy,networking,browser-based,5,\"evasive-behavior,used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,prone-to-misuse,pervasive-use\",,http-proxy,no,no,",
             "network": {
                 "application": "http-proxy",
                 "community_id": "1:1etDiAD3IsssiGZyu6KOHiAHtJ4=",
@@ -36952,7 +36740,6 @@
             "log": {
                 "level": "low"
             },
-            "message": "10.71.208.15,10.68.15.198,0.0.0.0,0.0.0.0,SectorProxy Browsing my3-user,,,web-browsing,vsys1,interconnect,proxy,ethernet1/2,ethernet1/3,HOST-LOGCOLLECTOR,2024/08/19 13:58:32,577801,1,18830,8097,0,0,0x1102000,tcp,alert,\"fpt2.example.com/Clear.HTML?ctx=Ls1.0&wl=True&session_id=425e6d9b-6193-46d4-b5a2-35ee68e38086&id=2fd84f97-783d-43d4-977f-1a9f6446550e&w=8DCC056FF6F008C&tkt=H3ihr9e92IdW6yd1ZgQ9S9GE/yxCfNn1WRJjtpTkl7bZYNRP0G8iRDJKxj9TXCkOCRKWke9IXcntwxu7pJ00Kju4SIo+ydc3O2XOKak2s+umUnAnqOU9xu81Pv6fr1zV2m0HeGUeEPpayNxh9AVB9lnwfYsQh0ENPN98KUyDCmN77AEdVF7P5Njwlc2nOpzkVKgP4vmPeQd/o32ZFgpNPNp2AS2MV2oUfqU6TL9lfhTdFQZLw+jek7u4uMmuUFdtYYLULZAPshhlHwnTi9mcdsP9624GSOhWC/mtNEFNWEzEmg6VbgmWtHq6GMPiAOFr&CustomerId=02C58649-E822-405B-B6C3-17A7509D2FCC\",Potential HTML Evasion Technique Detected in HTTP Response(91883),ua-generic,low,server-to-client,7395705320518981763,0x8000000000000000,10.0.0.0-10.255.255.255,10.0.0.0-10.255.255.255,,,0,,,1,,,,,,,,0,850,852,0,0,,fw1034,,,,,0,,0,2024/08/19 13:58:26,N/A,protocol-anomaly,AppThreat-8883-8920,0x0,0,4294967295,,,c1b9f945-e213-4cdf-b77d-2700446a3baf,805901,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2024-08-19T13:58:32.880+00:00,,,,internet-utility,general-internet,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,web-browsing,no,no,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:OO3gyDfAi++o8zf5dGU7xin0u0Y=",
@@ -37104,7 +36891,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "10.48.12.171,10.190.160.25,0.0.0.0,0.0.0.0,,,,not-applicable,vsys2,interconnect,public,ae2.1349,,HOST-LOGCOLLECTOR,2024/08/19 13:58:31,0,1,41526,443,0,0,0x2000,tcp,alert,,SCAN: Host Sweep(8002),any,medium,client-to-server,7361590532514024944,0x8000000000000000,10.0.0.0-10.255.255.255,European Union,,,0,,,0,,,,,,,,0,15,23,0,0,az1_vsys_internet,fw0096,,,,,0,,0,,N/A,scan,AppThreat-0-0,0x0,0,4294967295,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2024-08-19T13:58:31.761+00:00,,,0,unknown,unknown,unknown,1,,,not-applicable,no,no,",
             "network": {
                 "application": "not-applicable",
                 "community_id": "1:aBnNIJZRQ+VLRXkj5TNknk2rYLU=",
@@ -37246,7 +37032,6 @@
             "log": {
                 "level": "low"
             },
-            "message": "10.71.208.15,10.68.15.198,0.0.0.0,0.0.0.0,SectorProxy Browsing my3-user,,,web-browsing,vsys1,interconnect,proxy,ethernet1/2,ethernet1/3,HOST-LOGCOLLECTOR,2024/08/19 13:58:32,577801,1,18830,8097,0,0,0x1102000,tcp,alert,\"shadow\",Potential HTML Evasion Technique Detected in HTTP Response(91883),ua-generic,low,server-to-client,7395705320518981763,0x8000000000000000,10.0.0.0-10.255.255.255,10.0.0.0-10.255.255.255,,,0,,,1,,,,,,,,0,850,852,0,0,,fw1034,,,,,0,,0,2024/08/19 13:58:26,N/A,protocol-anomaly,AppThreat-8883-8920,0x0,0,4294967295,,,c1b9f945-e213-4cdf-b77d-2700446a3baf,805901,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2024-08-19T13:58:32.880+00:00,,,,internet-utility,general-internet,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,web-browsing,no,no,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:OO3gyDfAi++o8zf5dGU7xin0u0Y=",
@@ -37399,7 +37184,6 @@
             "log": {
                 "level": "low"
             },
-            "message": "192.168.1.2,10.71.208.15,0.0.0.0,0.0.0.0,file download test rule,contoso\\\\steve,,web-browsing,vsys1,HOMENET,EXTNET,ethernet1/2,ethernet1/1,log-profile1,2024/11/06 14:11:30,994313,2,37268,443,0,0,0x1002000,tcp,alert,\"elastic-agent.exe\",Windows Executable (EXE)(52020),computer-and-internet-info,low,server-to-client,7367538158076100804,0x8000000000000000,192.168.0.0-192.168.255.255,United States,,,0,,,1,,,,,,,,0,199,479,0,0,,pa555,artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-8.15.3+build202411051926-windows-x86_64.zip,,,,7213055707168598,,0,2024/11/06 14:11:30,N/A,N/A,AppThreat-8911-9049,0x0,0,4294967295,,,88e69ca4-8783-4b7c-9982-f73ec6f1a83c,1679420,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2024-11-06T14:11:30.036-05:00,,,,internet-utility,generate-internet,browser-based,2,\"used-bymalware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,web-browsing,no,no,",
             "network": {
                 "application": "web-browsing",
                 "community_id": "1:sA1Tr5zVqaZQn7PEngH9gMb+2Tg=",
@@ -37572,7 +37356,6 @@
             "log": {
                 "level": "medium"
             },
-            "message": "67.43.156.0,67.43.156.1,0.0.0.0,0.0.0.0,A_DST_L7D_DNS,domain\\user01,,dns-base,vsys1,Group,Servers,abc.123,abd.234,Panorama-Elastic,2024/10/01 10:43:54,34891187,2,59020,53,0,0,0x3000,tcp,sinkhole,\"*.domain.dev\",Suspicious Domain(12000000),any,medium,client-to-server,7401113521124350246,0x8000000000000000,10.0.0.0-10.255.255.255,10.0.0.0-10.255.255.255,,,0,,,0,,,,,,,,0,0,0,0,0,Core,AC5250,,,,,0,,0,,N/A,domain-edl,AppThreat-0-0,0x0,0,4291167295,,,5e791170-7507-4ab1-a951-79ebed0dad21,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2024-10-01T10:43:55.308+02:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",dns,dns-base,no,no,_reportid",
             "network": {
                 "application": "dns-base",
                 "community_id": "1:Sj3H9LtJYWFdWXjIqpG6+D2O7fs=",

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-threat-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-threat-sample.log-expected.json
@@ -50,7 +50,6 @@
             "log": {
                 "level": "informational"
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28191,1,52984,443,37679,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7726,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
             "network": {
                 "application": "ssl",
                 "community_id": [

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-time-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-time-sample.log-expected.json
@@ -246,7 +246,6 @@
             "log": {
                 "level": "4"
             },
-            "message": "10.0.0.10,175.16.199.1,10.0.0.20,10.0.0.30,rule,,d-user,app,vsys,s-zone,d-zone,inbound,outbound,log,,id,100,9000,9550,9200,9300,0,tcp,action,4,1000,user,src-loc,dst-loc,0,0,0,0,vsys-name,d-name,imsi,imei,1000,1000,1000,10,10,10,10,10,10,20,200,75,50,1000,1000,end,action,2021-11-23T00:44:44.930-08:00,1234567890,rule1,81.2.69.192,100,100,pcap,dug,100,100,1969-12-31T16:00:00.000-08:00,asd,ast,100,app-sc,cat,tech,4,char,con,no,no",
             "network": {
                 "application": "app",
                 "bytes": 10,

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-time-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-time-sample.log-expected.json
@@ -51,7 +51,6 @@
             "log": {
                 "level": "4"
             },
-            "message": "10.0.0.10,175.16.199.1,10.0.0.20,10.0.0.30,rule,,d-user,app,vsys,s-zone,d-zone,inbound,outbound,log,,id,100,9000,9550,9200,9300,0,tcp,action,4,1000,user,src-loc,dst-loc,0,0,0,0,vsys-name,d-name,imsi,imei,1000,1000,1000,10,10,10,10,10,10,20,200,75,50,1000,1000,end,action,2021-11-23T00:44:44.930-08:00,1234567890,rule1,81.2.69.192,100,100,pcap,dug,100,100,2021-11-23T00:44:44.930-08:00,asd,ast,100,app-sc,cat,tech,4,char,con,no,no",
             "network": {
                 "application": "app",
                 "bytes": 10,

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-traffic-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-traffic-sample.log-expected.json
@@ -49,7 +49,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.207,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,apple-maps,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:07,22751,1,55113,443,16418,443,0x400053,tcp,allow,7734,1758,5976,36,2018/11/30 15:59:04,586,computer-and-internet-info,0,32091112,0x0,192.168.0.0-192.168.255.255,United States,0,16,20,tcp-fin,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "apple-maps",
                 "bytes": 7734,

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-traffic-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-traffic-sample.log-expected.json
@@ -237,7 +237,6 @@
                 "nat_translated": true,
                 "non_standard_port_usage": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ping,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:09,24223,6,0,0,0,0,0x500019,icmp,allow,1176,588,588,12,2018/11/30 16:08:55,0,any,0,32091113,0x0,192.168.0.0-192.168.255.255,United States,0,6,6,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ping",
                 "bytes": 1176,
@@ -418,7 +417,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.207,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:09,24138,1,55114,80,51990,80,0x40001c,tcp,allow,1574,539,1035,11,2018/11/30 16:08:51,1,computer-and-internet-info,0,32091114,0x0,192.168.0.0-192.168.255.255,United States,0,6,5,tcp-fin,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "web-browsing",
                 "bytes": 1574,
@@ -607,7 +605,6 @@
                 "nat_translated": true,
                 "non_standard_port_usage": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ping,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:15,24043,6,0,0,0,0,0x500019,icmp,allow,1176,588,588,12,2018/11/30 16:09:01,0,any,0,32091115,0x0,192.168.0.0-192.168.255.255,United States,0,6,6,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ping",
                 "bytes": 1176,
@@ -788,7 +785,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.196,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,quic,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:15,23003,1,46774,443,15252,443,0x400019,udp,allow,3627,2014,1613,8,2018/11/30 16:07:13,0,any,0,32091116,0x0,192.168.0.0-192.168.255.255,United States,0,5,3,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "quic",
                 "bytes": 3627,
@@ -976,7 +972,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:15,23919,1,52408,443,40763,443,0x400053,tcp,allow,41753,20642,21111,113,2018/11/30 16:07:33,85,web-advertisements,0,32091117,0x0,192.168.0.0-192.168.255.255,United States,0,62,51,tcp-fin,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ssl",
                 "bytes": 41753,
@@ -1165,7 +1160,6 @@
                 "nat_translated": true,
                 "non_standard_port_usage": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ping,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:21,21394,6,0,0,0,0,0x500019,icmp,allow,1176,588,588,12,2018/11/30 16:09:07,0,any,0,32091118,0x0,192.168.0.0-192.168.255.255,United States,0,6,6,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ping",
                 "bytes": 1176,
@@ -1346,7 +1340,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,quic,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:21,23698,1,59190,443,52881,443,0x400019,udp,allow,7097,3365,3732,16,2018/11/30 16:07:04,15,any,0,32091119,0x0,192.168.0.0-192.168.255.255,United States,0,7,9,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "quic",
                 "bytes": 7097,
@@ -1534,7 +1527,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.207,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:22,24179,1,49728,53,26654,53,0x400019,udp,allow,301,80,221,2,2018/11/30 16:08:50,0,any,0,32091120,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 301,
@@ -1722,7 +1714,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.207,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:23,23933,1,50500,53,2486,53,0x400019,udp,allow,298,77,221,2,2018/11/30 16:08:51,0,any,0,32091121,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 298,
@@ -1910,7 +1901,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.207,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,apple-push-notifications,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:24,22662,1,55112,443,42021,443,0x400053,tcp,allow,9978,4509,5469,32,2018/11/30 15:58:59,593,computer-and-internet-info,0,32091122,0x0,192.168.0.0-192.168.255.255,United States,0,16,16,tcp-rst-from-client,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "apple-push-notifications",
                 "bytes": 9978,
@@ -2098,7 +2088,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.207,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:24,24161,1,57632,53,24377,53,0x400019,udp,allow,297,73,224,2,2018/11/30 16:08:52,0,any,0,32091123,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 297,
@@ -2286,7 +2275,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.207,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:24,24107,1,50271,53,48792,53,0x400019,udp,allow,186,69,117,2,2018/11/30 16:08:52,0,any,0,32091124,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 186,
@@ -2474,7 +2462,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.207,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:24,24063,1,54061,53,2987,53,0x400019,udp,allow,392,85,307,2,2018/11/30 16:08:52,0,any,0,32091125,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 392,
@@ -2662,7 +2649,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.207,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:24,24145,1,52701,53,6945,53,0x400019,udp,allow,440,75,365,2,2018/11/30 16:08:52,0,any,0,32091126,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 440,
@@ -2851,7 +2837,6 @@
                 "nat_translated": true,
                 "non_standard_port_usage": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ping,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:27,24245,6,0,0,0,0,0x500019,icmp,allow,1176,588,588,12,2018/11/30 16:09:13,0,any,0,32091127,0x0,192.168.0.0-192.168.255.255,United States,0,6,6,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ping",
                 "bytes": 1176,
@@ -3032,7 +3017,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:27,24167,1,62503,53,42208,53,0x400019,udp,allow,258,97,161,2,2018/11/30 16:08:54,1,any,0,32091128,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 258,
@@ -3220,7 +3204,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:28,24212,1,52442,443,14660,443,0x40001c,tcp,allow,9891,2086,7805,27,2018/11/30 16:08:54,17,web-advertisements,0,32091129,0x0,192.168.0.0-192.168.255.255,United States,0,14,13,tcp-fin,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ssl",
                 "bytes": 9891,
@@ -3408,7 +3391,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:28,24149,1,52441,443,16483,443,0x40001c,tcp,allow,8460,2354,6106,24,2018/11/30 16:08:54,17,web-advertisements,0,32091130,0x0,192.168.0.0-192.168.255.255,United States,0,13,11,tcp-fin,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ssl",
                 "bytes": 8460,
@@ -3597,7 +3579,6 @@
                 "nat_translated": true,
                 "non_standard_port_usage": true
             },
-            "message": "192.168.15.196,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ping,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:29,24185,2,0,0,0,0,0x500019,icmp,allow,392,196,196,4,2018/11/30 16:09:15,0,any,0,32091131,0x0,192.168.0.0-192.168.255.255,United States,0,2,2,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ping",
                 "bytes": 392,
@@ -3778,7 +3759,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ocsp,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:29,23856,1,52355,80,5570,80,0x40001c,tcp,allow,5790,2545,3245,36,2018/11/30 16:07:16,116,computer-and-internet-info,0,32091132,0x0,192.168.0.0-192.168.255.255,United States,0,19,17,tcp-fin,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ocsp",
                 "bytes": 5790,
@@ -3966,7 +3946,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.207,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:29,24173,1,50196,53,24430,53,0x400019,udp,allow,261,82,179,2,2018/11/30 16:08:57,0,any,0,32091133,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 261,
@@ -4154,7 +4133,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,traps-management-service,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:30,24257,1,52454,443,12122,443,0x400053,tcp,allow,6295,1758,4537,25,2018/11/30 16:09:13,0,computer-and-internet-info,0,32091134,0x0,192.168.0.0-192.168.255.255,United States,0,13,12,tcp-fin,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "traps-management-service",
                 "bytes": 6295,
@@ -4342,7 +4320,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,incomplete,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:32,24090,1,52445,4282,49145,4282,0x400019,tcp,allow,624,624,0,8,2018/11/30 16:09:12,13,any,0,32091135,0x0,192.168.0.0-192.168.255.255,United States,0,8,0,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "incomplete",
                 "bytes": 624,
@@ -4531,7 +4508,6 @@
                 "nat_translated": true,
                 "non_standard_port_usage": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ping,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:33,24242,6,0,0,0,0,0x500019,icmp,allow,1176,588,588,12,2018/11/30 16:09:19,0,any,0,32091136,0x0,192.168.0.0-192.168.255.255,United States,0,6,6,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ping",
                 "bytes": 1176,
@@ -4709,7 +4685,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.210,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:34,24190,1,35485,53,33110,53,0x400019,udp,allow,215,85,130,2,2018/11/30 16:09:02,0,any,0,32091137,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 215,
@@ -4893,7 +4868,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,quic,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:37,23892,1,62730,443,9299,443,0x400019,udp,allow,4867,2876,1991,12,2018/11/30 16:07:20,15,any,0,32091138,0x0,192.168.0.0-192.168.255.255,United States,0,6,6,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "quic",
                 "bytes": 4867,
@@ -5081,7 +5055,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:38,24360,1,52506,443,47194,443,0x40001c,tcp,allow,1623,1100,523,13,2018/11/30 16:09:21,0,business-and-economy,0,32091139,0x0,192.168.0.0-192.168.255.255,United States,0,8,5,tcp-rst-from-client,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ssl",
                 "bytes": 1623,
@@ -5269,7 +5242,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,quic,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:38,23952,1,60596,443,62921,443,0x400019,udp,allow,4405,1977,2428,9,2018/11/30 16:07:36,0,any,0,32091140,0x0,192.168.0.0-192.168.255.255,United States,0,5,4,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "quic",
                 "bytes": 4405,
@@ -5458,7 +5430,6 @@
                 "nat_translated": true,
                 "non_standard_port_usage": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ping,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:39,24328,6,0,0,0,0,0x500019,icmp,allow,1176,588,588,12,2018/11/30 16:09:25,0,any,0,32091141,0x0,192.168.0.0-192.168.255.255,United States,0,6,6,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ping",
                 "bytes": 1176,
@@ -5640,7 +5611,6 @@
                 "nat_translated": true,
                 "non_standard_port_usage": true
             },
-            "message": "192.168.15.210,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ping,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:39,24385,2,0,0,0,0,0x500019,icmp,allow,392,196,196,4,2018/11/30 16:09:25,0,any,0,32091142,0x0,192.168.0.0-192.168.255.255,United States,0,2,2,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ping",
                 "bytes": 392,
@@ -5821,7 +5791,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:39,24172,1,52514,443,41958,443,0x40001c,tcp,allow,7231,2228,5003,22,2018/11/30 16:09:22,0,web-advertisements,0,32091143,0x0,192.168.0.0-192.168.255.255,United States,0,12,10,tcp-fin,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ssl",
                 "bytes": 7231,
@@ -6009,7 +5978,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:40,24131,1,55155,53,51374,53,0x400019,udp,allow,267,96,171,2,2018/11/30 16:09:08,0,any,0,32091144,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 267,
@@ -6197,7 +6165,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,incomplete,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:40,24393,1,52445,4282,25566,4282,0x400019,tcp,allow,78,78,0,1,2018/11/30 16:09:33,0,any,0,32091145,0x0,192.168.0.0-192.168.255.255,United States,0,1,0,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "incomplete",
                 "bytes": 78,
@@ -6385,7 +6352,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,tanium,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:42,24976,1,52516,17472,63757,17472,0x40005e,tcp,allow,3402,1086,2316,20,2018/11/30 16:09:25,0,any,0,32091146,0x0,192.168.0.0-192.168.255.255,United States,0,11,9,tcp-rst-from-client,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "tanium",
                 "bytes": 3402,
@@ -6573,7 +6539,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:42,24348,1,52511,443,3803,443,0x400053,tcp,allow,16594,2628,13966,38,2018/11/30 16:09:21,4,computer-and-internet-info,0,32091147,0x0,192.168.0.0-192.168.255.255,United States,0,19,19,tcp-rst-from-client,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ssl",
                 "bytes": 16594,
@@ -6761,7 +6726,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:45,24046,1,3018,53,34994,53,0x400019,udp,allow,323,79,244,2,2018/11/30 16:09:12,0,any,0,32091148,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 323,
@@ -6949,7 +6913,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:45,24196,1,16569,53,38064,53,0x400019,udp,allow,300,95,205,2,2018/11/30 16:09:12,0,any,0,32091149,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 300,
@@ -7137,7 +7100,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:45,24264,1,52479,443,42924,443,0x400053,tcp,allow,6598,4296,2302,44,2018/11/30 16:09:19,8,insufficient-content,0,32091150,0x0,192.168.0.0-192.168.255.255,United States,0,24,20,tcp-fin,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ssl",
                 "bytes": 6598,
@@ -7325,7 +7287,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:45,24248,1,52478,443,58977,443,0x400053,tcp,allow,65588,58831,6757,104,2018/11/30 16:09:19,8,insufficient-content,0,32091151,0x0,192.168.0.0-192.168.255.255,Asia Pacific Region,0,63,41,tcp-fin,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ssl",
                 "bytes": 65588,
@@ -7513,7 +7474,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:45,24268,1,52502,443,64732,443,0x400053,tcp,allow,13076,4069,9007,32,2018/11/30 16:09:21,6,business-and-economy,0,32091152,0x0,192.168.0.0-192.168.255.255,United States,0,17,15,tcp-rst-from-client,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ssl",
                 "bytes": 13076,
@@ -7701,7 +7661,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:45,24175,1,52458,443,58292,443,0x40001c,tcp,allow,1761,1100,661,15,2018/11/30 16:09:14,13,computer-and-internet-info,0,32091153,0x0,192.168.0.0-192.168.255.255,United States,0,8,7,tcp-rst-from-client,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ssl",
                 "bytes": 1761,
@@ -7889,7 +7848,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:45,24312,1,52484,443,32209,443,0x400053,tcp,allow,14732,3596,11136,31,2018/11/30 16:09:19,8,computer-and-internet-info,0,32091154,0x0,192.168.0.0-192.168.255.255,United States,0,15,16,tcp-fin,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ssl",
                 "bytes": 14732,
@@ -8077,7 +8035,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:45,24164,1,52482,443,38822,443,0x400053,tcp,allow,14732,3596,11136,31,2018/11/30 16:09:19,8,computer-and-internet-info,0,32091155,0x0,192.168.0.0-192.168.255.255,United States,0,15,16,tcp-fin,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ssl",
                 "bytes": 14732,
@@ -8265,7 +8222,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,untrust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:45,24198,1,33769,53,16044,53,0x400019,udp,allow,266,84,182,2,2018/11/30 16:09:12,0,any,0,32091156,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 266,
@@ -8453,7 +8409,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,trust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:45,24184,1,14106,53,56614,53,0x400019,udp,allow,164,74,90,2,2018/11/30 16:09:12,0,any,0,32091157,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 164,
@@ -8641,7 +8596,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,untrust,trust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:45,24314,1,52503,443,53168,443,0x400053,tcp,allow,9400,2731,6669,30,2018/11/30 16:09:21,6,business-and-economy,0,32091158,0x0,192.168.0.0-192.168.255.255,United States,0,17,13,tcp-rst-from-client,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ssl",
                 "bytes": 9400,
@@ -8829,7 +8783,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,xtrust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:45,24204,1,52459,443,28012,443,0x40001c,tcp,allow,1761,1100,661,15,2018/11/30 16:09:14,13,computer-and-internet-info,0,32091159,0x0,192.168.0.0-192.168.255.255,United States,0,8,7,tcp-rst-from-client,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ssl",
                 "bytes": 1761,
@@ -9017,7 +8970,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,xuntrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:45,24234,1,52483,443,16050,443,0x400053,tcp,allow,14732,3596,11136,31,2018/11/30 16:09:19,8,computer-and-internet-info,0,32091160,0x0,192.168.0.0-192.168.255.255,Asia Pacific Region,0,15,16,tcp-fin,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ssl",
                 "bytes": 14732,
@@ -9206,7 +9158,6 @@
                 "nat_translated": true,
                 "non_standard_port_usage": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ping,vsys1,,,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:46,24390,6,0,0,0,0,0x500019,icmp,allow,1176,588,588,12,2018/11/30 16:09:31,0,any,0,32091161,0x0,192.168.0.0-192.168.255.255,United States,0,6,6,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ping",
                 "bytes": 1176,
@@ -9383,7 +9334,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:46,24093,1,38663,53,61722,53,0x400019,udp,allow,228,84,144,2,2018/11/30 16:09:13,0,any,0,32091162,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 228,
@@ -9571,7 +9521,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:46,24117,1,50443,53,14247,53,0x400019,udp,allow,337,131,206,2,2018/11/30 16:09:13,0,any,0,32091163,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 337,
@@ -9759,7 +9708,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:46,24142,1,54215,53,33580,53,0x400019,udp,allow,337,131,206,2,2018/11/30 16:09:13,0,any,0,32091164,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 337,
@@ -9947,7 +9895,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:46,24195,1,35827,53,13498,53,0x400019,udp,allow,252,83,169,2,2018/11/30 16:09:13,0,any,0,32091165,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 252,
@@ -10135,7 +10082,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:46,24124,1,60609,53,20365,53,0x400019,udp,allow,232,100,132,2,2018/11/30 16:09:13,0,any,0,32091166,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 232,
@@ -10323,7 +10269,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:46,24153,1,3248,53,61464,53,0x400019,udp,allow,206,79,127,2,2018/11/30 16:09:13,0,any,0,32091167,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 206,
@@ -10511,7 +10456,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.196,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:46,24122,1,49284,53,42877,53,0x400019,udp,allow,194,89,105,2,2018/11/30 16:09:13,0,any,0,32091168,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 194,
@@ -10699,7 +10643,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:46,24171,1,57732,53,5918,53,0x400019,udp,allow,269,97,172,2,2018/11/30 16:09:13,0,any,0,32091169,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 269,
@@ -10887,7 +10830,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:46,24069,1,49195,53,28944,53,0x400019,udp,allow,212,78,134,2,2018/11/30 16:09:13,0,any,0,32091170,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 212,
@@ -11075,7 +11017,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:46,24282,1,17266,53,13415,53,0x400019,udp,allow,252,73,179,2,2018/11/30 16:09:13,0,any,0,32091171,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 252,
@@ -11263,7 +11204,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:46,24218,1,48631,53,2489,53,0x400019,udp,allow,308,90,218,2,2018/11/30 16:09:13,0,any,0,32091172,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 308,
@@ -11451,7 +11391,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:46,24200,1,58540,53,49328,53,0x400019,udp,allow,249,77,172,2,2018/11/30 16:09:13,0,any,0,32091173,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 249,
@@ -11639,7 +11578,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:46,24224,1,42678,53,36036,53,0x400019,udp,allow,379,74,305,2,2018/11/30 16:09:13,0,any,0,32091174,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 379,
@@ -11827,7 +11765,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:47,24240,1,16576,53,33744,53,0x400019,udp,allow,603,76,527,2,2018/11/30 16:09:14,0,any,0,32091175,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 603,
@@ -12015,7 +11952,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:47,24183,1,39830,53,45809,53,0x400019,udp,allow,242,89,153,2,2018/11/30 16:09:14,0,any,0,32091176,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 242,
@@ -12203,7 +12139,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:47,24211,1,6185,53,3675,53,0x400019,udp,allow,240,71,169,2,2018/11/30 16:09:14,0,any,0,32091177,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 240,
@@ -12391,7 +12326,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:47,24253,1,8781,53,5787,53,0x400019,udp,allow,208,80,128,2,2018/11/30 16:09:14,0,any,0,32091178,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 208,
@@ -12579,7 +12513,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:47,24221,1,16788,53,12342,53,0x400019,udp,allow,253,72,181,2,2018/11/30 16:09:14,0,any,0,32091179,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 253,
@@ -12767,7 +12700,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:47,24310,1,45307,53,18729,53,0x400019,udp,allow,197,76,121,2,2018/11/30 16:09:14,0,any,0,32091180,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 197,
@@ -12955,7 +12887,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ocsp,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:47,24326,1,52520,80,57858,80,0x400053,tcp,allow,1927,681,1246,11,2018/11/30 16:09:29,0,computer-and-internet-info,0,32091181,0x0,192.168.0.0-192.168.255.255,United States,0,6,5,tcp-fin,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ocsp",
                 "bytes": 1927,
@@ -13143,7 +13074,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:47,24201,1,8503,53,2722,53,0x400019,udp,allow,394,79,315,2,2018/11/30 16:09:13,1,any,0,32091182,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 394,
@@ -13331,7 +13261,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:47,24130,1,6910,53,6674,53,0x400019,udp,allow,212,82,130,2,2018/11/30 16:09:14,0,any,0,32091183,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 212,
@@ -13519,7 +13448,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,incomplete,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:47,24237,1,52475,443,37427,443,0x40001c,tcp,allow,642,354,288,9,2018/11/30 16:09:17,12,any,0,32091184,0x0,192.168.0.0-192.168.255.255,United States,0,5,4,tcp-fin,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "incomplete",
                 "bytes": 642,
@@ -13707,7 +13635,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:47,24108,1,14342,53,22408,53,0x400019,udp,allow,225,76,149,2,2018/11/30 16:09:14,0,any,0,32091185,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 225,
@@ -13895,7 +13822,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:48,24247,1,48197,53,27899,53,0x400019,udp,allow,273,71,202,2,2018/11/30 16:09:15,0,any,0,32091186,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 273,
@@ -14083,7 +14009,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:48,24098,1,32296,53,52939,53,0x400019,udp,allow,270,75,195,2,2018/11/30 16:09:15,0,any,0,32091187,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 270,
@@ -14271,7 +14196,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.195,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ntp,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:48,24263,1,33870,123,42907,123,0x400053,udp,allow,180,90,90,2,2018/11/30 16:09:15,0,any,0,32091188,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ntp",
                 "bytes": 180,
@@ -14458,7 +14382,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.196,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:49,24258,1,54659,53,19658,53,0x400019,udp,drop ICMP,340,148,192,4,2018/11/30 16:09:16,0,any,0,32091189,0x0,192.168.0.0-192.168.255.255,United States,0,2,2,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 340,
@@ -14645,7 +14568,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:49,24155,1,57446,53,64352,53,0x400019,udp,reset client,291,83,208,2,2018/11/30 16:09:16,0,any,0,32091190,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 291,
@@ -14832,7 +14754,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:49,24232,1,22655,53,60126,53,0x400019,udp,reset server,184,84,100,2,2018/11/30 16:09:16,0,any,0,32091191,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 184,
@@ -15019,7 +14940,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:49,24330,1,52509,443,59771,443,0x40001a,tcp,reset both,9290,2053,7237,24,2018/11/30 16:09:21,10,business-and-economy,0,32091192,0x0,192.168.0.0-192.168.255.255,United States,0,13,11,tcp-rst-from-client,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ssl",
                 "bytes": 9290,
@@ -15207,7 +15127,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:49,23960,1,27192,53,35748,53,0x400019,udp,allow,202,93,109,2,2018/11/30 16:09:16,0,any,0,32091193,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 202,
@@ -15395,7 +15314,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:49,24236,1,30221,53,63701,53,0x400019,udp,allow,200,84,116,2,2018/11/30 16:09:16,0,any,0,32091194,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 200,
@@ -15583,7 +15501,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:49,24276,1,30570,53,57872,53,0x400019,udp,allow,160,64,96,2,2018/11/30 16:09:16,0,any,0,32091195,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 160,
@@ -15771,7 +15688,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:50,24299,1,52497,443,37581,443,0x40001c,tcp,allow,1754,1100,654,15,2018/11/30 16:09:21,11,business-and-economy,0,32091196,0x0,192.168.0.0-192.168.255.255,United States,0,8,7,tcp-rst-from-client,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ssl",
                 "bytes": 1754,
@@ -15959,7 +15875,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:50,24229,1,52498,443,19226,443,0x40001c,tcp,allow,1754,1100,654,15,2018/11/30 16:09:21,11,business-and-economy,0,32091197,0x0,192.168.0.0-192.168.255.255,United States,0,8,7,tcp-rst-from-client,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ssl",
                 "bytes": 1754,
@@ -16147,7 +16062,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:50,24283,1,52496,443,61721,443,0x40001c,tcp,allow,1754,1100,654,15,2018/11/30 16:09:21,11,business-and-economy,0,32091198,0x0,192.168.0.0-192.168.255.255,United States,0,8,7,tcp-rst-from-client,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ssl",
                 "bytes": 1754,
@@ -16335,7 +16249,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:50,24369,1,52510,443,10098,443,0x40001a,tcp,allow,10511,2691,7820,22,2018/11/30 16:09:21,11,web-advertisements,0,32091199,0x0,192.168.0.0-192.168.255.255,United States,0,12,10,tcp-rst-from-client,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ssl",
                 "bytes": 10511,
@@ -16523,7 +16436,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:50,24354,1,52495,443,4564,443,0x40001c,tcp,allow,1754,1100,654,15,2018/11/30 16:09:21,11,business-and-economy,0,32091200,0x0,192.168.0.0-192.168.255.255,United States,0,8,7,tcp-rst-from-client,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ssl",
                 "bytes": 1754,
@@ -16711,7 +16623,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,incomplete,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:50,24254,1,52486,443,32104,443,0x40001c,tcp,allow,490,276,214,7,2018/11/30 16:09:20,12,any,0,32091201,0x0,192.168.0.0-192.168.255.255,United States,0,4,3,tcp-fin,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "incomplete",
                 "bytes": 490,
@@ -16899,7 +16810,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,incomplete,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:50,24246,1,52489,443,14172,443,0x40001c,tcp,allow,490,276,214,7,2018/11/30 16:09:20,12,any,0,32091202,0x0,192.168.0.0-192.168.255.255,United States,0,4,3,tcp-fin,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "incomplete",
                 "bytes": 490,
@@ -17087,7 +16997,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,incomplete,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:50,24343,1,52490,443,10286,443,0x40001c,tcp,allow,490,276,214,7,2018/11/30 16:09:20,12,any,0,32091203,0x0,192.168.0.0-192.168.255.255,United States,0,4,3,tcp-fin,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "incomplete",
                 "bytes": 490,
@@ -17275,7 +17184,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,incomplete,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:50,24262,1,52493,443,30799,443,0x40001c,tcp,allow,556,276,280,8,2018/11/30 16:09:20,12,any,0,32091204,0x0,192.168.0.0-192.168.255.255,United States,0,4,4,tcp-fin,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "incomplete",
                 "bytes": 556,
@@ -17463,7 +17371,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:51,24281,1,59320,53,13490,53,0x400019,udp,allow,269,97,172,2,2018/11/30 16:09:18,0,any,0,32091205,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 269,
@@ -17652,7 +17559,6 @@
                 "nat_translated": true,
                 "non_standard_port_usage": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ping,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:52,24424,6,0,0,0,0,0x500019,icmp,allow,1176,588,588,12,2018/11/30 16:09:37,0,any,0,32091206,0x0,192.168.0.0-192.168.255.255,United States,0,6,6,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "ping",
                 "bytes": 1176,
@@ -17833,7 +17739,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:52,24230,1,13076,53,53751,53,0x400019,udp,allow,172,78,94,2,2018/11/30 16:09:19,0,any,0,32091207,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 172,
@@ -18021,7 +17926,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:52,24243,1,5511,53,21643,53,0x400019,udp,allow,242,72,170,2,2018/11/30 16:09:19,0,any,0,32091208,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 242,
@@ -18209,7 +18113,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:52,24077,1,9799,53,22446,53,0x400019,udp,allow,172,78,94,2,2018/11/30 16:09:19,0,any,0,32091209,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 172,
@@ -18397,7 +18300,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:52,24266,1,39169,53,22301,53,0x400019,udp,allow,172,78,94,2,2018/11/30 16:09:19,0,any,0,32091210,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 172,
@@ -18585,7 +18487,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:52,24269,1,42476,53,58124,53,0x400019,udp,allow,238,72,166,2,2018/11/30 16:09:19,0,any,0,32091211,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
             "network": {
                 "application": "dns",
                 "bytes": 238,
@@ -18772,7 +18673,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:36:18,15918,1,48091,30514,0,0,0x10005e,udp,allow,1196,606,590,2,2021/10/26 15:35:42,0,any,,7022390495259151829,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:36:18.455-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1196,
@@ -18945,7 +18845,6 @@
                     "connection"
                 ]
             },
-            "message": "81.2.69.145,81.2.69.145,,,any allow,,,insufficient-data,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:35:43,15917,1,138,138,0,0,0x19,udp,allow,243,243,0,1,2021/10/26 15:35:08,0,any,,7022390495259151828,0x0,United States,United States,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:35:43.451-07:00",
             "network": {
                 "application": "insufficient-data",
                 "bytes": 243,
@@ -19120,7 +19019,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:30:18,15916,1,57011,30514,0,0,0x10005e,udp,allow,1248,658,590,2,2021/10/26 15:29:42,0,any,,7022390495259151827,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:30:18.416-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1248,
@@ -19296,7 +19194,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:29:43,15915,1,55820,30514,0,0,0x10005e,udp,allow,1261,671,590,2,2021/10/26 15:29:07,0,any,,7022390495259151826,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:29:43.389-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1261,
@@ -19472,7 +19369,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:29:13,15914,1,33057,30514,0,0,0x10005e,udp,allow,1275,685,590,2,2021/10/26 15:28:37,0,any,,7022390495259151825,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:29:13.386-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1275,
@@ -19639,7 +19535,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,169.254.255.255,192.168.10.111,169.254.255.255,LAn-TO-WAn,,,insufficient-data,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 15:29:08,15913,1,138,138,41343,138,0x400019,udp,allow,243,243,0,1,2021/10/26 15:28:34,0,any,,7022390495259151824,0x0,169.254.0.0-169.254.255.255,169.254.0.0-169.254.255.255,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:29:08.386-07:00",
             "network": {
                 "application": "insufficient-data",
                 "bytes": 243,
@@ -19825,7 +19720,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:28:43,15912,1,40306,30514,0,0,0x10005e,udp,allow,2546,1366,1180,4,2021/10/26 15:28:07,0,any,,7022390495259151823,0x0,United States,United States,,2,2,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:28:43.383-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 2546,
@@ -20002,7 +19896,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 15:28:38,15911,1,50190,53,33708,53,0x400019,udp,allow,93,93,0,1,2021/10/26 15:28:05,0,any,,7022390495259151822,0x0,169.254.0.0-169.254.255.255,United States,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:28:38.383-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 93,
@@ -20188,7 +20081,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 15:28:38,15910,1,50372,53,42711,53,0x400019,udp,allow,104,104,0,1,2021/10/26 15:28:05,0,any,,7022390495259151821,0x0,169.254.0.0-169.254.255.255,United States,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:28:38.383-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 104,
@@ -20374,7 +20266,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 15:28:08,15911,1,50190,53,33708,53,0x400000,udp,allow,93,93,0,1,2021/10/26 15:28:05,0,any,,7022390495259151820,0x0,169.254.0.0-169.254.255.255,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:28:08.377-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 93,
@@ -20560,7 +20451,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 15:28:08,15910,1,50372,53,42711,53,0x400000,udp,allow,104,104,0,1,2021/10/26 15:28:05,0,any,,7022390495259151819,0x0,169.254.0.0-169.254.255.255,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:28:08.377-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 104,
@@ -20745,7 +20635,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:25:23,15909,1,59148,30514,0,0,0x10005e,udp,allow,1248,658,590,2,2021/10/26 15:24:47,0,any,,7022390495259151818,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:25:23.332-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1248,
@@ -20921,7 +20810,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:24:48,15908,1,56167,30514,0,0,0x10005e,udp,allow,1248,658,590,2,2021/10/26 15:24:12,0,any,,7022390495259151817,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:24:48.328-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1248,
@@ -21098,7 +20986,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.145,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 15:24:43,15907,1,52245,53,37697,53,0x400019,udp,allow,445,445,0,5,2021/10/26 15:24:01,7,any,,7022390495259151816,0x0,United States,United States,,5,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:24:43.328-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 445,
@@ -21284,7 +21171,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:24:13,15906,1,52587,30514,0,0,0x10005e,udp,allow,1196,606,590,2,2021/10/26 15:23:37,0,any,,7022390495259151815,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:24:13.325-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1196,
@@ -21461,7 +21347,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.145,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 15:24:03,15907,1,52245,53,37697,53,0x400000,udp,allow,89,89,0,1,2021/10/26 15:24:01,0,any,,7022390495259151814,0x0,United States,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:24:03.324-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 89,
@@ -21644,7 +21529,6 @@
                     "connection"
                 ]
             },
-            "message": "81.2.69.145,81.2.69.145,,,any allow,,,insufficient-data,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:23:38,15905,1,138,138,0,0,0x19,udp,allow,243,243,0,1,2021/10/26 15:23:06,0,any,,7022390495259151813,0x0,United States,United States,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:23:38.321-07:00",
             "network": {
                 "application": "insufficient-data",
                 "bytes": 243,
@@ -21819,7 +21703,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:19:43,15904,1,46849,30514,0,0,0x10005e,udp,allow,2504,1324,1180,4,2021/10/26 15:19:07,0,any,,7022390495259151812,0x0,United States,United States,,2,2,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:19:43.300-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 2504,
@@ -21996,7 +21879,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.145,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 15:19:08,15901,1,62637,53,4496,53,0x400019,udp,allow,455,455,0,5,2021/10/26 15:18:27,7,any,,7022390495259151811,0x0,United States,United States,,5,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:19:08.296-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 455,
@@ -22182,7 +22064,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:19:08,15903,1,34562,30514,0,0,0x10005e,udp,allow,1248,658,590,2,2021/10/26 15:18:32,0,any,,7022390495259151810,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:19:08.296-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1248,
@@ -22358,7 +22239,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:19:03,15902,1,51844,30514,0,0,0x10005e,udp,allow,1275,685,590,2,2021/10/26 15:18:27,0,any,,7022390495259151809,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:19:03.296-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1275,
@@ -22534,7 +22414,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:18:33,15900,1,35033,30514,0,0,0x10005e,udp,allow,1256,666,590,2,2021/10/26 15:17:57,0,any,,7022390495259151808,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:18:33.293-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1256,
@@ -22711,7 +22590,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.145,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 15:18:33,15901,1,62637,53,4496,53,0x400000,udp,allow,91,91,0,1,2021/10/26 15:18:27,0,any,,7022390495259151807,0x0,United States,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:18:33.293-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 91,
@@ -22898,7 +22776,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 15:18:28,15899,1,64743,53,45623,53,0x400019,udp,allow,76,76,0,1,2021/10/26 15:17:53,0,any,,7022390495259151806,0x0,169.254.0.0-169.254.255.255,United States,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:18:28.293-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 76,
@@ -23083,7 +22960,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:18:18,15898,1,33988,30514,0,0,0x10005e,udp,allow,1248,658,590,2,2021/10/26 15:17:42,0,any,,7022390495259151805,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:18:18.292-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1248,
@@ -23260,7 +23136,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.145,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 15:17:58,15897,1,58088,53,2425,53,0x400019,udp,allow,420,420,0,5,2021/10/26 15:17:19,7,any,,7022390495259151804,0x0,United States,United States,,5,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:17:58.289-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 420,
@@ -23447,7 +23322,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 15:17:58,15899,1,64743,53,45623,53,0x400000,udp,allow,76,76,0,1,2021/10/26 15:17:53,0,any,,7022390495259151803,0x0,169.254.0.0-169.254.255.255,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:17:58.289-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 76,
@@ -23632,7 +23506,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:17:43,15896,1,46213,30514,0,0,0x10005e,udp,allow,1261,671,590,2,2021/10/26 15:17:07,0,any,,7022390495259151802,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:17:43.288-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1261,
@@ -23809,7 +23682,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.145,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 15:17:23,15897,1,58088,53,2425,53,0x400000,udp,allow,84,84,0,1,2021/10/26 15:17:19,0,any,,7022390495259151801,0x0,United States,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:17:23.286-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 84,
@@ -23986,7 +23858,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,169.254.255.255,192.168.10.111,169.254.255.255,LAn-TO-WAn,,,insufficient-data,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 15:17:08,15895,1,138,138,33312,138,0x400019,udp,allow,243,243,0,1,2021/10/26 15:16:35,0,any,,7022390495259151800,0x0,169.254.0.0-169.254.255.255,169.254.0.0-169.254.255.255,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:17:08.274-07:00",
             "network": {
                 "application": "insufficient-data",
                 "bytes": 243,
@@ -24172,7 +24043,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:13:23,15894,1,33167,30514,0,0,0x10005e,udp,allow,1248,658,590,2,2021/10/26 15:12:47,0,any,,7022390495259151799,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:13:23.223-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1248,
@@ -24348,7 +24218,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:12:48,15893,1,55107,30514,0,0,0x10005e,udp,allow,1248,658,590,2,2021/10/26 15:12:12,0,any,,7022390495259151798,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:12:48.218-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1248,
@@ -24515,7 +24384,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,169.254.255.255,192.168.10.111,169.254.255.255,LAn-TO-WAn,,,netbios-ns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 15:12:33,15892,1,137,137,43254,137,0x400019,udp,allow,828,828,0,9,2021/10/26 15:11:59,1,any,,7022390495259151797,0x0,169.254.0.0-169.254.255.255,169.254.0.0-169.254.255.255,,9,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:12:33.216-07:00",
             "network": {
                 "application": "netbios-ns",
                 "bytes": 828,
@@ -24701,7 +24569,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:12:13,15891,1,47548,30514,0,0,0x10005e,udp,allow,1196,606,590,2,2021/10/26 15:11:37,0,any,,7022390495259151796,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:12:13.214-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1196,
@@ -24868,7 +24735,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,169.254.255.255,192.168.10.111,169.254.255.255,LAn-TO-WAn,,,netbios-ns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 15:12:03,15892,1,137,137,43254,137,0x400000,udp,allow,92,92,0,1,2021/10/26 15:11:59,0,any,,7022390495259151795,0x0,169.254.0.0-169.254.255.255,169.254.0.0-169.254.255.255,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:12:03.213-07:00",
             "network": {
                 "application": "netbios-ns",
                 "bytes": 92,
@@ -25051,7 +24917,6 @@
                     "connection"
                 ]
             },
-            "message": "81.2.69.145,81.2.69.145,,,any allow,,,insufficient-data,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:11:38,15890,1,138,138,0,0,0x19,udp,allow,243,243,0,1,2021/10/26 15:11:06,0,any,,7022390495259151794,0x0,United States,United States,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:11:38.211-07:00",
             "network": {
                 "application": "insufficient-data",
                 "bytes": 243,
@@ -25226,7 +25091,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:11:28,15889,1,51006,30514,0,0,0x10005e,udp,allow,1257,667,590,2,2021/10/26 15:10:52,0,any,,7022390495259151793,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:11:28.210-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1257,
@@ -25403,7 +25267,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.145,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 15:10:53,15887,1,54005,53,26689,53,0x400019,udp,allow,415,415,0,5,2021/10/26 15:10:12,7,any,,7022390495259151792,0x0,United States,United States,,5,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:10:53.206-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 415,
@@ -25589,7 +25452,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:10:53,15888,1,55910,30514,0,0,0x10005e,udp,allow,1248,658,590,2,2021/10/26 15:10:17,0,any,,7022390495259151791,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:10:53.206-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1248,
@@ -25765,7 +25627,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:10:18,15886,1,34126,30514,0,0,0x10005e,udp,allow,1257,667,590,2,2021/10/26 15:09:42,0,any,,7022390495259151790,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:10:18.203-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1257,
@@ -25942,7 +25803,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.145,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 15:10:18,15887,1,54005,53,26689,53,0x400000,udp,allow,83,83,0,1,2021/10/26 15:10:12,0,any,,7022390495259151789,0x0,United States,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:10:18.203-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 83,
@@ -26129,7 +25989,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.145,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 15:09:43,15884,1,60981,53,29365,53,0x400019,udp,allow,445,445,0,5,2021/10/26 15:09:00,7,any,,7022390495259151788,0x0,United States,United States,,5,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:09:43.200-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 445,
@@ -26315,7 +26174,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:09:38,15885,1,39542,30514,0,0,0x10005e,udp,allow,1252,662,590,2,2021/10/26 15:09:02,0,any,,7022390495259151787,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:09:38.199-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1252,
@@ -26492,7 +26350,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.145,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 15:09:03,15884,1,60981,53,29365,53,0x400000,udp,allow,89,89,0,1,2021/10/26 15:09:00,0,any,,7022390495259151786,0x0,United States,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:09:03.196-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 89,
@@ -26678,7 +26535,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:05:43,15883,1,60044,30514,0,0,0x10005e,udp,allow,1261,671,590,2,2021/10/26 15:05:07,0,any,,7022390495259151785,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:05:43.174-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1261,
@@ -26845,7 +26701,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,169.254.255.255,192.168.10.111,169.254.255.255,LAn-TO-WAn,,,insufficient-data,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 15:05:08,15882,1,138,138,13966,138,0x400019,udp,allow,243,243,0,1,2021/10/26 15:04:32,0,any,,7022390495259151784,0x0,169.254.0.0-169.254.255.255,169.254.0.0-169.254.255.255,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:05:08.170-07:00",
             "network": {
                 "application": "insufficient-data",
                 "bytes": 243,
@@ -27031,7 +26886,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 15:00:23,15881,1,60953,30514,0,0,0x10005e,udp,allow,1248,658,590,2,2021/10/26 14:59:47,0,any,,7022390495259151783,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T15:00:23.103-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1248,
@@ -27207,7 +27061,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:59:48,15880,1,46923,30514,0,0,0x10005e,udp,allow,1250,660,590,2,2021/10/26 14:59:12,0,any,,7022390495259151782,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:59:48.080-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1250,
@@ -27380,7 +27233,6 @@
                     "connection"
                 ]
             },
-            "message": "81.2.69.145,81.2.69.145,,,any allow,,,insufficient-data,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:59:43,15879,1,138,138,0,0,0x19,udp,allow,243,243,0,1,2021/10/26 14:59:09,0,any,,7022390495259151781,0x0,United States,United States,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:59:43.079-07:00",
             "network": {
                 "application": "insufficient-data",
                 "bytes": 243,
@@ -27555,7 +27407,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:59:13,15878,1,56778,30514,0,0,0x10005e,udp,allow,2551,1371,1180,4,2021/10/26 14:58:37,0,any,,7022390495259151780,0x0,United States,United States,,2,2,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:59:13.069-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 2551,
@@ -27731,7 +27582,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:58:43,15877,1,57681,30514,0,0,0x10005e,udp,allow,2545,1365,1180,4,2021/10/26 14:58:07,0,any,,7022390495259151779,0x0,United States,United States,,2,2,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:58:43.066-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 2545,
@@ -27908,7 +27758,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:58:38,15876,1,49770,53,4291,53,0x400019,udp,allow,104,104,0,1,2021/10/26 14:58:05,0,any,,7022390495259151778,0x0,169.254.0.0-169.254.255.255,United States,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:58:38.066-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 104,
@@ -28094,7 +27943,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:58:38,15875,1,49853,53,57145,53,0x400019,udp,allow,93,93,0,1,2021/10/26 14:58:05,0,any,,7022390495259151777,0x0,169.254.0.0-169.254.255.255,United States,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:58:38.066-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 93,
@@ -28279,7 +28127,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:58:18,15874,1,43504,30514,0,0,0x10005e,udp,allow,3827,2057,1770,6,2021/10/26 14:57:42,0,any,,7022390495259151776,0x0,United States,United States,,3,3,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:58:18.064-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 3827,
@@ -28456,7 +28303,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:58:08,15876,1,49770,53,4291,53,0x400000,udp,allow,104,104,0,1,2021/10/26 14:58:05,0,any,,7022390495259151775,0x0,169.254.0.0-169.254.255.255,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:58:08.063-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 104,
@@ -28642,7 +28488,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:58:08,15875,1,49853,53,57145,53,0x400000,udp,allow,93,93,0,1,2021/10/26 14:58:05,0,any,,7022390495259151774,0x0,169.254.0.0-169.254.255.255,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:58:08.063-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 93,
@@ -28827,7 +28672,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:57:48,15873,1,39863,30514,0,0,0x10005e,udp,allow,2544,1364,1180,4,2021/10/26 14:57:12,0,any,,7022390495259151773,0x0,United States,United States,,2,2,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:57:48.061-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 2544,
@@ -29004,7 +28848,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:57:43,15872,1,49309,53,63846,53,0x400019,udp,allow,120,120,0,1,2021/10/26 14:57:11,0,any,,7022390495259151772,0x0,169.254.0.0-169.254.255.255,United States,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:57:43.060-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 120,
@@ -29190,7 +29033,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:57:43,15871,1,65335,53,62966,53,0x400019,udp,allow,78,78,0,1,2021/10/26 14:57:10,0,any,,7022390495259151771,0x0,169.254.0.0-169.254.255.255,United States,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:57:43.060-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 78,
@@ -29376,7 +29218,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:57:43,15870,1,49290,53,21164,53,0x400019,udp,allow,78,78,0,1,2021/10/26 14:57:08,0,any,,7022390495259151770,0x0,169.254.0.0-169.254.255.255,United States,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:57:43.060-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 78,
@@ -29562,7 +29403,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:57:18,15872,1,49309,53,63846,53,0x400000,udp,allow,120,120,0,1,2021/10/26 14:57:11,0,any,,7022390495259151769,0x0,169.254.0.0-169.254.255.255,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:57:18.057-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 120,
@@ -29748,7 +29588,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:57:13,15871,1,65335,53,62966,53,0x400000,udp,allow,78,78,0,1,2021/10/26 14:57:10,0,any,,7022390495259151768,0x0,169.254.0.0-169.254.255.255,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:57:13.056-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 78,
@@ -29934,7 +29773,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:57:13,15870,1,49290,53,21164,53,0x400000,udp,allow,78,78,0,1,2021/10/26 14:57:08,0,any,,7022390495259151767,0x0,169.254.0.0-169.254.255.255,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:57:13.056-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 78,
@@ -30119,7 +29957,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:54:48,15869,1,51512,30514,0,0,0x10005e,udp,allow,1248,658,590,2,2021/10/26 14:54:12,0,any,,7022390495259151766,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:54:48.037-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1248,
@@ -30295,7 +30132,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:54:13,15868,1,38029,30514,0,0,0x10005e,udp,allow,1248,658,590,2,2021/10/26 14:53:37,0,any,,7022390495259151765,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:54:13.033-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1248,
@@ -30472,7 +30308,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.145,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:53:53,15867,1,63531,53,11038,53,0x400019,udp,allow,445,445,0,5,2021/10/26 14:53:12,7,any,,7022390495259151764,0x0,United States,United States,,5,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:53:53.030-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 445,
@@ -30658,7 +30493,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:53:38,15866,1,48349,30514,0,0,0x10005e,udp,allow,1261,671,590,2,2021/10/26 14:53:02,0,any,,7022390495259151763,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:53:38.029-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1261,
@@ -30835,7 +30669,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.145,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:53:18,15867,1,63531,53,11038,53,0x400000,udp,allow,89,89,0,1,2021/10/26 14:53:12,0,any,,7022390495259151762,0x0,United States,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:53:18.027-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 89,
@@ -31012,7 +30845,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,169.254.255.255,192.168.10.111,169.254.255.255,LAn-TO-WAn,,,insufficient-data,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:53:03,15865,1,138,138,37630,138,0x400019,udp,allow,243,243,0,1,2021/10/26 14:52:31,0,any,,7022390495259151761,0x0,169.254.0.0-169.254.255.255,169.254.0.0-169.254.255.255,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:53:03.026-07:00",
             "network": {
                 "application": "insufficient-data",
                 "bytes": 243,
@@ -31198,7 +31030,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:49:27,15864,1,54120,30514,0,0,0x10005e,udp,allow,1257,667,590,2,2021/10/26 14:48:56,0,any,,7022390495259151760,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:49:27.993-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1257,
@@ -31375,7 +31206,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.145,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:48:57,15862,1,57166,53,24626,53,0x400019,udp,allow,455,455,0,5,2021/10/26 14:48:15,7,any,,7022390495259151759,0x0,United States,United States,,5,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:48:57.989-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 455,
@@ -31561,7 +31391,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:48:47,15863,1,37688,30514,0,0,0x10005e,udp,allow,1252,662,590,2,2021/10/26 14:48:16,0,any,,7022390495259151758,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:48:47.988-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1252,
@@ -31738,7 +31567,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.145,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:48:17,15862,1,57166,53,24626,53,0x400000,udp,allow,91,91,0,1,2021/10/26 14:48:15,0,any,,7022390495259151757,0x0,United States,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:48:17.985-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 91,
@@ -31924,7 +31752,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:48:12,15861,1,42698,30514,0,0,0x10005e,udp,allow,1196,606,590,2,2021/10/26 14:47:41,0,any,,7022390495259151756,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:48:12.984-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1196,
@@ -32097,7 +31924,6 @@
                     "connection"
                 ]
             },
-            "message": "81.2.69.145,81.2.69.145,,,any allow,,,insufficient-data,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:47:42,15860,1,138,138,0,0,0x19,udp,allow,243,243,0,1,2021/10/26 14:47:07,0,any,,7022390495259151755,0x0,United States,United States,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:47:42.981-07:00",
             "network": {
                 "application": "insufficient-data",
                 "bytes": 243,
@@ -32272,7 +32098,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:39:27,15859,1,34566,30514,0,0,0x10005e,udp,allow,1257,667,590,2,2021/10/26 14:38:51,0,any,,7022390495259151754,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:39:27.846-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1257,
@@ -32449,7 +32274,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.145,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:38:52,15857,1,63149,53,50277,53,0x400019,udp,allow,445,445,0,5,2021/10/26 14:38:12,7,any,,7022390495259151753,0x0,United States,United States,,5,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:38:52.842-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 445,
@@ -32635,7 +32459,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:38:52,15858,1,35298,30514,0,0,0x10005e,udp,allow,1252,662,590,2,2021/10/26 14:38:16,0,any,,7022390495259151752,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:38:52.842-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1252,
@@ -32812,7 +32635,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.145,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:38:17,15857,1,63149,53,50277,53,0x400000,udp,allow,89,89,0,1,2021/10/26 14:38:12,0,any,,7022390495259151751,0x0,United States,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:38:17.838-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 89,
@@ -32998,7 +32820,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:37:17,15856,1,49286,30514,0,0,0x10005e,udp,allow,1250,660,590,2,2021/10/26 14:36:41,0,any,,7022390495259151750,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:37:17.827-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1250,
@@ -33174,7 +32995,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:36:42,15855,1,52810,30514,0,0,0x10005e,udp,allow,3826,2056,1770,6,2021/10/26 14:36:06,0,any,,7022390495259151749,0x0,United States,United States,,3,3,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:36:42.824-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 3826,
@@ -33350,7 +33170,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:36:12,15854,1,47737,30514,0,0,0x10005e,udp,allow,3817,2047,1770,6,2021/10/26 14:35:36,0,any,,7022390495259151748,0x0,United States,United States,,3,3,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:36:12.815-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 3817,
@@ -33527,7 +33346,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:36:07,15853,1,49674,53,24390,53,0x400019,udp,allow,120,120,0,1,2021/10/26 14:35:35,0,any,,7022390495259151747,0x0,169.254.0.0-169.254.255.255,United States,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:36:07.814-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 120,
@@ -33713,7 +33531,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:36:07,15852,1,49756,53,5637,53,0x400019,udp,allow,78,78,0,1,2021/10/26 14:35:33,0,any,,7022390495259151746,0x0,169.254.0.0-169.254.255.255,United States,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:36:07.814-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 78,
@@ -33899,7 +33716,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:36:07,15851,1,65398,53,50412,53,0x400019,udp,allow,78,78,0,1,2021/10/26 14:35:31,0,any,,7022390495259151745,0x0,169.254.0.0-169.254.255.255,United States,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:36:07.814-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 78,
@@ -34081,7 +33897,6 @@
                     "connection"
                 ]
             },
-            "message": "81.2.69.145,81.2.69.145,,,any allow,,,insufficient-data,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:35:42,15850,1,138,138,0,0,0x19,udp,allow,243,243,0,1,2021/10/26 14:35:06,0,any,,7022390495259151744,0x0,United States,United States,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:35:42.811-07:00",
             "network": {
                 "application": "insufficient-data",
                 "bytes": 243,
@@ -34257,7 +34072,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:35:37,15853,1,49674,53,24390,53,0x400000,udp,allow,120,120,0,1,2021/10/26 14:35:35,0,any,,7022390495259151743,0x0,169.254.0.0-169.254.255.255,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:35:37.811-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 120,
@@ -34443,7 +34257,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:35:37,15852,1,49756,53,5637,53,0x400000,udp,allow,78,78,0,1,2021/10/26 14:35:33,0,any,,7022390495259151742,0x0,169.254.0.0-169.254.255.255,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:35:37.811-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 78,
@@ -34629,7 +34442,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:35:37,15851,1,65398,53,50412,53,0x400000,udp,allow,78,78,0,1,2021/10/26 14:35:31,0,any,,7022390495259151741,0x0,169.254.0.0-169.254.255.255,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:35:37.811-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 78,
@@ -34814,7 +34626,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:33:17,15849,1,60919,30514,0,0,0x10005e,udp,allow,1250,660,590,2,2021/10/26 14:32:41,0,any,,7022390495259151740,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:33:17.791-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1250,
@@ -34990,7 +34801,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:32:42,15848,1,35027,30514,0,0,0x10005e,udp,allow,2550,1370,1180,4,2021/10/26 14:32:06,0,any,,7022390495259151739,0x0,United States,United States,,2,2,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:32:42.787-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 2550,
@@ -35166,7 +34976,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:32:37,15847,1,42014,30514,0,0,0x10005e,udp,allow,1248,658,590,2,2021/10/26 14:32:01,0,any,,7022390495259151738,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:32:37.784-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1248,
@@ -35343,7 +35152,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:32:07,15844,1,64624,53,32849,53,0x400019,udp,allow,93,93,0,1,2021/10/26 14:31:31,0,any,,7022390495259151737,0x0,169.254.0.0-169.254.255.255,United States,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:32:07.776-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 93,
@@ -35529,7 +35337,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:32:07,15845,1,64898,53,60860,53,0x400019,udp,allow,93,93,0,1,2021/10/26 14:31:31,0,any,,7022390495259151736,0x0,169.254.0.0-169.254.255.255,United States,,1,0,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:32:07.776-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 93,
@@ -35714,7 +35521,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:32:07,15846,1,37747,30514,0,0,0x10005e,udp,allow,3819,2049,1770,6,2021/10/26 14:31:31,0,any,,7022390495259151735,0x0,United States,United States,,3,3,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:32:07.776-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 3819,
@@ -35890,7 +35696,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:32:02,15843,1,37151,30514,0,0,0x10005e,udp,allow,1231,641,590,2,2021/10/26 14:31:26,0,any,,7022390495259151734,0x0,United States,United States,,1,1,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:32:02.775-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 1231,
@@ -36066,7 +35871,6 @@
             "labels": {
                 "non_standard_port_usage": true
             },
-            "message": "81.2.69.144,81.2.69.145,,,intrazone-default,,,syslog,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/10/26 14:31:37,15840,1,43096,30514,0,0,0x10005e,udp,allow,2544,1364,1180,4,2021/10/26 14:31:01,0,any,,7022390495259151733,0x0,United States,United States,,2,2,aged-out,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:31:37.773-07:00",
             "network": {
                 "application": "syslog",
                 "bytes": 2544,
@@ -36243,7 +36047,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:31:32,15845,1,64898,53,60860,53,0x400000,udp,allow,93,93,0,1,2021/10/26 14:31:31,0,any,,7022390495259151732,0x0,169.254.0.0-169.254.255.255,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:31:32.773-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 93,
@@ -36429,7 +36232,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,192.168.10.111,81.2.69.193,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:31:32,15844,1,64624,53,32849,53,0x400000,udp,allow,93,93,0,1,2021/10/26 14:31:31,0,any,,7022390495259151731,0x0,169.254.0.0-169.254.255.255,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:31:32.772-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 93,
@@ -36615,7 +36417,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,0.0.0.0,0.0.0.0,any to Intranet DCs,intranet\\\\sampleuser,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:31:32,15844,1,64624,53,32849,53,0x400000,udp,allow,93,93,0,1,2021/10/26 14:31:31,0,any,,7022390495259151731,0x0,169.254.0.0-169.254.255.255,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:31:32.772-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 93,
@@ -36813,7 +36614,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "81.2.69.193,81.2.69.193,0.0.0.0,0.0.0.0,any to Intranet DCs,intranet\\\\sampleuser$,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/10/26 14:31:32,15844,1,64624,53,32849,53,0x400000,udp,allow,93,93,0,1,2021/10/26 14:31:31,0,any,,7022390495259151731,0x0,169.254.0.0-169.254.255.255,United States,,1,0,n/a,0,0,0,0,,PA-VM,from-policy,\" \", , , , , , , , , , , , , , , , , , , ,,,,2021-10-26T14:31:32.772-07:00",
             "network": {
                 "application": "dns",
                 "bytes": 93,
@@ -36996,7 +36796,6 @@
                     "connection"
                 ]
             },
-            "message": "10.1.0.12,192.168.10.111,,,block-192.168.10.111,,,not-applicable,vsys1,private,public,ethernet1/2,,elastic,2023/10/04 09:50:23,0,1,55004,80,0,0,0x4000,tcp,drop,0,0,0,1,2023/10/04 09:50:19,0,any,,7286123782408766728,0x0,10.0.0.0-10.255.255.255,United States,,1,0,policy-deny,0,0,0,0,,PA-VM,from-policy,,,0,,0,,N/A,0,0,0,0,d3c00c09-dafc-47d0-8491-685b0bd8a1fe,0,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,2023-10-04T09:50:23.428-07:00,,,unknown,unknown,unknown,1,..,,not-applicable,no,no,0,NonProxyTraffic,",
             "network": {
                 "application": "not-applicable",
                 "bytes": 0,
@@ -37179,7 +36978,6 @@
                 "decrypted_traffic": true,
                 "nat_translated": true
             },
-            "message": "10.1.0.12,192.168.10.111,10.138.0.44,192.168.10.111,default allow,,,google-base,vsys1,private,public,ethernet1/2,ethernet1/1,elastic,2023/10/04 09:50:23,783,1,52714,443,12549,443,0x404400,tcp,allow,797,723,74,4,2023/10/04 09:50:18,0,search-engines,,7286123782408766727,0x0,10.0.0.0-10.255.255.255,United States,,3,1,n/a,0,0,0,0,,PA-VM,from-policy,,,0,,0,,N/A,0,0,0,0,798de89c-0538-4771-bf49-f0144fc6834e,0,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,2023-10-04T09:50:23.428-07:00,,,internet-utility,general-internet,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,google-base,no,no,0,NonProxyTraffic,",
             "network": {
                 "application": "google-base",
                 "bytes": 797,
@@ -37375,7 +37173,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "10.1.0.12,192.168.10.111,10.138.0.44,192.168.10.111,default allow,,,ssl,vsys1,private,public,ethernet1/2,ethernet1/1,elastic,2023/10/04 09:50:23,783,1,52714,443,12549,443,0x404000,tcp,allow,797,723,74,4,2023/10/04 09:50:18,0,any,,7286123782408766726,0x0,10.0.0.0-10.255.255.255,United States,,3,1,n/a,0,0,0,0,,PA-VM,from-policy,,,0,,0,,N/A,0,0,0,0,798de89c-0538-4771-bf49-f0144fc6834e,0,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,2023-10-04T09:50:23.428-07:00,,,encrypted-tunnel,networking,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,ssl,no,no,0,NonProxyTraffic,",
             "network": {
                 "application": "ssl",
                 "bytes": 797,
@@ -37572,7 +37369,6 @@
                 "decrypted_traffic": true,
                 "nat_translated": true
             },
-            "message": "10.4.19.160,192.168.10.1,10.1.0.13,192.168.10.1,Service-Apps,host/555-1212.example.com,,ssl,vsys1,trust-L3,untrust,ethernet1/3,ethernet1/1,Panorama-Example_Forwarder,2024/06/14 14:30:14,1556841,1,58234,443,53502,443,0x40041c,tcp,allow,5887,3715,2172,34,2024/06/14 14:25:58,240,web-advertisements,,7341478510372295372,0x8000000000000000,10.0.0.0-10.255.255.255,United States,,17,17,tcp-fin,15,0,0,0,,p-pa-ze0.example.com,from-policy,,,0,,0,,N/A,0,0,0,0,0f009045-0651-4dad-9370-89892c8d6aec,0,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,2024-06-14T14:30:15.154-04:00,,,encrypted-tunnel,networking,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,ssl,no,no,0",
             "network": {
                 "application": "ssl",
                 "bytes": 5887,
@@ -37782,7 +37578,6 @@
                 "decrypted_traffic": true,
                 "nat_translated": true
             },
-            "message": "10.4.19.160,192.168.10.1,10.1.0.13,192.168.10.1,Service-Apps,host/555-1212.example.com,host/867-5309.example.com,ssl,vsys1,trust-L3,untrust,ethernet1/3,ethernet1/1,Panorama-Example_Forwarder,2024/06/14 14:30:14,1556841,1,58234,443,53502,443,0x40041c,tcp,allow,5887,3715,2172,34,2024/06/14 14:25:58,240,web-advertisements,,7341478510372295372,0x8000000000000000,10.0.0.0-10.255.255.255,United States,,17,17,tcp-fin,15,0,0,0,,p-pa-ze0.example.com,from-policy,,,0,,0,,N/A,0,0,0,0,0f009045-0651-4dad-9370-89892c8d6aec,0,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,2024-06-14T14:30:15.154-04:00,,,encrypted-tunnel,networking,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,ssl,no,no,0",
             "network": {
                 "application": "ssl",
                 "bytes": 5887,
@@ -38006,7 +37801,6 @@
             "labels": {
                 "nat_translated": true
             },
-            "message": "10.68.12.154,89.160.20.113,81.2.69.193,89.160.20.113,myrule2-proxy-http-override,,,proxy-override-port-443,vsys2,interconnect,public,ae2.1849,ae1.419,HOST-LOGCOLLECTOR,2024/08/19 13:54:42,574479232,1,37168,443,44616,443,0x40005e,tcp,allow,12438,6781,5657,33,2024/08/19 13:53:50,51,any,,7361622383222556974,0x8000000000000000,10.0.0.0-10.255.255.255,United States,,17,16,tcp-fin,15,24,0,0,az2_vsys_internet,fw0102,from-policy,,,0,,0,,N/A,0,0,0,0,7f3f8009-ba35-4c3a-b831-b31892d740f3,0,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,2024-08-19T13:54:42.105+00:00,,,infrastructure,networking,client-server,1,,,proxy-override-port-443,no,no,0",
             "network": {
                 "application": "proxy-override-port-443",
                 "bytes": 12438,

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-tunnel-inspection-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-tunnel-inspection-sample.log-expected.json
@@ -50,7 +50,6 @@
             "log": {
                 "level": "4"
             },
-            "message": "10.0.0.10,175.16.199.1,10.0.0.20,10.0.0.30,rule,,d-user,app,vsys,s-zone,d-zone,inbound,outbound,log,,id,100,9000,9550,9200,9300,0,tcp,action,4,1000,user,src-loc,dst-loc,0,0,0,0,vsys-name,d-name,imsi,imei,1000,1000,1000,10,10,10,10,10,10,20,200,75,50,1000,1000,end,action,2021-11-23T00:44:44.930-08:00,1234567890,rule1,81.2.69.192,100,100,pcap,dug,100,100,2021-11-23T00:44:44.930-08:00,asd,ast,100,app-sc,cat,tech,4,char,con,no,no",
             "network": {
                 "application": "app",
                 "bytes": 10,

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-userid-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-userid-sample.log-expected.json
@@ -17,7 +17,6 @@
                 "kind": "event",
                 "original": "Nov 30 16:09:08 1,2021/03/24 11:00:49,013101001305,USERID,login,2305,2021/03/24 11:00:49,vsys1,81.2.69.193,domain\\name,,0,1,10800,0,0,<data-source-collected>,<data-source-type>,1252774,0x0,0,0,0,0,,FW01,1,,2021/03/24 11:00:49,1,0x80000000,name"
             },
-            "message": "vsys1,81.2.69.193,domain\\name,,0,1,10800,0,0,<data-source-collected>,<data-source-type>,1252774,0x0,0,0,0,0,,FW01,1,,2021/03/24 11:00:49,1,0x80000000,name",
             "network": {
                 "type": "ipv4"
             },

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-userid-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-userid-sample.log-expected.json
@@ -123,7 +123,6 @@
                 "kind": "event",
                 "original": "Nov 30 16:09:08 1,2021/03/24 10:59:45,013101001305,USERID,logout,2305,2021/03/24 10:59:45,vsys1,10.55.18.7,domain\\name,,0,1,0,0,0,<data-source-collected>,<data-source-type>,1252765,0x0,0,0,0,0,,FW01,1,,2021/03/24 10:59:45,1,0x80000000,name"
             },
-            "message": "vsys1,10.55.18.7,domain\\name,,0,1,0,0,0,<data-source-collected>,<data-source-type>,1252765,0x0,0,0,0,0,,FW01,1,,2021/03/24 10:59:45,1,0x80000000,name",
             "network": {
                 "type": "ipv4"
             },
@@ -218,7 +217,6 @@
                 "kind": "event",
                 "original": "Nov 30 16:09:08 1,2013/03/28 12:53:05,001701000225,USERID,login,12,2013/03/28 12:53:05,vsys1,172.17.128.92,plano2008r2\\administrator,test,0,1,2700,0,0,active-directory,unknown,1,0x0"
             },
-            "message": "vsys1,172.17.128.92,plano2008r2\\administrator,test,0,1,2700,0,0,active-directory,unknown,1,0x0",
             "network": {
                 "type": "ipv4"
             },
@@ -300,7 +298,6 @@
                 "kind": "event",
                 "original": "Nov 30 16:09:08 1,2013/03/28 12:53:05,001701000225,USERID,login,12,2013/03/28 12:53:05,vsys1,172.17.128.92,plano2008r2\\administrator,test,0,1,2700,0,0,active-directory,unknown,2,0x0"
             },
-            "message": "vsys1,172.17.128.92,plano2008r2\\administrator,test,0,1,2700,0,0,active-directory,unknown,2,0x0",
             "network": {
                 "type": "ipv4"
             },
@@ -382,7 +379,6 @@
                 "kind": "event",
                 "original": "Nov 30 16:09:08 1,2013/03/28 12:53:05,001701000225,USERID,login,12,2013/03/28 12:53:05,vsys1,172.17.128.92,plano2008r2\\administrator,test,0,1,2700,0,0,active-directory,unknown,3,0x0"
             },
-            "message": "vsys1,172.17.128.92,plano2008r2\\administrator,test,0,1,2700,0,0,active-directory,unknown,3,0x0",
             "network": {
                 "type": "ipv4"
             },
@@ -464,7 +460,6 @@
                 "kind": "event",
                 "original": "Nov 30 16:09:08 1,2013/03/28 12:53:05,001701000225,USERID,login,12,2013/03/28 12:53:05,vsys1,172.17.128.92,plano2008r2\\administrator,test,0,1,2700,0,0,active-directory,unknown,4,0x0"
             },
-            "message": "vsys1,172.17.128.92,plano2008r2\\administrator,test,0,1,2700,0,0,active-directory,unknown,4,0x0",
             "network": {
                 "type": "ipv4"
             },
@@ -546,7 +541,6 @@
                 "kind": "event",
                 "original": "Nov 30 16:09:08 1,2021/04/05 14:52:16,<serial-number>,USERID,login,2305,2021/04/05 14:52:16,vsys1,10.68.2.9,domain\\admin,,0,1,10800,0,0,vpn-client,globalprotect,1277996,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:52:16,1,0x80000000,admin"
             },
-            "message": "vsys1,10.68.2.9,domain\\admin,,0,1,10800,0,0,vpn-client,globalprotect,1277996,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:52:16,1,0x80000000,admin",
             "network": {
                 "type": "ipv4"
             },
@@ -641,7 +635,6 @@
                 "kind": "event",
                 "original": "Nov 30 16:09:08 1,2021/04/05 14:52:33,<serial-number>,USERID,logout,2305,2021/04/05 14:52:33,vsys1,10.68.2.9,domain\\admin,,0,1,0,0,0,vpn-client,globalprotect,1277997,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:52:34,1,0x80000000,admin"
             },
-            "message": "vsys1,10.68.2.9,domain\\admin,,0,1,0,0,0,vpn-client,globalprotect,1277997,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:52:34,1,0x80000000,admin",
             "network": {
                 "type": "ipv4"
             },
@@ -736,7 +729,6 @@
                 "kind": "event",
                 "original": "Nov 30 16:09:08 1,2021/04/05 14:53:10,<serial-number>,USERID,login,2305,2021/04/05 14:53:10,vsys1,10.68.2.9,subdomain\\admin,,0,1,10800,0,0,vpn-client,globalprotect,1277998,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:11,1,0x80000000,admin"
             },
-            "message": "vsys1,10.68.2.9,subdomain\\admin,,0,1,10800,0,0,vpn-client,globalprotect,1277998,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:11,1,0x80000000,admin",
             "network": {
                 "type": "ipv4"
             },
@@ -831,7 +823,6 @@
                 "kind": "event",
                 "original": "Nov 30 16:09:08 1,2021/04/05 14:53:31,<serial-number>,USERID,login,2305,2021/04/05 14:53:31,vsys1,10.68.2.9,admin,,0,1,10800,0,0,vpn-client,globalprotect,1277999,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:31,1,0x80000000,admin"
             },
-            "message": "vsys1,10.68.2.9,admin,,0,1,10800,0,0,vpn-client,globalprotect,1277999,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:31,1,0x80000000,admin",
             "network": {
                 "type": "ipv4"
             },
@@ -924,7 +915,6 @@
                 "kind": "event",
                 "original": "Nov 30 16:09:08 1,2021/04/05 14:53:31,<serial-number>,USERID,login,2305,2021/04/05 14:53:31,vsys1,10.68.2.9,user,,0,1,10800,0,0,vpn-client,globalprotect,1278000,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:31,1,0x80000000,user"
             },
-            "message": "vsys1,10.68.2.9,user,,0,1,10800,0,0,vpn-client,globalprotect,1278000,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:31,1,0x80000000,user",
             "network": {
                 "type": "ipv4"
             },
@@ -1017,7 +1007,6 @@
                 "kind": "event",
                 "original": "Nov 30 16:09:08 1,2021/04/05 14:53:49,<serial-number>,USERID,login,2305,2021/04/05 14:53:49,vsys1,10.68.2.9,admin,,0,1,10800,0,0,vpn-client,globalprotect,1278001,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:49,1,0x80000000,admin"
             },
-            "message": "vsys1,10.68.2.9,admin,,0,1,10800,0,0,vpn-client,globalprotect,1278001,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:49,1,0x80000000,admin",
             "network": {
                 "type": "ipv4"
             },
@@ -1110,7 +1099,6 @@
                 "kind": "event",
                 "original": "Nov 30 16:09:08 1,2021/04/05 14:53:52,<serial-number>,USERID,logout,2305,2021/04/05 14:53:52,vsys1,10.68.2.9,domain\\admin,,0,1,0,0,0,vpn-client,globalprotect,1278002,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:52,1,0x80000000,admin"
             },
-            "message": "vsys1,10.68.2.9,domain\\admin,,0,1,0,0,0,vpn-client,globalprotect,1278002,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:52,1,0x80000000,admin",
             "network": {
                 "type": "ipv4"
             },
@@ -1205,7 +1193,6 @@
                 "kind": "event",
                 "original": "1,2023/05/10 11:17:00,304565467,USERID,login,2561,2023/05/10 11:17:00,vsys1,10.9.3.250,YA072Z$@VIERWERK.NET,zwei.vierwerk.net,0,1,2700,0,0,active-directory,,4325687342567,0x0,0,0,0,0,,P250D-01,0,,2023/05/10 11:16:51,1,0x0,YA072Z$@VIERWERK.NET,,2023-05-10T11:17:01.416-04:00"
             },
-            "message": "vsys1,10.9.3.250,YA072Z$@VIERWERK.NET,zwei.vierwerk.net,0,1,2700,0,0,active-directory,,4325687342567,0x0,0,0,0,0,,P250D-01,0,,2023/05/10 11:16:51,1,0x0,YA072Z$@VIERWERK.NET,,2023-05-10T11:17:01.416-04:00",
             "network": {
                 "type": "ipv4"
             },
@@ -1301,7 +1288,6 @@
                 "kind": "event",
                 "original": "1,2023/05/10 11:17:00,304565467,USERID,login,2561,2023/05/10 11:17:00,vsys1,10.9.3.250,somedomain\\professor john$,zwei.vierwerk.net,0,1,2700,0,0,active-directory,,4325687342567,0x0,0,0,0,0,,P250D-01,0,,2023/05/10 11:16:51,1,0x0,YA072Z$@VIERWERK.NET,,2023-05-10T11:17:01.416-04:00"
             },
-            "message": "vsys1,10.9.3.250,somedomain\\professor john$,zwei.vierwerk.net,0,1,2700,0,0,active-directory,,4325687342567,0x0,0,0,0,0,,P250D-01,0,,2023/05/10 11:16:51,1,0x0,YA072Z$@VIERWERK.NET,,2023-05-10T11:17:01.416-04:00",
             "network": {
                 "type": "ipv4"
             },
@@ -1397,7 +1383,6 @@
                 "kind": "event",
                 "original": "1,2023/05/10 11:17:00,304565467,USERID,login,2561,2023/05/10 11:17:00,vsys1,10.9.3.250,professor john$@somedomain,zwei.vierwerk.net,0,1,2700,0,0,active-directory,,4325687342567,0x0,0,0,0,0,,P250D-01,0,,2023/05/10 11:16:51,1,0x0,YA072Z$@VIERWERK.NET,,2023-05-10T11:17:01.416-04:00"
             },
-            "message": "vsys1,10.9.3.250,professor john$@somedomain,zwei.vierwerk.net,0,1,2700,0,0,active-directory,,4325687342567,0x0,0,0,0,0,,P250D-01,0,,2023/05/10 11:16:51,1,0x0,YA072Z$@VIERWERK.NET,,2023-05-10T11:17:01.416-04:00",
             "network": {
                 "type": "ipv4"
             },
@@ -1493,7 +1478,6 @@
                 "kind": "event",
                 "original": "1,2023/05/10 11:17:00,304565467,USERID,login,2561,2023/05/10 11:17:00,vsys1,10.9.3.250,first.o'last@somedomain,zwei.vierwerk.net,0,1,2700,0,0,active-directory,,4325687342567,0x0,0,0,0,0,,P250D-01,0,,2023/05/10 11:16:51,1,0x0,YA072Z$@VIERWERK.NET,,2023-05-10T11:17:01.416-04:00"
             },
-            "message": "vsys1,10.9.3.250,first.o'last@somedomain,zwei.vierwerk.net,0,1,2700,0,0,active-directory,,4325687342567,0x0,0,0,0,0,,P250D-01,0,,2023/05/10 11:16:51,1,0x0,YA072Z$@VIERWERK.NET,,2023-05-10T11:17:01.416-04:00",
             "network": {
                 "type": "ipv4"
             },

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
@@ -1611,6 +1611,7 @@ processors:
       field:
         - _temp_
         - _conf
+        - message
       ignore_missing: true
 
 # Remove panw.panos fields that are copied into an ECS field.

--- a/packages/panw/manifest.yml
+++ b/packages/panw/manifest.yml
@@ -1,6 +1,6 @@
 name: panw
 title: Palo Alto Next-Gen Firewall
-version: "4.2.0"
+version: "4.3.0"
 description: Collect logs from Palo Alto next-gen firewalls with Elastic Agent.
 type: integration
 format_version: "3.0.3"

--- a/packages/panw/manifest.yml
+++ b/packages/panw/manifest.yml
@@ -1,6 +1,6 @@
 name: panw
 title: Palo Alto Next-Gen Firewall
-version: "4.3.0"
+version: "5.0.0"
 description: Collect logs from Palo Alto next-gen firewalls with Elastic Agent.
 type: integration
 format_version: "3.0.3"


### PR DESCRIPTION
- Breaking change

## Proposed commit message

During the parse of the PANW log messages, the original `message` field is parsed by a `grok` filter and generates a new partial `message` field.

This partial `message` field will then be parsed by the auxiliary ingest pipelines, but after the parse is completed, the field is not removed and is part of the final document.

Since ths `message` fields is the majority of the original source message, this can represent an increase of almost 50% in storage requirements for the PANW data stream.

This PR aims to remove this field.


## Related issues

- Closes #12511 