### PR TITLE
google_workspace: Omit pageToken from interval requests in chrome events

### DIFF
--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.30.2"
+  changes:
+    - description: Fix pageToken from reappearing in interval requests.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.30.1"
   changes:
     - description: Fix flaky test by renaming incorrect as.asn and as.organization_name fields.

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.30.2"
   changes:
-    - description: Fix pageToken from reappearing in interval requests.
+    - description: Prevent pageToken from incorrectly reappearing in interval requests.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/12666
 - version: "2.30.1"

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix pageToken from reappearing in interval requests.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/12666
 - version: "2.30.1"
   changes:
     - description: Fix flaky test by renaming incorrect as.asn and as.organization_name fields.

--- a/packages/google_workspace/data_stream/chrome/agent/stream/cel.yml.hbs
+++ b/packages/google_workspace/data_stream/chrome/agent/stream/cel.yml.hbs
@@ -41,7 +41,7 @@ program: |
         "maxResults": [string(state.batch_size)],
         "endTime": [string(state.end_time)],
         "startTime": [string(state.start_time)],
-        ?"pageToken": has(state.next_page_token) ? optional.of([string(state.next_page_token)]) : optional.none(),
+        ?"pageToken": state.?cursor.next_page_token.optMap(v, [string(v)]),
       }.format_query()
     ).do_request().as(resp, resp.StatusCode == 200 ?
       bytes(resp.Body).decode_json().as(body,{
@@ -56,9 +56,9 @@ program: |
           ),
         "cursor": {
            "last_timestamp": state.end_time,
+           ?"next_page_token": body.?nextPageToken,
          },
         "want_more": has(body.nextPageToken),
-        ?"next_page_token": body.?nextPageToken,
       })
     :
       {

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: "2.30.1"
+version: "2.30.2"
 source:
   license: Elastic-2.0
 description: Collect logs from Google Workspace with Elastic Agent.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
In chrome events, next_page_token is stored at the root-level 
of state. As it is enclosed in state.with(), this leads to 
next_page_token getting carried into subsequent 
interval requests. 

This change moves next_page_token inside cursor, thus 
removing from root-level. Also simplifies the pageToken query 
parameter calculation.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

**Tested using mito:**
1. Token at root-level (this carries token to next request.):
    ```
    mito -data <(echo '{"token": "TOKEN1"}') <(echo '
    state.with(
      {
        ?"token": (1 > 2) ? optional.of("TOKEN2") : optional.none()
      }
    )
    ')
    ```
    Returns:
    ```
    {
	    "token": "TOKEN1"
    }
    ```
    

2. Token at next-level (this omits token from next request):
    ```
    mito -data <(echo '{"next": {"token": "TOKEN1"}}') <(echo '
    state.with({
      "next": {
        ?"token": (1 > 2) ? optional.of("TOKEN2") : optional.none(),
      }
    })
    ')
    ```
    Returns:
    ```
    {
	    "next": {}
    }
    ```

