### PR TITLE
Fixed Queries in Gigamon Dashboards

### DIFF
--- a/packages/gigamon/changelog.yml
+++ b/packages/gigamon/changelog.yml
@@ -1,4 +1,18 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Fixed hardcoded timestamp in dashboard queries.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12664
+    - description: Modified title from Internal SSL Certificates expiration date to Expired TLS Certificate Details in NPM Dashboards.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12664
+    - description: Deleted Connection Resets widget in NPM Dashboards.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12664
+    - description: Rebuilt SMB Conversation widget in NPM Dashboards.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12664
 - version: "1.3.0"
   changes:
     - description: NPM dashboard added.

--- a/packages/gigamon/kibana/dashboard/gigamon-032aab7b-87b2-444c-8c86-956d092598fb.json
+++ b/packages/gigamon/kibana/dashboard/gigamon-032aab7b-87b2-444c-8c86-956d092598fb.json
@@ -845,7 +845,7 @@
                             },
                             {
                                 "id": "logs-*",
-                                "name": "c001313b-a4ee-4ec8-91bb-e412b3bbe5d2",
+                                "name": "3d025114-ff87-40b8-9fc3-c5800b2c5390",
                                 "type": "index-pattern"
                             }
                         ],
@@ -894,21 +894,21 @@
                                         "alias": null,
                                         "disabled": false,
                                         "field": "gigamon.ami.ssl_validity_not_after",
-                                        "index": "c001313b-a4ee-4ec8-91bb-e412b3bbe5d2",
+                                        "index": "3d025114-ff87-40b8-9fc3-c5800b2c5390",
                                         "key": "gigamon.ami.ssl_validity_not_after",
                                         "negate": false,
                                         "params": {
-                                            "lt": "2024-08-01T00:00:00.000+05:30"
+                                            "lt": "now"
                                         },
                                         "type": "range",
                                         "value": {
-                                            "lt": "2024-08-01T00:00:00.000+05:30"
+                                            "lt": "now"
                                         }
                                     },
                                     "query": {
                                         "range": {
                                             "gigamon.ami.ssl_validity_not_after": {
-                                                "lt": "2024-08-01T00:00:00.000+05:30"
+                                                "lt": "now"
                                             }
                                         }
                                     }
@@ -976,10 +976,16 @@
             {
                 "embeddableConfig": {
                     "attributes": {
+                        "description": "Expired TLS Certificate Details",
                         "references": [
                             {
                                 "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-f8c599bc-4580-4a39-a5fa-1cc2a68260d7",
+                                "name": "indexpattern-datasource-layer-f2bfa25e-3307-4990-9396-2a83c047bd87",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "64f4dbad-db20-450a-8897-b36af66997c0",
                                 "type": "index-pattern"
                             }
                         ],
@@ -988,17 +994,17 @@
                             "datasourceStates": {
                                 "formBased": {
                                     "layers": {
-                                        "f8c599bc-4580-4a39-a5fa-1cc2a68260d7": {
+                                        "f2bfa25e-3307-4990-9396-2a83c047bd87": {
                                             "columnOrder": [
-                                                "5b513fb1-7f19-4f04-b85f-e5b7f9ccc7ed",
-                                                "4f062c03-a3df-4b2c-bbfb-184f1899ae46",
-                                                "2008e32d-421d-41ce-8daa-747b57a1fe35",
-                                                "27dcd775-b0c5-4805-9670-6780d019d83f",
-                                                "ff65ac60-8d9b-41fe-b63e-1260aa77b113",
-                                                "c9c8b223-bffd-4990-bb41-9aa56a0ebbb7"
+                                                "00b64c0f-6ad7-49b0-97ad-620e892b52a0",
+                                                "fb36c053-2418-4fd4-b0c5-4d4f7149401f",
+                                                "9918b794-dee6-4d48-8cfa-985156eb6c71",
+                                                "35dbd18d-724e-4a71-a3d2-e3b95b391397",
+                                                "b4ff9561-a4c4-472b-94dd-bb19be1790df",
+                                                "088613fe-caa6-4a7a-a71d-041f58eeaca7"
                                             ],
                                             "columns": {
-                                                "2008e32d-421d-41ce-8daa-747b57a1fe35": {
+                                                "00b64c0f-6ad7-49b0-97ad-620e892b52a0": {
                                                     "customLabel": true,
                                                     "dataType": "ip",
                                                     "isBucketed": true,
@@ -1011,7 +1017,7 @@
                                                         "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
-                                                            "columnId": "ff65ac60-8d9b-41fe-b63e-1260aa77b113",
+                                                            "columnId": "b4ff9561-a4c4-472b-94dd-bb19be1790df",
                                                             "type": "column"
                                                         },
                                                         "orderDirection": "desc",
@@ -1019,38 +1025,24 @@
                                                         "parentFormat": {
                                                             "id": "terms"
                                                         },
-                                                        "size": 15
+                                                        "size": 10
                                                     },
                                                     "scale": "ordinal",
                                                     "sourceField": "gigamon.ami.src_ip"
                                                 },
-                                                "27dcd775-b0c5-4805-9670-6780d019d83f": {
+                                                "088613fe-caa6-4a7a-a71d-041f58eeaca7": {
                                                     "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Application",
-                                                    "operationType": "terms",
+                                                    "dataType": "date",
+                                                    "isBucketed": false,
+                                                    "label": "Expiration Details",
+                                                    "operationType": "max",
                                                     "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "ff65ac60-8d9b-41fe-b63e-1260aa77b113",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 15
+                                                        "emptyAsNull": true
                                                     },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "gigamon.ami.app_name"
+                                                    "scale": "ratio",
+                                                    "sourceField": "gigamon.ami.ssl_validity_not_after"
                                                 },
-                                                "4f062c03-a3df-4b2c-bbfb-184f1899ae46": {
+                                                "35dbd18d-724e-4a71-a3d2-e3b95b391397": {
                                                     "customLabel": true,
                                                     "dataType": "string",
                                                     "isBucketed": true,
@@ -1063,7 +1055,7 @@
                                                         "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
-                                                            "columnId": "ff65ac60-8d9b-41fe-b63e-1260aa77b113",
+                                                            "columnId": "b4ff9561-a4c4-472b-94dd-bb19be1790df",
                                                             "type": "column"
                                                         },
                                                         "orderDirection": "desc",
@@ -1071,16 +1063,16 @@
                                                         "parentFormat": {
                                                             "id": "terms"
                                                         },
-                                                        "size": 15
+                                                        "size": 10
                                                     },
                                                     "scale": "ordinal",
                                                     "sourceField": "gigamon.ami.ssl_issuer"
                                                 },
-                                                "5b513fb1-7f19-4f04-b85f-e5b7f9ccc7ed": {
+                                                "9918b794-dee6-4d48-8cfa-985156eb6c71": {
                                                     "customLabel": true,
                                                     "dataType": "string",
                                                     "isBucketed": true,
-                                                    "label": "Common Name",
+                                                    "label": "Common_name",
                                                     "operationType": "terms",
                                                     "params": {
                                                         "exclude": [],
@@ -1089,7 +1081,7 @@
                                                         "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
-                                                            "columnId": "ff65ac60-8d9b-41fe-b63e-1260aa77b113",
+                                                            "columnId": "b4ff9561-a4c4-472b-94dd-bb19be1790df",
                                                             "type": "column"
                                                         },
                                                         "orderDirection": "desc",
@@ -1097,24 +1089,12 @@
                                                         "parentFormat": {
                                                             "id": "terms"
                                                         },
-                                                        "size": 15
+                                                        "size": 10
                                                     },
                                                     "scale": "ordinal",
                                                     "sourceField": "gigamon.ami.ssl_common_name"
                                                 },
-                                                "c9c8b223-bffd-4990-bb41-9aa56a0ebbb7": {
-                                                    "customLabel": true,
-                                                    "dataType": "date",
-                                                    "isBucketed": false,
-                                                    "label": "Expiration Time",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "gigamon.ami.ssl_validity_not_after"
-                                                },
-                                                "ff65ac60-8d9b-41fe-b63e-1260aa77b113": {
+                                                "b4ff9561-a4c4-472b-94dd-bb19be1790df": {
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Count of records",
@@ -1124,6 +1104,32 @@
                                                     },
                                                     "scale": "ratio",
                                                     "sourceField": "___records___"
+                                                },
+                                                "fb36c053-2418-4fd4-b0c5-4d4f7149401f": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Application",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "b4ff9561-a4c4-472b-94dd-bb19be1790df",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "gigamon.ami.app_name"
                                                 }
                                             },
                                             "incompleteColumns": {},
@@ -1138,46 +1144,71 @@
                                     "layers": {}
                                 }
                             },
-                            "filters": [],
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "gigamon.ami.ssl_validity_not_after",
+                                        "index": "64f4dbad-db20-450a-8897-b36af66997c0",
+                                        "key": "gigamon.ami.ssl_validity_not_after",
+                                        "negate": false,
+                                        "params": {
+                                            "lt": "now"
+                                        },
+                                        "type": "range",
+                                        "value": {
+                                            "lt": "now"
+                                        }
+                                    },
+                                    "query": {
+                                        "range": {
+                                            "gigamon.ami.ssl_validity_not_after": {
+                                                "lt": "now"
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "data_stream.dataset : \"gigamon.ami\" "
+                                "query": "data_stream.dataset : \"gigamon.ami\" and gigamon.ami.ssl_validity_not_after : * "
                             },
                             "visualization": {
                                 "columns": [
                                     {
-                                        "columnId": "ff65ac60-8d9b-41fe-b63e-1260aa77b113",
+                                        "columnId": "9918b794-dee6-4d48-8cfa-985156eb6c71",
+                                        "isMetric": false,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "35dbd18d-724e-4a71-a3d2-e3b95b391397",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "00b64c0f-6ad7-49b0-97ad-620e892b52a0",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "fb36c053-2418-4fd4-b0c5-4d4f7149401f",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "b4ff9561-a4c4-472b-94dd-bb19be1790df",
                                         "hidden": true,
                                         "isTransposed": false
                                     },
                                     {
-                                        "columnId": "c9c8b223-bffd-4990-bb41-9aa56a0ebbb7",
+                                        "columnId": "088613fe-caa6-4a7a-a71d-041f58eeaca7",
                                         "isMetric": true,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "5b513fb1-7f19-4f04-b85f-e5b7f9ccc7ed",
-                                        "isMetric": false,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "4f062c03-a3df-4b2c-bbfb-184f1899ae46",
-                                        "isMetric": false,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "2008e32d-421d-41ce-8daa-747b57a1fe35",
-                                        "isMetric": false,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "27dcd775-b0c5-4805-9670-6780d019d83f",
-                                        "isMetric": false,
                                         "isTransposed": false
                                     }
                                 ],
-                                "layerId": "f8c599bc-4580-4a39-a5fa-1cc2a68260d7",
+                                "layerId": "f2bfa25e-3307-4990-9396-2a83c047bd87",
                                 "layerType": "data"
                             }
                         },
@@ -1185,17 +1216,18 @@
                         "type": "lens",
                         "visualizationType": "lnsDatatable"
                     },
+                    "description": "Expired TLS Certificate Details",
                     "enhancements": {}
                 },
                 "gridData": {
                     "h": 15,
-                    "i": "846e11e1-efc8-4311-88a7-cadb7aca1ad4",
+                    "i": "f9544843-bd1e-4bf5-ab73-446de2b324b9",
                     "w": 24,
                     "x": 0,
                     "y": 54
                 },
-                "panelIndex": "846e11e1-efc8-4311-88a7-cadb7aca1ad4",
-                "title": "TLS Certificate Validity Details[Gigamon AMI]",
+                "panelIndex": "f9544843-bd1e-4bf5-ab73-446de2b324b9",
+                "title": "Expired TLS Certificate Details[Gigamon AMI]",
                 "type": "lens"
             },
             {
@@ -1354,6 +1386,206 @@
                 },
                 "panelIndex": "a7f83583-f83e-41fb-bce5-fd13fc774a8f",
                 "title": "Application Overview[Gigamon AMI]",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "description": "",
