### PR TITLE
[o365] Static fields for use by security rules

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.9.0"
+  changes:
+    - description: Static fields for use by security rules.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12545
 - version: "2.8.1"
   changes:
     - description: Silence absent URL complaints in debug logs.

--- a/packages/o365/data_stream/audit/fields/fields.yml
+++ b/packages/o365/data_stream/audit/fields/fields.yml
@@ -219,6 +219,8 @@
       object_type_mapping_type: '*'
     - name: Experience
       type: keyword
+    - name: ExtendedProperties.RequestType
+      type: keyword
     - name: ExtendedProperties.*
       type: object
       object_type: keyword
@@ -275,6 +277,8 @@
       type: keyword
     - name: Members
       type: flattened
+    - name: ModifiedProperties.Role_DisplayName.NewValue
+      type: keyword
     - name: ModifiedProperties.*.*
       type: object
       object_type: keyword
@@ -302,6 +306,20 @@
     - name: OrganizationName
       type: keyword
     - name: OriginatingServer
+      type: keyword
+    - name: Parameters.AccessRights
+      type: keyword
+    - name: Parameters.AllowFederatedUsers
+      type: keyword
+    - name: Parameters.AllowGuestUser
+      type: keyword
+    - name: Parameters.Enabled
+      type: keyword
+    - name: Parameters.ForwardAsAttachmentTo
+      type: keyword
+    - name: Parameters.ForwardTo
+      type: keyword
+    - name: Parameters.RedirectTo
       type: keyword
     - name: Parameters.*
       type: object

--- a/packages/o365/docs/README.md
+++ b/packages/o365/docs/README.md
@@ -291,6 +291,7 @@ An example event for `audit` looks as following:
 | o365.audit.ExchangeMetaData.UniqueID |  | keyword |
 | o365.audit.Experience |  | keyword |
 | o365.audit.ExtendedProperties.\* |  | object |
+| o365.audit.ExtendedProperties.RequestType |  | keyword |
 | o365.audit.ExternalAccess |  | boolean |
 | o365.audit.FileSizeBytes |  | long |
 | o365.audit.GroupName |  | keyword |
@@ -316,6 +317,7 @@ An example event for `audit` looks as following:
 | o365.audit.MailboxOwnerUPN |  | keyword |
 | o365.audit.Members |  | flattened |
 | o365.audit.ModifiedProperties.\*.\* |  | object |
+| o365.audit.ModifiedProperties.Role_DisplayName.NewValue |  | keyword |
 | o365.audit.Name |  | keyword |
 | o365.audit.NewValue |  | keyword |
 | o365.audit.ObjectDisplayName |  | keyword |
@@ -328,6 +330,13 @@ An example event for `audit` looks as following:
 | o365.audit.OrganizationName |  | keyword |
 | o365.audit.OriginatingServer |  | keyword |
 | o365.audit.Parameters.\* |  | object |
+| o365.audit.Parameters.AccessRights |  | keyword |
+| o365.audit.Parameters.AllowFederatedUsers |  | keyword |
+| o365.audit.Parameters.AllowGuestUser |  | keyword |
+| o365.audit.Parameters.Enabled |  | keyword |
+| o365.audit.Parameters.ForwardAsAttachmentTo |  | keyword |
+| o365.audit.Parameters.ForwardTo |  | keyword |
+| o365.audit.Parameters.RedirectTo |  | keyword |
 | o365.audit.Platform |  | keyword |
 | o365.audit.PolicyDetails |  | flattened |
 | o365.audit.PolicyId |  | keyword |

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft Office 365
-version: "2.8.1"
+version: "2.9.0"
 description: Collect logs from Microsoft Office 365 with Elastic Agent.
 type: integration
 format_version: "3.0.2"


### PR DESCRIPTION
## Proposed commit message

```
[o365] Static fields for use by security rules

Our security rules[1] use fields in `o365.audit.*`, some of which are
dynamic fields. When the `total_fields` limit is reached, additional
dynamic fields will be ignored, which can interfere with execution of
the rules.

This change adds static field definitions as necessary to never ignore
fields used by the security rules.

[1]: https://github.com/elastic/integrations/tree/main/packages/security_detection_engine/kibana/security_rule
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
