### PR TITLE
Updated description on ssl node to be uniform and include links to online documentation

### DIFF
--- a/packages/akamai/changelog.yml
+++ b/packages/akamai/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.27.3"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "2.27.2"
   changes:
     - description: Events with the same requestId are now properly indexed. Previously, multiple records with the same requestId could conflict (and be dropped) due to variations in other fields like httpMessage.bytes or httpMessage.responseHeaders.

--- a/packages/akamai/data_stream/siem/manifest.yml
+++ b/packages/akamai/data_stream/siem/manifest.yml
@@ -85,10 +85,11 @@ streams:
         description: URL to proxy connections in the form of http\[s\]://<user>:<password>@<server name/ip>:<port>
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/akamai/manifest.yml
+++ b/packages/akamai/manifest.yml
@@ -1,6 +1,6 @@
 name: akamai
 title: Akamai
-version: "2.27.2"
+version: "2.27.3"
 description: Collect logs from Akamai with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/amazon_security_lake/changelog.yml
+++ b/packages/amazon_security_lake/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "2.3.0"
   changes:
     - description: Add support for Access Point ARN when collecting logs via the AWS S3 Bucket.

--- a/packages/amazon_security_lake/data_stream/event/manifest.yml
+++ b/packages/amazon_security_lake/data_stream/event/manifest.yml
@@ -241,7 +241,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/amazon_security_lake/manifest.yml
+++ b/packages/amazon_security_lake/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: amazon_security_lake
 title: Amazon Security Lake
-version: "2.3.0"
+version: "2.3.1"
 description: Collect logs from Amazon Security Lake with Elastic Agent.
 type: integration
 categories: ["aws", "security"]

--- a/packages/atlassian_bitbucket/changelog.yml
+++ b/packages/atlassian_bitbucket/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "2.3.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` set to "pipeline_error".

--- a/packages/atlassian_bitbucket/data_stream/audit/manifest.yml
+++ b/packages/atlassian_bitbucket/data_stream/audit/manifest.yml
@@ -122,10 +122,11 @@ streams:
         default: 24h
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: proxy_url
         type: text
         title: Proxy URL

--- a/packages/atlassian_bitbucket/manifest.yml
+++ b/packages/atlassian_bitbucket/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: atlassian_bitbucket
 title: Atlassian Bitbucket
-version: "2.3.0"
+version: "2.3.1"
 description: Collect logs from Atlassian Bitbucket with Elastic Agent.
 type: integration
 categories:

--- a/packages/atlassian_confluence/changelog.yml
+++ b/packages/atlassian_confluence/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.27.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.27.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` set to "pipeline_error".

--- a/packages/atlassian_confluence/data_stream/audit/manifest.yml
+++ b/packages/atlassian_confluence/data_stream/audit/manifest.yml
@@ -130,10 +130,11 @@ streams:
         default: 24h
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: proxy_url
         type: text
         title: Proxy URL

--- a/packages/atlassian_confluence/manifest.yml
+++ b/packages/atlassian_confluence/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: atlassian_confluence
 title: Atlassian Confluence
-version: "1.27.0"
+version: "1.27.1"
 description: Collect logs from Atlassian Confluence with Elastic Agent.
 type: integration
 categories:

--- a/packages/atlassian_jira/changelog.yml
+++ b/packages/atlassian_jira/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.28.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.28.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` set to "pipeline_error".

--- a/packages/atlassian_jira/data_stream/audit/manifest.yml
+++ b/packages/atlassian_jira/data_stream/audit/manifest.yml
@@ -130,10 +130,11 @@ streams:
         default: 24h
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: proxy_url
         type: text
         title: Proxy URL

--- a/packages/atlassian_jira/manifest.yml
+++ b/packages/atlassian_jira/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: atlassian_jira
 title: Atlassian Jira
-version: "1.28.0"
+version: "1.28.1"
 description: Collect logs from Atlassian Jira with Elastic Agent.
 type: integration
 categories:

--- a/packages/auth0/changelog.yml
+++ b/packages/auth0/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.19.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` set to "pipeline_error".

--- a/packages/auth0/data_stream/logs/manifest.yml
+++ b/packages/auth0/data_stream/logs/manifest.yml
@@ -39,8 +39,8 @@ streams:
         secret: true
       - name: ssl
         type: yaml
-        title: TLS
-        description: Options for enabling TLS for the listening webhook endpoint. See the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html) for a list of all options.
+        title: SSL Configuration
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/auth0/manifest.yml
+++ b/packages/auth0/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: auth0
 title: "Auth0"
-version: "1.19.0"
+version: "1.19.1"
 description: Collect logs from Auth0 with Elastic Agent.
 type: integration
 categories:

--- a/packages/barracuda/changelog.yml
+++ b/packages/barracuda/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.17.2"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.17.1"
   changes:
     - description: Update links to getting started docs

--- a/packages/barracuda/data_stream/waf/manifest.yml
+++ b/packages/barracuda/data_stream/waf/manifest.yml
@@ -91,7 +91,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/barracuda/manifest.yml
+++ b/packages/barracuda/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: barracuda
 title: "Barracuda Web Application Firewall"
-version: "1.17.1"
+version: "1.17.2"
 description: "Collect logs from Barracuda Web Application Firewall with Elastic Agent."
 type: integration
 source:

--- a/packages/barracuda_cloudgen_firewall/changelog.yml
+++ b/packages/barracuda_cloudgen_firewall/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.14.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` set to "pipeline_error".

