### PR TITLE
Update logstash owner in manifest

### DIFF
--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -18,7 +18,7 @@ conditions:
   elastic:
     subscription: basic
 owner:
-  github: elastic/stack-monitoring
+  github: elastic/logstash
   type: elastic
 screenshots:
   - src: /img/kibana-logstash-log.png
@@ -131,4 +131,3 @@ policy_templates:
             multi: false
             required: false
             show_user: false
-     


### PR DESCRIPTION
## Proposed commit message

Update `logstash` owner in the package manifest to be the same defined in `.github/CODEOWNERS` file.

This difference between `.github/CODEOWNERS` and the package manifest is causing errors in builds triggered from PRs. Example: https://buildkite.com/elastic/integrations/builds/21798

## Related issues

- https://github.com/elastic/integrations/pull/12625
