### PR TITLE
zscaler_zia: update kibana constraint to support 9.0.0

### DIFF
--- a/packages/zscaler_zia/changelog.yml
+++ b/packages/zscaler_zia/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.7.0"
+  changes:
+    - description: Update Kibana constraint to support 9.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12777
 - version: "3.6.3"
   changes:
     - description: Use source.nat.ip as alternate for geo IPs in firewall and web logs.

--- a/packages/zscaler_zia/manifest.yml
+++ b/packages/zscaler_zia/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: zscaler_zia
 title: Zscaler Internet Access
-version: "3.6.3"
+version: "3.7.0"
 description: Collect logs from Zscaler Internet Access (ZIA) with Elastic Agent.
 type: integration
 categories:
@@ -11,7 +11,7 @@ source:
   license: "Elastic-2.0"
 conditions:
   kibana:
-    version: "^8.13.0"
+    version: "^8.13.0 || ^9.0.0"
   elastic:
     subscription: "basic"
 screenshots:


### PR DESCRIPTION
## Proposed commit message

Updated minor version and Kibana constraints to support 9.0.0.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Install latest elastic-package (currently v0.109.1)
- Run a local 9.0.0 stack with `elastic-package stack up -d -v --version=9.0.0-SNAPSHOT`
- Run tests in affected packages with `elastic-package test`
- Install the integration manually and check everything works as expected