--- a/packages/barracuda_cloudgen_firewall/data_stream/log/manifest.yml
+++ b/packages/barracuda_cloudgen_firewall/data_stream/log/manifest.yml
@@ -32,11 +32,11 @@ streams:
           - v2
       - name: ssl
         type: yaml
-        title: TLS configuration
+        title: SSL Configuration
         multi: false
         required: false
         show_user: true
-        description: Options for enabling TLS mode. See the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html) for a list of all options.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/barracuda_cloudgen_firewall/manifest.yml
+++ b/packages/barracuda_cloudgen_firewall/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: barracuda_cloudgen_firewall
 title: Barracuda CloudGen Firewall Logs
-version: "1.14.0"
+version: "1.14.1"
 description: Collect logs from Barracuda CloudGen Firewall devices with Elastic Agent.
 categories: ["network", "security", "firewall_security"]
 type: integration

--- a/packages/bitdefender/changelog.yml
+++ b/packages/bitdefender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "2.3.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/bitdefender/data_stream/push_configuration/manifest.yml
+++ b/packages/bitdefender/data_stream/push_configuration/manifest.yml
@@ -9,7 +9,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/bitdefender/data_stream/push_notifications/manifest.yml
+++ b/packages/bitdefender/data_stream/push_notifications/manifest.yml
@@ -39,8 +39,8 @@ streams:
         secret: true
       - name: ssl
         type: yaml
-        title: TLS
-        description: Options for enabling TLS for the listening webhook endpoint. See the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html) for a list of all options.
+        title: SSL Configuration
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/bitdefender/data_stream/push_statistics/manifest.yml
+++ b/packages/bitdefender/data_stream/push_statistics/manifest.yml
@@ -9,7 +9,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/bitdefender/manifest.yml
+++ b/packages/bitdefender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: bitdefender
 title: "BitDefender"
-version: "2.3.0"
+version: "2.3.1"
 source:
   license: "Elastic-2.0"
 description: "Ingest BitDefender GravityZone logs and data"

--- a/packages/canva/changelog.yml
+++ b/packages/canva/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "0.4.0"
   changes:
     - description: Add support for Access Point ARN when collecting logs via the AWS S3 Bucket.

--- a/packages/canva/data_stream/audit/manifest.yml
+++ b/packages/canva/data_stream/audit/manifest.yml
@@ -202,7 +202,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/canva/manifest.yml
+++ b/packages/canva/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: canva
 title: Canva
-version: 0.4.0
+version: 0.4.1
 description: Collect logs from Canva with Elastic Agent.
 type: integration
 categories:

--- a/packages/carbonblack_edr/changelog.yml
+++ b/packages/carbonblack_edr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.20.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.20.0"
   changes:
     - description: Allow the usage of deprecated log input and support for stack 9.0

--- a/packages/carbonblack_edr/data_stream/log/manifest.yml
+++ b/packages/carbonblack_edr/data_stream/log/manifest.yml
@@ -22,10 +22,11 @@ streams:
         show_user: true
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/carbonblack_edr/manifest.yml
+++ b/packages/carbonblack_edr/manifest.yml
@@ -1,6 +1,6 @@
 name: carbonblack_edr
 title: VMware Carbon Black EDR
-version: "1.20.0"
+version: "1.20.1"
 description: Collect logs from VMware Carbon Black EDR with Elastic Agent.
 type: integration
 format_version: "3.0.3"

--- a/packages/cisa_kevs/changelog.yml
+++ b/packages/cisa_kevs/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.4.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` set to "pipeline_error".

--- a/packages/cisa_kevs/data_stream/vulnerability/manifest.yml
+++ b/packages/cisa_kevs/data_stream/vulnerability/manifest.yml
@@ -34,10 +34,11 @@ streams:
         default: 60m
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/cisa_kevs/manifest.yml
+++ b/packages/cisa_kevs/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: cisa_kevs
 title: "CISA Known Exploited Vulnerabilities"
-version: "1.4.0"
+version: "1.4.1"
 description: "This package allows the ingest of known exploited vulnerabilities according to the Cybersecurity and Infrastructure Security Agency of the United States of America. This information could be used to enrich or track exisiting vulnerabilities that are known to be exploited in the wild."
 type: integration
 categories:

--- a/packages/cisco_meraki/changelog.yml
+++ b/packages/cisco_meraki/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.27.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.27.0"
   changes:
     - description: "Migrate log stream to saved search."

--- a/packages/cisco_meraki/data_stream/events/manifest.yml
+++ b/packages/cisco_meraki/data_stream/events/manifest.yml
@@ -39,8 +39,8 @@ streams:
         secret: true
       - name: ssl
         type: yaml
-        title: TLS
-        description: Options for enabling TLS for the listening webhook endpoint. See the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html) for a list of all options.
+        title: SSL Configuration
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/cisco_meraki/data_stream/log/manifest.yml
+++ b/packages/cisco_meraki/data_stream/log/manifest.yml
@@ -100,8 +100,8 @@ streams:
         default: false
       - name: ssl
         type: yaml
-        title: TLS
-        description: Options for enabling TLS for the listening TCP socket. See the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html) for a list of all options.
+        title: SSL Configuration
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/cisco_meraki/manifest.yml
+++ b/packages/cisco_meraki/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cisco_meraki
 title: Cisco Meraki
-version: "1.27.0"
+version: "1.27.1"
 description: Collect logs from Cisco Meraki with Elastic Agent.
 type: integration
 categories:

--- a/packages/cisco_secure_endpoint/changelog.yml
+++ b/packages/cisco_secure_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.28.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "2.28.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` set to "pipeline_error".

