### PR TITLE
Added description on ssl.* nodes in data_streams owned by obs-cloudnative-monitoring

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,7 +1,12 @@
 # newer versions go on top
+- version: "1.80.1"
+  changes:
+    - description: Added description to ssl.certificate_authorities and ssl.verification_mode, including links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12756
 - version: 1.80.0
   changes:
-    - description: Add support for Kibana `9.0.0` 
+    - description: Add support for Kibana `9.0.0`
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12535
 - version: 1.70.2

--- a/packages/kubernetes/data_stream/apiserver/manifest.yml
+++ b/packages/kubernetes/data_stream/apiserver/manifest.yml
@@ -42,6 +42,7 @@ streams:
         show_user: true
         default:
           - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/kubernetes/data_stream/container/manifest.yml
+++ b/packages/kubernetes/data_stream/container/manifest.yml
@@ -41,6 +41,7 @@ streams:
         required: true
         show_user: true
         default: none
+        description: SSL verfication mode. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: add_resource_metadata_config
         type: yaml
         title: Add node and namespace metadata
@@ -60,6 +61,7 @@ streams:
         multi: true
         required: false
         show_user: false
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/kubernetes/data_stream/node/manifest.yml
+++ b/packages/kubernetes/data_stream/node/manifest.yml
@@ -41,12 +41,14 @@ streams:
         required: true
         show_user: true
         default: none
+        description: SSL verfication mode. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: ssl.certificate_authorities
         type: text
         title: SSL Certificate Authorities
         multi: true
         required: false
         show_user: false
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/kubernetes/data_stream/pod/manifest.yml
+++ b/packages/kubernetes/data_stream/pod/manifest.yml
@@ -41,12 +41,14 @@ streams:
         required: true
         show_user: true
         default: none
+        description: SSL verfication mode. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: ssl.certificate_authorities
         type: text
         title: SSL Certificate Authorities
         multi: true
         required: false
         show_user: false
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: add_resource_metadata_config
         type: yaml
         title: Add node and namespace metadata

--- a/packages/kubernetes/data_stream/state_container/manifest.yml
+++ b/packages/kubernetes/data_stream/state_container/manifest.yml
@@ -54,6 +54,7 @@ streams:
         multi: true
         required: false
         show_user: false
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: add_resource_metadata_config
         type: yaml
         title: Add node and namespace metadata

--- a/packages/kubernetes/data_stream/state_cronjob/manifest.yml
+++ b/packages/kubernetes/data_stream/state_cronjob/manifest.yml
@@ -54,6 +54,7 @@ streams:
         multi: true
         required: false
         show_user: false
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/kubernetes/data_stream/state_daemonset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_daemonset/manifest.yml
@@ -55,6 +55,7 @@ streams:
         required: false
         show_user: false
         default: # /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/kubernetes/data_stream/state_deployment/manifest.yml
+++ b/packages/kubernetes/data_stream/state_deployment/manifest.yml
@@ -54,6 +54,7 @@ streams:
         multi: true
         required: false
         show_user: false
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/kubernetes/data_stream/state_job/manifest.yml
+++ b/packages/kubernetes/data_stream/state_job/manifest.yml
@@ -54,6 +54,7 @@ streams:
         multi: true
         required: false
         show_user: false
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/kubernetes/data_stream/state_namespace/manifest.yml
+++ b/packages/kubernetes/data_stream/state_namespace/manifest.yml
@@ -54,6 +54,7 @@ streams:
         multi: true
         required: false
         show_user: false
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/kubernetes/data_stream/state_node/manifest.yml
+++ b/packages/kubernetes/data_stream/state_node/manifest.yml
@@ -54,6 +54,7 @@ streams:
         multi: true
         required: false
         show_user: false
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
@@ -54,6 +54,7 @@ streams:
         multi: true
         required: false
         show_user: false
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
@@ -54,6 +54,7 @@ streams:
         multi: true
         required: false
         show_user: false
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/kubernetes/data_stream/state_pod/manifest.yml
+++ b/packages/kubernetes/data_stream/state_pod/manifest.yml
@@ -54,6 +54,7 @@ streams:
         multi: true
         required: false
         show_user: false
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: add_resource_metadata_config
         type: yaml
         title: Add node and namespace metadata

--- a/packages/kubernetes/data_stream/state_replicaset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_replicaset/manifest.yml
@@ -54,6 +54,7 @@ streams:
         multi: true
         required: false
         show_user: false
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
+++ b/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
@@ -54,6 +54,7 @@ streams:
         multi: true
         required: false
         show_user: false
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/kubernetes/data_stream/state_service/manifest.yml
+++ b/packages/kubernetes/data_stream/state_service/manifest.yml
@@ -54,6 +54,7 @@ streams:
         multi: true
         required: false
         show_user: false
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/kubernetes/data_stream/state_statefulset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_statefulset/manifest.yml
@@ -54,6 +54,7 @@ streams:
         multi: true
         required: false
         show_user: false
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/kubernetes/data_stream/state_storageclass/manifest.yml
+++ b/packages/kubernetes/data_stream/state_storageclass/manifest.yml
@@ -54,6 +54,7 @@ streams:
         multi: true
         required: false
         show_user: false
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/kubernetes/data_stream/system/manifest.yml
+++ b/packages/kubernetes/data_stream/system/manifest.yml
@@ -41,12 +41,14 @@ streams:
         required: true
         show_user: true
         default: none
+        description: SSL verfication mode. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: ssl.certificate_authorities
         type: text
         title: SSL Certificate Authorities
         multi: true
         required: false
         show_user: false
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/kubernetes/data_stream/volume/manifest.yml
+++ b/packages/kubernetes/data_stream/volume/manifest.yml
@@ -41,12 +41,14 @@ streams:
         required: true
         show_user: true
         default: none
+        description: SSL verfication mode. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: ssl.certificate_authorities
         type: text
         title: SSL Certificate Authorities
         multi: true
         required: false
         show_user: false
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: kubernetes
 title: Kubernetes
-version: 1.80.0
+version: 1.80.1
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Added description to ssl.certificate_authorities and ssl.verification_mode, including links to documentation. Integrations owned by obs-cloudnative-monitoring


## Proposed commit message
Added description to ssl.certificate_authorities and ssl.verification_mode, including links to documentation. Integrations owned by obs-cloudnative-monitoring

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

Originally, we updatesd the descriptions on all the files in integrations. This created some issues with so many teams needing to validate the files. This is currently a partial update with files that are owned by obs-cloudnative-monitoring.

git diff main | grep description: | grep + | sort -u
results in the update fields for the ssl node description and the changelog.yml

## Related issues

Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #12704
- Relates #11792