+                    "enhancements": {},
+                    "hidePanelTitles": true,
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
+                        "description": "",
+                        "id": "",
+                        "params": {
+                            "fontSize": 12,
+                            "markdown": "**Insecure Protocol/Service/Port**\n\nServices, protocols, or ports that transmit data or authentication credentials (for example, password/passphrase) in clear-text over the Internet",
+                            "openLinksInNewTab": false
+                        },
+                        "title": "",
+                        "type": "markdown",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 6,
+                    "i": "4f971a25-e30d-4550-b820-55678e388ee0",
+                    "w": 24,
+                    "x": 24,
+                    "y": 75
+                },
+                "panelIndex": "4f971a25-e30d-4550-b820-55678e388ee0",
+                "title": "",
+                "type": "visualization"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-707db7dc-7bda-4553-b9a6-cbeba1925faf",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "707db7dc-7bda-4553-b9a6-cbeba1925faf": {
+                                            "columnOrder": [
+                                                "26f37cb3-6272-468b-b0bf-311911f4bad0",
+                                                "cdcb22ee-4be6-4a4c-a7e1-ef3f5be3892a"
+                                            ],
+                                            "columns": {
+                                                "26f37cb3-6272-468b-b0bf-311911f4bad0": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 5 values of gigamon.ami.app_name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [
+                                                            "ftp",
+                                                            "telnet",
+                                                            "pop3",
+                                                            "imap",
+                                                            "smb",
+                                                            "snmp"
+                                                        ],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "cdcb22ee-4be6-4a4c-a7e1-ef3f5be3892a",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 5
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "gigamon.ami.app_name"
+                                                },
+                                                "cdcb22ee-4be6-4a4c-a7e1-ef3f5be3892a": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of records",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset : \"gigamon.ami\" "
+                            },
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "allowMultipleMetrics": false,
+                                        "categoryDisplay": "default",
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "sort": "desc",
+                                                "steps": [
+                                                    {
+                                                        "colorIndex": 0,
+                                                        "paletteId": "eui_amsterdam_color_blind",
+                                                        "touched": false,
+                                                        "type": "categorical"
+                                                    },
+                                                    {
+                                                        "colorIndex": 1,
+                                                        "paletteId": "eui_amsterdam_color_blind",
+                                                        "touched": true,
+                                                        "type": "categorical"
+                                                    },
+                                                    {
+                                                        "colorIndex": 9,
+                                                        "paletteId": "eui_amsterdam_color_blind",
+                                                        "touched": false,
+                                                        "type": "categorical"
+                                                    }
+                                                ],
+                                                "type": "gradient"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "707db7dc-7bda-4553-b9a6-cbeba1925faf",
+                                        "layerType": "data",
+                                        "legendDisplay": "default",
+                                        "metrics": [
+                                            "cdcb22ee-4be6-4a4c-a7e1-ef3f5be3892a"
+                                        ],
+                                        "nestedLegend": false,
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "26f37cb3-6272-468b-b0bf-311911f4bad0"
+                                        ],
+                                        "secondaryGroups": []
+                                    }
+                                ],
+                                "shape": "treemap"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsPie"
+                    },
+                    "enhancements": {}
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "e7ce60d7-9327-4d64-9ca1-6c814506375b",
+                    "w": 24,
+                    "x": 24,
+                    "y": 81
+                },
+                "panelIndex": "e7ce60d7-9327-4d64-9ca1-6c814506375b",
+                "title": "Insecure protocols[Gigamon AMI]",
                 "type": "lens"
             },
             {
@@ -1566,50 +1798,11 @@
             },
             {
                 "embeddableConfig": {
-                    "description": "",
-                    "enhancements": {},
-                    "hidePanelTitles": true,
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "id": "",
-                        "params": {
-                            "fontSize": 12,
-                            "markdown": "**Insecure Protocol/Service/Port**\n\nServices, protocols, or ports that transmit data or authentication credentials (for example, password/passphrase) in clear-text over the Internet",
-                            "openLinksInNewTab": false
-                        },
-                        "title": "",
-                        "type": "markdown",
-                        "uiState": {}
-                    }
-                },
-                "gridData": {
-                    "h": 6,
-                    "i": "4f971a25-e30d-4550-b820-55678e388ee0",
-                    "w": 24,
-                    "x": 24,
-                    "y": 75
-                },
-                "panelIndex": "4f971a25-e30d-4550-b820-55678e388ee0",
-                "title": "",
-                "type": "visualization"
-            },
-            {
-                "embeddableConfig": {
                     "attributes": {
                         "references": [
                             {
                                 "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-707db7dc-7bda-4553-b9a6-cbeba1925faf",
+                                "name": "indexpattern-datasource-layer-eea40633-1ee7-46a8-88f2-fc96ea82626e",
                                 "type": "index-pattern"
                             }
                         ],
@@ -1618,45 +1811,13 @@
                             "datasourceStates": {
                                 "formBased": {
                                     "layers": {
-                                        "707db7dc-7bda-4553-b9a6-cbeba1925faf": {
+                                        "eea40633-1ee7-46a8-88f2-fc96ea82626e": {
                                             "columnOrder": [
-                                                "26f37cb3-6272-468b-b0bf-311911f4bad0",
-                                                "cdcb22ee-4be6-4a4c-a7e1-ef3f5be3892a"
+                                                "5a7cf6af-299d-4f0a-a134-17bad74b1953",
+                                                "00304a89-1833-463e-be89-6878d80fdec6"
                                             ],
                                             "columns": {
-                                                "26f37cb3-6272-468b-b0bf-311911f4bad0": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 5 values of gigamon.ami.app_name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [
-                                                            "ftp",
-                                                            "telnet",
-                                                            "pop3",
-                                                            "imap",
-                                                            "smb",
-                                                            "snmp"
-                                                        ],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "cdcb22ee-4be6-4a4c-a7e1-ef3f5be3892a",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 5
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "gigamon.ami.app_name"
-                                                },
-                                                "cdcb22ee-4be6-4a4c-a7e1-ef3f5be3892a": {
+                                                "00304a89-1833-463e-be89-6878d80fdec6": {
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Count of records",
@@ -1666,6 +1827,31 @@
                                                     },
                                                     "scale": "ratio",
                                                     "sourceField": "___records___"
+                                                },
+                                                "5a7cf6af-299d-4f0a-a134-17bad74b1953": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 5 values of gigamon.ami.http_version",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "00304a89-1833-463e-be89-6878d80fdec6",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 5
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "gigamon.ami.http_version"
                                                 }
                                             },
                                             "incompleteColumns": {},
@@ -1689,7 +1875,6 @@
                             "visualization": {
                                 "layers": [
                                     {
-                                        "allowMultipleMetrics": false,
                                         "categoryDisplay": "default",
                                         "colorMapping": {
                                             "assignments": [],
@@ -1697,22 +1882,14 @@
                                                 "sort": "desc",
                                                 "steps": [
                                                     {
-                                                        "colorIndex": 0,
-                                                        "paletteId": "eui_amsterdam_color_blind",
+                                                        "colorCode": "#eb1989",
                                                         "touched": false,
-                                                        "type": "categorical"
+                                                        "type": "colorCode"
                                                     },
                                                     {
-                                                        "colorIndex": 1,
-                                                        "paletteId": "eui_amsterdam_color_blind",
+                                                        "colorCode": "#1f88e9",
                                                         "touched": true,
-                                                        "type": "categorical"
-                                                    },
-                                                    {
-                                                        "colorIndex": 9,
-                                                        "paletteId": "eui_amsterdam_color_blind",
-                                                        "touched": false,
-                                                        "type": "categorical"
+                                                        "type": "colorCode"
                                                     }
                                                 ],
                                                 "type": "gradient"
@@ -1730,21 +1907,20 @@
                                                 }
                                             ]
                                         },
-                                        "layerId": "707db7dc-7bda-4553-b9a6-cbeba1925faf",
+                                        "layerId": "eea40633-1ee7-46a8-88f2-fc96ea82626e",
                                         "layerType": "data",
                                         "legendDisplay": "default",
                                         "metrics": [
-                                            "cdcb22ee-4be6-4a4c-a7e1-ef3f5be3892a"
+                                            "00304a89-1833-463e-be89-6878d80fdec6"
                                         ],
                                         "nestedLegend": false,
                                         "numberDisplay": "percent",
                                         "primaryGroups": [
-                                            "26f37cb3-6272-468b-b0bf-311911f4bad0"
-                                        ],
-                                        "secondaryGroups": []
+                                            "5a7cf6af-299d-4f0a-a134-17bad74b1953"
+                                        ]
                                     }
                                 ],
-                                "shape": "treemap"
+                                "shape": "donut"
                             }
                         },
                         "title": "",
@@ -1754,14 +1930,14 @@
                     "enhancements": {}
                 },
                 "gridData": {
-                    "h": 15,
-                    "i": "e7ce60d7-9327-4d64-9ca1-6c814506375b",
+                    "h": 18,
+                    "i": "720a352e-155e-4a3e-87bf-86ddfb52061d",
                     "w": 24,
                     "x": 24,
-                    "y": 81
+                    "y": 96
                 },
-                "panelIndex": "e7ce60d7-9327-4d64-9ca1-6c814506375b",
-                "title": "Insecure protocols[Gigamon AMI]",
+                "panelIndex": "720a352e-155e-4a3e-87bf-86ddfb52061d",
+                "title": "HTTP Version[Gigamon AMI]",
                 "type": "lens"
             },
             {
@@ -1947,150 +2123,6 @@
                 },
                 "panelIndex": "2f77e26f-85cf-47aa-a467-4886a34a6845",
                 "title": "SSH Sessions[Gigamon AMI]",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-eea40633-1ee7-46a8-88f2-fc96ea82626e",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "eea40633-1ee7-46a8-88f2-fc96ea82626e": {
