### PR TITLE
apm: change tail_sampling_storage_limit config default to 0GB

### DIFF
--- a/packages/apm/changelog.yml
+++ b/packages/apm/changelog.yml
@@ -1,6 +1,6 @@
-- version: 9.0.0
+- version: 9.0.0-preview-1738343125
   changes:
-    - description: Remove data streams from integration package
+    - description: Change default sampling.tail.storage_limit to 0
       type: breaking-change
       link: https://github.com/elastic/integrations/pull/12543
 - version: 8.15.0-preview-1716438434

--- a/packages/apm/changelog.yml
+++ b/packages/apm/changelog.yml
@@ -1,3 +1,8 @@
+- version: 9.0.0
+  changes:
+    - description: Remove data streams from integration package
+      type: breaking-change
+      link: https://github.com/elastic/integrations/pull/12543
 - version: 8.15.0-preview-1716438434
   changes:
     - description: Remove data streams from integration package

--- a/packages/apm/changelog.yml
+++ b/packages/apm/changelog.yml
@@ -1,6 +1,6 @@
 - version: 9.0.0-preview-1738343125
   changes:
-    - description: Change default sampling.tail.storage_limit to 0
+    - description: Change default sampling.tail.storage_limit config to 0
       type: breaking-change
       link: https://github.com/elastic/integrations/pull/12543
 - version: 8.15.0-preview-1716438434

--- a/packages/apm/changelog.yml
+++ b/packages/apm/changelog.yml
@@ -1,6 +1,6 @@
 - version: 9.0.0-preview-1738343125
   changes:
-    - description: Change default sampling.tail.storage_limit config to 0
+    - description: Change default sampling.tail.storage_limit config to 0GB
       type: breaking-change
       link: https://github.com/elastic/integrations/pull/12543
 - version: 8.15.0-preview-1716438434

--- a/packages/apm/manifest.yml
+++ b/packages/apm/manifest.yml
@@ -171,7 +171,7 @@ policy_templates:
             default: false
           - name: tail_sampling_storage_limit
             type: text
-            default: ""
+            default: "0"
         template_path: template.yml.hbs
 owner:
   type: elastic

--- a/packages/apm/manifest.yml
+++ b/packages/apm/manifest.yml
@@ -171,7 +171,7 @@ policy_templates:
             default: false
           - name: tail_sampling_storage_limit
             type: text
-            default: "3GB"
+            default: ""
         template_path: template.yml.hbs
 owner:
   type: elastic

--- a/packages/apm/manifest.yml
+++ b/packages/apm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.0
 name: apm
 title: Elastic APM
-version: 8.15.0-preview-1716438434
+version: 9.0.0
 description: Monitor, detect, and diagnose complex application performance issues.
 type: integration
 categories: ["elastic_stack", "monitoring"]
@@ -10,7 +10,7 @@ conditions:
     capabilities:
       - apm
   kibana:
-    version: ^8.15.0
+    version: ^9.0.0
 icons:
   - src: /img/logo_apm.svg
     title: APM Logo

--- a/packages/apm/manifest.yml
+++ b/packages/apm/manifest.yml
@@ -171,7 +171,7 @@ policy_templates:
             default: false
           - name: tail_sampling_storage_limit
             type: text
-            default: "0"
+            default: "0GB"
         template_path: template.yml.hbs
 owner:
   type: elastic

--- a/packages/apm/manifest.yml
+++ b/packages/apm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.0
 name: apm
 title: Elastic APM
-version: 9.0.0
+version: 9.0.0-preview-1738343125
 description: Monitor, detect, and diagnose complex application performance issues.
 type: integration
 categories: ["elastic_stack", "monitoring"]


### PR DESCRIPTION
## Proposed commit message

`sampling.tail.storage_limit` is 0 by default in 9.0. See https://github.com/elastic/apm-server/pull/15467 .
As UI validation requires unit (e.g. GB), set apm integration default storage limit to `0GB` which carries the same meaning.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
