### PR TITLE
Prom Integration enable v9 Kibana support

### DIFF
--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add support for Kibana `9.0.0` 
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/12535
+      link: https://github.com/elastic/integrations/pull/12659
 - version: "1.22.0"
   changes:
     - description: Added custom configuration option to all data streams.

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.23.0"
+  changes:
+    - description: Add support for Kibana `9.0.0` 
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12535
 - version: "1.22.0"
   changes:
     - description: Added custom configuration option to all data streams.

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.0"
 name: prometheus
 title: Prometheus
-version: 1.22.0
+version: 1.23.0
 description: Collect metrics from Prometheus servers with Elastic Agent.
 type: integration
 categories:
@@ -10,7 +10,7 @@ categories:
   - containers
 conditions:
   kibana:
-    version: "^8.16.0"
+    version: "^8.16.0 || ^9.0.0"
   elastic:
     subscription: basic
 screenshots:


### PR DESCRIPTION
- Enhancement

## Proposed commit message

WHAT: Enabling support for Prometheus integrations for 9.0 version
WHY: Is needed in order to enable above integrations in version 9.0.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

1. Clone Pr
2. elastic-package build with v0.109.1
3. elastic-package stack up -d -v --version=9.0.0-SNAPSHOT to install a local ES
4. Install an agent + Fleet with prementioned integrations enabled

## Related issues

- Relates #https://github.com/elastic/integrations/issues/12529 

## Screenshots

For Remote Write:

<img width="1698" alt="prometheus_rw" src="https://github.com/user-attachments/assets/1aab878d-2a02-40ca-b22d-a26f16f98a25" />

For Collector:

<img width="1698" alt="prometheus_collector" src="https://github.com/user-attachments/assets/e130014b-3ad3-446d-8f71-6d98f025e94c" />


