### PR TITLE
Update ti_crowdstrike required API scopes in documentation

### DIFF
--- a/packages/ti_crowdstrike/docs/README.md
+++ b/packages/ti_crowdstrike/docs/README.md
@@ -50,10 +50,10 @@ This module has been tested against the **CrowdStrike Falcon Intelligence API Ve
 4. API Endpoint url
 5. Required scopes for each data stream :
 
-    | Data Stream   | Scope         |
-    | ------------- | ------------- |
-    | Intel         | read:intel    |
-    | IOC           | read:iocs     |
+    | Data Stream    | Scope                               |
+    | -------------  | -------------                       |
+    | Intel          | read:intel                          |
+    | IOC            | read:iocs<br/>read:ioc-management   |
 
 Follow the [documentation](https://www.crowdstrike.com/blog/tech-center/consume-ioc-and-threat-feeds/) for enabling the scopes from the CrowdStrike console.
 


### PR DESCRIPTION
## Proposed commit message

Documentation update to clarify that the CrowdStrike Falcon Intelligence integration also requires the `ioc-management:read` API scope, if pulling IOC data.

## Checklist

- ~~[ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.~~
- ~~[ ] I have verified that all data streams collect metrics or logs.~~
- ~~[ ] I have added an entry to my package's `changelog.yml` file.~~
- ~~[ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~~
- ~~[ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

## Author's Checklist

- [ ] Doc build successful

## How to test this PR locally

Documentation-only change

## Related issues

- n/a 

## Screenshots

n/a
