### PR TITLE
Changed ownership of logstash package to logstash team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -275,7 +275,7 @@
 /packages/linux @elastic/elastic-agent-data-plane
 /packages/lmd @elastic/ml-ui @elastic/sec-applied-ml
 /packages/log @elastic/elastic-agent-data-plane
-/packages/logstash @elastic/stack-monitoring
+/packages/logstash @elastic/logstash
 /packages/lumos @elastic/security-service-integrations
 /packages/lyve_cloud @elastic/security-service-integrations
 /packages/m365_defender @elastic/security-service-integrations


### PR DESCRIPTION
## Proposed commit message

This PR changes the code ownership of the `logstash` integration package from the @elastic/stack-monitoring team to the @elastic/logstash team.

The main reason behind this proposed change is that the Logstash team completely owns this package and since they are actively developing and maintaining it, it makes sense to cede code ownership on that folder and allow them to move faster.
