### PR TITLE
[Security Rules] Update security rules package to v8.16.7

### DIFF
--- a/packages/security_detection_engine/changelog.yml
+++ b/packages/security_detection_engine/changelog.yml
@@ -4,7 +4,7 @@
   changes:
     - description: Release security rules update
       type: enhancement
-      link: https://github.com/elastic/integrations/pulls/0000
+      link: https://github.com/elastic/integrations/pull/12679
 - version: 8.16.7-beta.1
   changes:
     - description: Release security rules update

--- a/packages/security_detection_engine/changelog.yml
+++ b/packages/security_detection_engine/changelog.yml
@@ -1,5 +1,10 @@
 # newer versions go on top
 # NOTE: please use pre-release versions (e.g. -beta.0) until a package is ready for production
+- version: 8.16.7
+  changes:
+    - description: Release security rules update
+      type: enhancement
+      link: https://github.com/elastic/integrations/pulls/0000
 - version: 8.16.7-beta.1
   changes:
     - description: Release security rules update

--- a/packages/security_detection_engine/manifest.yml
+++ b/packages/security_detection_engine/manifest.yml
@@ -21,4 +21,4 @@ source:
   license: Elastic-2.0
 title: Prebuilt Security Detection Rules
 type: integration
-version: 8.16.7-beta.1
+version: 8.16.7


### PR DESCRIPTION

## What does this PR do?
Update the Security Rules package to version 8.16.7.
Autogenerated from commit  https://github.com/elastic/detection-rules/tree/a254f5ca907cc5b1d8c3f5122f57f0eb18a5b7f3

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] ~I have verified that all data streams collect metrics or logs.~
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Author's Checklist
- Install the most recently release security rules in the Detection Engine
- Install the package
- Confirm the update is available in Kibana. Click "Update X rules" or "Install X rules"
- Look at the changes made after the install and confirm they are consistent

## How to test this PR locally
- Perform the above checklist, and use `package-storage` to build EPR from source

## Related issues
None

## Screenshots
None
