### PR TITLE
[Exchange Server] Fix log.offset mapping type

### DIFF
--- a/packages/microsoft_exchange_server/changelog.yml
+++ b/packages/microsoft_exchange_server/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix log.offset mapping type
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/12740
+      link: https://github.com/elastic/integrations/pull/12748
 - version: "1.2.0"
   changes:
     - description: Add 9.0.0 constraint.

--- a/packages/microsoft_exchange_server/changelog.yml
+++ b/packages/microsoft_exchange_server/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Fix log.offset mapping type
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12740
 - version: "1.2.0"
   changes:
     - description: Add 9.0.0 constraint.

--- a/packages/microsoft_exchange_server/data_stream/httpproxy/fields/fields.yml
+++ b/packages/microsoft_exchange_server/data_stream/httpproxy/fields/fields.yml
@@ -145,4 +145,4 @@
 - name: log.file.inode
   type: keyword
 - name: log.offset
-  type: keyword
+  type: long

--- a/packages/microsoft_exchange_server/data_stream/imap4_pop3/fields/fields.yml
+++ b/packages/microsoft_exchange_server/data_stream/imap4_pop3/fields/fields.yml
@@ -33,4 +33,4 @@
 - name: log.file.inode
   type: keyword
 - name: log.offset
-  type: keyword
+  type: long

--- a/packages/microsoft_exchange_server/data_stream/messagetracking/fields/fields.yml
+++ b/packages/microsoft_exchange_server/data_stream/messagetracking/fields/fields.yml
@@ -47,4 +47,4 @@
 - name: log.file.inode
   type: keyword
 - name: log.offset
-  type: keyword
+  type: long

--- a/packages/microsoft_exchange_server/data_stream/smtp/fields/fields.yml
+++ b/packages/microsoft_exchange_server/data_stream/smtp/fields/fields.yml
@@ -25,4 +25,4 @@
 - name: log.file.inode
   type: keyword
 - name: log.offset
-  type: keyword
+  type: long

--- a/packages/microsoft_exchange_server/manifest.yml
+++ b/packages/microsoft_exchange_server/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: microsoft_exchange_server
 title: "Microsoft Exchange Server"
-version: 1.2.0
+version: 1.2.1
 source:
   license: "Elastic-2.0"
 description: Collect logs from Microsoft Exchange Server with Elastic Agent.


### PR DESCRIPTION
Change log.offset mapping to long as its exported by filebeat:
https://www.elastic.co/guide/en/beats/filebeat/current/exported-fields-log.html