### PR TITLE
[jamf_pro] Fix mapping of `jamf_pro.inventory.general.enrollment_method`

### DIFF
--- a/packages/jamf_pro/changelog.yml
+++ b/packages/jamf_pro/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.3"
+  changes:
+    - description: Fix mapping of jamf_pro.inventory.general.enrollment_method.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12532
 - version: "0.2.2"
   changes:
     - description: Inventory date formatting for filter.

--- a/packages/jamf_pro/data_stream/inventory/_dev/test/pipeline/test-inventory.json
+++ b/packages/jamf_pro/data_stream/inventory/_dev/test/pipeline/test-inventory.json
@@ -218,6 +218,11 @@
                     "jamfBinaryVersion": "11.4.1-t1712591696",
                     "platform": "Mac",
                     "barcode1": "null",
+                    "enrollmentMethod": {
+                        "id": "7",
+                        "objectName": "Corp Div 1.20.0",
+                        "objectType": "PreStage enrollment"
+                    },
                     "remoteManagement": {
                         "managed": true
                     },

--- a/packages/jamf_pro/data_stream/inventory/_dev/test/pipeline/test-inventory.json-expected.json
+++ b/packages/jamf_pro/data_stream/inventory/_dev/test/pipeline/test-inventory.json-expected.json
@@ -256,6 +256,11 @@
                         "barcode1": "null",
                         "declarative_device_management_enabled": false,
                         "enrolled_via_automated_device_enrollment": false,
+                        "enrollment_method": {
+                            "id": "7",
+                            "object_name": "Corp Div 1.20.0",
+                            "object_type": "PreStage enrollment"
+                        },
                         "initial_entry_date": "2024-06-19",
                         "itunes_store_account_active": false,
                         "jamf_binary_version": "11.4.1-t1712591696",

--- a/packages/jamf_pro/data_stream/inventory/fields/fields-general.yml
+++ b/packages/jamf_pro/data_stream/inventory/fields/fields-general.yml
@@ -67,7 +67,14 @@
             - name: distribution_point
               type: keyword
             - name: enrollment_method
-              type: keyword
+              type: group
+              fields:
+                - name: id
+                  type: keyword
+                - name: object_name
+                  type: keyword
+                - name: object_type
+                  type: keyword
             - name: extension_attributes
               type: group
             - name: last_cloud_backup_date

--- a/packages/jamf_pro/docs/README.md
+++ b/packages/jamf_pro/docs/README.md
@@ -239,7 +239,9 @@ The following non-ECS fields are used in inventory documents:
 | jamf_pro.inventory.general.declarative_device_management_enabled |  | boolean |
 | jamf_pro.inventory.general.distribution_point |  | keyword |
 | jamf_pro.inventory.general.enrolled_via_automated_device_enrollment |  | boolean |
-| jamf_pro.inventory.general.enrollment_method |  | keyword |
+| jamf_pro.inventory.general.enrollment_method.id |  | keyword |
+| jamf_pro.inventory.general.enrollment_method.object_name |  | keyword |
+| jamf_pro.inventory.general.enrollment_method.object_type |  | keyword |
 | jamf_pro.inventory.general.initial_entry_date |  | date |
 | jamf_pro.inventory.general.itunes_store_account_active |  | boolean |
 | jamf_pro.inventory.general.jamf_binary_version |  | keyword |

--- a/packages/jamf_pro/manifest.yml
+++ b/packages/jamf_pro/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.5
 name: jamf_pro
 title: "Jamf Pro"
-version: 0.2.2
+version: 0.2.3
 source:
   license: "Elastic-2.0"
 description: "Collect logs and inventory data from Jamf Pro with Elastic Agent"


### PR DESCRIPTION
## Proposed commit message

```
[jamf_pro] Fix mapping of `jamf_pro.inventory.general.enrollment_method`

Trying to map an object as a keyword resulted in events be dropped with
messages like:

    Cannot index event '...' (status=400): {
      "type": "document_parsing_exception",
      "reason": "[1:8701] failed to parse field [jamf_pro.inventory.general.enrollment_method] of type [keyword] in document with id '...'. Preview of field's value: '...'",
      "caused_by": {
        "type": "illegal_argument_exception",
        "reason": "Expected text at 1:8624 but found START_OBJECT"
      }
    }, dropping event!

The correct structure is in the API documentation[1]. The incoming field
is named `general.enrollmentMethod`.

[1]: https://developer.jamf.com/jamf-pro/v11.4.0/reference/get_v1-computers-inventory
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Closes #12021