### PR TITLE
Cloudflare Logpush: Add ignore_empty_value flag to set processors when fields may be missing

### DIFF
--- a/packages/cloudflare_logpush/data_stream/access_request/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/access_request/elasticsearch/ingest_pipeline/default.yml
@@ -65,6 +65,7 @@ processors:
   - set:
       field: event.action
       copy_from: cloudflare_logpush.access_request.action
+      ignore_empty_value: true
   - rename:
       field: json.Allowed
       target_field: cloudflare_logpush.access_request.allowed
@@ -87,6 +88,7 @@ processors:
   - set:
       field: url.domain
       copy_from: cloudflare_logpush.access_request.app.domain
+      ignore_empty_value: true
   - rename:
       field: json.AppUUID
       target_field: cloudflare_logpush.access_request.app.uuid
@@ -102,6 +104,7 @@ processors:
   - set:
       field: client.geo.country_name
       copy_from: cloudflare_logpush.access_request.country
+      ignore_empty_value: true
   - rename:
       field: json.Email
       target_field: cloudflare_logpush.access_request.user.email
@@ -109,6 +112,7 @@ processors:
   - set:
       field: user.email
       copy_from: cloudflare_logpush.access_request.user.email
+      ignore_empty_value: true
   - rename:
       field: json.IPAddress
       target_field: cloudflare_logpush.access_request.client.ip
@@ -116,6 +120,7 @@ processors:
   - set:
       field: client.ip
       copy_from: cloudflare_logpush.access_request.client.ip
+      ignore_empty_value: true
 # Geo enrichment
   - geoip:
       field: client.ip
@@ -151,6 +156,7 @@ processors:
   - set:
       field: event.id
       copy_from: cloudflare_logpush.access_request.ray.id
+      ignore_empty_value: true
   - rename:
       field: json.TemporaryAccessApprovers
       target_field: cloudflare_logpush.access_request.temp_access.approvers
@@ -166,6 +172,7 @@ processors:
   - set:
       field: user.id
       copy_from: cloudflare_logpush.access_request.user.id
+      ignore_empty_value: true
 # Create related fields
   - append:
       field: related.ip

--- a/packages/cloudflare_logpush/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -89,7 +89,7 @@ processors:
   - set:
       field: user.email
       copy_from: cloudflare_logpush.audit.actor.email
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.ActorID
       target_field: cloudflare_logpush.audit.actor.id
@@ -97,7 +97,7 @@ processors:
   - set:
       field: user.id
       copy_from: cloudflare_logpush.audit.actor.id
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.ActorIP
       target_field: cloudflare_logpush.audit.actor.ip
@@ -111,7 +111,7 @@ processors:
   - set:
       field: source.ip
       copy_from: cloudflare_logpush.audit.actor.ip
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.ActorType
       target_field: cloudflare_logpush.audit.actor.type
@@ -123,7 +123,7 @@ processors:
   - set:
       field: event.id
       copy_from: cloudflare_logpush.audit.id
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.Interface
       target_field: cloudflare_logpush.audit.interface
@@ -132,7 +132,7 @@ processors:
   - set:
       field: event.provider
       copy_from: cloudflare_logpush.audit.interface
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.Metadata
       target_field: cloudflare_logpush.audit.metadata

--- a/packages/cloudflare_logpush/data_stream/casb/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/casb/elasticsearch/ingest_pipeline/default.yml
@@ -113,6 +113,7 @@ processors:
   - set:
       field: event.id
       copy_from: cloudflare_logpush.casb.finding.id
+      ignore_empty_value: true
   - rename:
       field: json.IntegrationDisplayName
       target_field: cloudflare_logpush.casb.integration.name

--- a/packages/cloudflare_logpush/data_stream/device_posture/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/device_posture/elasticsearch/ingest_pipeline/default.yml
@@ -64,6 +64,7 @@ processors:
   - set:
       field: user_agent.version
       copy_from: cloudflare_logpush.device_posture.version
+      ignore_empty_value: true
   - rename:
       field: json.DeviceID
       target_field: cloudflare_logpush.device_posture.host.id
@@ -71,6 +72,7 @@ processors:
   - set:
       field: host.id
       copy_from: cloudflare_logpush.device_posture.host.id
