### PR TITLE
Updated description on ssl node in data_stream to be uniform and include links to online documentation for integrations owned by obs-infraobs-integrations

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.41.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12727
 - version: "2.41.0"
   changes:
     - description: Ignore long `cloudtrail.request_parameters` and `cloudtrail.response_elements` fields.

--- a/packages/aws/data_stream/cloudtrail/manifest.yml
+++ b/packages/aws/data_stream/cloudtrail/manifest.yml
@@ -212,7 +212,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         default: |
           #certificate_authorities:
           #  - |

--- a/packages/aws/data_stream/guardduty/manifest.yml
+++ b/packages/aws/data_stream/guardduty/manifest.yml
@@ -67,7 +67,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/aws/data_stream/inspector/manifest.yml
+++ b/packages/aws/data_stream/inspector/manifest.yml
@@ -66,7 +66,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/aws/data_stream/securityhub_findings/manifest.yml
+++ b/packages/aws/data_stream/securityhub_findings/manifest.yml
@@ -59,7 +59,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/aws/data_stream/securityhub_insights/manifest.yml
+++ b/packages/aws/data_stream/securityhub_insights/manifest.yml
@@ -51,7 +51,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,4 +1,4 @@
-format_version: 3.0.0
+format_version: 3.3.1
 name: aws
 title: AWS
 version: 2.41.1
@@ -11,7 +11,7 @@ conditions:
   elastic:
     subscription: basic
   kibana:
-    version: "^8.16.2"
+    version: "^8.16.2 || ^9.0.0"
 screenshots:
   - src: /img/metricbeat-aws-overview.png
     title: metricbeat aws overview

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.3.1
+format_version: 3.0.0
 name: aws
 title: AWS
-version: 2.41.0
+version: 2.41.1
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:
@@ -11,7 +11,7 @@ conditions:
   elastic:
     subscription: basic
   kibana:
-    version: "^8.16.2 || ^9.0.0"
+    version: "^8.16.2"
 screenshots:
   - src: /img/metricbeat-aws-overview.png
     title: metricbeat aws overview

--- a/packages/hadoop/changelog.yml
+++ b/packages/hadoop/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12727
 - version: "1.8.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/hadoop/data_stream/application/manifest.yml
+++ b/packages/hadoop/data_stream/application/manifest.yml
@@ -38,7 +38,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/hadoop/data_stream/cluster/manifest.yml
+++ b/packages/hadoop/data_stream/cluster/manifest.yml
@@ -33,7 +33,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/hadoop/data_stream/datanode/manifest.yml
+++ b/packages/hadoop/data_stream/datanode/manifest.yml
@@ -33,7 +33,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/hadoop/data_stream/namenode/manifest.yml
+++ b/packages/hadoop/data_stream/namenode/manifest.yml
@@ -33,7 +33,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/hadoop/data_stream/node_manager/manifest.yml
+++ b/packages/hadoop/data_stream/node_manager/manifest.yml
@@ -33,7 +33,7 @@ streams:
       - name: ssl
         type: yaml
         title: SSL Configuration
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/hadoop/manifest.yml
+++ b/packages/hadoop/manifest.yml
@@ -10,7 +10,7 @@ categories:
   - big_data
 conditions:
   kibana:
-    version: "^8.13.0"
+    version: "^8.13.0 || ^9.0.0"
   elastic:
     subscription: basic
 screenshots:

--- a/packages/hadoop/manifest.yml
+++ b/packages/hadoop/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: hadoop
 title: Hadoop
-version: "1.8.0"
+version: "1.8.1"
 description: Collect metrics from Apache Hadoop with Elastic Agent.
 type: integration
 categories:
@@ -10,7 +10,7 @@ categories:
   - big_data
 conditions:
   kibana:
-    version: "^8.13.0 || ^9.0.0"
+    version: "^8.13.0"
   elastic:
     subscription: basic
 screenshots:

--- a/packages/kafka_log/changelog.yml
+++ b/packages/kafka_log/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.8.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12727
 - version: "1.8.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/kafka_log/data_stream/generic/manifest.yml
+++ b/packages/kafka_log/data_stream/generic/manifest.yml
@@ -226,8 +226,8 @@ streams:
         show_user: false
       - name: ssl
         type: yaml
-        title: TLS
-        description: Options for enabling TLS for the listening webhook endpoint. See the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html) for a list of all options.
+        title: SSL Configuration
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/kafka_log/manifest.yml
+++ b/packages/kafka_log/manifest.yml
@@ -3,10 +3,10 @@ name: kafka_log
 title: Custom Kafka Logs
 description: Collect data from kafka topic with Elastic Agent.
 type: integration
-version: "1.8.0"
+version: "1.8.1"
 conditions:
   kibana:
-    version: "^8.13.0 || ^9.0.0"
+    version: "^8.13.0"
   elastic:
     subscription: basic
 categories:

--- a/packages/kafka_log/manifest.yml
+++ b/packages/kafka_log/manifest.yml
@@ -6,7 +6,7 @@ type: integration
 version: "1.8.1"
 conditions:
   kibana:
-    version: "^8.13.0"
+    version: "^8.13.0 || ^9.0.0"
   elastic:
     subscription: basic
 categories:

--- a/packages/vsphere/changelog.yml
+++ b/packages/vsphere/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12727
 - version: "1.18.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/vsphere/data_stream/log/manifest.yml
+++ b/packages/vsphere/data_stream/log/manifest.yml
@@ -116,7 +116,7 @@ streams:
           #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
           #   7RhLQyWn2u00L7/9Omw=
           #   -----END CERTIFICATE-----
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
         multi: false
         required: false
         show_user: false

--- a/packages/vsphere/manifest.yml
+++ b/packages/vsphere/manifest.yml
@@ -1,7 +1,7 @@
 title: VMware vSphere
 format_version: "3.0.2"
 name: vsphere
-version: "1.18.0"
+version: "1.18.1"
 description: This Elastic integration collects metrics and logs from vSphere/vCenter servers
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - virtualization
 conditions:
   kibana:
-    version: "^8.16.2 || ^9.0.0"
+    version: "^8.16.2"
   elastic:
     subscription: basic
 screenshots:

--- a/packages/vsphere/manifest.yml
+++ b/packages/vsphere/manifest.yml
@@ -9,7 +9,7 @@ categories:
   - virtualization
 conditions:
   kibana:
-    version: "^8.16.2"
+    version: "^8.16.2 || ^9.0.0"
   elastic:
     subscription: basic
 screenshots:


### PR DESCRIPTION
## Proposed commit message

Updated ssl node descriptions in data_streams owned by obs-infraobs-integrations. Includes all the datastreams for aws. One is owned by all security-service-integrations and one is owned by obs-ds-hosted-services. This commit updates or adds descriptions to the ssl node to be uniform and to include links to online documentation.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

Originally, we update the descriptions on all the files. This created some issues with so many teams needing to validate the files. This is currently a partial update with files that are owned by obs-infraobs-integrations, plus all the aws streams.
One is owned by all security-service-integrations and one is owned by obs-ds-hosted-services.  As such the only verification would be to check that was what updates is uniform.
```

git diff main | grep description: | grep + | sort -u
results in the update fields for the ssl node description and the changelog.yml
```

## Related issues

- Closes #12703
- Relates #11792