--- a/packages/cisco_secure_endpoint/data_stream/event/manifest.yml
+++ b/packages/cisco_secure_endpoint/data_stream/event/manifest.yml
@@ -67,10 +67,11 @@ streams:
         default: 24h
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/cisco_secure_endpoint/manifest.yml
+++ b/packages/cisco_secure_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cisco_secure_endpoint
 title: Cisco Secure Endpoint
-version: "2.28.0"
+version: "2.28.1"
 description: Collect logs from Cisco Secure Endpoint (AMP) with Elastic Agent.
 type: integration
 categories:

--- a/packages/claroty_ctd/changelog.yml
+++ b/packages/claroty_ctd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "0.4.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/claroty_ctd/data_stream/event/manifest.yml
+++ b/packages/claroty_ctd/data_stream/event/manifest.yml
@@ -36,7 +36,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: SSL config for host.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/claroty_ctd/manifest.yml
+++ b/packages/claroty_ctd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.4
 name: claroty_ctd
 title: Claroty CTD
-version: 0.4.0
+version: 0.4.1
 description: Collect logs from Claroty CTD using Elastic Agent.
 type: integration
 categories:

--- a/packages/cyberarkpas/changelog.yml
+++ b/packages/cyberarkpas/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.26.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "2.26.0"
   changes:
     - description: Allow the usage of deprecated log input and support for stack 9.0

--- a/packages/cyberarkpas/data_stream/audit/manifest.yml
+++ b/packages/cyberarkpas/data_stream/audit/manifest.yml
@@ -74,11 +74,11 @@ streams:
           - forwarded
       - name: ssl
         type: yaml
-        title: TLS configuration
+        title: SSL Configuration
         multi: false
         required: false
         show_user: true
-        description: Options for enabling TLS mode. See the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html) for a list of all options.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: preserve_original_event
         required: true
         show_user: true

--- a/packages/cyberarkpas/manifest.yml
+++ b/packages/cyberarkpas/manifest.yml
@@ -1,6 +1,6 @@
 name: cyberarkpas
 title: CyberArk Privileged Access Security
-version: "2.26.0"
+version: "2.26.1"
 description: Collect logs from CyberArk Privileged Access Security with Elastic Agent.
 type: integration
 format_version: "3.0.3"

--- a/packages/digital_guardian/changelog.yml
+++ b/packages/digital_guardian/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.2"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.3.1"
   changes:
     - description: Correct time formats, data size parsing

--- a/packages/digital_guardian/data_stream/arc/manifest.yml
+++ b/packages/digital_guardian/data_stream/arc/manifest.yml
@@ -78,7 +78,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/digital_guardian/manifest.yml
+++ b/packages/digital_guardian/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: digital_guardian
 title: Digital Guardian
-version: "1.3.1"
+version: "1.3.2"
 description: Collect logs from Digital Guardian with Elastic Agent.
 type: integration
 categories:

--- a/packages/entityanalytics_entra_id/changelog.yml
+++ b/packages/entityanalytics_entra_id/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.5.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/entityanalytics_entra_id/data_stream/entity/manifest.yml
+++ b/packages/entityanalytics_entra_id/data_stream/entity/manifest.yml
@@ -106,7 +106,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/entityanalytics_entra_id/manifest.yml
+++ b/packages/entityanalytics_entra_id/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: entityanalytics_entra_id
 title: "Microsoft Entra ID Entity Analytics"
-version: "1.5.0"
+version: "1.5.1"
 description: "Collect identities from Microsoft Entra ID (formerly Azure Active Directory) with Elastic Agent."
 type: integration
 categories:

--- a/packages/entityanalytics_okta/changelog.yml
+++ b/packages/entityanalytics_okta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.8.0"
   changes:
     - description: Add "event.original" field when "preserve_original_event" is set.

--- a/packages/entityanalytics_okta/data_stream/user/manifest.yml
+++ b/packages/entityanalytics_okta/data_stream/user/manifest.yml
@@ -77,7 +77,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/entityanalytics_okta/manifest.yml
+++ b/packages/entityanalytics_okta/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: entityanalytics_okta
 title: Okta Entity Analytics
