### PR TITLE
packages/cel - add 'condition' variable

### DIFF
--- a/packages/cel/agent/input/input.yml.hbs
+++ b/packages/cel/agent/input/input.yml.hbs
@@ -1,3 +1,7 @@
+{{#if condition}}
+condition: {{condition}}
+{{/if}}
+
 data_stream:
   dataset: {{data_stream.dataset}}
 interval: {{resource_interval}}

--- a/packages/cel/changelog.yml
+++ b/packages/cel/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.14.0"
+  changes:
+    - description: Add a 'condition' configuration option for specifying to Elastic Agent when it should run the input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12555
 - version: "1.13.0"
   changes:
     - description: Add xsd configuration option inside input.

--- a/packages/cel/manifest.yml
+++ b/packages/cel/manifest.yml
@@ -19,6 +19,14 @@ policy_templates:
     input: cel
     template_path: input.yml.hbs
     vars:
+      - name: condition
+        title: Condition
+        description: |
+          Condition to filter when to collect this input. See  [Dynamic Input Configuration](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html) for details.
+        type: text
+        multi: false
+        required: false
+        show_user: false
       - name: data_stream.dataset
         type: text
         title: Dataset name
@@ -358,6 +366,7 @@ policy_templates:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
       - name: tags
         type: text
         title: Tags
@@ -373,6 +382,7 @@ policy_templates:
         show_user: false
         description: >
           The request tracer logs HTTP requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_filename) for details.
+
 owner:
   github: elastic/security-service-integrations
   type: elastic

--- a/packages/cel/manifest.yml
+++ b/packages/cel/manifest.yml
@@ -3,7 +3,7 @@ name: cel
 title: Custom API using Common Expression Language
 description: Collect custom events from an API with Elastic agent
 type: input
-version: "1.13.0"
+version: "1.14.0"
 categories:
   - custom
 conditions:


### PR DESCRIPTION
## Proposed commit message

```
Add a user configurable 'condition' variable to allow users to control when 
the input should run. An example use case would be to apply Kubernetes 
autodiscovery conditions.

See https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html

Closes #12521
```