### PR TITLE
[CI]Fix imports backport

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -125,8 +125,6 @@ with_mage() {
 
     local install_packages=(
             "github.com/magefile/mage"
-            "github.com/elastic/go-licenser"
-            "golang.org/x/tools/cmd/goimports"
             "github.com/jstemmer/go-junit-report"
             "gotest.tools/gotestsum"
     )


### PR DESCRIPTION
## Proposed commit message

Remove dependencies from buildkite scripts (`with_mage`), so they are based on go.mod and go.sum files.


## Related issues

- Relates #11143


