### PR TITLE
mimecast.audit_events: Prevent pageToken from incorrectly reappearing in interval requests

### DIFF
--- a/packages/mimecast/changelog.yml
+++ b/packages/mimecast/changelog.yml
@@ -2,7 +2,7 @@
 - version: "2.5.1"
   changes:
     - description: Prevent pageToken from incorrectly reappearing in interval requests.
-      type: enhancement
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/12770
 - version: "2.5.0"
   changes:

--- a/packages/mimecast/changelog.yml
+++ b/packages/mimecast/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Prevent pageToken from incorrectly reappearing in interval requests.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/12770
 - version: "2.5.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/mimecast/changelog.yml
+++ b/packages/mimecast/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.1"
+  changes:
+    - description: Prevent pageToken from incorrectly reappearing in interval requests.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.5.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/mimecast/data_stream/audit_events/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/audit_events/agent/stream/cel.yml.hbs
@@ -83,7 +83,7 @@ program: |
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
           bytes(resp.Body).decode_json().as(body, body.?fail.orValue([]).size() == 0 ?
-            {
+            (has(body.?meta.pagination.next) && size(body.data) != 0).as(want_more, {
               "events": body.data.map(e, {"message": e.encode_json()}),
               "cursor": {
                 "last": (
@@ -97,19 +97,16 @@ program: |
                   ).format(time_layout.RFC3339)
                 ),
               },
-              ?"last_page": has(body.?meta.pagination.next) && size(body.data) != 0 ?
-                optional.of({
-                  ?"next": body.?meta.pagination.next,
-                  "data": req.data,
-                })
-              :
-                optional.none(),
+              "last_page": {
+                ?"next": want_more ? body.?meta.pagination.next : optional.none(),
+                ?"data": want_more ? req.?data : optional.none(),
+              },
               "token": {
                 "access_token": token.access_token,
                 "expires": token.expires,
               },
-              "want_more": has(body.?meta.pagination.next) && size(body.data) != 0,
-            }
+              "want_more": want_more,
+            })
           :
             // Mimecast can return failure states with a 200. This
             // is detected by a non-empty fail array at the root