-version: "1.8.0"
+version: "1.8.1"
 description: "Collect User Identities from Okta with Elastic Agent."
 type: integration
 categories:

--- a/packages/eset_protect/changelog.yml
+++ b/packages/eset_protect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.5.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/eset_protect/data_stream/detection/manifest.yml
+++ b/packages/eset_protect/data_stream/detection/manifest.yml
@@ -75,7 +75,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/eset_protect/data_stream/device_task/manifest.yml
+++ b/packages/eset_protect/data_stream/device_task/manifest.yml
@@ -67,7 +67,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/eset_protect/data_stream/event/manifest.yml
+++ b/packages/eset_protect/data_stream/event/manifest.yml
@@ -69,7 +69,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: true
         show_user: true

--- a/packages/eset_protect/manifest.yml
+++ b/packages/eset_protect/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: eset_protect
 title: ESET PROTECT
-version: "1.5.0"
+version: "1.5.1"
 description: Collect logs from ESET PROTECT with Elastic Agent.
 type: integration
 categories:

--- a/packages/fortinet_fortigate/changelog.yml
+++ b/packages/fortinet_fortigate/changelog.yml
@@ -5,7 +5,7 @@
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12503
 - version: "1.28.0"
-  changes:     
+  changes:    
     - description: ECS version updated to 8.17.0.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12571

--- a/packages/fortinet_fortigate/changelog.yml
+++ b/packages/fortinet_fortigate/changelog.yml
@@ -5,7 +5,7 @@
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12503
 - version: "1.28.0"
-  changes:    
+  changes:
     - description: ECS version updated to 8.17.0.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12571

--- a/packages/fortinet_fortigate/changelog.yml
+++ b/packages/fortinet_fortigate/changelog.yml
@@ -5,7 +5,7 @@
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12503
 - version: "1.28.0"
-  changes:
+  changes:     
     - description: ECS version updated to 8.17.0.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12571

--- a/packages/github/changelog.yml
+++ b/packages/github/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "2.3.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/github/data_stream/audit/manifest.yml
+++ b/packages/github/data_stream/audit/manifest.yml
@@ -63,10 +63,11 @@ streams:
         default: https://api.github.com
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: proxy_url
         type: text
         title: Proxy URL

--- a/packages/github/data_stream/code_scanning/manifest.yml
+++ b/packages/github/data_stream/code_scanning/manifest.yml
@@ -51,10 +51,11 @@ streams:
         default: https://api.github.com
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: proxy_url
         type: text
         title: Proxy URL

--- a/packages/github/data_stream/dependabot/manifest.yml
+++ b/packages/github/data_stream/dependabot/manifest.yml
@@ -51,10 +51,11 @@ streams:
         default: https://api.github.com
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: proxy_url
         type: text
         title: Proxy URL

--- a/packages/github/data_stream/issues/manifest.yml
+++ b/packages/github/data_stream/issues/manifest.yml
@@ -82,10 +82,11 @@ streams:
         default: https://api.github.com
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: proxy_url
         type: text
         title: Proxy URL

--- a/packages/github/data_stream/secret_scanning/manifest.yml
+++ b/packages/github/data_stream/secret_scanning/manifest.yml
@@ -60,10 +60,11 @@ streams:
         default: https://api.github.com
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: proxy_url
         type: text
         title: Proxy URL

--- a/packages/github/manifest.yml
+++ b/packages/github/manifest.yml
@@ -1,6 +1,6 @@
 name: github
 title: GitHub
-version: "2.3.0"
+version: "2.3.1"
 description: Collect logs from GitHub with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.30.3"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "2.30.2"
   changes:
     - description: Prevent pageToken from incorrectly reappearing in interval requests.

--- a/packages/google_workspace/data_stream/access_transparency/manifest.yml
+++ b/packages/google_workspace/data_stream/access_transparency/manifest.yml
@@ -58,7 +58,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/google_workspace/data_stream/alert/manifest.yml
+++ b/packages/google_workspace/data_stream/alert/manifest.yml
@@ -74,7 +74,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/google_workspace/data_stream/chrome/manifest.yml
+++ b/packages/google_workspace/data_stream/chrome/manifest.yml
@@ -74,7 +74,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: SSL Config for the host i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/google_workspace/data_stream/context_aware_access/manifest.yml
+++ b/packages/google_workspace/data_stream/context_aware_access/manifest.yml
@@ -58,7 +58,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/google_workspace/data_stream/device/manifest.yml
+++ b/packages/google_workspace/data_stream/device/manifest.yml
@@ -58,7 +58,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/google_workspace/data_stream/gcp/manifest.yml
+++ b/packages/google_workspace/data_stream/gcp/manifest.yml
@@ -58,7 +58,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/google_workspace/data_stream/group_enterprise/manifest.yml
+++ b/packages/google_workspace/data_stream/group_enterprise/manifest.yml
@@ -58,7 +58,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/google_workspace/data_stream/rules/manifest.yml
+++ b/packages/google_workspace/data_stream/rules/manifest.yml
@@ -58,7 +58,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/google_workspace/data_stream/token/manifest.yml
+++ b/packages/google_workspace/data_stream/token/manifest.yml
@@ -58,7 +58,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: "2.30.2"
+version: "2.30.3"
 source:
   license: Elastic-2.0
 description: Collect logs from Google Workspace with Elastic Agent.

