### PR TITLE
[AWS S3] Introduce start timestamp and ignore older timespan to AWS S3 based integrations

### DIFF
--- a/packages/amazon_security_lake/changelog.yml
+++ b/packages/amazon_security_lake/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.0"
+  changes:
+    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12645
 - version: "2.4.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/amazon_security_lake/changelog.yml
+++ b/packages/amazon_security_lake/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.5.0"
   changes:
-    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+    - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12645
 - version: "2.4.0"

--- a/packages/amazon_security_lake/data_stream/event/agent/stream/aws-s3.yml.hbs
+++ b/packages/amazon_security_lake/data_stream/event/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/amazon_security_lake/data_stream/event/manifest.yml
+++ b/packages/amazon_security_lake/data_stream/event/manifest.yml
@@ -98,14 +98,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: queue_url
         type: text
         title: "[SQS] Queue URL"

--- a/packages/amazon_security_lake/data_stream/event/manifest.yml
+++ b/packages/amazon_security_lake/data_stream/event/manifest.yml
@@ -92,6 +92,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed. It is a required parameter for collecting logs via the AWS S3 Bucket.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: queue_url
         type: text
         title: "[SQS] Queue URL"

--- a/packages/amazon_security_lake/manifest.yml
+++ b/packages/amazon_security_lake/manifest.yml
@@ -1,13 +1,13 @@
 format_version: "3.0.3"
 name: amazon_security_lake
 title: Amazon Security Lake
-version: "2.4.0"
+version: "2.5.0"
 description: Collect logs from Amazon Security Lake with Elastic Agent.
 type: integration
 categories: ["aws", "security"]
 conditions:
   kibana:
-    version: "^8.16.2 || ^9.0.0"
+    version: "^8.16.5 || ^9.0.0"
   elastic:
     subscription: basic
 screenshots:

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.42.0"
   changes:
-    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+    - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12645
 - version: "2.41.1"

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.42.0"
+  changes:
+    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12645
 - version: "2.41.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/aws/data_stream/apigateway_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/apigateway_logs/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/aws/data_stream/apigateway_logs/manifest.yml
+++ b/packages/aws/data_stream/apigateway_logs/manifest.yml
@@ -75,6 +75,20 @@ streams:
         show_user: false
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/aws/data_stream/apigateway_logs/manifest.yml
+++ b/packages/aws/data_stream/apigateway_logs/manifest.yml
@@ -81,14 +81,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/aws/data_stream/cloudfront_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/cloudfront_logs/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/aws/data_stream/cloudfront_logs/manifest.yml
+++ b/packages/aws/data_stream/cloudfront_logs/manifest.yml
@@ -51,6 +51,20 @@ streams:
         show_user: false
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/aws/data_stream/cloudfront_logs/manifest.yml
+++ b/packages/aws/data_stream/cloudfront_logs/manifest.yml
@@ -57,14 +57,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/aws/data_stream/cloudtrail/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/cloudtrail/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/aws/data_stream/cloudtrail/manifest.yml
+++ b/packages/aws/data_stream/cloudtrail/manifest.yml
@@ -34,14 +34,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: queue_url
         type: text
         title: "[SQS] Queue URL"

--- a/packages/aws/data_stream/cloudtrail/manifest.yml
+++ b/packages/aws/data_stream/cloudtrail/manifest.yml
@@ -28,6 +28,20 @@ streams:
         required: false
         show_user: true
         description: Mandatory if the "Collect logs via S3 Bucket" switch is on. It is a required parameter for collecting logs via the AWS S3 Bucket unless you set a Bucket ARN.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: queue_url
         type: text
         title: "[SQS] Queue URL"

--- a/packages/aws/data_stream/ec2_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/ec2_logs/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/aws/data_stream/ec2_logs/manifest.yml
+++ b/packages/aws/data_stream/ec2_logs/manifest.yml
@@ -58,14 +58,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/aws/data_stream/ec2_logs/manifest.yml
+++ b/packages/aws/data_stream/ec2_logs/manifest.yml
@@ -52,6 +52,20 @@ streams:
         show_user: false
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/aws/data_stream/elb_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/elb_logs/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/aws/data_stream/elb_logs/manifest.yml
+++ b/packages/aws/data_stream/elb_logs/manifest.yml
@@ -51,6 +51,20 @@ streams:
         show_user: false
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/aws/data_stream/elb_logs/manifest.yml
+++ b/packages/aws/data_stream/elb_logs/manifest.yml
@@ -57,14 +57,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/aws/data_stream/emr_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/emr_logs/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/aws/data_stream/emr_logs/manifest.yml
+++ b/packages/aws/data_stream/emr_logs/manifest.yml
@@ -29,6 +29,20 @@ streams:
         required: false
         show_user: true
         description: Mandatory if the "Collect logs via S3 Bucket" switch is on. It is a required parameter for collecting logs via the AWS S3 Bucket unless you set a Bucket ARN.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: queue_url
         type: text
         title: "[SQS] Queue URL"

--- a/packages/aws/data_stream/emr_logs/manifest.yml
+++ b/packages/aws/data_stream/emr_logs/manifest.yml
@@ -35,14 +35,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: queue_url
         type: text
         title: "[SQS] Queue URL"

--- a/packages/aws/data_stream/firewall_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/firewall_logs/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/aws/data_stream/firewall_logs/manifest.yml
+++ b/packages/aws/data_stream/firewall_logs/manifest.yml
@@ -51,6 +51,20 @@ streams:
         show_user: false
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/aws/data_stream/firewall_logs/manifest.yml
+++ b/packages/aws/data_stream/firewall_logs/manifest.yml
@@ -57,14 +57,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/aws/data_stream/guardduty/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/guardduty/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/aws/data_stream/guardduty/manifest.yml
+++ b/packages/aws/data_stream/guardduty/manifest.yml
@@ -173,14 +173,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: queue_url
         type: text
         title: "[SQS] Queue URL"