+      ignore_empty_value: true
   - rename:
       field: json.DeviceManufacturer
       target_field: cloudflare_logpush.device_posture.host.manufacturer
@@ -86,6 +88,7 @@ processors:
   - set:
       field: host.name
       copy_from: cloudflare_logpush.device_posture.host.name
+      ignore_empty_value: true
   - rename:
       field: json.DeviceSerialNumber
       target_field: cloudflare_logpush.device_posture.host.serial
@@ -97,6 +100,7 @@ processors:
   - set:
       field: host.os.family
       copy_from: cloudflare_logpush.device_posture.host.os.family
+      ignore_empty_value: true
   - rename:
       field: json.OSVersion
       target_field: cloudflare_logpush.device_posture.host.os.version
@@ -104,6 +108,7 @@ processors:
   - set:
       field: host.os.version
       copy_from: cloudflare_logpush.device_posture.host.os.version
+      ignore_empty_value: true
   - rename:
       field: json.PolicyID
       target_field: cloudflare_logpush.device_posture.rule.id
@@ -111,6 +116,7 @@ processors:
   - set:
       field: rule.id
       copy_from: cloudflare_logpush.device_posture.rule.id
+      ignore_empty_value: true
   - rename:
       field: json.PostureCheckName
       target_field: cloudflare_logpush.device_posture.rule.name
@@ -118,6 +124,7 @@ processors:
   - set:
       field: rule.name
       copy_from: cloudflare_logpush.device_posture.rule.name
+      ignore_empty_value: true
   - rename:
       field: json.PostureCheckType
       target_field: cloudflare_logpush.device_posture.rule.category
@@ -125,6 +132,7 @@ processors:
   - set:
       field: rule.category
       copy_from: cloudflare_logpush.device_posture.rule.category
+      ignore_empty_value: true
   - rename:
       field: json.PostureEvaluatedResult
       target_field: cloudflare_logpush.device_posture.eval.result

--- a/packages/cloudflare_logpush/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
@@ -58,7 +58,7 @@ processors:
   - set:
       field: cloudflare_logpush.dns.timestamp
       copy_from: '@timestamp'
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.SourceIP
       target_field: cloudflare_logpush.dns.source.ip
@@ -72,7 +72,7 @@ processors:
   - set:
       field: source.ip
       copy_from: cloudflare_logpush.dns.source.ip
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.QueryName
       target_field: cloudflare_logpush.dns.query.name
@@ -80,7 +80,7 @@ processors:
   - set:
       field: dns.question.name
       copy_from: cloudflare_logpush.dns.query.name
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.QueryType
       target_field: cloudflare_logpush.dns.query.type

--- a/packages/cloudflare_logpush/data_stream/dns_firewall/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/dns_firewall/elasticsearch/ingest_pipeline/default.yml
@@ -77,6 +77,7 @@ processors:
   - set:
       field: source.ip
       copy_from: cloudflare_logpush.dns_firewall.source.ip
+      ignore_empty_value: true
       tag: set_source_ip
 # Geo enrichment (source IP)
   - geoip:
@@ -112,6 +113,7 @@ processors:
   - set:
       field: dns.question.name
       copy_from: cloudflare_logpush.dns_firewall.question.name
+      ignore_empty_value: true
       tag: set_question_name
 
   - convert:

--- a/packages/cloudflare_logpush/data_stream/firewall_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/elasticsearch/ingest_pipeline/default.yml
@@ -58,7 +58,7 @@ processors:
   - set:
       field: cloudflare_logpush.firewall_event.timestamp
       copy_from: '@timestamp'
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.Action
       target_field: cloudflare_logpush.firewall_event.action
@@ -66,7 +66,7 @@ processors:
   - set:
       field: event.action
       copy_from: cloudflare_logpush.firewall_event.action
-      ignore_failure: true
+      ignore_empty_value: true
   - lowercase:
       field: event.action
       ignore_missing: true
@@ -77,7 +77,7 @@ processors:
   - set:
       field: http.request.method
       copy_from: cloudflare_logpush.firewall_event.client.request.method
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.EdgeResponseStatus
       target_field: cloudflare_logpush.firewall_event.edge.response.status