--- a/packages/imperva_cloud_waf/changelog.yml
+++ b/packages/imperva_cloud_waf/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.2"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.5.1"
   changes:
     - description: Tolerate no separator in log files.

--- a/packages/imperva_cloud_waf/data_stream/event/manifest.yml
+++ b/packages/imperva_cloud_waf/data_stream/event/manifest.yml
@@ -94,7 +94,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false
@@ -319,7 +319,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/imperva_cloud_waf/manifest.yml
+++ b/packages/imperva_cloud_waf/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: imperva_cloud_waf
 title: Imperva Cloud WAF
-version: "1.5.1"
+version: "1.5.2"
 description: Collect logs from Imperva Cloud WAF with Elastic Agent.
 type: integration
 categories:

--- a/packages/jamf_compliance_reporter/changelog.yml
+++ b/packages/jamf_compliance_reporter/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.2"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.15.1"
   changes:
     - description: Update links to getting started docs

--- a/packages/jamf_compliance_reporter/data_stream/log/manifest.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/manifest.yml
@@ -33,7 +33,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false
@@ -108,7 +108,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate, keys, supported_protocols, verification_mode etc. See [SSL](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-server-config) for details.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/jamf_compliance_reporter/manifest.yml
+++ b/packages/jamf_compliance_reporter/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: jamf_compliance_reporter
 title: Jamf Compliance Reporter
-version: "1.15.1"
+version: "1.15.2"
 description: Collect logs from Jamf Compliance Reporter with Elastic Agent.
 type: integration
 categories:

--- a/packages/jumpcloud/changelog.yml
+++ b/packages/jumpcloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.14.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/jumpcloud/data_stream/events/manifest.yml
+++ b/packages/jumpcloud/data_stream/events/manifest.yml
@@ -50,7 +50,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/jumpcloud/manifest.yml
+++ b/packages/jumpcloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: jumpcloud
 title: "JumpCloud"
-version: "1.14.0"
+version: "1.14.1"
 description: "Collect logs from JumpCloud Directory as a Service"
 type: integration
 categories:

--- a/packages/ping_federate/changelog.yml
+++ b/packages/ping_federate/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "0.1.0"
   changes:
     - description: Initial Release.

--- a/packages/ping_federate/data_stream/audit/manifest.yml
+++ b/packages/ping_federate/data_stream/audit/manifest.yml
@@ -44,7 +44,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false
@@ -179,7 +179,7 @@ streams:
   - input: filestream
     enabled: false
     template_path: filestream.yml.hbs
-    title:  Audit logs
+    title: Audit logs
     description: Collect PingFederate audit logs via Filestream.
     vars:
       - name: paths

--- a/packages/ping_federate/manifest.yml
+++ b/packages/ping_federate/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: ping_federate
 title: PingFederate
-version: 0.1.0
+version: 0.1.1
 description: Collect logs from PingFederate with Elastic Agent.
 type: integration
 categories:

--- a/packages/prisma_access/changelog.yml
+++ b/packages/prisma_access/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.3.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/prisma_access/data_stream/event/manifest.yml
+++ b/packages/prisma_access/data_stream/event/manifest.yml
@@ -36,7 +36,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: true
         show_user: true

--- a/packages/prisma_access/manifest.yml
+++ b/packages/prisma_access/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.4
 name: prisma_access
 title: Palo Alto Prisma Access
-version: 1.3.0
+version: 1.3.1
 description: Collect logs from Palo Alto Prisma Access with Elastic Agent.
 type: integration
 categories:

--- a/packages/pulse_connect_secure/changelog.yml
+++ b/packages/pulse_connect_secure/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "2.4.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/pulse_connect_secure/data_stream/log/manifest.yml
+++ b/packages/pulse_connect_secure/data_stream/log/manifest.yml
@@ -84,11 +84,11 @@ streams:
           - pulse_connect_secure-log
       - name: ssl
         type: yaml
-        title: TLS configuration
+        title: SSL Configuration
         multi: false
         required: false
         show_user: true
-        description: Options for enabling TLS mode. See the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html) for a list of all options.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: preserve_original_event
         required: true
         show_user: true

--- a/packages/pulse_connect_secure/manifest.yml
+++ b/packages/pulse_connect_secure/manifest.yml
@@ -1,6 +1,6 @@
 name: pulse_connect_secure
 title: Pulse Connect Secure
-version: "2.4.0"
+version: "2.4.1"
 description: Collect logs from Pulse Connect Secure with Elastic Agent.
 type: integration
 icons:

