### PR TITLE
[CI][docs] Update docs with new special comment for PRs

### DIFF
--- a/docs/ci_pipelines.md
+++ b/docs/ci_pipelines.md
@@ -19,6 +19,13 @@ This pipeline is in charge of testing the packages with a local Elastic stack.
 Special comments that can be added in the Pull Request (by Elastic employees):
 - `/test` or `buildkite test this`: a new build is triggered.
 - `/test benchmark fullreport`: a new build is triggered creating a full benchmark report (it will be posted as a GitHub comment in the PR).
+- `/test stack <version>`: a new build is triggered in [integration-test-stack pipeline](https://buildkite.com/elastic/integrations-test-stack) where
+  the packages updated in the PR will be tested using the Elastic stack version `<version>` set in the comment.
+    - The new build will appear as another check status (not required).
+    - Examples:
+        - `/test stack 8.17.0`
+        - `/test stack 8.18.0-SNAPSHOT`
+        - `/test stack 9.0.0-SNAPSHOT`
 
 There are some environment variables that can be added into this pipeline:
 - **FORCE_CHECK_ALL**: If `true`, this forces the CI to check all packages even if those packages have no file updated/added/deleted. Default: `false`.


### PR DESCRIPTION
## Proposed commit message

Update docs about CI pipelines to include the new special comment that can be posted in Pull Requests to trigger builds to test packages with an specific Elastic stack version.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Test comment in a PR: https://github.com/elastic/integrations/pull/12536

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Relates https://github.com/elastic/integrations/pull/12536
- Relates https://github.com/elastic/integrations/pull/12516

## Screenshots

Examples of the GitHub check status:
- Pending status:
![Pending check status](https://github.com/user-attachments/assets/8ccf7e5a-e038-40b0-8b47-50ae3ec6d226)
- Finished (success) status:
![Success status](https://github.com/user-attachments/assets/6938ca03-ae48-46e7-8236-55e81c1134aa)

