### PR TITLE
[CI] Try to trigger workflow to block paths on PRs created by github actions and comments

### DIFF
--- a/.github/workflows/block-paths.yml
+++ b/.github/workflows/block-paths.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-blocked-paths:
-    if: ${{ github.event_name == "pull_request" || (github.event_name == "issue_comment" && github.event.issue.pull_request && github.event.comment.body == '/check-blocked-paths') }}
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.comment.body == '/check-blocked-paths') }}
     name: Check for blocked path changes
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/block-paths.yml
+++ b/.github/workflows/block-paths.yml
@@ -3,11 +3,12 @@ name: Block Changes
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  check_suite:
-    types: [completed]
+  issue_comment:
+    types: [created]
 
 jobs:
   check-blocked-paths:
+    if: ${{ github.event_name == "pull_request" || (github.event_name == "issue_comment" && github.event.issue.pull_request && github.event.comment.body == '/check-blocked-paths') }}
     name: Check for blocked path changes
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Proposed commit message

Update check-blocked paths GitHub Action workflow to add a mechanism to trigger this workflow in pull requests created by other GitHub Actions.

Example: https://github.com/elastic/integrations/pull/12684

Follows: #12668 

Related docs:
- `github` context: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context
- `pull_request` payload: https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request
- `issue_comment` payload: https://docs.github.com/en/webhooks/webhook-events-and-payloads#issue_comment
