### PR TITLE
Updated description on ssl node in manifest.yml to be uniform and link to online documentation for integrations owned by stack-monitoring

### DIFF
--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.17.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12754
 - version: "1.17.0"
   changes:
     - description: Allow the usage of deprecated log input and support for stack 9.0

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 1.17.0
+version: 1.17.1
 description: Elasticsearch Integration
 type: integration
 icons:
@@ -89,7 +89,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate, certificate_authorities, verification_mode etc. See [SSL](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/kibana/changelog.yml
+++ b/packages/kibana/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.6.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12754
 - version: "2.6.0"
   changes:
     - description: Allow the usage of deprecated log input and support for stack 9.0

--- a/packages/kibana/manifest.yml
+++ b/packages/kibana/manifest.yml
@@ -1,6 +1,6 @@
 name: kibana
 title: Kibana
-version: 2.6.0
+version: 2.6.1
 description: Collect logs and metrics from Kibana with Elastic Agent.
 type: integration
 icons:
@@ -66,7 +66,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate, certificate_authorities, verification_mode etc. See [SSL](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
             multi: false
             required: false
             show_user: false


### PR DESCRIPTION
Updated ssl node descriptions in manifest.yml for integrations owned by stack-monitoring. This commit updates descriptions to the ssl node to be uniform with other integrations that are being updated.

## Proposed commit message
Updated ssl node descriptions in manifest.yml for integrations owned by stack-monitoring. This commit updates descriptions to the ssl node to be uniform

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## Related issues

- Closes #12711
- Relates #11792

## How to test this PR locally
Originally, we update the descriptions on all the files. This created some issues with so many teams needing to validate the files. This is currently a partial update with files that are owned by sec-deployment-and-devices,
One is owned by bs-infraobs-integrations. As such the only verification would be to check that was what updates is uniform. Note that the metrics type datastream points to a metricbeat documentation while logs point to filebeat.


git diff main | grep description: | grep + | sort -u
results in the update fields for the ssl node description and the changelog.yml