-                                            "columnOrder": [
-                                                "5a7cf6af-299d-4f0a-a134-17bad74b1953",
-                                                "00304a89-1833-463e-be89-6878d80fdec6"
-                                            ],
-                                            "columns": {
-                                                "00304a89-1833-463e-be89-6878d80fdec6": {
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Count of records",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                },
-                                                "5a7cf6af-299d-4f0a-a134-17bad74b1953": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 5 values of gigamon.ami.http_version",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "00304a89-1833-463e-be89-6878d80fdec6",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 5
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "gigamon.ami.http_version"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "indexpattern": {
-                                    "layers": {}
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset : \"gigamon.ami\" "
-                            },
-                            "visualization": {
-                                "layers": [
-                                    {
-                                        "categoryDisplay": "default",
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "sort": "desc",
-                                                "steps": [
-                                                    {
-                                                        "colorCode": "#eb1989",
-                                                        "touched": false,
-                                                        "type": "colorCode"
-                                                    },
-                                                    {
-                                                        "colorCode": "#1f88e9",
-                                                        "touched": true,
-                                                        "type": "colorCode"
-                                                    }
-                                                ],
-                                                "type": "gradient"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rule": {
-                                                        "type": "other"
-                                                    },
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "eea40633-1ee7-46a8-88f2-fc96ea82626e",
-                                        "layerType": "data",
-                                        "legendDisplay": "default",
-                                        "metrics": [
-                                            "00304a89-1833-463e-be89-6878d80fdec6"
-                                        ],
-                                        "nestedLegend": false,
-                                        "numberDisplay": "percent",
-                                        "primaryGroups": [
-                                            "5a7cf6af-299d-4f0a-a134-17bad74b1953"
-                                        ]
-                                    }
-                                ],
-                                "shape": "donut"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsPie"
-                    },
-                    "enhancements": {}
-                },
-                "gridData": {
-                    "h": 18,
-                    "i": "720a352e-155e-4a3e-87bf-86ddfb52061d",
-                    "w": 24,
-                    "x": 24,
-                    "y": 96
-                },
-                "panelIndex": "720a352e-155e-4a3e-87bf-86ddfb52061d",
-                "title": "HTTP Version[Gigamon AMI]",
                 "type": "lens"
             },
             {
@@ -2310,7 +2342,6 @@
                                         "6df89022-0b31-47d3-b7b4-b39627957e1c": {
                                             "columnOrder": [
                                                 "aac2dc70-0b94-48fc-b76d-d59cd1a20125",
-                                                "c563d768-91e0-498b-9c13-5533ef6b6ef2",
                                                 "12675a8a-b1db-4f71-a1a0-1a806a18ef9e"
                                             ],
                                             "columns": {
@@ -2329,7 +2360,7 @@
                                                     "customLabel": true,
                                                     "dataType": "ip",
                                                     "isBucketed": true,
-                                                    "label": "Source",
+                                                    "label": "Conversations",
                                                     "operationType": "terms",
                                                     "params": {
                                                         "exclude": [],
@@ -2344,41 +2375,17 @@
                                                         "orderDirection": "desc",
                                                         "otherBucket": false,
                                                         "parentFormat": {
-                                                            "id": "terms"
+                                                            "id": "multi_terms"
                                                         },
+                                                        "secondaryFields": [
+                                                            "gigamon.ami.dst_ip"
+                                                        ],
                                                         "size": 15
                                                     },
                                                     "scale": "ordinal",
                                                     "sourceField": "gigamon.ami.src_ip"
-                                                },
-                                                "c563d768-91e0-498b-9c13-5533ef6b6ef2": {
-                                                    "customLabel": true,
-                                                    "dataType": "ip",
-                                                    "isBucketed": true,
-                                                    "label": "Destination ",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "12675a8a-b1db-4f71-a1a0-1a806a18ef9e",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 15
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "gigamon.ami.dst_ip"
                                                 }
                                             },
-                                            "incompleteColumns": {},
                                             "sampling": 1
                                         }
                                     }
@@ -2399,14 +2406,13 @@
                             "visualization": {
                                 "columns": [
                                     {
+                                        "alignment": "left",
                                         "columnId": "aac2dc70-0b94-48fc-b76d-d59cd1a20125",
                                         "isTransposed": false
                                     },
                                     {
-                                        "columnId": "c563d768-91e0-498b-9c13-5533ef6b6ef2",
-                                        "isTransposed": false
-                                    },
-                                    {
+                                        "alignment": "left",
+                                        "colorMode": "none",
                                         "columnId": "12675a8a-b1db-4f71-a1a0-1a806a18ef9e",
                                         "isTransposed": false
                                     }
@@ -2587,7 +2593,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2025-01-24T05:41:14.594Z",
+    "created_at": "2025-01-30T09:43:04.134Z",
     "id": "gigamon-032aab7b-87b2-444c-8c86-956d092598fb",
     "managed": false,
     "references": [
@@ -2623,12 +2629,17 @@
         },
         {
             "id": "logs-*",
-            "name": "039714a2-0b5f-4ce1-aea0-35887146d978:c001313b-a4ee-4ec8-91bb-e412b3bbe5d2",
+            "name": "039714a2-0b5f-4ce1-aea0-35887146d978:3d025114-ff87-40b8-9fc3-c5800b2c5390",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "846e11e1-efc8-4311-88a7-cadb7aca1ad4:indexpattern-datasource-layer-f8c599bc-4580-4a39-a5fa-1cc2a68260d7",
+            "name": "f9544843-bd1e-4bf5-ab73-446de2b324b9:indexpattern-datasource-layer-f2bfa25e-3307-4990-9396-2a83c047bd87",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "f9544843-bd1e-4bf5-ab73-446de2b324b9:64f4dbad-db20-450a-8897-b36af66997c0",
             "type": "index-pattern"
         },
         {
@@ -2638,12 +2649,17 @@
         },
         {
             "id": "logs-*",
+            "name": "e7ce60d7-9327-4d64-9ca1-6c814506375b:indexpattern-datasource-layer-707db7dc-7bda-4553-b9a6-cbeba1925faf",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
             "name": "ca21225a-3af7-4bc9-8602-433089592d5f:indexpattern-datasource-layer-fd16c376-c72d-484f-b22d-b1e48d9806c1",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "e7ce60d7-9327-4d64-9ca1-6c814506375b:indexpattern-datasource-layer-707db7dc-7bda-4553-b9a6-cbeba1925faf",
+            "name": "720a352e-155e-4a3e-87bf-86ddfb52061d:indexpattern-datasource-layer-eea40633-1ee7-46a8-88f2-fc96ea82626e",
             "type": "index-pattern"
         },
         {
@@ -2664,11 +2680,6 @@
         {
             "id": "logs-*",
             "name": "2f77e26f-85cf-47aa-a467-4886a34a6845:14efcd52-a120-4efe-8502-da61db173619",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
-            "name": "720a352e-155e-4a3e-87bf-86ddfb52061d:indexpattern-datasource-layer-eea40633-1ee7-46a8-88f2-fc96ea82626e",
             "type": "index-pattern"
         },
         {

--- a/packages/gigamon/kibana/dashboard/gigamon-855a64dc-1a72-403f-932b-a5b848378f7e.json
+++ b/packages/gigamon/kibana/dashboard/gigamon-855a64dc-1a72-403f-932b-a5b848378f7e.json
@@ -213,7 +213,7 @@
                             },
                             {
                                 "id": "logs-*",
-                                "name": "c8822484-f6d7-438a-8d37-aea5210af207",
+                                "name": "52052cb9-b643-46ae-91bf-0887dac30a18",
                                 "type": "index-pattern"
                             }
                         ],
@@ -381,21 +381,21 @@
                                         "alias": null,
                                         "disabled": false,
                                         "field": "gigamon.ami.ssl_validity_not_after",
-                                        "index": "c8822484-f6d7-438a-8d37-aea5210af207",
+                                        "index": "52052cb9-b643-46ae-91bf-0887dac30a18",
                                         "key": "gigamon.ami.ssl_validity_not_after",
                                         "negate": false,
                                         "params": {
-                                            "lt": "2024-01-01T00:00:00.000+05:30"
+                                            "lt": "now"
                                         },
                                         "type": "range",
                                         "value": {
-                                            "lt": "2024-01-01T00:00:00.000+05:30"
+                                            "lt": "now"
                                         }
                                     },
                                     "query": {
                                         "range": {
                                             "gigamon.ami.ssl_validity_not_after": {
-                                                "lt": "2024-01-01T00:00:00.000+05:30"
+                                                "lt": "now"
                                             }
                                         }
                                     }
@@ -511,7 +511,7 @@
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
-                                    "currentIndexPatternId": "e3f451b1-4c23-4305-bcbf-0bc812d1ba07",
+                                    "currentIndexPatternId": "logs-*",
                                     "layers": {
                                         "5276360b-3935-40fb-81fc-d50d8f9ea03f": {
                                             "columnOrder": [
@@ -546,7 +546,7 @@
                                                             "type": "column"
                                                         },
                                                         "orderDirection": "desc",
-                                                        "otherBucket": true,
+                                                        "otherBucket": false,
                                                         "parentFormat": {
                                                             "id": "terms"
                                                         },
@@ -557,7 +557,7 @@
                                                 }
                                             },
                                             "incompleteColumns": {},
-                                            "indexPatternId": "e3f451b1-4c23-4305-bcbf-0bc812d1ba07",
+                                            "indexPatternId": "logs-*",
                                             "sampling": 1
                                         }
                                     }