@@ -91,7 +91,7 @@ processors:
   - set:
       field: http.response.status_code
       copy_from: cloudflare_logpush.firewall_event.edge.response.status
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.RuleID
       target_field: cloudflare_logpush.firewall_event.rule.id
@@ -99,7 +99,7 @@ processors:
   - set:
       field: rule.id
       copy_from: cloudflare_logpush.firewall_event.rule.id
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.ClientASN
       target_field: cloudflare_logpush.firewall_event.client.asn.value
@@ -113,7 +113,7 @@ processors:
   - set:
       field: source.as.number
       copy_from: cloudflare_logpush.firewall_event.client.asn.value
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.ClientCountry
       target_field: cloudflare_logpush.firewall_event.client.country
@@ -121,7 +121,7 @@ processors:
   - set:
       field: source.geo.country_iso_code
       copy_from: cloudflare_logpush.firewall_event.client.country
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.ClientIP
       target_field: cloudflare_logpush.firewall_event.client.ip
@@ -135,7 +135,7 @@ processors:
   - set:
       field: source.ip
       copy_from: cloudflare_logpush.firewall_event.client.ip
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.ClientASNDescription
       target_field: cloudflare_logpush.firewall_event.client.asn.description
@@ -212,7 +212,7 @@ processors:
   - set:
       field: url.scheme
       copy_from: cloudflare_logpush.firewall_event.client.request.scheme
-      ignore_failure: true
+      ignore_empty_value: true
   - user_agent:
       field: json.ClientRequestUserAgent
       if: ctx.json?.ClientRequestUserAgent != ''
@@ -264,6 +264,7 @@ processors:
   - set:
       field: event.id
       copy_from: cloudflare_logpush.firewall_event.ray.id
+      ignore_empty_value: true
   - rename:
       field: json.Source
       target_field: cloudflare_logpush.firewall_event.source

--- a/packages/cloudflare_logpush/data_stream/gateway_network/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_network/elasticsearch/ingest_pipeline/default.yml
@@ -65,6 +65,7 @@ processors:
   - set:
       field: event.action
       copy_from: cloudflare_logpush.gateway_network.action
+      ignore_empty_value: true
   - rename:
       field: json.DestinationIP
       target_field: cloudflare_logpush.gateway_network.destination.ip
@@ -72,6 +73,7 @@ processors:
   - set:
       field: destination.ip
       copy_from: cloudflare_logpush.gateway_network.destination.ip
+      ignore_empty_value: true
 # Geo enrichment (destination IP)
   - geoip:
       field: destination.ip
@@ -99,6 +101,7 @@ processors:
   - set:
       field: destination.port
       copy_from: cloudflare_logpush.gateway_network.destination.port
+      ignore_empty_value: true
   - rename:
       field: json.DeviceID
       target_field: cloudflare_logpush.gateway_network.host.id
@@ -106,6 +109,7 @@ processors:
   - set:
       field: host.id
       copy_from: cloudflare_logpush.gateway_network.host.id
+      ignore_empty_value: true
   - rename:
       field: json.DeviceName
       target_field: cloudflare_logpush.gateway_network.host.name
@@ -113,6 +117,7 @@ processors:
   - set:
       field: host.name
       copy_from: cloudflare_logpush.gateway_network.host.name
+      ignore_empty_value: true
   - rename:
       field: json.SNI
       target_field: cloudflare_logpush.gateway_network.sni
@@ -120,9 +125,11 @@ processors:
   - set:
       field: tls.client.server_name
       copy_from: cloudflare_logpush.gateway_network.sni
+      ignore_empty_value: true
   - set:
       field: destination.domain
       copy_from: tls.client.server_name
+      ignore_empty_value: true
   - rename:
       field: json.SessionID
       target_field: cloudflare_logpush.gateway_network.session_id
@@ -130,6 +137,7 @@ processors:
   - set:
       field: event.id
       copy_from: cloudflare_logpush.gateway_network.session_id
+      ignore_empty_value: true
   - rename:
       field: json.SourceIP
       target_field: cloudflare_logpush.gateway_network.source.ip
@@ -137,6 +145,7 @@ processors:
   - set:
       field: source.ip
       copy_from: cloudflare_logpush.gateway_network.source.ip
+      ignore_empty_value: true
 # Geo enrichment (source IP)
   - geoip:
       field: source.ip
