### PR TITLE
Try to trigger workflow to block paths on PRs created by github actions

### DIFF
--- a/.github/workflows/block-paths.yml
+++ b/.github/workflows/block-paths.yml
@@ -3,6 +3,8 @@ name: Block Changes
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  check_suite:
+    types: [completed]
 
 jobs:
   check-blocked-paths:


### PR DESCRIPTION
Github actions are not executed on events caused by creating pull requests from Github actions, to avoid infinite recursion. In our case this blocks PRs automated with actions.

Try to trigger the block paths workflow after checking the suites.