### PR TITLE
[elastic_agent] Add missing apm-server tail sampling monitoring metrics mappings

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.0.4"
+  changes:
+    - description: Add missing apm-server tail sampling monitoring metrics mappings
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12568
 - version: "2.0.3"
   changes:
     - description: Restore Agent errors visualisation to Elastic-Agent agent info dashboard

--- a/packages/elastic_agent/data_stream/apm_server_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/apm_server_metrics/fields/beat-fields.yml
@@ -358,8 +358,38 @@
                       type: long
             - name: unset
               type: long
-        - name: sampling.transactions_dropped
-          type: long
+        - name: sampling
+          type: group
+          fields:
+            - name: tail
+              type: group
+              fields:
+                - name: dynamic_service_groups
+                  type: long
+                - name: events
+                  type: group
+                  fields:
+                    - name: dropped
+                      type: long
+                    - name: failed_writes
+                      type: long
+                    - name: head_unsampled
+                      type: long
+                    - name: processed
+                      type: long
+                    - name: sampled
+                      type: long
+                    - name: stored
+                      type: long
+                - name: storage
+                  type: group
+                  fields:
+                    - name: lsm_size
+                      type: long
+                    - name: value_log_size
+                      type: long
+            - name: transactions_dropped
+              type: long
         - name: server
           type: group
           fields:

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 2.0.3
+version: 2.0.4
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 3.1.4


### PR DESCRIPTION
## Proposed commit message

[elastic_agent] Add missing apm-server tail sampling monitoring metrics mappings

Tail-based sampling monitoring metrics were missed in the bugfix in #10414 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Part of https://github.com/elastic/apm-server/issues/14247

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
