### PR TITLE
Updated description on ssl node to include links to online documentation for integrations owned by customer-architects

### DIFF
--- a/packages/ess_billing/changelog.yml
+++ b/packages/ess_billing/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12711
 - version: "1.0.0"
   changes:
     - description: GA release of the integration, addition of credit endpoint

--- a/packages/ess_billing/manifest.yml
+++ b/packages/ess_billing/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.2
 name: ess_billing
 title: "Elasticsearch Service Billing"
-version: 1.0.0
+version: 1.0.1
 source:
   license: "Elastic-2.0"
 description: "Collects billing metrics from Elasticsearch Service billing API"
@@ -69,7 +69,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
             multi: false
             required: false
             show_user: false


### PR DESCRIPTION
## Proposed commit message

Updates description field on ssl node in manifest.yml. Description is consistent with other integrations. This issue tracks change to integration owned by customer-architects

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

Originally, we update the descriptions on all the files. This created some issues with so many teams needing to validate the files. This is currently a partial update with files that are owned by customer-architects.

git diff main | grep description: | grep + | sort -u
results in the update fields for the ssl node description and the changelog.yml


## Related issues

- Closes #12699
- Relates #11792
