### PR TITLE
[cisco_asa] Fix issue with linking time zone mapping to agent config

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: "Fix issue with linking time zone mapping to agent config."
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/12579
 - version: "2.41.0"
   changes:
     - description: "Add advanced option for time zone mapping and support parsing extra timestamp in header."

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.41.1"
+  changes:
+    - description: "Fix issue with linking time zone mapping to agent config."
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.41.0"
   changes:
     - description: "Add advanced option for time zone mapping and support parsing extra timestamp in header."

--- a/packages/cisco_asa/data_stream/log/agent/stream/stream.yml.hbs
+++ b/packages/cisco_asa/data_stream/log/agent/stream/stream.yml.hbs
@@ -16,11 +16,15 @@ tags:
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}
-{{#if tz_offset}}
 fields_under_root: true
 fields:
   _conf:
+{{#if tz_offset}}
     tz_offset: "{{tz_offset}}"
+{{/if}}
+{{#if tz_map}}
+    tz_map:
+      {{tz_map}}
 {{/if}}
 processors:
 - add_locale: ~

--- a/packages/cisco_asa/data_stream/log/agent/stream/tcp.yml.hbs
+++ b/packages/cisco_asa/data_stream/log/agent/stream/tcp.yml.hbs
@@ -15,11 +15,15 @@ publisher_pipeline.disable_host: true
 {{#if ssl}}
 ssl: {{ssl}}
 {{/if}}
-{{#if tz_offset}}
 fields_under_root: true
 fields:
   _conf:
+{{#if tz_offset}}
     tz_offset: "{{tz_offset}}"
+{{/if}}
+{{#if tz_map}}
+    tz_map:
+      {{tz_map}}
 {{/if}}
 processors:
 - add_locale: ~

--- a/packages/cisco_asa/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/cisco_asa/data_stream/log/agent/stream/udp.yml.hbs
@@ -15,11 +15,15 @@ tags:
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}
-{{#if tz_offset}}
 fields_under_root: true
 fields:
   _conf:
+{{#if tz_offset}}
     tz_offset: "{{tz_offset}}"
+{{/if}}
+{{#if tz_map}}
+    tz_map:
+      {{tz_map}}
 {{/if}}
 processors:
 - add_locale: ~

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_asa
 title: Cisco ASA
-version: "2.41.0"
+version: "2.41.1"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- Fixed missing tz_map reference in agent files

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Tested manually with logfile, tcp, and udp inputs and verified that tz_map is being applied correctly.

![Screenshot 2025-02-03 at 3 19 54 PM](https://github.com/user-attachments/assets/12716df3-72ae-4dca-9416-1e9d47299622)

```json
{
  "agent": {
    "name": "agent1",
    "id": "00907d09-2b61-40d4-8cfc-89ee66f7dd6c",
    "ephemeral_id": "29c1b216-477a-44e3-ae55-3e2cb9e7fa47",
    "type": "filebeat",
    "version": "8.17.0"
  },
  "elastic_agent": {
    "id": "00907d09-2b61-40d4-8cfc-89ee66f7dd6c",
    "version": "8.17.0",
    "snapshot": false
  },
  "input": {
    "type": "tcp"
  },
  "@timestamp": "2025-01-14T08:00:46.000-06:00",
  "data_stream": {
    "namespace": "default",
    "type": "logs",
    "dataset": "cisco_asa.log"
  },
  "host": {
    "hostname": "hosst.domain.com"
  },
  "event": {
    "severity": 4,
    "reason": "IPv4 Address <10.1.1.1> IPv6 address <::> assigned to session",
    "original": "Jan 14 08:00:46 hosst.domain.com : Jan 14 08:00:46 CST: %ASA-svc-4-722051: Group <GroupPolicy_XXXXX> User <uXXX> IP <192.168.10.1> IPv4 Address <10.1.1.1> IPv6 address <::> assigned to session",
    "code": "722051",
    "timezone": "America/Chicago",
    "kind": "event",
    "type": [
      "connection",
      "info"
    ],
    "agent_id_status": "verified",
    "ingested": "2025-02-03T21:13:37Z",
    "action": "address-assigned",
    "category": [
      "network"
    ],
    "dataset": "cisco_asa.log",
    "outcome": "success"
  }
  // other fields omitted for brevity
}
```