--- a/packages/servicenow/changelog.yml
+++ b/packages/servicenow/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.9.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "0.9.0"
   changes:
     - description: Add option to parse fields containing only display values in S3.

--- a/packages/servicenow/data_stream/event/manifest.yml
+++ b/packages/servicenow/data_stream/event/manifest.yml
@@ -142,7 +142,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: SSL config for host. i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false
@@ -431,7 +431,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: SSL config for host. i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/servicenow/manifest.yml
+++ b/packages/servicenow/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: servicenow
 title: "ServiceNow"
-version: 0.9.0
+version: 0.9.1
 description: "Collect logs from ServiceNow with Elastic Agent."
 type: integration
 categories:

--- a/packages/symantec_endpoint/changelog.yml
+++ b/packages/symantec_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.18.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "2.18.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/symantec_endpoint/data_stream/log/manifest.yml
+++ b/packages/symantec_endpoint/data_stream/log/manifest.yml
@@ -109,8 +109,8 @@ streams:
         default: false
       - name: ssl
         type: yaml
-        title: TLS
-        description: Options for enabling TLS for the listening TCP socket. See the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html) for a list of all options.
+        title: SSL Configuration
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/symantec_endpoint/manifest.yml
+++ b/packages/symantec_endpoint/manifest.yml
@@ -1,6 +1,6 @@
 name: symantec_endpoint
 title: Symantec Endpoint Protection
-version: "2.18.0"
+version: "2.18.1"
 description: Collect logs from Symantec Endpoint Protection with Elastic Agent.
 type: integration
 format_version: "3.0.3"

--- a/packages/symantec_endpoint_security/changelog.yml
+++ b/packages/symantec_endpoint_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.6.0"
   changes:
     - description: Add support for Access Point ARN when collecting logs via the AWS S3 Bucket.

--- a/packages/symantec_endpoint_security/data_stream/event/manifest.yml
+++ b/packages/symantec_endpoint_security/data_stream/event/manifest.yml
@@ -194,7 +194,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/symantec_endpoint_security/manifest.yml
+++ b/packages/symantec_endpoint_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: symantec_endpoint_security
 title: Symantec Endpoint Security
-version: "1.6.0"
+version: "1.6.1"
 description: Collect logs from Symantec Endpoint Security with Elastic Agent.
 type: integration
 categories:

--- a/packages/sysdig/changelog.yml
+++ b/packages/sysdig/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.2"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "0.2.1"
   changes:
     - description: Update links to getting started docs

--- a/packages/sysdig/data_stream/alerts/manifest.yml
+++ b/packages/sysdig/data_stream/alerts/manifest.yml
@@ -45,8 +45,8 @@ streams:
         secret: true
       - name: ssl
         type: yaml
-        title: TLS
-        description: Options for enabling TLS for the listening webhook endpoint. See the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html) for a list of all options.
+        title: SSL Configuration
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/sysdig/manifest.yml
+++ b/packages/sysdig/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: sysdig
 title: "Sysdig"
-version: 0.2.1
+version: 0.2.2
 description: "Collect alerts from Sysdig using Elastic Agent."
 type: integration
 categories:

--- a/packages/thycotic_ss/changelog.yml
+++ b/packages/thycotic_ss/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.11.0"
   changes:
     - description: Allow the usage of deprecated log input and support for stack 9.0

--- a/packages/thycotic_ss/data_stream/logs/manifest.yml
+++ b/packages/thycotic_ss/data_stream/logs/manifest.yml
@@ -125,7 +125,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/thycotic_ss/manifest.yml
+++ b/packages/thycotic_ss/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: thycotic_ss
 title: "Thycotic Secret Server"
-version: "1.11.0"
+version: "1.11.1"
 source:
   license: "Elastic-2.0"
 description: "Thycotic Secret Server logs"