@@ -1208,7 +1208,7 @@
                                                 }
                                             },
                                             "incompleteColumns": {},
-                                            "indexPatternId": "e3f451b1-4c23-4305-bcbf-0bc812d1ba07",
+                                            "indexPatternId": "logs-*",
                                             "sampling": 1
                                         }
                                     }
@@ -1300,7 +1300,7 @@
                     "enhancements": {}
                 },
                 "gridData": {
-                    "h": 15,
+                    "h": 21,
                     "i": "2ba5611d-c9c5-4ace-bc10-7ca77c30173b",
                     "w": 24,
                     "x": 24,
@@ -1423,7 +1423,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2025-01-24T05:32:40.733Z",
+    "created_at": "2025-02-06T10:37:13.951Z",
     "id": "gigamon-855a64dc-1a72-403f-932b-a5b848378f7e",
     "managed": false,
     "references": [
@@ -1439,7 +1439,7 @@
         },
         {
             "id": "logs-*",
-            "name": "f8298c20-12fa-44e3-a9ab-139a3d78d841:c8822484-f6d7-438a-8d37-aea5210af207",
+            "name": "f8298c20-12fa-44e3-a9ab-139a3d78d841:52052cb9-b643-46ae-91bf-0887dac30a18",
             "type": "index-pattern"
         },
         {

--- a/packages/gigamon/kibana/dashboard/gigamon-8d02ca6f-9333-4cab-8b8a-a141e9fccdcf.json
+++ b/packages/gigamon/kibana/dashboard/gigamon-8d02ca6f-9333-4cab-8b8a-a141e9fccdcf.json
@@ -341,7 +341,7 @@
                     "y": 7
                 },
                 "panelIndex": "30518088-e48c-4a42-9763-8aa4a65ed2fb",
-                "title": "Total Bytes per ASN[Gigamon AMI]",
+                "title": "Total Bytes over time[Gigamon AMI]",
                 "type": "lens"
             },
             {
@@ -2561,198 +2561,6 @@
                         "references": [
                             {
                                 "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-6a5321dc-8ffb-4a78-a957-202290f407fb",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "6a5321dc-8ffb-4a78-a957-202290f407fb": {
-                                            "columnOrder": [
-                                                "c7e3d87e-5939-4f8e-b3dd-21fff6065fcd",
-                                                "b12eaec6-adff-4a45-9f87-8de6c56bb398",
-                                                "1c852f2d-8205-414c-bbdd-58efc4ade859"
-                                            ],
-                                            "columns": {
-                                                "1c852f2d-8205-414c-bbdd-58efc4ade859": {
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Count of records",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                },
-                                                "b12eaec6-adff-4a45-9f87-8de6c56bb398": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 15 values of gigamon.ami.tcp_flag_reset",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "1c852f2d-8205-414c-bbdd-58efc4ade859",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 15
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "gigamon.ami.tcp_flag_reset"
-                                                },
-                                                "c7e3d87e-5939-4f8e-b3dd-21fff6065fcd": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                }
-                                            },
-                                            "ignoreGlobalFilters": false,
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "indexpattern": {
-                                    "layers": {}
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset : \"gigamon.ami\" "
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "1c852f2d-8205-414c-bbdd-58efc4ade859"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "sort": "desc",
-                                                "steps": [
-                                                    {
-                                                        "colorIndex": 4,
-                                                        "paletteId": "kibana_v7_legacy",
-                                                        "touched": false,
-                                                        "type": "categorical"
-                                                    },
-                                                    {
-                                                        "colorIndex": 5,
-                                                        "paletteId": "kibana_v7_legacy",
-                                                        "touched": true,
-                                                        "type": "categorical"
-                                                    },
-                                                    {
-                                                        "colorIndex": 6,
-                                                        "paletteId": "kibana_v7_legacy",
-                                                        "touched": false,
-                                                        "type": "categorical"
-                                                    }
-                                                ],
-                                                "type": "gradient"
-                                            },
-                                            "paletteId": "kibana_v7_legacy",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rule": {
-                                                        "type": "other"
-                                                    },
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "6a5321dc-8ffb-4a78-a957-202290f407fb",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "splitAccessor": "b12eaec6-adff-4a45-9f87-8de6c56bb398",
-                                        "xAccessor": "c7e3d87e-5939-4f8e-b3dd-21fff6065fcd"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false,
-                                    "position": "right",
-                                    "showSingleSeries": false
-                                },
-                                "preferredSeriesType": "line",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {}
-                },
-                "gridData": {
-                    "h": 15,
-                    "i": "b92bc92f-8c07-442b-9c9f-0b0fee8aea41",
-                    "w": 15,
-                    "x": 0,
-                    "y": 122
-                },
-                "panelIndex": "b92bc92f-8c07-442b-9c9f-0b0fee8aea41",
-                "title": "Connections Reset[Gigamon AMI]",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-a41958df-5565-453d-86a9-7cfca50a938d",
                                 "type": "index-pattern"
                             }
@@ -2909,8 +2717,8 @@
                 "gridData": {
                     "h": 15,
                     "i": "66f31331-457a-4df4-98c7-d3f377345a13",
-                    "w": 15,
-                    "x": 15,
+                    "w": 24,
+                    "x": 0,
                     "y": 122
                 },
                 "panelIndex": "66f31331-457a-4df4-98c7-d3f377345a13",
@@ -3165,8 +2973,8 @@
                 "gridData": {
                     "h": 15,
                     "i": "6f9438ee-b893-4c69-9735-f07567811c89",
-                    "w": 18,
-                    "x": 30,
+                    "w": 24,
+                    "x": 24,
                     "y": 122
                 },
                 "panelIndex": "6f9438ee-b893-4c69-9735-f07567811c89",