@@ -164,6 +173,7 @@ processors:
   - set:
       field: source.port
       copy_from: cloudflare_logpush.gateway_network.source.port
+      ignore_empty_value: true
   - rename:
       field: json.Transport
       target_field: cloudflare_logpush.gateway_network.transport
@@ -171,6 +181,7 @@ processors:
   - set:
       field: network.transport
       copy_from: cloudflare_logpush.gateway_network.transport
+      ignore_empty_value: true
   - rename:
       field: json.UserID
       target_field: cloudflare_logpush.gateway_network.user.id
@@ -178,6 +189,7 @@ processors:
   - set:
       field: user.id
       copy_from: cloudflare_logpush.gateway_network.user.id
+      ignore_empty_value: true
   - rename:
       field: json.Email
       target_field: cloudflare_logpush.gateway_network.user.email
@@ -185,6 +197,7 @@ processors:
   - set:
       field: user.email
       copy_from: cloudflare_logpush.gateway_network.user.email
+      ignore_empty_value: true
 # Custom fields
   - rename:
       field: json.AccountID

--- a/packages/cloudflare_logpush/data_stream/http_request/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/http_request/elasticsearch/ingest_pipeline/default.yml
@@ -57,9 +57,9 @@ processors:
           field: error.message
           value: "{{{_ingest.on_failure_message}}}"
   - set:
-      if: ctx.cloudflare_logpush?.http_request?.edge?.start_time != null
       field: '@timestamp'
       copy_from: cloudflare_logpush.http_request.edge.start_time
+      ignore_empty_value: true
   - script:
       lang: painless
       tag: painless_edge_end_timestamp_to_milli
@@ -141,7 +141,7 @@ processors:
   - set:
       field: destination.ip
       copy_from: cloudflare_logpush.http_request.origin.ip
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.ClientRequestMethod
       target_field: cloudflare_logpush.http_request.client.request.method
@@ -149,7 +149,7 @@ processors:
   - set:
       field: http.request.method
       copy_from: cloudflare_logpush.http_request.client.request.method
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.EdgeResponseContentType
       target_field: cloudflare_logpush.http_request.edge.response.content_type
@@ -157,7 +157,7 @@ processors:
   - set:
       field: http.response.mime_type
       copy_from: cloudflare_logpush.http_request.edge.response.content_type
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.EdgeResponseStatus
       target_field: cloudflare_logpush.http_request.edge.response.status
@@ -171,7 +171,7 @@ processors:
   - set:
       field: http.response.status_code
       copy_from: cloudflare_logpush.http_request.edge.response.status
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.ClientASN
       target_field: cloudflare_logpush.http_request.client.asn
@@ -185,7 +185,7 @@ processors:
   - set:
       field: source.as.number
       copy_from: cloudflare_logpush.http_request.client.asn
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.ClientCountry
       target_field: cloudflare_logpush.http_request.client.country
@@ -193,7 +193,7 @@ processors:
   - set:
       field: source.geo.country_iso_code
       copy_from: cloudflare_logpush.http_request.client.country
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.ClientIP
       target_field: cloudflare_logpush.http_request.client.ip
@@ -207,7 +207,7 @@ processors:
   - set:
       field: source.ip
       copy_from: cloudflare_logpush.http_request.client.ip
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.BotDetectionIDs
       target_field: cloudflare_logpush.http_request.bot.detection_ids
@@ -652,6 +652,7 @@ processors:
   - set:
       field: event.id
       copy_from: cloudflare_logpush.http_request.ray.id
+      ignore_empty_value: true
   - rename:
       field: json.RequestHeaders
       target_field: cloudflare_logpush.http_request.request.header

--- a/packages/cloudflare_logpush/data_stream/magic_ids/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/elasticsearch/ingest_pipeline/default.yml
@@ -79,6 +79,7 @@ processors:
   - set:
       field: destination.ip
       copy_from: cloudflare_logpush.magic_ids.destination.ip
+      ignore_empty_value: true
       tag: set_destination_ip
 # Geo enrichment (destination IP)
   - geoip:
@@ -112,6 +113,7 @@ processors:
   - set:
       field: destination.port
       copy_from: cloudflare_logpush.magic_ids.destination.port
