### PR TITLE
[ci] Remove .github folder from skip_ci_on_only_changed

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -13,7 +13,7 @@
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$|^/test benchmark fullreport$",
       "skip_ci_labels": [],
       "skip_target_branches": [],
-      "skip_ci_on_only_changed": ["^.github/", "^docs/"],
+      "skip_ci_on_only_changed": ["^docs/"],
       "always_require_ci_on_changed": []
     },
     {

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -13,7 +13,7 @@
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$|^/test benchmark fullreport$",
       "skip_ci_labels": [],
       "skip_target_branches": [],
-      "skip_ci_on_only_changed": ["^docs/"],
+      "skip_ci_on_only_changed": ["^.github/workflows/", "^.github/dependabot.yml", "^.github/ISSUE_TEMPLATE/", "^docs/"],
       "always_require_ci_on_changed": []
     },
     {


### PR DESCRIPTION
## Proposed commit message

Buildkite builds should be triggered if `.github/CODEOWNERS` file is modified.
To avoid updating the owner without updating the corresponding package manifest or similar errors.

Relates https://github.com/elastic/integrations/pull/12625

Buildkite builds failing: https://buildkite.com/elastic/integrations/builds/21798