@@ -3486,10 +3294,16 @@
             {
                 "embeddableConfig": {
                     "attributes": {
+                        "description": "Expired TLS Certificate Details",
                         "references": [
                             {
                                 "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-5546cb49-e873-4d72-bead-eacba7db5107",
+                                "name": "indexpattern-datasource-layer-f2bfa25e-3307-4990-9396-2a83c047bd87",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "6b3663f5-3f2a-4de9-82e2-5f1801e78313",
                                 "type": "index-pattern"
                             }
                         ],
@@ -3498,18 +3312,21 @@
                             "datasourceStates": {
                                 "formBased": {
                                     "layers": {
-                                        "5546cb49-e873-4d72-bead-eacba7db5107": {
+                                        "f2bfa25e-3307-4990-9396-2a83c047bd87": {
                                             "columnOrder": [
-                                                "a418b3b7-eb5e-4048-9963-64015b3cd261",
-                                                "faafcf38-e3fd-40ca-90b4-6051ff209a9d",
-                                                "af2f4e67-7434-4f64-944d-48d0de34c9f9"
+                                                "00b64c0f-6ad7-49b0-97ad-620e892b52a0",
+                                                "fb36c053-2418-4fd4-b0c5-4d4f7149401f",
+                                                "9918b794-dee6-4d48-8cfa-985156eb6c71",
+                                                "35dbd18d-724e-4a71-a3d2-e3b95b391397",
+                                                "b4ff9561-a4c4-472b-94dd-bb19be1790df",
+                                                "088613fe-caa6-4a7a-a71d-041f58eeaca7"
                                             ],
                                             "columns": {
-                                                "a418b3b7-eb5e-4048-9963-64015b3cd261": {
+                                                "00b64c0f-6ad7-49b0-97ad-620e892b52a0": {
                                                     "customLabel": true,
-                                                    "dataType": "string",
+                                                    "dataType": "ip",
                                                     "isBucketed": true,
-                                                    "label": "Common Name",
+                                                    "label": "Server ip",
                                                     "operationType": "terms",
                                                     "params": {
                                                         "exclude": [],
@@ -3518,7 +3335,7 @@
                                                         "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
-                                                            "columnId": "af2f4e67-7434-4f64-944d-48d0de34c9f9",
+                                                            "columnId": "b4ff9561-a4c4-472b-94dd-bb19be1790df",
                                                             "type": "column"
                                                         },
                                                         "orderDirection": "desc",
@@ -3526,12 +3343,76 @@
                                                         "parentFormat": {
                                                             "id": "terms"
                                                         },
-                                                        "size": 15
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "gigamon.ami.src_ip"
+                                                },
+                                                "088613fe-caa6-4a7a-a71d-041f58eeaca7": {
+                                                    "customLabel": true,
+                                                    "dataType": "date",
+                                                    "isBucketed": false,
+                                                    "label": "Expiration Details",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "gigamon.ami.ssl_validity_not_after"
+                                                },
+                                                "35dbd18d-724e-4a71-a3d2-e3b95b391397": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Issuer",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "b4ff9561-a4c4-472b-94dd-bb19be1790df",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "gigamon.ami.ssl_issuer"
+                                                },
+                                                "9918b794-dee6-4d48-8cfa-985156eb6c71": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Common_name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "b4ff9561-a4c4-472b-94dd-bb19be1790df",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
                                                     },
                                                     "scale": "ordinal",
                                                     "sourceField": "gigamon.ami.ssl_common_name"
                                                 },
-                                                "af2f4e67-7434-4f64-944d-48d0de34c9f9": {
+                                                "b4ff9561-a4c4-472b-94dd-bb19be1790df": {
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Count of records",
@@ -3542,19 +3423,31 @@
                                                     "scale": "ratio",
                                                     "sourceField": "___records___"
                                                 },
-                                                "faafcf38-e3fd-40ca-90b4-6051ff209a9d": {
+                                                "fb36c053-2418-4fd4-b0c5-4d4f7149401f": {
                                                     "customLabel": true,
-                                                    "dataType": "date",
+                                                    "dataType": "string",
                                                     "isBucketed": true,
-                                                    "label": "Expiration Date",
-                                                    "operationType": "date_histogram",
+                                                    "label": "Application",
+                                                    "operationType": "terms",
                                                     "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": false,
-                                                        "interval": "d"
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "b4ff9561-a4c4-472b-94dd-bb19be1790df",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
                                                     },
-                                                    "scale": "interval",
-                                                    "sourceField": "gigamon.ami.ssl_validity_not_after"
+                                                    "scale": "ordinal",
+                                                    "sourceField": "gigamon.ami.app_name"
                                                 }
                                             },
                                             "incompleteColumns": {},
@@ -3569,28 +3462,71 @@
                                     "layers": {}
                                 }
                             },
-                            "filters": [],
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "gigamon.ami.ssl_validity_not_after",
+                                        "index": "6b3663f5-3f2a-4de9-82e2-5f1801e78313",
+                                        "key": "gigamon.ami.ssl_validity_not_after",
+                                        "negate": false,
+                                        "params": {
+                                            "lt": "now"
+                                        },
+                                        "type": "range",
+                                        "value": {
+                                            "lt": "now"
+                                        }
+                                    },
+                                    "query": {
+                                        "range": {
+                                            "gigamon.ami.ssl_validity_not_after": {
+                                                "lt": "now"
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "data_stream.dataset : \"gigamon.ami\" "
+                                "query": "data_stream.dataset : \"gigamon.ami\" and gigamon.ami.ssl_validity_not_after : * "
                             },
                             "visualization": {
                                 "columns": [
                                     {
-                                        "columnId": "a418b3b7-eb5e-4048-9963-64015b3cd261",
+                                        "columnId": "9918b794-dee6-4d48-8cfa-985156eb6c71",
+                                        "isMetric": false,
                                         "isTransposed": false
                                     },
                                     {
-                                        "columnId": "faafcf38-e3fd-40ca-90b4-6051ff209a9d",
+                                        "columnId": "35dbd18d-724e-4a71-a3d2-e3b95b391397",
                                         "isTransposed": false
                                     },
                                     {
-                                        "columnId": "af2f4e67-7434-4f64-944d-48d0de34c9f9",
+                                        "columnId": "00b64c0f-6ad7-49b0-97ad-620e892b52a0",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "fb36c053-2418-4fd4-b0c5-4d4f7149401f",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "b4ff9561-a4c4-472b-94dd-bb19be1790df",
+                                        "hidden": true,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "088613fe-caa6-4a7a-a71d-041f58eeaca7",
+                                        "isMetric": true,
                                         "isTransposed": false
                                     }
                                 ],
-                                "layerId": "5546cb49-e873-4d72-bead-eacba7db5107",
+                                "layerId": "f2bfa25e-3307-4990-9396-2a83c047bd87",
                                 "layerType": "data"
                             }
                         },
@@ -3598,17 +3534,18 @@
                         "type": "lens",
                         "visualizationType": "lnsDatatable"
                     },
+                    "description": "Expired TLS Certificate Details",
                     "enhancements": {}
                 },
                 "gridData": {
                     "h": 16,
-                    "i": "09421985-d9a6-419f-9173-0b8c40518945",
+                    "i": "4285d628-b8fe-4452-8b23-3a0ec86670fe",
                     "w": 24,
                     "x": 0,
                     "y": 155
                 },
-                "panelIndex": "09421985-d9a6-419f-9173-0b8c40518945",
-                "title": "Internal SSL Certificates expiration date[Gigamon AMI]",
+                "panelIndex": "4285d628-b8fe-4452-8b23-3a0ec86670fe",
+                "title": "Expired TLS Certificate Details[Gigamon AMI]",
                 "type": "lens"
             },
             {
@@ -5707,7 +5644,7 @@
                         "references": [
                             {
                                 "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-06411437-af39-4bff-af94-085b3a8f2e63",
+                                "name": "indexpattern-datasource-layer-935d8866-db33-4903-a0b6-ba35ca5942b9",
                                 "type": "index-pattern"
                             }
                         ],
@@ -5716,22 +5653,21 @@
                             "datasourceStates": {
                                 "formBased": {
                                     "layers": {
-                                        "06411437-af39-4bff-af94-085b3a8f2e63": {
+                                        "935d8866-db33-4903-a0b6-ba35ca5942b9": {
                                             "columnOrder": [
-                                                "94d13395-dbe4-439d-9ee6-980d436f1cde",
-                                                "4ea071c2-3c14-4fef-9c1e-0cbdac293423",
-                                                "b6086c9e-c8ec-47e3-9f92-0f9f0d4f7732",
-                                                "a3abc892-1149-4579-abce-cdf8fc15b238",
-                                                "40db351e-b683-44b3-bd03-6ecad62d6368",
-                                                "d5c133ac-8cdf-4fb1-8f2d-22086cfd85a1",
-                                                "9b15aa8f-f45b-4357-895f-2a8d3084ff83"
+                                                "d3a5f1a8-b75d-4319-bb9d-8eb3d18cd33a",
+                                                "18f5937e-eb99-4fd1-b5da-d6c87733cecc",
+                                                "5d9bb00a-e7e8-4862-b2a6-5b247f476a08",
+                                                "61c26a0c-f365-4a39-b3b7-202a799c8b48",
+                                                "a5b092b5-e9d1-48fb-9975-2f71cc9d0a85",
+                                                "c65b1593-e1eb-4472-8e7a-ffc8d6ec1863"
                                             ],
                                             "columns": {
-                                                "40db351e-b683-44b3-bd03-6ecad62d6368": {
+                                                "18f5937e-eb99-4fd1-b5da-d6c87733cecc": {
                                                     "customLabel": true,
                                                     "dataType": "string",
                                                     "isBucketed": true,
-                                                    "label": "SMB Service",
+                                                    "label": "SMB Filename",
                                                     "operationType": "terms",
                                                     "params": {
                                                         "exclude": [],
@@ -5740,7 +5676,7 @@
                                                         "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
-                                                            "columnId": "9b15aa8f-f45b-4357-895f-2a8d3084ff83",
+                                                            "columnId": "c65b1593-e1eb-4472-8e7a-ffc8d6ec1863",
                                                             "type": "column"
                                                         },
                                                         "orderDirection": "desc",
@@ -5748,16 +5684,42 @@
                                                         "parentFormat": {
                                                             "id": "terms"
                                                         },
-                                                        "size": 15
+                                                        "size": 5
                                                     },
                                                     "scale": "ordinal",
-                                                    "sourceField": "gigamon.ami.smb_service"
+                                                    "sourceField": "gigamon.ami.smb_filename"
                                                 },
-                                                "4ea071c2-3c14-4fef-9c1e-0cbdac293423": {
+                                                "5d9bb00a-e7e8-4862-b2a6-5b247f476a08": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "SMB Host",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "c65b1593-e1eb-4472-8e7a-ffc8d6ec1863",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 5
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "gigamon.ami.smb_host"
+                                                },
+                                                "61c26a0c-f365-4a39-b3b7-202a799c8b48": {
                                                     "customLabel": true,
                                                     "dataType": "ip",
                                                     "isBucketed": true,
-                                                    "label": "Destination ip",
+                                                    "label": "Source Address",
                                                     "operationType": "terms",
                                                     "params": {
                                                         "exclude": [],
@@ -5766,7 +5728,7 @@
                                                         "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
-                                                            "columnId": "9b15aa8f-f45b-4357-895f-2a8d3084ff83",
+                                                            "columnId": "c65b1593-e1eb-4472-8e7a-ffc8d6ec1863",
                                                             "type": "column"
                                                         },
                                                         "orderDirection": "desc",
@@ -5774,41 +5736,42 @@
                                                         "parentFormat": {
                                                             "id": "terms"
                                                         },
-                                                        "size": 15
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "gigamon.ami.dst_ip"
-                                                },
-                                                "94d13395-dbe4-439d-9ee6-980d436f1cde": {
-                                                    "customLabel": true,
-                                                    "dataType": "ip",
-                                                    "isBucketed": true,
-                                                    "label": "Source ip",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "9b15aa8f-f45b-4357-895f-2a8d3084ff83",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 15
+                                                        "size": 5
                                                     },
                                                     "scale": "ordinal",
                                                     "sourceField": "gigamon.ami.src_ip"
                                                 },
-                                                "9b15aa8f-f45b-4357-895f-2a8d3084ff83": {
+                                                "a5b092b5-e9d1-48fb-9975-2f71cc9d0a85": {
+                                                    "customLabel": true,
+                                                    "dataType": "ip",
+                                                    "isBucketed": true,
+                                                    "label": "Destination Address",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "c65b1593-e1eb-4472-8e7a-ffc8d6ec1863",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 5
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "gigamon.ami.dst_ip"
+                                                },
+                                                "c65b1593-e1eb-4472-8e7a-ffc8d6ec1863": {
+                                                    "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "Count of records",
+                                                    "label": "Connections",
                                                     "operationType": "count",
                                                     "params": {
                                                         "emptyAsNull": true
@@ -5816,11 +5779,11 @@
                                                     "scale": "ratio",
                                                     "sourceField": "___records___"
                                                 },
-                                                "a3abc892-1149-4579-abce-cdf8fc15b238": {
+                                                "d3a5f1a8-b75d-4319-bb9d-8eb3d18cd33a": {
                                                     "customLabel": true,
                                                     "dataType": "string",
                                                     "isBucketed": true,
-                                                    "label": "SMB Command",
+                                                    "label": "SMB Path",
                                                     "operationType": "terms",
                                                     "params": {
                                                         "exclude": [],
@@ -5829,7 +5792,7 @@
                                                         "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
-                                                            "columnId": "9b15aa8f-f45b-4357-895f-2a8d3084ff83",
+                                                            "columnId": "c65b1593-e1eb-4472-8e7a-ffc8d6ec1863",
                                                             "type": "column"
                                                         },
                                                         "orderDirection": "desc",
@@ -5837,64 +5800,13 @@
                                                         "parentFormat": {
                                                             "id": "terms"
                                                         },
-                                                        "size": 15
+                                                        "size": 5
                                                     },
                                                     "scale": "ordinal",
-                                                    "sourceField": "gigamon.ami.smb_command_string"
-                                                },
-                                                "b6086c9e-c8ec-47e3-9f92-0f9f0d4f7732": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "SMB user id",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "9b15aa8f-f45b-4357-895f-2a8d3084ff83",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 15
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "gigamon.ami.smb_user_id"
-                                                },
-                                                "d5c133ac-8cdf-4fb1-8f2d-22086cfd85a1": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "SMB Version",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "9b15aa8f-f45b-4357-895f-2a8d3084ff83",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 15
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "gigamon.ami.smb_version_value"
+                                                    "sourceField": "gigamon.ami.smb_path"
                                                 }
                                             },
+                                            "ignoreGlobalFilters": false,
                                             "incompleteColumns": {},
                                             "sampling": 1
                                         }
@@ -5916,37 +5828,37 @@
                             "visualization": {
                                 "columns": [
                                     {
-                                        "columnId": "4ea071c2-3c14-4fef-9c1e-0cbdac293423",
+                                        "columnId": "c65b1593-e1eb-4472-8e7a-ffc8d6ec1863",
+                                        "isMetric": true,
                                         "isTransposed": false
                                     },
                                     {
-                                        "columnId": "94d13395-dbe4-439d-9ee6-980d436f1cde",
+                                        "columnId": "d3a5f1a8-b75d-4319-bb9d-8eb3d18cd33a",
                                         "isMetric": false,
                                         "isTransposed": false
                                     },
                                     {
-                                        "columnId": "a3abc892-1149-4579-abce-cdf8fc15b238",
+                                        "columnId": "18f5937e-eb99-4fd1-b5da-d6c87733cecc",
                                         "isMetric": false,
                                         "isTransposed": false
                                     },
                                     {
-                                        "columnId": "40db351e-b683-44b3-bd03-6ecad62d6368",
+                                        "columnId": "5d9bb00a-e7e8-4862-b2a6-5b247f476a08",
+                                        "isMetric": false,
                                         "isTransposed": false
                                     },
                                     {
-                                        "columnId": "d5c133ac-8cdf-4fb1-8f2d-22086cfd85a1",
+                                        "columnId": "61c26a0c-f365-4a39-b3b7-202a799c8b48",
+                                        "isMetric": false,
                                         "isTransposed": false
                                     },
                                     {
-                                        "columnId": "b6086c9e-c8ec-47e3-9f92-0f9f0d4f7732",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "9b15aa8f-f45b-4357-895f-2a8d3084ff83",
+                                        "columnId": "a5b092b5-e9d1-48fb-9975-2f71cc9d0a85",
+                                        "isMetric": false,
                                         "isTransposed": false
                                     }
                                 ],
-                                "layerId": "06411437-af39-4bff-af94-085b3a8f2e63",
+                                "layerId": "935d8866-db33-4903-a0b6-ba35ca5942b9",
                                 "layerType": "data"
                             }
                         },
@@ -5954,17 +5866,18 @@
                         "type": "lens",
                         "visualizationType": "lnsDatatable"
                     },
+                    "description": "",
                     "enhancements": {}
                 },
                 "gridData": {
-                    "h": 17,
-                    "i": "bd7d85ed-c677-4a68-b184-2456ddf674a0",
+                    "h": 14,
+                    "i": "a8ca7ca6-c3cb-4457-9519-89fa274da7ca",
                     "w": 48,
                     "x": 0,
                     "y": 262
                 },
-                "panelIndex": "bd7d85ed-c677-4a68-b184-2456ddf674a0",
-                "title": "Detailed SMB Conversation[Gigamon AMI]",
+                "panelIndex": "a8ca7ca6-c3cb-4457-9519-89fa274da7ca",
+                "title": "Detailed SMB conversation[Gigamon AMI]",
                 "type": "lens"
             }
         ],
@@ -5973,7 +5886,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2025-01-25T16:39:45.005Z",
+    "created_at": "2025-02-06T10:38:13.633Z",
     "id": "gigamon-8d02ca6f-9333-4cab-8b8a-a141e9fccdcf",
     "managed": false,
     "references": [
@@ -6044,11 +5957,6 @@
         },
         {
             "id": "logs-*",
-            "name": "b92bc92f-8c07-442b-9c9f-0b0fee8aea41:indexpattern-datasource-layer-6a5321dc-8ffb-4a78-a957-202290f407fb",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
             "name": "66f31331-457a-4df4-98c7-d3f377345a13:indexpattern-datasource-layer-a41958df-5565-453d-86a9-7cfca50a938d",
             "type": "index-pattern"
         },
@@ -6069,7 +5977,12 @@
         },
         {
             "id": "logs-*",
-            "name": "09421985-d9a6-419f-9173-0b8c40518945:indexpattern-datasource-layer-5546cb49-e873-4d72-bead-eacba7db5107",
+            "name": "4285d628-b8fe-4452-8b23-3a0ec86670fe:indexpattern-datasource-layer-f2bfa25e-3307-4990-9396-2a83c047bd87",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "4285d628-b8fe-4452-8b23-3a0ec86670fe:6b3663f5-3f2a-4de9-82e2-5f1801e78313",
             "type": "index-pattern"
         },
         {
@@ -6154,7 +6067,7 @@
         },
         {
             "id": "logs-*",
-            "name": "bd7d85ed-c677-4a68-b184-2456ddf674a0:indexpattern-datasource-layer-06411437-af39-4bff-af94-085b3a8f2e63",
+            "name": "a8ca7ca6-c3cb-4457-9519-89fa274da7ca:indexpattern-datasource-layer-935d8866-db33-4903-a0b6-ba35ca5942b9",
             "type": "index-pattern"
         }
     ],

