### PR TITLE
AWS Firehose for 9.0.0 enablement

### DIFF
--- a/packages/awsfirehose/changelog.yml
+++ b/packages/awsfirehose/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Add support for Kibana `9.0.0` 
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12641
 - version: "1.4.0"
   changes:
     - description: Add support for Amazon Bedrock guardrails metrics.

--- a/packages/awsfirehose/manifest.yml
+++ b/packages/awsfirehose/manifest.yml
@@ -1,7 +1,7 @@
-format_version: "3.1.0"
+format_version: "3.3.0"
 name: awsfirehose
 title: Amazon Data Firehose
-version: 1.4.0
+version: 1.5.0
 description: Stream logs and metrics from Amazon Data Firehose into Elastic Cloud.
 type: integration
 categories:
@@ -10,7 +10,7 @@ categories:
   - aws
 conditions:
   kibana:
-    version: "^8.13.0"
+    version: "^8.13.0 || ^9.0.0"
 owner:
   github: elastic/obs-ds-hosted-services
   type: elastic


### PR DESCRIPTION
- Enhancement


## Proposed commit message

WHAT: Enabling support for AWS Firehose integrations for 9.0 version
WHY: Is needed in order to enable above integrations in version 9.0.0


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## How to test this PR locally

1. Clone Pr
2. elastic-package build with v0.109.1
3. elastic-package stack up -d -v --version=9.0.0-SNAPSHOT to install a local ES

## Related issues

- Relates #https://github.com/elastic/integrations/issues/12529