--- a/packages/aws/data_stream/guardduty/manifest.yml
+++ b/packages/aws/data_stream/guardduty/manifest.yml
@@ -167,6 +167,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: queue_url
         type: text
         title: "[SQS] Queue URL"

--- a/packages/aws/data_stream/route53_resolver_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/route53_resolver_logs/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/aws/data_stream/route53_resolver_logs/manifest.yml
+++ b/packages/aws/data_stream/route53_resolver_logs/manifest.yml
@@ -174,6 +174,20 @@ streams:
         show_user: false
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/aws/data_stream/route53_resolver_logs/manifest.yml
+++ b/packages/aws/data_stream/route53_resolver_logs/manifest.yml
@@ -180,14 +180,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/aws/data_stream/s3access/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/s3access/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/aws/data_stream/s3access/manifest.yml
+++ b/packages/aws/data_stream/s3access/manifest.yml
@@ -57,14 +57,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries older than the given timespan. Timespan is calculated from the current time to processing entry's last modified timestamp. Accepts a time duration like `48h` or `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/aws/data_stream/s3access/manifest.yml
+++ b/packages/aws/data_stream/s3access/manifest.yml
@@ -51,6 +51,20 @@ streams:
         show_user: false
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries older than the given timespan. Timespan is calculated from the current time to processing entry's last modified timestamp. Accepts a time duration like `48h` or `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/aws/data_stream/vpcflow/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/vpcflow/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/aws/data_stream/vpcflow/manifest.yml
+++ b/packages/aws/data_stream/vpcflow/manifest.yml
@@ -65,14 +65,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries older than the given timespan. Timespan is calculated from the current time to processing entry's last modified timestamp. Accepts a time duration like `48h` or `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/aws/data_stream/vpcflow/manifest.yml
+++ b/packages/aws/data_stream/vpcflow/manifest.yml
@@ -59,6 +59,20 @@ streams:
         show_user: false
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries older than the given timespan. Timespan is calculated from the current time to processing entry's last modified timestamp. Accepts a time duration like `48h` or `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/aws/data_stream/waf/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/waf/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/aws/data_stream/waf/manifest.yml
+++ b/packages/aws/data_stream/waf/manifest.yml
@@ -57,14 +57,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries older than the given timespan. Timespan is calculated from the current time to processing entry's last modified timestamp. Accepts a time duration like `48h` or `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/aws/data_stream/waf/manifest.yml
+++ b/packages/aws/data_stream/waf/manifest.yml
@@ -51,6 +51,20 @@ streams:
         show_user: false
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries older than the given timespan. Timespan is calculated from the current time to processing entry's last modified timestamp. Accepts a time duration like `48h` or `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.1
 name: aws
 title: AWS
-version: 2.41.1
+version: 2.42.0
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:
@@ -11,7 +11,7 @@ conditions:
   elastic:
     subscription: basic
   kibana:
-    version: "^8.16.2 || ^9.0.0"
+    version: "^8.16.5 || ^9.0.0"
 screenshots:
   - src: /img/metricbeat-aws-overview.png
     title: metricbeat aws overview

--- a/packages/aws_bedrock/changelog.yml
+++ b/packages/aws_bedrock/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.2.0"
+  changes:
+    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12645
 - version: "1.1.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/aws_bedrock/changelog.yml
+++ b/packages/aws_bedrock/changelog.yml
@@ -1,6 +1,6 @@
 - version: "1.2.0"
   changes:
-    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+    - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12645
 - version: "1.1.0"

