### PR TITLE
Update Kubernetes container logs documentation

### DIFF
--- a/packages/kubernetes/_dev/build/docs/README.md
+++ b/packages/kubernetes/_dev/build/docs/README.md
@@ -84,6 +84,17 @@ the masters won't be visible. In these cases it won't be possible to use `schedu
 The container-logs dataset requires access to the log files in each Kubernetes node where the container logs are stored.
 This defaults to `/var/log/containers/*${kubernetes.container.id}.log`.
 
+It uses the [Filestream input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-filestream.html)
+and defines it's ID as: `id: kubernetes-container-logs-${kubernetes.pod.name}-${kubernetes.container.id}`. For every
+container the Elastic-Agent will generate an instance of the Filestream input harvesting the `paths` defined in the
+configuration. So make sure the paths are unique per container.
+
+For more details about how those variables are resolved and the input
+configuration rendered, refer to:
+- [Elastic-Agent providers](https://www.elastic.co/guide/en/fleet/current/providers.html)
+- [Kubernetes autodiscovery with Elastic Agent](https://www.elastic.co/guide/en/fleet/current/elastic-agent-kubernetes-autodiscovery.html)
+- [Conditions based autodiscover](https://www.elastic.co/guide/en/fleet/current/conditions-based-autodiscover.html)
+
 #### Routing
 
 The container-logs data stream allows routing logs to a different *dataset* or *namespace* using pod annotations.

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.70.2
+  changes:
+    - description: Update the container logs documentation
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12538
 - version: 1.70.1
   changes:
     - description: Fix kubernetes.pod.cpu.usage.nanocores unit

--- a/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
@@ -1,3 +1,14 @@
+{{!
+  Because we use `${kubernetes.container.id}` in the ID, an instance
+  of this input will be generated for every container, so `paths` must
+  always be unique per container otherwise there will be data
+  duplication, at the extreme this will overload Filebeat and cause
+  data ingestion issues.
+
+  This ID is also mentioned in the `README.md, so if it is changed, it
+  needs to be updated there as well.
+}}
+
 id: kubernetes-container-logs-${kubernetes.pod.name}-${kubernetes.container.id}
 paths:
 {{#each paths}}

--- a/packages/kubernetes/data_stream/container_logs/manifest.yml
+++ b/packages/kubernetes/data_stream/container_logs/manifest.yml
@@ -13,6 +13,12 @@ streams:
         multi: true
         default:
           - /var/log/containers/*${kubernetes.container.id}.log
+        description: >-
+          For every container in the cluster an instance of the input
+          will be created harvesting all paths defined here, even if
+          the paths contain no variable! Refer to the [integration
+          documentation](https://www.elastic.co/guide/en/integrations/current/kubernetes.html)
+          for more details.
       - name: symlinks
         type: bool
         title: Use Symlinks
@@ -42,7 +48,7 @@ streams:
         default: auto
       - name: condition
         title: Condition
-        description: Condition to filter when to apply this datastream. Refer to [Kubernetes provider](http://localhost:8000/guide/providers.html#kubernetes-provider) to find the available keys and to [Conditions](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html#conditions) on how to use the available keys in conditions.
+        description: Condition to filter when to apply this datastream. Refer to [Kubernetes provider](https://www.elastic.co/guide/en/fleet/current/kubernetes-provider.html) to find the available keys and to [Conditions](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html#conditions) on how to use the available keys in conditions.
         type: text
         multi: false
         required: false

--- a/packages/kubernetes/data_stream/container_logs/manifest.yml
+++ b/packages/kubernetes/data_stream/container_logs/manifest.yml
@@ -14,8 +14,9 @@ streams:
         default:
           - /var/log/containers/*${kubernetes.container.id}.log
         description: >-
-          For every container in the cluster an instance of the input
-          will be created harvesting all paths defined here, even if
+          For every container the Elastic-Agent can see (usually every
+          container on the node) an instance of the input will be
+          created harvesting all paths defined here, even if 
           the paths contain no variable! Refer to the [integration
           documentation](https://www.elastic.co/guide/en/integrations/current/kubernetes.html)
           for more details.

--- a/packages/kubernetes/docs/README.md
+++ b/packages/kubernetes/docs/README.md
@@ -84,6 +84,17 @@ the masters won't be visible. In these cases it won't be possible to use `schedu
 The container-logs dataset requires access to the log files in each Kubernetes node where the container logs are stored.
 This defaults to `/var/log/containers/*${kubernetes.container.id}.log`.
 
+It uses the [Filestream input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-filestream.html)
+and defines it's ID as: `id: kubernetes-container-logs-${kubernetes.pod.name}-${kubernetes.container.id}`. For every
+container the Elastic-Agent will generate an instance of the Filestream input harvesting the `paths` defined in the
+configuration. So make sure the paths are unique per container.
+
+For more details about how those variables are resolved and the input
+configuration rendered, refer to:
+- [Elastic-Agent providers](https://www.elastic.co/guide/en/fleet/current/providers.html)
+- [Kubernetes autodiscovery with Elastic Agent](https://www.elastic.co/guide/en/fleet/current/elastic-agent-kubernetes-autodiscovery.html)
+- [Conditions based autodiscover](https://www.elastic.co/guide/en/fleet/current/conditions-based-autodiscover.html)
+
 #### Routing
 
 The container-logs data stream allows routing logs to a different *dataset* or *namespace* using pod annotations.

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: kubernetes
 title: Kubernetes
-version: 1.70.1
+version: 1.70.2
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

This commit updates the Kubernetes Container Logs documentation to better explain that an input is always generated for every container.

It also fixes a broken link.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] ~~I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] ~~I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~~
- [ ] ~~I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

~~## Author's Checklist~~
## How to test this PR locally

```
cd packages/kubernetes
elastic-package build
elastic-package stack up -v -d
```
Navigate to https://localhost:5601/app/integrations/detail/kubernetes-1.70.2/overview
Check the new entry under "container-logs"

Add the integration, go to Collect Kubernetes container logs -> Advanced options -> Kubernetes container log path and check the new documentation for this field.

~~## Related issues~~
~~## Screenshots~~