--- a/packages/gigamon/kibana/dashboard/gigamon-e733c64e-6ea9-4dd6-a8ca-3914274598f3.json
+++ b/packages/gigamon/kibana/dashboard/gigamon-e733c64e-6ea9-4dd6-a8ca-3914274598f3.json
@@ -72,12 +72,13 @@
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
+                                    "currentIndexPatternId": "logs-*",
                                     "layers": {
                                         "5ccdb314-f7d5-4e07-9da8-deec1f9e87bf": {
                                             "columnOrder": [
+                                                "e32792b6-ba88-4a3c-b79b-29aca09b1d6c",
                                                 "70a483ba-bcfe-48a0-aa40-4131f1dec8e5",
                                                 "625ddbd7-3cdd-439b-8e5b-db9ee6fac426",
-                                                "e32792b6-ba88-4a3c-b79b-29aca09b1d6c",
                                                 "db087f3b-b8da-4938-b07c-a47d953d2bae",
                                                 "27e19327-2ca3-4498-b0cf-6cea45866c75"
                                             ],
@@ -114,7 +115,7 @@
                                                         "parentFormat": {
                                                             "id": "terms"
                                                         },
-                                                        "size": 25
+                                                        "size": 15
                                                     },
                                                     "scale": "ordinal",
                                                     "sourceField": "gigamon.ami.dst_ip"
@@ -136,11 +137,11 @@
                                                             "type": "column"
                                                         },
                                                         "orderDirection": "desc",