--- a/packages/aws_bedrock/data_stream/invocation/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws_bedrock/data_stream/invocation/agent/stream/aws-s3.yml.hbs
@@ -33,6 +33,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless non_aws_bucket_name}}
 {{#unless access_point_arn}}

--- a/packages/aws_bedrock/data_stream/invocation/manifest.yml
+++ b/packages/aws_bedrock/data_stream/invocation/manifest.yml
@@ -177,14 +177,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: bucket_list_interval
         type: text
         title: Bucket List Interval

--- a/packages/aws_bedrock/data_stream/invocation/manifest.yml
+++ b/packages/aws_bedrock/data_stream/invocation/manifest.yml
@@ -171,6 +171,20 @@ streams:
         default: 1
         show_user: true
         description: Number of workers that will process the S3 objects listed. (Required when `bucket_arn` or `access_point_arn` are set).
+      - name: start_timestamp
+        type: text
+        title: "Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: bucket_list_interval
         type: text
         title: Bucket List Interval

--- a/packages/aws_bedrock/manifest.yml
+++ b/packages/aws_bedrock/manifest.yml
@@ -3,7 +3,7 @@ name: aws_bedrock
 title: Amazon Bedrock
 description: Collect Amazon Bedrock model invocation logs and runtime metrics with Elastic Agent.
 type: integration
-version: "1.1.0"
+version: "1.2.0"
 categories:
   - aws
   - cloud
@@ -11,7 +11,7 @@ categories:
   - security
 conditions:
   kibana:
-    version: "^8.16.2 || ^9.0.0"
+    version: "^8.16.5 || ^9.0.0"
   elastic:
     subscription: basic
 policy_templates:

--- a/packages/aws_logs/changelog.yml
+++ b/packages/aws_logs/changelog.yml
@@ -1,6 +1,6 @@
 - version: "1.8.0"
   changes:
-    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+    - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12645
 - version: 1.7.0

--- a/packages/aws_logs/changelog.yml
+++ b/packages/aws_logs/changelog.yml
@@ -1,6 +1,11 @@
+- version: "1.8.0"
+  changes:
+    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12645
 - version: 1.7.0
   changes:
-    - description: Add support for Kibana `9.0.0` 
+    - description: Add support for Kibana `9.0.0`
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12637
 - version: "1.6.1"

--- a/packages/aws_logs/data_stream/generic/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws_logs/data_stream/generic/agent/stream/aws-s3.yml.hbs
@@ -31,6 +31,14 @@ When using an S3 bucket, you can specify only one of the following options:
 number_of_workers: {{ number_of_workers }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{#if bucket_list_prefix }}
 bucket_list_prefix: {{ bucket_list_prefix }}
 {{/if}}

--- a/packages/aws_logs/data_stream/generic/manifest.yml
+++ b/packages/aws_logs/data_stream/generic/manifest.yml
@@ -191,14 +191,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: bucket_list_interval
         type: text
         title: Bucket List Interval

--- a/packages/aws_logs/data_stream/generic/manifest.yml
+++ b/packages/aws_logs/data_stream/generic/manifest.yml
@@ -185,6 +185,20 @@ streams:
         default: 1
         show_user: true
         description: Number of workers that will process the S3 objects listed. (Required when `bucket_arn` or `access_point_arn` are set).
+      - name: start_timestamp
+        type: text
+        title: "Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: bucket_list_interval
         type: text
         title: Bucket List Interval

--- a/packages/aws_logs/manifest.yml
+++ b/packages/aws_logs/manifest.yml
@@ -3,7 +3,7 @@ name: aws_logs
 title: Custom AWS Logs
 description: Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.
 type: integration
-version: "1.7.0"
+version: "1.8.0"
 categories:
   - cloud
   - observability
@@ -11,7 +11,7 @@ categories:
   - aws
 conditions:
   kibana:
-    version: "^8.16.2 || ^9.0.0"
+    version: "^8.16.5 || ^9.0.0"
   elastic:
     subscription: basic
 policy_templates:

--- a/packages/canva/changelog.yml
+++ b/packages/canva/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "0.6.0"
   changes:
-    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+    - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12645
 - version: "0.5.0"

--- a/packages/canva/changelog.yml
+++ b/packages/canva/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.0"
+  changes:
+    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12645
 - version: "0.5.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/canva/data_stream/audit/agent/stream/aws-s3.yml.hbs
+++ b/packages/canva/data_stream/audit/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/canva/data_stream/audit/manifest.yml
+++ b/packages/canva/data_stream/audit/manifest.yml
@@ -118,6 +118,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed. It is a required parameter for collecting logs via the AWS S3 Bucket.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/canva/data_stream/audit/manifest.yml
+++ b/packages/canva/data_stream/audit/manifest.yml
@@ -124,14 +124,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/canva/manifest.yml
+++ b/packages/canva/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: canva
 title: Canva
-version: "0.5.0"
+version: "0.6.0"
 description: Collect logs from Canva with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - productivity
 conditions:
   kibana:
-    version: "^8.16.2 || ^9.0.0"
+    version: "^8.16.5 || ^9.0.0"
   elastic:
     subscription: basic
 screenshots:

--- a/packages/carbon_black_cloud/changelog.yml
+++ b/packages/carbon_black_cloud/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.9.0"
   changes:
-    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+    - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12645
 - version: "2.8.1"

--- a/packages/carbon_black_cloud/changelog.yml
+++ b/packages/carbon_black_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.9.0"
+  changes:
+    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12645
 - version: "2.8.1"
   changes:
     - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.

--- a/packages/carbon_black_cloud/data_stream/alert/agent/stream/aws-s3.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/alert/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/carbon_black_cloud/data_stream/alert/manifest.yml
+++ b/packages/carbon_black_cloud/data_stream/alert/manifest.yml
@@ -93,6 +93,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/carbon_black_cloud/data_stream/alert/manifest.yml
+++ b/packages/carbon_black_cloud/data_stream/alert/manifest.yml
@@ -99,14 +99,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/carbon_black_cloud/data_stream/alert_v7/agent/stream/aws-s3.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/alert_v7/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/carbon_black_cloud/data_stream/alert_v7/manifest.yml
+++ b/packages/carbon_black_cloud/data_stream/alert_v7/manifest.yml
@@ -93,6 +93,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/carbon_black_cloud/data_stream/alert_v7/manifest.yml
+++ b/packages/carbon_black_cloud/data_stream/alert_v7/manifest.yml
@@ -99,14 +99,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/carbon_black_cloud/data_stream/endpoint_event/agent/stream/aws-s3.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/endpoint_event/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/carbon_black_cloud/data_stream/endpoint_event/manifest.yml
+++ b/packages/carbon_black_cloud/data_stream/endpoint_event/manifest.yml
@@ -45,14 +45,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/carbon_black_cloud/data_stream/endpoint_event/manifest.yml
+++ b/packages/carbon_black_cloud/data_stream/endpoint_event/manifest.yml
@@ -39,6 +39,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/carbon_black_cloud/data_stream/watchlist_hit/agent/stream/aws-s3.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/watchlist_hit/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/carbon_black_cloud/data_stream/watchlist_hit/manifest.yml
+++ b/packages/carbon_black_cloud/data_stream/watchlist_hit/manifest.yml
@@ -45,14 +45,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/carbon_black_cloud/data_stream/watchlist_hit/manifest.yml
+++ b/packages/carbon_black_cloud/data_stream/watchlist_hit/manifest.yml
@@ -39,6 +39,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/carbon_black_cloud/manifest.yml
+++ b/packages/carbon_black_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: carbon_black_cloud
 title: VMware Carbon Black Cloud
-version: "2.8.1"
+version: "2.9.0"
 description: Collect logs from VMWare Carbon Black Cloud with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - edr_xdr
 conditions:
   kibana:
-    version: "^8.16.2"
+    version: "^8.16.5"
 screenshots:
   - src: /img/carbon_black_cloud-screenshot.png
     title: Carbon Black Cloud alert dashboard screenshot

--- a/packages/cisco_umbrella/changelog.yml
+++ b/packages/cisco_umbrella/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.30.0"
   changes:
-    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+    - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12645
 - version: "1.29.0"

--- a/packages/cisco_umbrella/changelog.yml
+++ b/packages/cisco_umbrella/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.30.0"
+  changes:
+    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12645
 - version: "1.29.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/cisco_umbrella/data_stream/log/agent/stream/aws-s3.yml.hbs
+++ b/packages/cisco_umbrella/data_stream/log/agent/stream/aws-s3.yml.hbs
@@ -9,6 +9,12 @@ access_point_arn: {{access_point_arn}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}/
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 {{#if file_selectors}}
 file_selectors:
 {{file_selectors}}

--- a/packages/cisco_umbrella/data_stream/log/manifest.yml
+++ b/packages/cisco_umbrella/data_stream/log/manifest.yml
@@ -52,6 +52,20 @@ streams:
         show_user: true
         default: 1
         description: Required for Cisco Managed S3. Number of workers that will process the S3 objects listed. Minimum is 1.
+      - name: start_timestamp
+        type: text
+        title: "Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: bucket_list_interval
         type: text
         title: Bucket List Interval

--- a/packages/cisco_umbrella/data_stream/log/manifest.yml
+++ b/packages/cisco_umbrella/data_stream/log/manifest.yml
@@ -58,14 +58,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: bucket_list_interval
         type: text
         title: Bucket List Interval

--- a/packages/cisco_umbrella/manifest.yml
+++ b/packages/cisco_umbrella/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cisco_umbrella
 title: Cisco Umbrella
-version: "1.29.0"
+version: "1.30.0"
 description: Collect logs from Cisco Umbrella with Elastic Agent.
 type: integration
 categories:
@@ -10,7 +10,7 @@ categories:
   - dns_security
 conditions:
   kibana:
-    version: "^8.16.2 || ^9.0.0"
+    version: "^8.16.5 || ^9.0.0"
 icons:
   - src: /img/cisco.svg
     title: cisco

--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.35.0"
   changes:
-    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+    - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12645
 - version: "1.34.1"

--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.35.0"
+  changes:
+    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12645
 - version: "1.34.1"
   changes:
     - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.

--- a/packages/cloudflare_logpush/data_stream/access_request/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/access_request/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless cloudflare_r2_access_request}}
 {{#unless cloudflare_r2}}

--- a/packages/cloudflare_logpush/data_stream/access_request/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/access_request/manifest.yml
@@ -121,6 +121,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/access_request/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/access_request/manifest.yml
@@ -127,14 +127,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/audit/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/audit/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless cloudflare_r2_audit}}
 {{#unless cloudflare_r2}}

--- a/packages/cloudflare_logpush/data_stream/audit/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/audit/manifest.yml
@@ -121,6 +121,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/audit/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/audit/manifest.yml
@@ -127,14 +127,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/casb/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/casb/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless cloudflare_r2_casb}}
 {{#unless cloudflare_r2}}

--- a/packages/cloudflare_logpush/data_stream/casb/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/casb/manifest.yml
@@ -121,6 +121,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/casb/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/casb/manifest.yml
@@ -127,14 +127,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/device_posture/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/device_posture/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,15 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
+
 {{! AWS S3 bucket ARN options }}
 {{#unless cloudflare_r2_device_posture}}
 {{#unless cloudflare_r2}}

--- a/packages/cloudflare_logpush/data_stream/dns/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/dns/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless cloudflare_r2_dns}}
 {{#unless cloudflare_r2}}

--- a/packages/cloudflare_logpush/data_stream/dns/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/dns/manifest.yml
@@ -121,6 +121,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/dns/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/dns/manifest.yml
@@ -127,14 +127,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/dns_firewall/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/dns_firewall/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless cloudflare_r2_dns_firewall}}
 {{#unless cloudflare_r2}}

--- a/packages/cloudflare_logpush/data_stream/firewall_event/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless cloudflare_r2_firewall_event}}
 {{#unless cloudflare_r2}}

--- a/packages/cloudflare_logpush/data_stream/gateway_dns/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/gateway_dns/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless cloudflare_r2_gateway_dns}}
 {{#unless cloudflare_r2}}

--- a/packages/cloudflare_logpush/data_stream/gateway_http/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/gateway_http/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless cloudflare_r2_gateway_http}}
 {{#unless cloudflare_r2}}

--- a/packages/cloudflare_logpush/data_stream/gateway_network/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/gateway_network/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless cloudflare_r2_gateway_network}}
 {{#unless cloudflare_r2}}

--- a/packages/cloudflare_logpush/data_stream/http_request/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/http_request/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,15 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
+
 {{! AWS S3 bucket ARN options }}
 {{#unless cloudflare_r2_http_request}}
 {{#unless cloudflare_r2}}

--- a/packages/cloudflare_logpush/data_stream/magic_ids/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless cloudflare_r2_magic_ids}}
 {{#unless cloudflare_r2}}

--- a/packages/cloudflare_logpush/data_stream/magic_ids/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/manifest.yml
@@ -121,6 +121,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/magic_ids/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/manifest.yml
@@ -127,14 +127,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/nel_report/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/nel_report/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless cloudflare_r2_nel_report}}
 {{#unless cloudflare_r2}}

--- a/packages/cloudflare_logpush/data_stream/nel_report/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/nel_report/manifest.yml
@@ -121,6 +121,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/nel_report/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/nel_report/manifest.yml
@@ -127,14 +127,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/network_analytics/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/network_analytics/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless cloudflare_r2_network_analytics}}
 {{#unless cloudflare_r2}}

--- a/packages/cloudflare_logpush/data_stream/network_analytics/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/network_analytics/manifest.yml
@@ -121,6 +121,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/network_analytics/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/network_analytics/manifest.yml
@@ -127,14 +127,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/network_session/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/network_session/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless cloudflare_r2_network_session}}
 {{#unless cloudflare_r2}}

--- a/packages/cloudflare_logpush/data_stream/network_session/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/network_session/manifest.yml
@@ -121,6 +121,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/network_session/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/network_session/manifest.yml
@@ -127,14 +127,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/sinkhole_http/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/sinkhole_http/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless cloudflare_r2_sinkhole_http}}
 {{#unless cloudflare_r2}}

--- a/packages/cloudflare_logpush/data_stream/sinkhole_http/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/sinkhole_http/manifest.yml
@@ -121,6 +121,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/sinkhole_http/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/sinkhole_http/manifest.yml
@@ -127,14 +127,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless cloudflare_r2_spectrum_event}}
 {{#unless cloudflare_r2}}

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/manifest.yml
@@ -121,6 +121,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/manifest.yml
@@ -127,14 +127,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/workers_trace/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/workers_trace/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless cloudflare_r2_workers_trace}}
 {{#unless cloudflare_r2}}

--- a/packages/cloudflare_logpush/data_stream/workers_trace/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/workers_trace/manifest.yml
@@ -121,6 +121,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/workers_trace/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/workers_trace/manifest.yml
@@ -127,14 +127,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/manifest.yml
+++ b/packages/cloudflare_logpush/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cloudflare_logpush
 title: Cloudflare Logpush
-version: "1.34.1"
+version: "1.35.0"
 description: Collect and parse logs from Cloudflare API with Elastic Agent.
 type: integration
 categories:
@@ -10,7 +10,7 @@ categories:
   - cdn_security
 conditions:
   kibana:
-    version: "^8.16.2 || ^9.0.0"
+    version: "^8.16.5 || ^9.0.0"
 screenshots:
   - src: /img/cloudflare_logpush-overview1.png
     title: Cloudflare Logpush - Zero Trust Overview

--- a/packages/f5_bigip/changelog.yml
+++ b/packages/f5_bigip/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.27.0"
+  changes:
+    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12645
 - version: "1.26.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/f5_bigip/changelog.yml
+++ b/packages/f5_bigip/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.27.0"
   changes:
-    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+    - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12645
 - version: "1.26.0"

--- a/packages/f5_bigip/data_stream/log/agent/stream/aws-s3.yml.hbs
+++ b/packages/f5_bigip/data_stream/log/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/f5_bigip/data_stream/log/manifest.yml
+++ b/packages/f5_bigip/data_stream/log/manifest.yml
@@ -85,6 +85,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/f5_bigip/data_stream/log/manifest.yml
+++ b/packages/f5_bigip/data_stream/log/manifest.yml
@@ -91,14 +91,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/f5_bigip/manifest.yml
+++ b/packages/f5_bigip/manifest.yml
@@ -1,14 +1,14 @@
 format_version: "3.0.2"
 name: f5_bigip
 title: F5 BIG-IP
-version: "1.26.0"
+version: "1.27.0"
 description: Collect logs from F5 BIG-IP with Elastic Agent.
 type: integration
 categories:
   - security
 conditions:
   kibana:
-    version: "^8.16.2 || ^9.0.0"
+    version: "^8.16.5 || ^9.0.0"
   elastic:
     subscription: basic
 screenshots:

--- a/packages/imperva_cloud_waf/changelog.yml
+++ b/packages/imperva_cloud_waf/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.9.0"
   changes:
-    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+    - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12645
 - version: "1.8.0"

--- a/packages/imperva_cloud_waf/changelog.yml
+++ b/packages/imperva_cloud_waf/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.0"
+  changes:
+    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12645
 - version: "1.8.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/imperva_cloud_waf/data_stream/event/agent/stream/aws-s3.yml.hbs
+++ b/packages/imperva_cloud_waf/data_stream/event/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/imperva_cloud_waf/data_stream/event/manifest.yml
+++ b/packages/imperva_cloud_waf/data_stream/event/manifest.yml
@@ -201,14 +201,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: queue_url
         type: text
         title: "[SQS] Queue URL"

--- a/packages/imperva_cloud_waf/data_stream/event/manifest.yml
+++ b/packages/imperva_cloud_waf/data_stream/event/manifest.yml
@@ -195,6 +195,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed. It is a required parameter for collecting logs via the AWS S3 Bucket.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: queue_url
         type: text
         title: "[SQS] Queue URL"

--- a/packages/imperva_cloud_waf/manifest.yml
+++ b/packages/imperva_cloud_waf/manifest.yml
@@ -1,14 +1,14 @@
 format_version: 3.0.3
 name: imperva_cloud_waf
 title: Imperva Cloud WAF
-version: "1.8.0"
+version: "1.9.0"
 description: Collect logs from Imperva Cloud WAF with Elastic Agent.
 type: integration
 categories:
   - security
 conditions:
   kibana:
-    version: "^8.16.2 || ^9.0.0"
+    version: "^8.16.5 || ^9.0.0"
   elastic:
     subscription: basic
 screenshots:

--- a/packages/jamf_protect/changelog.yml
+++ b/packages/jamf_protect/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.11.0"
   changes:
-    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+    - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12645
 - version: "2.10.0"

--- a/packages/jamf_protect/changelog.yml
+++ b/packages/jamf_protect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.11.0"
+  changes:
+    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12645
 - version: "2.10.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/jamf_protect/data_stream/alerts/agent/stream/aws-s3.yml.hbs
+++ b/packages/jamf_protect/data_stream/alerts/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless jamf_protect_bucket_name}}
 {{#unless global_bucket_name}}

--- a/packages/jamf_protect/data_stream/alerts/manifest.yml
+++ b/packages/jamf_protect/data_stream/alerts/manifest.yml
@@ -98,6 +98,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/jamf_protect/data_stream/alerts/manifest.yml
+++ b/packages/jamf_protect/data_stream/alerts/manifest.yml
@@ -104,14 +104,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/jamf_protect/data_stream/telemetry/agent/stream/aws-s3.yml.hbs
+++ b/packages/jamf_protect/data_stream/telemetry/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless jamf_protect_bucket_name}}
 {{#unless global_bucket_name}}

--- a/packages/jamf_protect/data_stream/telemetry/manifest.yml
+++ b/packages/jamf_protect/data_stream/telemetry/manifest.yml
@@ -98,6 +98,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/jamf_protect/data_stream/telemetry/manifest.yml
+++ b/packages/jamf_protect/data_stream/telemetry/manifest.yml
@@ -104,14 +104,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/jamf_protect/data_stream/telemetry_legacy/agent/stream/aws-s3.yml.hbs
+++ b/packages/jamf_protect/data_stream/telemetry_legacy/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless jamf_protect_bucket_name}}
 {{#unless global_bucket_name}}

--- a/packages/jamf_protect/data_stream/telemetry_legacy/manifest.yml
+++ b/packages/jamf_protect/data_stream/telemetry_legacy/manifest.yml
@@ -98,6 +98,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/jamf_protect/data_stream/telemetry_legacy/manifest.yml
+++ b/packages/jamf_protect/data_stream/telemetry_legacy/manifest.yml
@@ -104,14 +104,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/jamf_protect/data_stream/web_threat_events/agent/stream/aws-s3.yml.hbs
+++ b/packages/jamf_protect/data_stream/web_threat_events/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless jamf_protect_bucket_name}}
 {{#unless global_bucket_name}}

--- a/packages/jamf_protect/data_stream/web_threat_events/manifest.yml
+++ b/packages/jamf_protect/data_stream/web_threat_events/manifest.yml
@@ -113,14 +113,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/jamf_protect/data_stream/web_threat_events/manifest.yml
+++ b/packages/jamf_protect/data_stream/web_threat_events/manifest.yml
@@ -107,6 +107,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/jamf_protect/data_stream/web_traffic_events/agent/stream/aws-s3.yml.hbs
+++ b/packages/jamf_protect/data_stream/web_traffic_events/agent/stream/aws-s3.yml.hbs
@@ -21,6 +21,14 @@ bucket_list_prefix: {{ bucket_list_prefix }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
 
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
+
 {{! AWS S3 bucket ARN options }}
 {{#unless jamf_protect_bucket_name}}
 {{#unless global_bucket_name}}

--- a/packages/jamf_protect/data_stream/web_traffic_events/manifest.yml
+++ b/packages/jamf_protect/data_stream/web_traffic_events/manifest.yml
@@ -113,14 +113,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/jamf_protect/data_stream/web_traffic_events/manifest.yml
+++ b/packages/jamf_protect/data_stream/web_traffic_events/manifest.yml
@@ -107,6 +107,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/jamf_protect/manifest.yml
+++ b/packages/jamf_protect/manifest.yml
@@ -1,14 +1,14 @@
 format_version: 3.0.3
 name: jamf_protect
 title: Jamf Protect
-version: "2.10.0"
+version: "2.11.0"
 description: Receives events from Jamf Protect with Elastic Agent.
 type: integration
 categories:
   - security
 conditions:
   kibana:
-    version: "^8.16.2 || ^9.0.0"
+    version: "^8.16.5 || ^9.0.0"
 screenshots:
   - src: /img/jamfprotect_kibana.png
     title: Jamf Protect Kibana

--- a/packages/sentinel_one_cloud_funnel/changelog.yml
+++ b/packages/sentinel_one_cloud_funnel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.0"
+  changes:
+    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12645
 - version: "1.9.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/sentinel_one_cloud_funnel/changelog.yml
+++ b/packages/sentinel_one_cloud_funnel/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.10.0"
   changes:
-    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+    - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12645
 - version: "1.9.0"

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/agent/stream/aws-s3.yml.hbs
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/manifest.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/manifest.yml
@@ -45,14 +45,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/manifest.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/manifest.yml
@@ -39,6 +39,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/sentinel_one_cloud_funnel/manifest.yml
+++ b/packages/sentinel_one_cloud_funnel/manifest.yml
@@ -1,13 +1,13 @@
 format_version: "3.0.2"
 name: sentinel_one_cloud_funnel
 title: SentinelOne Cloud Funnel
-version: "1.9.0"
+version: "1.10.0"
 description: Collect logs from SentinelOne Cloud Funnel with Elastic Agent.
 type: integration
 categories: ["security", "edr_xdr"]
 conditions:
   kibana:
-    version: "^8.16.2 || ^9.0.0"
+    version: "^8.16.5 || ^9.0.0"
   elastic:
     subscription: basic
 screenshots:

--- a/packages/servicenow/changelog.yml
+++ b/packages/servicenow/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "0.11.0"
   changes:
-    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+    - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12645
 - version: "0.10.0"

--- a/packages/servicenow/changelog.yml
+++ b/packages/servicenow/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.11.0"
+  changes:
+    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12645
 - version: "0.10.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/servicenow/data_stream/event/agent/stream/aws-s3.yml.hbs
+++ b/packages/servicenow/data_stream/event/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/servicenow/data_stream/event/manifest.yml
+++ b/packages/servicenow/data_stream/event/manifest.yml
@@ -250,6 +250,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/servicenow/data_stream/event/manifest.yml
+++ b/packages/servicenow/data_stream/event/manifest.yml
@@ -256,14 +256,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/servicenow/manifest.yml
+++ b/packages/servicenow/manifest.yml
@@ -1,14 +1,14 @@
 format_version: 3.2.1
 name: servicenow
 title: "ServiceNow"
-version: "0.10.0"
+version: "0.11.0"
 description: "Collect logs from ServiceNow with Elastic Agent."
 type: integration
 categories:
   - security
 conditions:
   kibana:
-    version: "^8.16.2 || ^9.0.0"
+    version: "^8.16.5 || ^9.0.0"
   elastic:
     subscription: "basic"
 screenshots:

--- a/packages/sublime_security/changelog.yml
+++ b/packages/sublime_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.0"
+  changes:
+    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12645
 - version: "1.6.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/sublime_security/changelog.yml
+++ b/packages/sublime_security/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.7.0"
   changes:
-    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+    - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12645
 - version: "1.6.0"

--- a/packages/sublime_security/data_stream/audit/agent/stream/aws-s3.yml.hbs
+++ b/packages/sublime_security/data_stream/audit/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/sublime_security/data_stream/email_message/agent/stream/aws-s3.yml.hbs
+++ b/packages/sublime_security/data_stream/email_message/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/sublime_security/data_stream/email_message/manifest.yml
+++ b/packages/sublime_security/data_stream/email_message/manifest.yml
@@ -50,14 +50,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: queue_url
         type: text
         title: '[SQS] Queue URL'

--- a/packages/sublime_security/data_stream/email_message/manifest.yml
+++ b/packages/sublime_security/data_stream/email_message/manifest.yml
@@ -44,6 +44,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: queue_url
         type: text
         title: '[SQS] Queue URL'

--- a/packages/sublime_security/data_stream/message_event/agent/stream/aws-s3.yml.hbs
+++ b/packages/sublime_security/data_stream/message_event/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/sublime_security/data_stream/message_event/manifest.yml
+++ b/packages/sublime_security/data_stream/message_event/manifest.yml
@@ -123,6 +123,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: queue_url
         type: text
         title: '[SQS] Queue URL'

--- a/packages/sublime_security/data_stream/message_event/manifest.yml
+++ b/packages/sublime_security/data_stream/message_event/manifest.yml
@@ -129,14 +129,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: queue_url
         type: text
         title: '[SQS] Queue URL'

--- a/packages/sublime_security/manifest.yml
+++ b/packages/sublime_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: sublime_security
 title: Sublime Security
-version: "1.6.0"
+version: "1.7.0"
 description: Collect logs from Sublime Security with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - email_security
 conditions:
   kibana:
-    version: "^8.16.2 || ^9.0.0"
+    version: "^8.16.5 || ^9.0.0"
   elastic:
     subscription: basic
 screenshots:

--- a/packages/symantec_endpoint_security/changelog.yml
+++ b/packages/symantec_endpoint_security/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.9.0"
   changes:
-    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+    - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12645
 - version: "1.8.0"

--- a/packages/symantec_endpoint_security/changelog.yml
+++ b/packages/symantec_endpoint_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.0"
+  changes:
+    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12645
 - version: "1.8.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/symantec_endpoint_security/data_stream/event/agent/stream/aws-s3.yml.hbs
+++ b/packages/symantec_endpoint_security/data_stream/event/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/symantec_endpoint_security/data_stream/event/manifest.yml
+++ b/packages/symantec_endpoint_security/data_stream/event/manifest.yml
@@ -126,6 +126,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/symantec_endpoint_security/data_stream/event/manifest.yml
+++ b/packages/symantec_endpoint_security/data_stream/event/manifest.yml
@@ -132,14 +132,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/symantec_endpoint_security/manifest.yml
+++ b/packages/symantec_endpoint_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: symantec_endpoint_security
 title: Symantec Endpoint Security
-version: "1.8.0"
+version: "1.9.0"
 description: Collect logs from Symantec Endpoint Security with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - edr_xdr
 conditions:
   kibana:
-    version: "^8.16.2 || ^9.0.0"
+    version: "^8.16.5 || ^9.0.0"
   elastic:
     subscription: "basic"
 screenshots:

--- a/packages/tanium/changelog.yml
+++ b/packages/tanium/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.0"
+  changes:
+    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12645
 - version: "1.15.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/tanium/changelog.yml
+++ b/packages/tanium/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.16.0"
   changes:
-    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+    - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12645
 - version: "1.15.0"

--- a/packages/tanium/data_stream/action_history/agent/stream/aws-s3.yml.hbs
+++ b/packages/tanium/data_stream/action_history/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/tanium/data_stream/action_history/manifest.yml
+++ b/packages/tanium/data_stream/action_history/manifest.yml
@@ -36,14 +36,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/tanium/data_stream/action_history/manifest.yml
+++ b/packages/tanium/data_stream/action_history/manifest.yml
@@ -30,6 +30,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/tanium/data_stream/client_status/agent/stream/aws-s3.yml.hbs
+++ b/packages/tanium/data_stream/client_status/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/tanium/data_stream/client_status/manifest.yml
+++ b/packages/tanium/data_stream/client_status/manifest.yml
@@ -91,14 +91,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/tanium/data_stream/client_status/manifest.yml
+++ b/packages/tanium/data_stream/client_status/manifest.yml
@@ -85,6 +85,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/tanium/data_stream/discover/agent/stream/aws-s3.yml.hbs
+++ b/packages/tanium/data_stream/discover/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/tanium/data_stream/discover/manifest.yml
+++ b/packages/tanium/data_stream/discover/manifest.yml
@@ -36,14 +36,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/tanium/data_stream/discover/manifest.yml
+++ b/packages/tanium/data_stream/discover/manifest.yml
@@ -30,6 +30,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/tanium/data_stream/endpoint_config/agent/stream/aws-s3.yml.hbs
+++ b/packages/tanium/data_stream/endpoint_config/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/tanium/data_stream/endpoint_config/manifest.yml
+++ b/packages/tanium/data_stream/endpoint_config/manifest.yml
@@ -36,14 +36,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/tanium/data_stream/endpoint_config/manifest.yml
+++ b/packages/tanium/data_stream/endpoint_config/manifest.yml
@@ -30,6 +30,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/tanium/data_stream/reporting/agent/stream/aws-s3.yml.hbs
+++ b/packages/tanium/data_stream/reporting/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/tanium/data_stream/reporting/manifest.yml
+++ b/packages/tanium/data_stream/reporting/manifest.yml
@@ -91,14 +91,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/tanium/data_stream/reporting/manifest.yml
+++ b/packages/tanium/data_stream/reporting/manifest.yml
@@ -85,6 +85,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/tanium/data_stream/threat_response/agent/stream/aws-s3.yml.hbs
+++ b/packages/tanium/data_stream/threat_response/agent/stream/aws-s3.yml.hbs
@@ -14,6 +14,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/tanium/data_stream/threat_response/manifest.yml
+++ b/packages/tanium/data_stream/threat_response/manifest.yml
@@ -36,14 +36,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/tanium/data_stream/threat_response/manifest.yml
+++ b/packages/tanium/data_stream/threat_response/manifest.yml
@@ -30,6 +30,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/tanium/manifest.yml
+++ b/packages/tanium/manifest.yml
@@ -1,14 +1,14 @@
 format_version: "3.0.3"
 name: tanium
 title: Tanium
-version: "1.15.0"
+version: "1.16.0"
 description: This Elastic integration collects logs from Tanium with Elastic Agent.
 type: integration
 categories:
   - security
 conditions:
   kibana:
-    version: "^8.16.2 || ^9.0.0"
+    version: "^8.16.5 || ^9.0.0"
   elastic:
     subscription: "basic"
 screenshots:

--- a/packages/trellix_edr_cloud/changelog.yml
+++ b/packages/trellix_edr_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.0"
+  changes:
+    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12645
 - version: "1.7.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/trellix_edr_cloud/changelog.yml
+++ b/packages/trellix_edr_cloud/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.8.0"
   changes:
-    - description: Add support to configure start_timestamp & ignore_older configurations for AWS S3 backed inputs
+    - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12645
 - version: "1.7.0"

--- a/packages/trellix_edr_cloud/data_stream/event/agent/stream/aws-s3.yml.hbs
+++ b/packages/trellix_edr_cloud/data_stream/event/agent/stream/aws-s3.yml.hbs
@@ -13,6 +13,12 @@ bucket_list_interval: {{interval}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}
 {{/if}}
+{{#if start_timestamp}}
+start_timestamp: {{start_timestamp}}
+{{/if}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 
 {{else}}
 

--- a/packages/trellix_edr_cloud/data_stream/event/manifest.yml
+++ b/packages/trellix_edr_cloud/data_stream/event/manifest.yml
@@ -36,14 +36,14 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+        description: If set, only read S3 objects with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
       - name: ignore_older
         type: text
         title: "[S3] Ignore Older Timespan"
         multi: false
         required: false
         show_user: false
-        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
+        description: If set, ignore S3 objects whose Last-Modified time is before the ignore older timespan. Timespan is checked from the current time to S3 object's Last-Modified time. Accepts a duration like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/trellix_edr_cloud/data_stream/event/manifest.yml
+++ b/packages/trellix_edr_cloud/data_stream/event/manifest.yml
@@ -30,6 +30,20 @@ streams:
         show_user: true
         default: 5
         description: Number of workers that will process the S3 objects listed.
+      - name: start_timestamp
+        type: text
+        title: "[S3] Start Timestamp"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, only accept bucket entries with last modified timestamp newer than the given timestamp. Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format. For example, "2020-10-10T10:30:00Z" (UTC) or "2020-10-10T10:30:00Z+02:30" (with zone offset).
+      - name: ignore_older
+        type: text
+        title: "[S3] Ignore Older Timespan"
+        multi: false
+        required: false
+        show_user: false
+        description: If set, ignore bucket entries not within the provided timespan. Timespan is checked from the current time to processing entry's last modified timestamp. Accepts a timestamp like `48h`, `2h30m`.
       - name: visibility_timeout
         type: text
         title: "[SQS] Visibility Timeout"

--- a/packages/trellix_edr_cloud/manifest.yml
+++ b/packages/trellix_edr_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: trellix_edr_cloud
 title: Trellix EDR Cloud
-version: "1.7.0"
+version: "1.8.0"
 description: Collect logs from Trellix EDR Cloud with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - security
 conditions:
   kibana:
-    version: "^8.16.2 || ^9.0.0"
+    version: "^8.16.5 || ^9.0.0"
   elastic:
     subscription: basic
 screenshots:


### PR DESCRIPTION
## Proposed commit message

Introduce `Ignore Older Timespan` and `Start Timestamp` properties to integrations backed by AWS S3 input,

- **Ignore Older Timespan**: Accepts a timespan in which entries are accepted for processing
- **Start Timestamp**: Accepts a timestamp from which objects are accepted for processing

Configuring these properties allows S3 input to efficiently manage its internal registry. For example, setting `Ignore Older Timespan` to `2h` makes the S3 input registry only track entries within the last 2 hours. Once entries are beyond the timespan, input can remove them from the registry, thus reducing memory consumption. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Closes https://github.com/elastic/integrations/issues/11919
- Relates https://github.com/elastic/beats/pull/41817

### Screenshots

Configuration rendered (Title matching existing format)

![image](https://github.com/user-attachments/assets/b9ba7152-831b-4903-b847-9dd3e7b7436d)