--- a/packages/ti_abusech/changelog.yml
+++ b/packages/ti_abusech/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "2.5.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/ti_abusech/data_stream/malware/manifest.yml
+++ b/packages/ti_abusech/data_stream/malware/manifest.yml
@@ -45,10 +45,11 @@ streams:
         description: "Indicator is expired after this duration since its last seen timestamp. Use [Elasticsearch time units](https://www.elastic.co/guide/en/elasticsearch/reference/current/api-conventions.html#time-units) in days, hours, or minutes (e.g 10d). Default `90d`."
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/ti_abusech/data_stream/malwarebazaar/manifest.yml
+++ b/packages/ti_abusech/data_stream/malwarebazaar/manifest.yml
@@ -46,10 +46,11 @@ streams:
           Indicator is expired after this duration since its last seen timestamp. Use [Elasticsearch time units](https://www.elastic.co/guide/en/elasticsearch/reference/current/api-conventions.html#time-units) in days, hours, or minutes (e.g 10d). Default `90d`.
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/ti_abusech/data_stream/threatfox/manifest.yml
+++ b/packages/ti_abusech/data_stream/threatfox/manifest.yml
@@ -54,10 +54,11 @@ streams:
           Indicator is expired after this duration since its last seen timestamp. Use [Elasticsearch time units](https://www.elastic.co/guide/en/elasticsearch/reference/current/api-conventions.html#time-units) in days, hours, or minutes (e.g 10d). Default `90d`.
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/ti_abusech/data_stream/url/manifest.yml
+++ b/packages/ti_abusech/data_stream/url/manifest.yml
@@ -38,10 +38,11 @@ streams:
         description: Interval for polling indicators from AbuseCH data dump. As data dump is generated every 5 minutes, it should be greater than 5 minutes. Default `1h`.
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/ti_abusech/manifest.yml
+++ b/packages/ti_abusech/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_abusech
 title: AbuseCH
-version: "2.5.0"
+version: "2.5.1"
 description: Ingest threat intelligence indicators from URL Haus, Malware Bazaar, and Threat Fox feeds with Elastic Agent.
 type: integration
 format_version: "3.0.3"

--- a/packages/ti_anomali/changelog.yml
+++ b/packages/ti_anomali/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.25.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.25.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/ti_anomali/data_stream/threatstream/manifest.yml
+++ b/packages/ti_anomali/data_stream/threatstream/manifest.yml
@@ -48,8 +48,8 @@ streams:
         secret: true
       - name: ssl
         type: yaml
-        title: TLS
-        description: Options for enabling TLS for the listening webhook endpoint. See the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html) for a list of all options.
+        title: SSL Configuration
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false
@@ -91,3 +91,4 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+

--- a/packages/ti_anomali/manifest.yml
+++ b/packages/ti_anomali/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_anomali
 title: Anomali
-version: "1.25.0"
+version: "1.25.1"
 description: Ingest threat intelligence indicators from Anomali with Elastic Agent.
 type: integration
 format_version: 3.0.2

--- a/packages/ti_custom/changelog.yml
+++ b/packages/ti_custom/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.7.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "0.7.0"
   changes:
     - description: Add mapping for log file fingerprint.

--- a/packages/ti_custom/data_stream/indicator/manifest.yml
+++ b/packages/ti_custom/data_stream/indicator/manifest.yml
@@ -93,7 +93,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate, key, certificate_authorities, and [other SSL options](https://www.elastic.co/guide/en/beats/filebeacurrent/configuration-ssl.html).
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/ti_custom/manifest.yml
+++ b/packages/ti_custom/manifest.yml
@@ -3,7 +3,7 @@ name: ti_custom
 title: Custom Threat Intelligence
 description: Ingest threat intelligence data in STIX 2.1 format with Elastic Agent
 type: integration
-version: 0.7.0
+version: 0.7.1
 categories:
   - custom
   - security

--- a/packages/ti_cybersixgill/changelog.yml
+++ b/packages/ti_cybersixgill/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.32.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.32.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/ti_cybersixgill/data_stream/threat/manifest.yml
+++ b/packages/ti_cybersixgill/data_stream/threat/manifest.yml
@@ -73,10 +73,11 @@ streams:
         description: How far back to look for indicators the first time the agent is started. Supported units for this parameter are h/m/s.
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/ti_cybersixgill/manifest.yml
+++ b/packages/ti_cybersixgill/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_cybersixgill
 title: Cybersixgill
-version: "1.32.0"
+version: "1.32.1"
 description: Ingest threat intelligence indicators from Cybersixgill with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/ti_eset/changelog.yml
+++ b/packages/ti_eset/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.5.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/ti_eset/data_stream/apt/manifest.yml
+++ b/packages/ti_eset/data_stream/apt/manifest.yml
@@ -63,10 +63,11 @@ streams:
         description: Maximum number of records to pull in one request.
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/ti_eset/data_stream/botnet/manifest.yml
+++ b/packages/ti_eset/data_stream/botnet/manifest.yml
@@ -63,10 +63,11 @@ streams:
         description: Maximum number of records to pull in one request.
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/ti_eset/data_stream/cc/manifest.yml
+++ b/packages/ti_eset/data_stream/cc/manifest.yml
@@ -63,10 +63,11 @@ streams:
         description: Maximum number of records to pull in one request.
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/ti_eset/data_stream/domains/manifest.yml
+++ b/packages/ti_eset/data_stream/domains/manifest.yml
@@ -63,10 +63,11 @@ streams:
         description: Maximum number of records to pull in one request.
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/ti_eset/data_stream/files/manifest.yml
+++ b/packages/ti_eset/data_stream/files/manifest.yml
@@ -63,10 +63,11 @@ streams:
         description: Maximum number of records to pull in one request.
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/ti_eset/data_stream/ip/manifest.yml
+++ b/packages/ti_eset/data_stream/ip/manifest.yml
@@ -63,10 +63,11 @@ streams:
         description: Maximum number of records to pull in one request.
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/ti_eset/data_stream/url/manifest.yml
+++ b/packages/ti_eset/data_stream/url/manifest.yml
@@ -63,10 +63,11 @@ streams:
         description: Maximum number of records to pull in one request.
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/ti_eset/manifest.yml
+++ b/packages/ti_eset/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_eset
 title: "ESET Threat Intelligence"
-version: "1.5.0"
+version: "1.5.1"
 description: "Ingest threat intelligence indicators from ESET Threat Intelligence with Elastic Agent."
 type: integration
 categories:

--- a/packages/ti_misp/changelog.yml
+++ b/packages/ti_misp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.37.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.37.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/ti_misp/data_stream/threat/manifest.yml
+++ b/packages/ti_misp/data_stream/threat/manifest.yml
@@ -83,12 +83,13 @@ streams:
         default: 10m
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
         default: |
           #verification_mode: none
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/ti_misp/data_stream/threat_attributes/manifest.yml
+++ b/packages/ti_misp/data_stream/threat_attributes/manifest.yml
@@ -101,12 +101,13 @@ streams:
         default: false
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
         default: |
           # verification_mode: none
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/ti_misp/manifest.yml
+++ b/packages/ti_misp/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_misp
 title: MISP
-version: "1.37.0"
+version: "1.37.1"
 description: Ingest threat intelligence indicators from MISP platform with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/ti_otx/changelog.yml
+++ b/packages/ti_otx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.27.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.27.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/ti_otx/data_stream/pulses_subscribed/manifest.yml
+++ b/packages/ti_otx/data_stream/pulses_subscribed/manifest.yml
@@ -81,7 +81,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/ti_otx/data_stream/threat/manifest.yml
+++ b/packages/ti_otx/data_stream/threat/manifest.yml
@@ -74,10 +74,11 @@ streams:
         description: "A comma separated list of indicator types to retrieve, example: 'domain,IPv4,hostname,url,FileHash-SHA256'"
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: true
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/ti_otx/manifest.yml
+++ b/packages/ti_otx/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_otx
 title: AlienVault OTX
-version: "1.27.0"
+version: "1.27.1"
 description: Ingest threat intelligence indicators from AlienVault Open Threat Exchange (OTX) with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/ti_threatq/changelog.yml
+++ b/packages/ti_threatq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.30.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.30.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/ti_threatq/data_stream/threat/manifest.yml
+++ b/packages/ti_threatq/data_stream/threat/manifest.yml
@@ -91,12 +91,13 @@ streams:
         description: Maximum number of records to pull in one request.
       - name: ssl
         type: yaml
-        title: SSL
+        title: SSL Configuration
         multi: false
         required: false
         show_user: false
         default: |
           #verification_mode: none
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/ti_threatq/manifest.yml
+++ b/packages/ti_threatq/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_threatq
 title: ThreatQuotient
-version: "1.30.0"
+version: "1.30.1"
 description: Ingest threat intelligence indicators from ThreatQuotient with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/tines/changelog.yml
+++ b/packages/tines/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.2"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.14.1"
   changes:
     - description: Workaround missing dynamic template for options fields.

--- a/packages/tines/data_stream/audit_logs/manifest.yml
+++ b/packages/tines/data_stream/audit_logs/manifest.yml
@@ -9,7 +9,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/tines/data_stream/time_saved/manifest.yml
+++ b/packages/tines/data_stream/time_saved/manifest.yml
@@ -9,7 +9,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/tines/manifest.yml
+++ b/packages/tines/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: tines
 title: "Tines"
-version: "1.14.1"
+version: "1.14.2"
 description: "Tines Logs & Time Saved Reports"
 type: integration
 categories:

--- a/packages/trendmicro/changelog.yml
+++ b/packages/trendmicro/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.6.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "2.6.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/trendmicro/data_stream/deep_security/manifest.yml
+++ b/packages/trendmicro/data_stream/deep_security/manifest.yml
@@ -47,7 +47,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/trendmicro/manifest.yml
+++ b/packages/trendmicro/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: trendmicro
 title: Trend Micro Deep Security
-version: "2.6.0"
+version: "2.6.1"
 description: Collect logs from Trend Micro Deep Security with Elastic Agent.
 type: integration
 categories:

--- a/packages/vectra_detect/changelog.yml
+++ b/packages/vectra_detect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/87129
 - version: "1.12.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/vectra_detect/data_stream/log/manifest.yml
+++ b/packages/vectra_detect/data_stream/log/manifest.yml
@@ -37,7 +37,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/vectra_detect/manifest.yml
+++ b/packages/vectra_detect/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: vectra_detect
 title: Vectra Detect
-version: "1.12.0"
+version: "1.12.1"
 source:
   license: Elastic-2.0
 description: Collect logs from Vectra Detect with Elastic Agent.


### PR DESCRIPTION
## Proposed commit message
This commit updates or adds descriptions to the ssl node to be uniform and to include links to online documentation. Updated files belong to security-service-integrations

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally
Originally, we update the descriptions on all the files. This created some issues with so many teams needing to validate the files. This is currently a partial update with files that are owned by security-service-integrations. As such the only verification would be to check that was what updates is uniform.
`
> git diff main | grep description: | grep + | sort -u
 results in the update fields for the ssl node description and the changelog.yml
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
+    - description: Updated SSL description to be uniform and to include links to documentation.
`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

Partial
- Relates #11792

