### PR TITLE
[O11y][System] Fix dashboard query in `[Metrics System] Host overview`

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix dashboard query in [Metrics System] Host overview.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1 #Fix me
+      link: https://github.com/elastic/integrations/pull/12612
 - version: "1.64.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.64.1"
+  changes:
+    - description: Fix dashboard query in [Metrics System] Host overview.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1 #Fix me
 - version: "1.64.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/system/kibana/dashboard/system-79ffd6e0-faa0-11e6-947f-177f697178b8.json
+++ b/packages/system/kibana/dashboard/system-79ffd6e0-faa0-11e6-947f-177f697178b8.json
@@ -63,7 +63,7 @@
                                     },
                                     {
                                         "match_phrase": {
-                                            "data_stream.dataset": "system.filestream"
+                                            "data_stream.dataset": "system.filesystem"
                                         }
                                     },
                                     {

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: system
 title: System
-version: "1.64.0"
+version: "1.64.1"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Bugfix
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

- Fix dashboard query in [Metrics System] Host overview

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #11528

## Screenshots

![screencapture-localhost-5601-app-dashboards-2025-02-04-15_41_51](https://github.com/user-attachments/assets/63381061-d355-4457-8dc4-5d452942f69d)