--- a/packages/mimecast/data_stream/audit_events/sample_event.json
+++ b/packages/mimecast/data_stream/audit_events/sample_event.json
@@ -1,27 +1,27 @@
 {
     "@timestamp": "2024-10-17T02:06:50.000Z",
     "agent": {
-        "ephemeral_id": "d3d233d7-62b7-40f6-8de7-d3c2937d6dae",
-        "id": "b6346117-4ee0-428a-9d74-6580e405feeb",
-        "name": "elastic-agent-20780",
+        "ephemeral_id": "9d307917-d823-49c5-99de-422de2e4de90",
+        "id": "38f355c8-68cd-43d6-bd0a-1e57a3d29eea",
+        "name": "elastic-agent-60619",
         "type": "filebeat",
-        "version": "8.14.0"
+        "version": "8.15.0"
     },
     "client": {
         "ip": "203.59.201.168"
     },
     "data_stream": {
         "dataset": "mimecast.audit_events",
-        "namespace": "54489",
+        "namespace": "26694",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "b6346117-4ee0-428a-9d74-6580e405feeb",
+        "id": "38f355c8-68cd-43d6-bd0a-1e57a3d29eea",
         "snapshot": false,
-        "version": "8.14.0"
+        "version": "8.15.0"
     },
     "event": {
         "action": "api-application-updated",
@@ -32,7 +32,7 @@
         "created": "2024-10-17T02:06:50.000Z",
         "dataset": "mimecast.audit_events",
         "id": "eNoVzk0PgiAAgOH_wrUO4SizrYOasxUzs6jWLYURfqEg6Wr99-z-bs_7AZplRjFBwQp4E3y5t3G7w1SVz9KxwxtJj7mVNripeP7WV3N2-3AohNUFGw0DmMY2aqOeq7MZfCKqyME1jeUMv_qAdVub6MJdnprZIYz2PS3u-bNuB54kfA2m4GGo6ErJ_zZCi4UD51OQGd3JiqlMUjYu-eTkIdey0di_mNJC1mAFvz-isz1f",
-        "ingested": "2024-12-05T00:52:32Z",
+        "ingested": "2025-02-13T15:17:26Z",
         "original": "{\"auditType\":\"API Application Updated\",\"category\":\"account_logs\",\"eventInfo\":\"API Gateway Application testing Updated. Application Program Interface Addendum (22 September 2022) acknowledged, Date: 2024-10-17, Time: 02:06:50+0000, IP: 203.59.201.168, Application: Administration Console\",\"eventTime\":\"2024-10-17T02:06:50+0000\",\"id\":\"eNoVzk0PgiAAgOH_wrUO4SizrYOasxUzs6jWLYURfqEg6Wr99-z-bs_7AZplRjFBwQp4E3y5t3G7w1SVz9KxwxtJj7mVNripeP7WV3N2-3AohNUFGw0DmMY2aqOeq7MZfCKqyME1jeUMv_qAdVub6MJdnprZIYz2PS3u-bNuB54kfA2m4GGo6ErJ_zZCi4UD51OQGd3JiqlMUjYu-eTkIdey0di_mNJC1mAFvz-isz1f\",\"user\":\"user.name@company.mime-api.com\"}"
     },
     "input": {

--- a/packages/mimecast/docs/README.md
+++ b/packages/mimecast/docs/README.md
@@ -136,27 +136,27 @@ An example event for `audit_events` looks as following:
 {
     "@timestamp": "2024-10-17T02:06:50.000Z",
     "agent": {
-        "ephemeral_id": "d3d233d7-62b7-40f6-8de7-d3c2937d6dae",
-        "id": "b6346117-4ee0-428a-9d74-6580e405feeb",
-        "name": "elastic-agent-20780",
+        "ephemeral_id": "9d307917-d823-49c5-99de-422de2e4de90",
+        "id": "38f355c8-68cd-43d6-bd0a-1e57a3d29eea",
+        "name": "elastic-agent-60619",
         "type": "filebeat",
-        "version": "8.14.0"
+        "version": "8.15.0"
     },
     "client": {
         "ip": "203.59.201.168"
     },
     "data_stream": {
         "dataset": "mimecast.audit_events",
-        "namespace": "54489",
+        "namespace": "26694",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "b6346117-4ee0-428a-9d74-6580e405feeb",
+        "id": "38f355c8-68cd-43d6-bd0a-1e57a3d29eea",
         "snapshot": false,
-        "version": "8.14.0"
+        "version": "8.15.0"
     },
     "event": {
         "action": "api-application-updated",
@@ -167,7 +167,7 @@ An example event for `audit_events` looks as following:
         "created": "2024-10-17T02:06:50.000Z",
         "dataset": "mimecast.audit_events",
         "id": "eNoVzk0PgiAAgOH_wrUO4SizrYOasxUzs6jWLYURfqEg6Wr99-z-bs_7AZplRjFBwQp4E3y5t3G7w1SVz9KxwxtJj7mVNripeP7WV3N2-3AohNUFGw0DmMY2aqOeq7MZfCKqyME1jeUMv_qAdVub6MJdnprZIYz2PS3u-bNuB54kfA2m4GGo6ErJ_zZCi4UD51OQGd3JiqlMUjYu-eTkIdey0di_mNJC1mAFvz-isz1f",
-        "ingested": "2024-12-05T00:52:32Z",
+        "ingested": "2025-02-13T15:17:26Z",
         "original": "{\"auditType\":\"API Application Updated\",\"category\":\"account_logs\",\"eventInfo\":\"API Gateway Application testing Updated. Application Program Interface Addendum (22 September 2022) acknowledged, Date: 2024-10-17, Time: 02:06:50+0000, IP: 203.59.201.168, Application: Administration Console\",\"eventTime\":\"2024-10-17T02:06:50+0000\",\"id\":\"eNoVzk0PgiAAgOH_wrUO4SizrYOasxUzs6jWLYURfqEg6Wr99-z-bs_7AZplRjFBwQp4E3y5t3G7w1SVz9KxwxtJj7mVNripeP7WV3N2-3AohNUFGw0DmMY2aqOeq7MZfCKqyME1jeUMv_qAdVub6MJdnprZIYz2PS3u-bNuB54kfA2m4GGo6ErJ_zZCi4UD51OQGd3JiqlMUjYu-eTkIdey0di_mNJC1mAFvz-isz1f\",\"user\":\"user.name@company.mime-api.com\"}"
     },
     "input": {

--- a/packages/mimecast/manifest.yml
+++ b/packages/mimecast/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: mimecast
 title: "Mimecast"
-version: "2.5.0"
+version: "2.5.1"
 description: Collect logs from Mimecast with Elastic Agent.
 type: integration
 categories: ["security", "email_security"]


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
See title

> [!NOTE]
> To reviewers:
> - Issue is described in detail in a similar fix: https://github.com/elastic/integrations/pull/12666
> - Also see test 1 below to know how pagetoken (in current version) is wrongly getting carried into next request and how PR fixes it.


<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
1. Final `response state` from system tests in current vs updated (PR):
  - Current:

    ```json
        {
        ...
        "cursor": {
              "last": "2025-02-13T15:32:15Z"
          },
        "events": [],
        "last_page": {
              "data": [
                  {
                      "endDateTime": "2025-02-13T15:32:13Z",
                      "startDateTime": "2025-02-12T15:32:13Z"
                  }
              ],
              "next": "lasttoken"
          },
        ...
        }
    ``` 

  - Updated (PR):

    ```json
        {
        ...
        "cursor": {
              "last": "2025-02-13T15:17:25Z"
          },
        "events": [],
        "last_page": {},
        ...
        }
    ``` 

2. System tests should pass.

```
2025/02/13 21:02:15 DEBUG found 0 hits in logs-mimecast.audit_events-87315 data stream
2025/02/13 21:02:17 DEBUG found 0 hits in logs-mimecast.audit_events-87315 data stream
2025/02/13 21:02:18 DEBUG found 4 hits in logs-mimecast.audit_events-87315 data stream
--- Test results for package: mimecast - START ---
╭──────────┬──────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE  │ DATA STREAM  │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├──────────┼──────────────┼───────────┼───────────┼────────┼───────────────┤
│ mimecast │ audit_events │ system    │ v2        │ PASS   │ 39.601001542s │
╰──────────┴──────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: mimecast - END   ---
Done
```

