### PR TITLE
[CI] Remove issue_comment event in block-paths workflow

### DIFF
--- a/.github/workflows/block-paths.yml
+++ b/.github/workflows/block-paths.yml
@@ -3,12 +3,9 @@ name: Block Changes
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  issue_comment:
-    types: [created]
 
 jobs:
   check-blocked-paths:
-    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.comment.body == '/check-blocked-paths') }}
     name: Check for blocked path changes
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Proposed commit message

Keep just the `pull_request` event for block-paths github workflow.

In case, this GitHub action is not triggered because the PR has been created by another Github Action workflow, that PR can be closed and re-opened in order to trigger the corresponding GitHub action workflow.

Related [docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow):

> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs. 


Follows #12668
Follows #12688