### PR TITLE
[mimecast] Fix cursor time formatting and selection

### DIFF
--- a/packages/mimecast/changelog.yml
+++ b/packages/mimecast/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.2"
+  changes:
+    - description: Fix cursor time formatting and selection.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12518
 - version: "2.4.1"
   changes:
     - description: Remove invalid remove processor.

--- a/packages/mimecast/data_stream/archive_search_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/archive_search_logs/agent/stream/cel.yml.hbs
@@ -93,11 +93,18 @@ program: |
             {
               "events": body.data.map(e, e[state.data_path].map(l, {"message": l.encode_json()})).flatten(),
               "cursor": {
-                "last": ([now] + body.data.map(e,
-                  e[state.data_path].map(l,
-                    l[state.time_field].parse_time(["2006-01-02T15:04:05-0700", time_layout.RFC3339])
-                  )
-                ).flatten()).max().format(time_layout.RFC3339),
+                "last": (
+                  body.data.map(e,
+                    e[state.data_path].map(l,
+                      l[state.time_field].parse_time(["2006-01-02T15:04:05-0700", time_layout.RFC3339])
+                    )
+                  ).flatten().as(time_fields,
+                    (size(time_fields) > 0) ?
+                      time_fields.max()
+                    :
+                      now
+                  ).format(time_layout.RFC3339)
+                ),
               },
               ?"last_page": has(body.?meta.pagination.next) && size(body.data) != 0 ?
                 optional.of({

--- a/packages/mimecast/data_stream/audit_events/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/audit_events/agent/stream/cel.yml.hbs
@@ -86,7 +86,16 @@ program: |
             {
               "events": body.data.map(e, {"message": e.encode_json()}),
               "cursor": {
-                "last": ([now] + body.data.map(e, e[state.time_field].parse_time(["2006-01-02T15:04:05-0700", time_layout.RFC3339]))).max().format(time_layout.RFC3339),
+                "last": (
+                  body.data.map(e,
+                    e[state.time_field].parse_time(["2006-01-02T15:04:05-0700", time_layout.RFC3339])
+                  ).as(time_fields,
+                    (size(time_fields) > 0) ?
+                      time_fields.max()
+                    :
+                      now
+                  ).format(time_layout.RFC3339)
+                ),
               },
               ?"last_page": has(body.?meta.pagination.next) && size(body.data) != 0 ?
                 optional.of({

--- a/packages/mimecast/data_stream/audit_events/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/audit_events/agent/stream/cel.yml.hbs
@@ -61,7 +61,7 @@ program: |
     ).as(token, !has(token.access_token) ? token :
       {
         "data": state.?last_page.data.orValue([{
-          state.start_field: state.?cursor.last.orValue(now - duration(state.look_back)).format(time_layout.RFC3339),
+          state.start_field: state.?cursor.last.orValue((now - duration(state.look_back)).format(time_layout.RFC3339)),
           state.end_field: now.format(time_layout.RFC3339),
         }]),
       }.as(req,
@@ -86,7 +86,7 @@ program: |
             {
               "events": body.data.map(e, {"message": e.encode_json()}),
               "cursor": {
-                "last": ([now] + body.data.map(e, e[state.time_field].parse_time(["2006-01-02T15:04:05-0700", time_layout.RFC3339]))).max(),
+                "last": ([now] + body.data.map(e, e[state.time_field].parse_time(["2006-01-02T15:04:05-0700", time_layout.RFC3339]))).max().format(time_layout.RFC3339),
               },
               ?"last_page": has(body.?meta.pagination.next) && size(body.data) != 0 ?
                 optional.of({

--- a/packages/mimecast/data_stream/dlp_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/dlp_logs/agent/stream/cel.yml.hbs
@@ -93,11 +93,18 @@ program: |
             {
               "events": body.data.map(e, e[state.data_path].map(l, {"message": l.encode_json()})).flatten(),
               "cursor": {
-                "last": ([now] + body.data.map(e,
-                  e[state.data_path].map(l,
-                    l[state.time_field].parse_time(["2006-01-02T15:04:05-0700", time_layout.RFC3339])
-                  )
-                ).flatten()).max().format(time_layout.RFC3339),
+                "last": (
+                  body.data.map(e,
+                    e[state.data_path].map(l,
+                      l[state.time_field].parse_time(["2006-01-02T15:04:05-0700", time_layout.RFC3339])
+                    )
+                  ).flatten().as(time_fields,
+                    (size(time_fields) > 0) ?
+                      time_fields.max()
+                    :
+                      now
+                  ).format(time_layout.RFC3339)
+                ),
               },
               ?"last_page": has(body.?meta.pagination.next) && size(body.data) != 0 ?
                 optional.of({

--- a/packages/mimecast/data_stream/message_release_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/message_release_logs/agent/stream/cel.yml.hbs
@@ -93,11 +93,18 @@ program: |
             {
               "events": body.data.map(e, e[state.data_path].map(l, {"message": l.encode_json()})).flatten(),
               "cursor": {
-                "last": ([now] + body.data.map(e,
-                  e[state.data_path].map(l,
-                    l[state.time_field].parse_time(["2006-01-02T15:04:05-0700", time_layout.RFC3339])
-                  )
-                ).flatten()).max().format(time_layout.RFC3339),
+                "last": (
+                  body.data.map(e,
+                    e[state.data_path].map(l,
+                      l[state.time_field].parse_time(["2006-01-02T15:04:05-0700", time_layout.RFC3339])
+                    )
+                  ).flatten().as(time_fields,
+                    (size(time_fields) > 0) ?
+                      time_fields.max()
+                    :
+                      now
+                  ).format(time_layout.RFC3339)
+                ),
               },
               ?"last_page": has(body.?meta.pagination.next) && size(body.data) != 0 ?
                 optional.of({

--- a/packages/mimecast/data_stream/threat_intel_malware_customer/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/threat_intel_malware_customer/agent/stream/cel.yml.hbs
@@ -91,7 +91,14 @@ program: |
                 // type has a later timestamp, then the time at the API
                 // has progressed past the last indicator and we do not
                 // need to reach back that far.
-                "last": ([now] + body.objects.map(e, timestamp(e.modified))).max().format(time_layout.RFC3339),
+                "last": (
+                  body.objects.map(e, timestamp(e.modified)).as(times,
+                    (size(times) > 0) ?
+                      times.max()
+                    :
+                      now
+                  ).format(time_layout.RFC3339)
+                ),
                 ?"token": resp.?Header["X-Mc-Threat-Feed-Next-Token"][?0],
               },
               "token": {

--- a/packages/mimecast/data_stream/threat_intel_malware_grid/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/threat_intel_malware_grid/agent/stream/cel.yml.hbs
@@ -91,7 +91,14 @@ program: |
                 // type has a later timestamp, then the time at the API
                 // has progressed past the last indicator and we do not
                 // need to reach back that far.
-                "last": ([now] + body.objects.map(e, timestamp(e.modified))).max().format(time_layout.RFC3339),
+                "last": (
+                  body.objects.map(e, timestamp(e.modified)).as(times,
+                    (size(times) > 0) ?
+                      times.max()
+                    :
+                      now
+                  ).format(time_layout.RFC3339)
+                ),
                 ?"token": resp.?Header["X-Mc-Threat-Feed-Next-Token"][?0],
               },
               "token": {

--- a/packages/mimecast/data_stream/ttp_ap_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/ttp_ap_logs/agent/stream/cel.yml.hbs
@@ -93,11 +93,18 @@ program: |
             {
               "events": body.data.map(e, e[state.data_path].map(l, {"message": l.encode_json()})).flatten(),
               "cursor": {
-                "last": ([now] + body.data.map(e,
-                  e[state.data_path].map(l,
-                    l[state.time_field].parse_time(["2006-01-02T15:04:05-0700", time_layout.RFC3339])
-                  )
-                ).flatten()).max().format(time_layout.RFC3339),
+                "last": (
+                  body.data.map(e,
+                    e[state.data_path].map(l,
+                      l[state.time_field].parse_time(["2006-01-02T15:04:05-0700", time_layout.RFC3339])
+                    )
+                  ).flatten().as(time_fields,
+                    (size(time_fields) > 0) ?
+                      time_fields.max()
+                    :
+                      now
+                  ).format(time_layout.RFC3339)
+                ),
               },
               ?"last_page": has(body.?meta.pagination.next) && size(body.data) != 0 ?
                 optional.of({

--- a/packages/mimecast/data_stream/ttp_ip_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/ttp_ip_logs/agent/stream/cel.yml.hbs
@@ -93,11 +93,18 @@ program: |
             {
               "events": body.data.map(e, e[state.data_path].map(l, {"message": l.encode_json()})).flatten(),
               "cursor": {
-                "last": ([now] + body.data.map(e,
-                  e[state.data_path].map(l,
-                    l[state.time_field].parse_time(["2006-01-02T15:04:05-0700", time_layout.RFC3339])
-                  )
-                ).flatten()).max().format(time_layout.RFC3339),
+                "last": (
+                  body.data.map(e,
+                    e[state.data_path].map(l,
+                      l[state.time_field].parse_time(["2006-01-02T15:04:05-0700", time_layout.RFC3339])
+                    )
+                  ).flatten().as(time_fields,
+                    (size(time_fields) > 0) ?
+                      time_fields.max()
+                    :
+                      now
+                  ).format(time_layout.RFC3339)
+                ),
               },
               ?"last_page": has(body.?meta.pagination.next) && size(body.data) != 0 ?
                 optional.of({

--- a/packages/mimecast/data_stream/ttp_url_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/ttp_url_logs/agent/stream/cel.yml.hbs
@@ -93,11 +93,18 @@ program: |
             {
               "events": body.data.map(e, e[state.data_path].map(l, {"message": l.encode_json()})).flatten(),
               "cursor": {
-                "last": ([now] + body.data.map(e,
-                  e[state.data_path].map(l,
-                    l[state.time_field].parse_time(["2006-01-02T15:04:05-0700", time_layout.RFC3339])
-                  )
-                ).flatten()).max().format(time_layout.RFC3339),
+                "last": (
+                  body.data.map(e,
+                    e[state.data_path].map(l,
+                      l[state.time_field].parse_time(["2006-01-02T15:04:05-0700", time_layout.RFC3339])
+                    )
+                  ).flatten().as(time_fields,
+                    (size(time_fields) > 0) ?
+                      time_fields.max()
+                    :
+                      now
+                  ).format(time_layout.RFC3339)
+                ),
               },
               ?"last_page": has(body.?meta.pagination.next) && size(body.data) != 0 ?
                 optional.of({

--- a/packages/mimecast/manifest.yml
+++ b/packages/mimecast/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: mimecast
 title: "Mimecast"
-version: "2.4.1"
+version: "2.4.2"
 description: Collect logs from Mimecast with Elastic Agent.
 type: integration
 categories: ["security", "email_security"]


### PR DESCRIPTION
## Proposed commit message

```
[mimecast] Fix cursor time formatting and selection

In the `audit_events` data stream, the `state.cursor.last` value was
handled as a time type, but when cursor data is reloaded from the file
the value will be a string. The change matches the behavior in other
data streams: explicitly format the time as a string when storing it,
and handle it as a string when reading it.

The logic for selecting a time for the cursor was to take the max of
returned times and `now`. This will usually use the time `now` as the
new starting point, instead of the time of last data. The fix is to only
use `now` if there is no returned data, and otherwise use the latest
returned time.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