+      ignore_empty_value: true
       tag: set_destination_port
 
 # Handle source IP and port
@@ -123,6 +125,7 @@ processors:
   - set:
       field: source.ip
       copy_from: cloudflare_logpush.magic_ids.source.ip
+      ignore_empty_value: true
       tag: set_source_ip
 # Geo enrichment (source IP)
   - geoip:
@@ -156,6 +159,7 @@ processors:
   - set:
       field: source.port
       copy_from: cloudflare_logpush.magic_ids.source.port
+      ignore_empty_value: true
       tag: set_source_port
 
   - rename:
@@ -166,6 +170,7 @@ processors:
   - set:
       field: network.transport
       copy_from: cloudflare_logpush.magic_ids.transport
+      ignore_empty_value: true
       tag: set_transport_protocol
 
   - rename:
@@ -176,6 +181,7 @@ processors:
   - set:
       field: event.action
       copy_from: cloudflare_logpush.magic_ids.action
+      ignore_empty_value: true
       tag: set_event_action
   - append:
        field: event.type

--- a/packages/cloudflare_logpush/data_stream/nel_report/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/nel_report/elasticsearch/ingest_pipeline/default.yml
@@ -58,7 +58,7 @@ processors:
   - set:
       field: cloudflare_logpush.nel_report.timestamp
       copy_from: '@timestamp'
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.Type
       target_field: cloudflare_logpush.nel_report.error.type
@@ -66,7 +66,7 @@ processors:
   - set:
       field: error.type
       copy_from: cloudflare_logpush.nel_report.error.type
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.ClientIPASN
       target_field: cloudflare_logpush.nel_report.client.ip.asn.value

--- a/packages/cloudflare_logpush/data_stream/network_analytics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/network_analytics/elasticsearch/ingest_pipeline/default.yml
@@ -58,7 +58,7 @@ processors:
   - set:
       field: cloudflare_logpush.network_analytics.timestamp
       copy_from: '@timestamp'
-      ignore_failure: true
+      ignore_empty_value: true
   - set:
       field: cloudflare_logpush.network_analytics.outcome
       value: success
@@ -70,7 +70,7 @@ processors:
   - set:
       field: event.outcome
       copy_from: cloudflare_logpush.network_analytics.outcome
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.DestinationASN
       target_field: cloudflare_logpush.network_analytics.destination.asn
@@ -84,7 +84,7 @@ processors:
   - set:
       field: destination.as.number
       copy_from: cloudflare_logpush.network_analytics.destination.asn
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.IPDestinationAddress
       target_field: cloudflare_logpush.network_analytics.destination.ip
@@ -98,7 +98,7 @@ processors:
   - set:
       field: destination.ip
       copy_from: cloudflare_logpush.network_analytics.destination.ip
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.DestinationPort
       target_field: cloudflare_logpush.network_analytics.destination.port
@@ -112,7 +112,7 @@ processors:
   - set:
       field: destination.port
       copy_from: cloudflare_logpush.network_analytics.destination.port
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.Direction
       target_field: cloudflare_logpush.network_analytics.direction
@@ -120,7 +120,7 @@ processors:
   - set:
       field: network.direction
       copy_from: cloudflare_logpush.network_analytics.direction
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.IPProtocolName
       target_field: cloudflare_logpush.network_analytics.ip.protocol.name
@@ -128,7 +128,7 @@ processors:
   - set:
       field: network.transport
       copy_from: cloudflare_logpush.network_analytics.ip.protocol.name
-      ignore_failure: true
+      ignore_empty_value: true
   - lowercase:
       field: network.transport
       ignore_missing: true
@@ -145,7 +145,7 @@ processors:
   - set:
       field: source.ip
       copy_from: cloudflare_logpush.network_analytics.source.ip
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.SourceASN
       target_field: cloudflare_logpush.network_analytics.source.asn
@@ -159,7 +159,7 @@ processors:
   - set:
       field: source.as.number
       copy_from: cloudflare_logpush.network_analytics.source.asn
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.SourcePort
       target_field: cloudflare_logpush.network_analytics.source.port
@@ -173,7 +173,7 @@ processors:
   - set:
       field: source.port
       copy_from: cloudflare_logpush.network_analytics.source.port
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.RuleID
       target_field: cloudflare_logpush.network_analytics.rule.id