-                                                        "otherBucket": true,
+                                                        "otherBucket": false,
                                                         "parentFormat": {
                                                             "id": "terms"
                                                         },
-                                                        "size": 25
+                                                        "size": 15
                                                     },
                                                     "scale": "ordinal",
                                                     "sourceField": "gigamon.ami.src_ip"
@@ -199,6 +200,7 @@
                                                 }
                                             },
                                             "incompleteColumns": {},
+                                            "indexPatternId": "logs-*",
                                             "sampling": 1
                                         }
                                     }
@@ -220,6 +222,7 @@
                                 "columns": [
                                     {
                                         "columnId": "70a483ba-bcfe-48a0-aa40-4131f1dec8e5",
+                                        "isMetric": false,
                                         "isTransposed": false
                                     },
                                     {
@@ -260,337 +263,6 @@
                 },
                 "panelIndex": "c3ac490a-3407-4c20-81ee-5e7b72cd7644",
                 "title": "Server Latency[Gigamon AMI]",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-40542048-bf27-455d-8ace-4cfeec0547cf",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "40542048-bf27-455d-8ace-4cfeec0547cf": {
-                                            "columnOrder": [
-                                                "5f34c17c-7b3b-4256-93b7-ddf5e41d7df4",
-                                                "f2f6b6f3-0c7c-41bb-9be5-531537209c28",
-                                                "db6e80c9-0060-41d7-a63e-a2ed17ae2e8f",
-                                                "e3f2c762-3b9e-488c-83fa-d9e2bdd9e7d3"
-                                            ],
-                                            "columns": {
-                                                "5f34c17c-7b3b-4256-93b7-ddf5e41d7df4": {
-                                                    "customLabel": true,
-                                                    "dataType": "ip",
-                                                    "isBucketed": true,
-                                                    "label": "Source IP",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "e3f2c762-3b9e-488c-83fa-d9e2bdd9e7d3",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 25
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "gigamon.ami.src_ip"
-                                                },
-                                                "db6e80c9-0060-41d7-a63e-a2ed17ae2e8f": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Tcp Flag Reset",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "e3f2c762-3b9e-488c-83fa-d9e2bdd9e7d3",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 25
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "gigamon.ami.tcp_flag_reset"
-                                                },
-                                                "e3f2c762-3b9e-488c-83fa-d9e2bdd9e7d3": {
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Count of records",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                },
-                                                "f2f6b6f3-0c7c-41bb-9be5-531537209c28": {
-                                                    "customLabel": true,
-                                                    "dataType": "ip",
-                                                    "isBucketed": true,
-                                                    "label": "Destination IP",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "e3f2c762-3b9e-488c-83fa-d9e2bdd9e7d3",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 25
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "gigamon.ami.dst_ip"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "indexpattern": {
-                                    "layers": {}
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset : \"gigamon.ami\" "
-                            },
-                            "visualization": {
-                                "columns": [
-                                    {
-                                        "columnId": "5f34c17c-7b3b-4256-93b7-ddf5e41d7df4",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "f2f6b6f3-0c7c-41bb-9be5-531537209c28",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "db6e80c9-0060-41d7-a63e-a2ed17ae2e8f",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "e3f2c762-3b9e-488c-83fa-d9e2bdd9e7d3",
-                                        "hidden": true,
-                                        "isTransposed": false
-                                    }
-                                ],
-                                "layerId": "40542048-bf27-455d-8ace-4cfeec0547cf",
-                                "layerType": "data"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsDatatable"
-                    },
-                    "description": "Session info that are experiencing an abrupt end to a tcp connection, due to some error.",
-                    "enhancements": {}
-                },
-                "gridData": {
-                    "h": 15,
-                    "i": "b07089af-c0bf-453a-8f75-3da528c947f7",
-                    "w": 24,
-                    "x": 24,
-                    "y": 15
-                },
-                "panelIndex": "b07089af-c0bf-453a-8f75-3da528c947f7",
-                "title": "TCP Resets (aborts)[Gigamon AMI]",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-c3f5a560-d315-4963-9020-22bfb2a43957",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "c3f5a560-d315-4963-9020-22bfb2a43957": {
-                                            "columnOrder": [
-                                                "295e8196-b59f-4980-811a-9e7150e86527",
-                                                "b9e58b9f-9c15-409e-823c-630483c7bd51"
-                                            ],
-                                            "columns": {
-                                                "295e8196-b59f-4980-811a-9e7150e86527": {
-                                                    "dataType": "ip",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10 values of gigamon.ami.dst_ip",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "b9e58b9f-9c15-409e-823c-630483c7bd51",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "gigamon.ami.dst_ip"
-                                                },
-                                                "b9e58b9f-9c15-409e-823c-630483c7bd51": {
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Count of records",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "indexpattern": {
-                                    "layers": {}
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset : \"gigamon.ami\" and gigamon.ami.tcp_rtt_app \u003e 2"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "b9e58b9f-9c15-409e-823c-630483c7bd51"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rule": {
-                                                        "type": "other"
-                                                    },
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "c3f5a560-d315-4963-9020-22bfb2a43957",
-                                        "layerType": "data",
-                                        "seriesType": "bar_horizontal",
-                                        "xAccessor": "295e8196-b59f-4980-811a-9e7150e86527",
-                                        "yConfig": [
-                                            {
-                                                "color": "#ef7e66",
-                                                "forAccessor": "b9e58b9f-9c15-409e-823c-630483c7bd51"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {}
-                },
-                "gridData": {
-                    "h": 15,
-                    "i": "20a5f52f-3dc0-48d5-8f60-1bbdf657b49e",
-                    "w": 24,
-                    "x": 0,
-                    "y": 24
-                },
-                "panelIndex": "20a5f52f-3dc0-48d5-8f60-1bbdf657b49e",
-                "title": "Top 10 worst performing Servers[Gigamon AMI]",
                 "type": "lens"
             },
             {
@@ -760,7 +432,7 @@
                     "i": "730c317d-8817-466a-9219-fdab1bf7b810",
                     "w": 24,
                     "x": 24,
-                    "y": 30
+                    "y": 15
                 },
                 "panelIndex": "730c317d-8817-466a-9219-fdab1bf7b810",
                 "title": "Slow performing Applications [Gigamon AMI]",
@@ -772,7 +444,7 @@
                         "references": [
                             {
                                 "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-c0c6f334-8d4e-4cb8-939d-df6c7a549561",
+                                "name": "indexpattern-datasource-layer-c3f5a560-d315-4963-9020-22bfb2a43957",
                                 "type": "index-pattern"
                             }
                         ],
@@ -781,16 +453,39 @@
                             "datasourceStates": {
                                 "formBased": {
                                     "layers": {
-                                        "c0c6f334-8d4e-4cb8-939d-df6c7a549561": {
+                                        "c3f5a560-d315-4963-9020-22bfb2a43957": {
                                             "columnOrder": [
-                                                "0bd0279a-6bc5-4827-9428-1c1bfb16603a",
-                                                "04ea5c1a-cac9-45d7-9556-308a138da8be",
-                                                "1f72bf44-7a79-4471-9a32-312af7167537",
-                                                "5ecbc989-6b77-4e1f-ad0e-bf4d07b65714",
-                                                "044818b1-5ce8-4dc6-8e7a-2df1decaf94d"
+                                                "295e8196-b59f-4980-811a-9e7150e86527",
+                                                "b9e58b9f-9c15-409e-823c-630483c7bd51"
                                             ],
                                             "columns": {
-                                                "044818b1-5ce8-4dc6-8e7a-2df1decaf94d": {
+                                                "295e8196-b59f-4980-811a-9e7150e86527": {
+                                                    "customLabel": true,
+                                                    "dataType": "ip",
+                                                    "isBucketed": true,
+                                                    "label": "Worst Perforing Servers",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "b9e58b9f-9c15-409e-823c-630483c7bd51",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "gigamon.ami.dst_ip"
+                                                },
+                                                "b9e58b9f-9c15-409e-823c-630483c7bd51": {
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Count of records",
@@ -800,112 +495,6 @@
                                                     },
                                                     "scale": "ratio",
                                                     "sourceField": "___records___"
-                                                },
-                                                "04ea5c1a-cac9-45d7-9556-308a138da8be": {
-                                                    "customLabel": true,
-                                                    "dataType": "ip",
-                                                    "isBucketed": true,
-                                                    "label": "Server",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "044818b1-5ce8-4dc6-8e7a-2df1decaf94d",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 25
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "gigamon.ami.dst_ip"
-                                                },
-                                                "0bd0279a-6bc5-4827-9428-1c1bfb16603a": {
-                                                    "customLabel": true,
-                                                    "dataType": "ip",
-                                                    "isBucketed": true,
-                                                    "label": "Client",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "044818b1-5ce8-4dc6-8e7a-2df1decaf94d",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 23
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "gigamon.ami.src_ip"
-                                                },
-                                                "1f72bf44-7a79-4471-9a32-312af7167537": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Applicatio",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [
-                                                            "Classification-unknown"
-                                                        ],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "044818b1-5ce8-4dc6-8e7a-2df1decaf94d",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 25
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "gigamon.ami.app_name"
-                                                },
-                                                "5ecbc989-6b77-4e1f-ad0e-bf4d07b65714": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "tcp_rtt",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "044818b1-5ce8-4dc6-8e7a-2df1decaf94d",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 25
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "gigamon.ami.tcp_rtt"
                                                 }
                                             },
                                             "incompleteColumns": {},
@@ -924,51 +513,88 @@
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "data_stream.dataset : \"gigamon.ami\" "
+                                "query": "data_stream.dataset : \"gigamon.ami\" and gigamon.ami.tcp_rtt_app \u003e 2"
                             },
                             "visualization": {
-                                "columns": [
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
                                     {
-                                        "columnId": "0bd0279a-6bc5-4827-9428-1c1bfb16603a",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "04ea5c1a-cac9-45d7-9556-308a138da8be",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "1f72bf44-7a79-4471-9a32-312af7167537",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "5ecbc989-6b77-4e1f-ad0e-bf4d07b65714",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "044818b1-5ce8-4dc6-8e7a-2df1decaf94d",
-                                        "isTransposed": false
+                                        "accessors": [
+                                            "b9e58b9f-9c15-409e-823c-630483c7bd51"
+                                        ],
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "c3f5a560-d315-4963-9020-22bfb2a43957",
+                                        "layerType": "data",
+                                        "seriesType": "bar_horizontal",
+                                        "xAccessor": "295e8196-b59f-4980-811a-9e7150e86527",
+                                        "yConfig": [
+                                            {
+                                                "color": "#ef7e66",
+                                                "forAccessor": "b9e58b9f-9c15-409e-823c-630483c7bd51"
+                                            }
+                                        ]
                                     }
                                 ],
-                                "layerId": "c0c6f334-8d4e-4cb8-939d-df6c7a549561",
-                                "layerType": "data"
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_horizontal",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
                             }
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsDatatable"
+                        "visualizationType": "lnsXY"
                     },
-                    "description": "Sessions with respective TCP Rtt",
                     "enhancements": {}
                 },
                 "gridData": {
-                    "h": 15,
-                    "i": "8fa462dc-65b1-446d-bd57-5868edf3354c",
+                    "h": 20,
+                    "i": "20a5f52f-3dc0-48d5-8f60-1bbdf657b49e",
                     "w": 24,
                     "x": 0,
-                    "y": 39
+                    "y": 24
                 },
-                "panelIndex": "8fa462dc-65b1-446d-bd57-5868edf3354c",
-                "title": "Network Latency[Gigamon AMI]",
+                "panelIndex": "20a5f52f-3dc0-48d5-8f60-1bbdf657b49e",
+                "title": "Top 10 worst performing Servers[Gigamon AMI]",
                 "type": "lens"
             },
             {
@@ -1170,10 +796,215 @@
                     "i": "a6629af9-b16e-44d4-bd77-1dfb1edb8a75",
                     "w": 24,
                     "x": 24,
-                    "y": 45
+                    "y": 30
                 },
                 "panelIndex": "a6629af9-b16e-44d4-bd77-1dfb1edb8a75",
                 "title": "Lost Data[Gigamon AMI]",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-c0c6f334-8d4e-4cb8-939d-df6c7a549561",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "c0c6f334-8d4e-4cb8-939d-df6c7a549561": {
+                                            "columnOrder": [
+                                                "0bd0279a-6bc5-4827-9428-1c1bfb16603a",
+                                                "04ea5c1a-cac9-45d7-9556-308a138da8be",
+                                                "1f72bf44-7a79-4471-9a32-312af7167537",
+                                                "5ecbc989-6b77-4e1f-ad0e-bf4d07b65714",
+                                                "044818b1-5ce8-4dc6-8e7a-2df1decaf94d"
+                                            ],
+                                            "columns": {
+                                                "044818b1-5ce8-4dc6-8e7a-2df1decaf94d": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of records",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                },
+                                                "04ea5c1a-cac9-45d7-9556-308a138da8be": {
+                                                    "customLabel": true,
+                                                    "dataType": "ip",
+                                                    "isBucketed": true,
+                                                    "label": "Server",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "044818b1-5ce8-4dc6-8e7a-2df1decaf94d",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 25
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "gigamon.ami.dst_ip"
+                                                },
+                                                "0bd0279a-6bc5-4827-9428-1c1bfb16603a": {
+                                                    "customLabel": true,
+                                                    "dataType": "ip",
+                                                    "isBucketed": true,
+                                                    "label": "Client",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "044818b1-5ce8-4dc6-8e7a-2df1decaf94d",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 23
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "gigamon.ami.src_ip"
+                                                },
+                                                "1f72bf44-7a79-4471-9a32-312af7167537": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Applicatio",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [
+                                                            "Classification-unknown"
+                                                        ],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "044818b1-5ce8-4dc6-8e7a-2df1decaf94d",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 25
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "gigamon.ami.app_name"
+                                                },
+                                                "5ecbc989-6b77-4e1f-ad0e-bf4d07b65714": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "tcp_rtt",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "044818b1-5ce8-4dc6-8e7a-2df1decaf94d",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 25
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "gigamon.ami.tcp_rtt"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset : \"gigamon.ami\" "
+                            },
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "columnId": "0bd0279a-6bc5-4827-9428-1c1bfb16603a",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "04ea5c1a-cac9-45d7-9556-308a138da8be",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "1f72bf44-7a79-4471-9a32-312af7167537",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "5ecbc989-6b77-4e1f-ad0e-bf4d07b65714",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "044818b1-5ce8-4dc6-8e7a-2df1decaf94d",
+                                        "isTransposed": false
+                                    }
+                                ],
+                                "layerId": "c0c6f334-8d4e-4cb8-939d-df6c7a549561",
+                                "layerType": "data"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsDatatable"
+                    },
+                    "description": "Sessions with respective TCP Rtt",
+                    "enhancements": {}
+                },
+                "gridData": {
+                    "h": 16,
+                    "i": "8fa462dc-65b1-446d-bd57-5868edf3354c",
+                    "w": 24,
+                    "x": 0,
+                    "y": 44
+                },
+                "panelIndex": "8fa462dc-65b1-446d-bd57-5868edf3354c",
+                "title": "Network Latency[Gigamon AMI]",
                 "type": "lens"
             },
             {
@@ -1283,8 +1114,8 @@
                     "h": 15,
                     "i": "735f65bf-40c1-4b14-bec9-a2d07ad726a7",
                     "w": 24,
-                    "x": 0,
-                    "y": 54
+                    "x": 24,
+                    "y": 45
                 },
                 "panelIndex": "735f65bf-40c1-4b14-bec9-a2d07ad726a7",
                 "title": "Average DNS Response time on the network[Gigamon AMI]",
