### PR TITLE
Re-enable CI when changing .github directory

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -13,7 +13,7 @@
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$|^/test benchmark fullreport$",
       "skip_ci_labels": [],
       "skip_target_branches": [],
-      "skip_ci_on_only_changed": ["^.github/", "^docs/"],
+      "skip_ci_on_only_changed": ["^docs/"],
       "always_require_ci_on_changed": []
     },
     {


### PR DESCRIPTION
We have some checks for codeowners that should be also executed if only the codeowners file change, re-enable by now these checks and we can polish them later.