@@ -181,7 +181,7 @@ processors:
   - set:
       field: rule.id
       copy_from: cloudflare_logpush.network_analytics.rule.id
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.AttackCampaignID
       target_field: cloudflare_logpush.network_analytics.attack.campaign.id
@@ -201,7 +201,7 @@ processors:
   - set:
       field: cloudflare_logpush.network_analytics.colo.geo_location
       copy_from: cloudflare_logpush.network_analytics.colo.geo_hash
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.ColoID
       target_field: cloudflare_logpush.network_analytics.colo.id
@@ -231,7 +231,7 @@ processors:
   - set:
       field: cloudflare_logpush.network_analytics.destination.geo_location
       copy_from: cloudflare_logpush.network_analytics.destination.geo_hash
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.GREChecksum
       target_field: cloudflare_logpush.network_analytics.gre.checksum
@@ -563,7 +563,7 @@ processors:
   - set:
       field: cloudflare_logpush.network_analytics.source.geo_location
       copy_from: cloudflare_logpush.network_analytics.source.geo_hash
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.TCPAcknowledgementNumber
       target_field: cloudflare_logpush.network_analytics.tcp.acknowledgement_number

--- a/packages/cloudflare_logpush/data_stream/network_session/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/network_session/elasticsearch/ingest_pipeline/default.yml
@@ -102,6 +102,7 @@ processors:
   - set:
       field: destination.bytes
       copy_from: cloudflare_logpush.network_session.destination.bytes
+      ignore_empty_value: true
   - rename:
       field: json.BytesSent
       target_field: cloudflare_logpush.network_session.source.bytes
@@ -109,6 +110,7 @@ processors:
   - set:
       field: source.bytes
       copy_from: cloudflare_logpush.network_session.source.bytes
+      ignore_empty_value: true
   - rename:
       field: json.DeviceID
       target_field: cloudflare_logpush.network_session.host.id
@@ -116,6 +118,7 @@ processors:
   - set:
       field: host.id
       copy_from: cloudflare_logpush.network_session.host.id
+      ignore_empty_value: true
   - rename:
       field: json.DeviceName
       target_field: cloudflare_logpush.network_session.host.name
@@ -123,6 +126,7 @@ processors:
   - set:
       field: host.name
       copy_from: cloudflare_logpush.network_session.host.name
+      ignore_empty_value: true
   - rename:
       field: json.OriginIP
       target_field: cloudflare_logpush.network_session.destination.ip
@@ -130,6 +134,7 @@ processors:
   - set:
       field: destination.ip
       copy_from: cloudflare_logpush.network_session.destination.ip
+      ignore_empty_value: true
 # Geo enrichment (destination IP)
   - geoip:
       field: destination.ip
@@ -157,6 +162,7 @@ processors:
   - set:
       field: destination.port
       copy_from: cloudflare_logpush.network_session.destination.port
+      ignore_empty_value: true
   - rename:
       field: json.OriginTLSCertificateIssuer
       target_field: cloudflare_logpush.network_session.tls.server.certificate.issuer
@@ -164,6 +170,7 @@ processors:
   - set:
       field: tls.server.issuer
       copy_from: cloudflare_logpush.network_session.tls.server.certificate.issuer
+      ignore_empty_value: true
   - rename:
       field: json.Protocol
       target_field: cloudflare_logpush.network_session.transport
@@ -171,6 +178,7 @@ processors:
   - set:
       field: network.transport
       copy_from: cloudflare_logpush.network_session.transport
+      ignore_empty_value: true
   - rename:
       field: json.SessionID
       target_field: cloudflare_logpush.network_session.session.id
@@ -178,6 +186,7 @@ processors:
   - set:
       field: event.id
       copy_from: cloudflare_logpush.network_session.session.id
+      ignore_empty_value: true
   - rename:
       field: json.SessionStartTime
       target_field: cloudflare_logpush.network_session.session.start
@@ -185,6 +194,7 @@ processors:
   - set:
       field: event.start
       copy_from: cloudflare_logpush.network_session.session.start
+      ignore_empty_value: true
   - rename:
       field: json.SessionEndTime
       target_field: cloudflare_logpush.network_session.session.end