@@ -1296,7 +1127,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2025-01-24T05:33:04.530Z",
+    "created_at": "2025-01-30T09:17:55.779Z",
     "id": "gigamon-e733c64e-6ea9-4dd6-a8ca-3914274598f3",
     "managed": false,
     "references": [
@@ -1307,7 +1138,7 @@
         },
         {
             "id": "logs-*",
-            "name": "b07089af-c0bf-453a-8f75-3da528c947f7:indexpattern-datasource-layer-40542048-bf27-455d-8ace-4cfeec0547cf",
+            "name": "730c317d-8817-466a-9219-fdab1bf7b810:indexpattern-datasource-layer-4075f59d-f023-4b0d-945c-bf1a5dcee87f",
             "type": "index-pattern"
         },
         {
@@ -1317,17 +1148,12 @@
         },
         {
             "id": "logs-*",
-            "name": "730c317d-8817-466a-9219-fdab1bf7b810:indexpattern-datasource-layer-4075f59d-f023-4b0d-945c-bf1a5dcee87f",
+            "name": "a6629af9-b16e-44d4-bd77-1dfb1edb8a75:indexpattern-datasource-layer-0034057d-bfb0-459f-869b-385f354ed921",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
             "name": "8fa462dc-65b1-446d-bd57-5868edf3354c:indexpattern-datasource-layer-c0c6f334-8d4e-4cb8-939d-df6c7a549561",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
-            "name": "a6629af9-b16e-44d4-bd77-1dfb1edb8a75:indexpattern-datasource-layer-0034057d-bfb0-459f-869b-385f354ed921",
             "type": "index-pattern"
         },
         {

--- a/packages/gigamon/manifest.yml
+++ b/packages/gigamon/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.3
 name: gigamon
 title: Gigamon
-version: "1.3.0"
+version: "1.3.1"
 description: Collect logs from Gigamon with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Type of change
- Bug


## Proposed commit message
Updated the Expired TLS Certificate Details widget in AppInsights dashboards to use real-time data instead of a hardcoded date. The title was also changed from "Internal SSL Certificates Expiration Date" to "Expired TLS Certificate Details" in NPM Dashboards. Removed the Connection Reset widget and rebuilt the SMB Conversation widget in the NPM Dashboard.


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Screenshots
Before change
![image](https://github.com/user-attachments/assets/e470f0b6-a22d-4142-8d7c-dcfc73944c82)

After Change
![image](https://github.com/user-attachments/assets/67b97f4e-b9a5-4560-81a9-8033265b2d3b)