@@ -192,6 +202,7 @@ processors:
   - set:
       field: event.end
       copy_from: cloudflare_logpush.network_session.session.end
+      ignore_empty_value: true
   - rename:
       field: json.SourceIP
       target_field: cloudflare_logpush.network_session.source.ip
@@ -199,6 +210,7 @@ processors:
   - set:
       field: source.ip
       copy_from: cloudflare_logpush.network_session.source.ip
+      ignore_empty_value: true
 # Geo enrichment (source IP)
   - geoip:
       field: source.ip
@@ -226,6 +238,7 @@ processors:
   - set:
       field: source.port
       copy_from: cloudflare_logpush.network_session.source.port
+      ignore_empty_value: true
   - rename:
       field: json.UserID
       target_field: cloudflare_logpush.network_session.user.id
@@ -233,6 +246,7 @@ processors:
   - set:
       field: user.id
       copy_from: cloudflare_logpush.network_session.user.id
+      ignore_empty_value: true
   - rename:
       field: json.Email
       target_field: cloudflare_logpush.network_session.user.email
@@ -240,6 +254,7 @@ processors:
   - set:
       field: user.email
       copy_from: cloudflare_logpush.network_session.user.email
+      ignore_empty_value: true
   - rename:
       field: json.VirtualNetworkID
       target_field: cloudflare_logpush.network_session.vlan.id
@@ -247,6 +262,7 @@ processors:
   - set:
       field: network.vlan.id
       copy_from: cloudflare_logpush.network_session.vlan.id
+      ignore_empty_value: true
 # Custom fields
   - rename:
       field: json.AccountID

--- a/packages/cloudflare_logpush/data_stream/sinkhole_http/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/sinkhole_http/elasticsearch/ingest_pipeline/default.yml
@@ -77,6 +77,7 @@ processors:
   - set:
       field: destination.ip
       copy_from: cloudflare_logpush.sinkhole_http.destination.ip
+      ignore_empty_value: true
       tag: set_destination_ip
 # Geo enrichment (destination IP)
   - geoip:
@@ -112,6 +113,7 @@ processors:
   - set:
       field: source.ip
       copy_from: cloudflare_logpush.sinkhole_http.source.ip
+      ignore_empty_value: true
       tag: set_source_ip
 # Geo enrichment (source IP)
   - geoip:
@@ -147,6 +149,7 @@ processors:
   - set:
       field: http.request.body.content
       copy_from: cloudflare_logpush.sinkhole_http.request.body.content
+      ignore_empty_value: true
       tag: set_http_body
   - rename:
       field: json.BodyLength
@@ -156,6 +159,7 @@ processors:
   - set:
       field: http.request.body.bytes
       copy_from: cloudflare_logpush.sinkhole_http.request.body.bytes
+      ignore_empty_value: true
       tag: set_http_body_bytes
   - rename:
       field: json.Method
@@ -165,6 +169,7 @@ processors:
   - set:
       field: http.request.method
       copy_from: cloudflare_logpush.sinkhole_http.request.method
+      ignore_empty_value: true
       tag: set_http_method
   - rename:
       field: json.Referrer
@@ -174,6 +179,7 @@ processors:
   - set:
       field: http.request.referrer
       copy_from: cloudflare_logpush.sinkhole_http.request.referrer
+      ignore_empty_value: true
       tag: set_http_referrer
 
   - rename:
@@ -184,6 +190,7 @@ processors:
   - set:
       field: host.name
       copy_from: cloudflare_logpush.sinkhole_http.host.name
+      ignore_empty_value: true
       tag: set_http_host
   - rename:
       field: json.URI
@@ -213,6 +220,7 @@ processors:
   - set:
       field: user.name
       copy_from: cloudflare_logpush.sinkhole_http.user.name
+      ignore_empty_value: true
       tag: set_username
 
 # Custom fields

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/elasticsearch/ingest_pipeline/default.yml
@@ -58,7 +58,7 @@ processors:
   - set:
       field: cloudflare_logpush.spectrum_event.timestamp
       copy_from: '@timestamp'
-      ignore_failure: true
+      ignore_empty_value: true
   - script:
       lang: painless
       tag: painless_connect_timestamp_to_milli
@@ -99,7 +99,7 @@ processors:
   - set:
       field: event.start
       copy_from: cloudflare_logpush.spectrum_event.connect.time
-      ignore_failure: true
+      ignore_empty_value: true
   - script:
       lang: painless
       tag: painless_disconnect_timestamp_to_milli
@@ -140,7 +140,7 @@ processors:
   - set:
       field: event.end
       copy_from: cloudflare_logpush.spectrum_event.disconnect.time
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.Event
       target_field: cloudflare_logpush.spectrum_event.action
@@ -148,7 +148,7 @@ processors:
   - set:
       field: event.action
       copy_from: cloudflare_logpush.spectrum_event.action
-      ignore_failure: true
+      ignore_empty_value: true
   - lowercase:
       field: event.action
       ignore_missing: true
@@ -165,7 +165,7 @@ processors:
   - set:
       field: destination.bytes
       copy_from: cloudflare_logpush.spectrum_event.origin.bytes
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.OriginIP
       target_field: cloudflare_logpush.spectrum_event.origin.ip
@@ -179,7 +179,7 @@ processors:
   - set:
       field: destination.ip
       copy_from: cloudflare_logpush.spectrum_event.origin.ip
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.OriginPort
       target_field: cloudflare_logpush.spectrum_event.origin.port
@@ -193,7 +193,7 @@ processors:
   - set:
       field: destination.port
       copy_from: cloudflare_logpush.spectrum_event.origin.port
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.Application
       target_field: cloudflare_logpush.spectrum_event.application
@@ -201,7 +201,7 @@ processors:
   - set:
       field: event.id
       copy_from: cloudflare_logpush.spectrum_event.application
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.Status
       target_field: cloudflare_logpush.spectrum_event.status
@@ -215,7 +215,7 @@ processors:
   - set:
       field: http.response.status_code
       copy_from: cloudflare_logpush.spectrum_event.status
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.ClientAsn
       target_field: cloudflare_logpush.spectrum_event.client.asn
@@ -229,7 +229,7 @@ processors:
   - set:
       field: source.as.number
       copy_from: cloudflare_logpush.spectrum_event.client.asn
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.ClientBytes
       target_field: cloudflare_logpush.spectrum_event.client.bytes
@@ -243,7 +243,7 @@ processors:
   - set:
       field: source.bytes
       copy_from: cloudflare_logpush.spectrum_event.client.bytes
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.ClientCountry
       target_field: cloudflare_logpush.spectrum_event.client.country
@@ -251,7 +251,7 @@ processors:
   - set:
       field: source.geo.country_iso_code
       copy_from: cloudflare_logpush.spectrum_event.client.country
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.ClientIP
       target_field: cloudflare_logpush.spectrum_event.client.ip
@@ -265,7 +265,7 @@ processors:
   - set:
       field: source.ip
       copy_from: cloudflare_logpush.spectrum_event.client.ip
-      ignore_failure: true
+      ignore_empty_value: true
   - convert:
       field: json.ClientPort
       target_field: cloudflare_logpush.spectrum_event.client.port
@@ -279,7 +279,7 @@ processors:
   - set:
       field: source.port
       copy_from: cloudflare_logpush.spectrum_event.client.port
-      ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: json.ClientMatchedIpFirewall
       target_field: cloudflare_logpush.spectrum_event.client.matched_ip_firewall
@@ -291,7 +291,7 @@ processors:
   - set:
       field: network.transport
       copy_from: cloudflare_logpush.spectrum_event.client.protocol
-      ignore_failure: true
+      ignore_empty_value: true
   - lowercase:
       field: network.transport
       ignore_missing: true

--- a/packages/cloudflare_logpush/data_stream/workers_trace/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/workers_trace/elasticsearch/ingest_pipeline/default.yml
@@ -57,6 +57,7 @@ processors:
   - set:
       field: event.action
       copy_from: cloudflare_logpush.workers_trace.type
+      ignore_empty_value: true
       tag: set_event_action
 
   # Set event.outcome

--- a/packages/cloudflare_logpush/manifest.yml
+++ b/packages/cloudflare_logpush/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cloudflare_logpush
 title: Cloudflare Logpush
-version: "1.32.0"
+version: "1.33.0"
 description: Collect and parse logs from Cloudflare API with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

See title.

Continuation of https://github.com/elastic/integrations/pull/12674.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
