### PR TITLE
Updated description on ssl nodes in package level manifest.yml for files owned by obs-infraobs-integrations

### DIFF
--- a/packages/activemq/changelog.yml
+++ b/packages/activemq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: Added description to ssl nodes including links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12780
 - version: "1.8.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/activemq/manifest.yml
+++ b/packages/activemq/manifest.yml
@@ -111,7 +111,7 @@ policy_templates:
               #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
               #   7RhLQyWn2u00L7/9Omw=
               #   -----END CERTIFICATE-----
-            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/activemq/manifest.yml
+++ b/packages/activemq/manifest.yml
@@ -1,6 +1,6 @@
 name: activemq
 title: ActiveMQ
-version: "1.8.0"
+version: "1.8.1"
 description: Collect logs and metrics from ActiveMQ instances with Elastic Agent.
 type: integration
 icons:
@@ -111,7 +111,7 @@ policy_templates:
               #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
               #   7RhLQyWn2u00L7/9Omw=
               #   -----END CERTIFICATE-----
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.29.1"
+  changes:
+    - description: Added description to ssl nodes including links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12780
 - version: "1.29.0"
   changes:
     - description: Support SSL/TLS for status data stream.

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.5
 name: apache
 title: Apache HTTP Server
-version: "1.29.0"
+version: "1.29.1"
 source:
   license: Elastic-2.0
 description: Collect logs and metrics from Apache servers with Elastic Agent.
@@ -79,7 +79,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false
@@ -127,7 +127,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -79,7 +79,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
             multi: false
             required: false
             show_user: false
@@ -127,7 +127,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.1"
+  changes:
+    - description: Added description to ssl nodes including links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12780
 - version: "1.9.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/apache_tomcat/manifest.yml
+++ b/packages/apache_tomcat/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: apache_tomcat
 title: Apache Tomcat
-version: "1.9.0"
+version: "1.9.1"
 description: Collect and parse logs and metrics from Apache Tomcat servers with Elastic Agent.
 categories: ["web", "observability"]
 type: integration
@@ -66,7 +66,7 @@ policy_templates:
               #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
               #   7RhLQyWn2u00L7/9Omw=
               #   -----END CERTIFICATE-----
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/apache_tomcat/manifest.yml
+++ b/packages/apache_tomcat/manifest.yml
@@ -66,7 +66,7 @@ policy_templates:
               #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
               #   7RhLQyWn2u00L7/9Omw=
               #   -----END CERTIFICATE-----
-            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/ceph/changelog.yml
+++ b/packages/ceph/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: Added description to ssl nodes including links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12780
 - version: "1.8.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/ceph/manifest.yml
+++ b/packages/ceph/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: ceph
 title: Ceph
-version: "1.8.0"
+version: "1.8.1"
 description: This Elastic integration collects metrics from Ceph instance.
 type: integration
 categories:
@@ -72,7 +72,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/ceph/manifest.yml
+++ b/packages/ceph/manifest.yml
@@ -72,7 +72,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/citrix_adc/changelog.yml
+++ b/packages/citrix_adc/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.1"
+  changes:
+    - description: Added description to ssl nodes in package level manifest.yml file to including links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12780
 - version: "1.15.0"
   changes:
     - description: "Add support for parsing RFC5424 syslog messages"

--- a/packages/citrix_adc/manifest.yml
+++ b/packages/citrix_adc/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: citrix_adc
 title: Citrix ADC
-version: "1.15.0"
+version: "1.15.1"
 description: This Elastic integration collects logs and metrics from Citrix ADC product.
 type: integration
 categories:
@@ -88,7 +88,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/couchbase/changelog.yml
+++ b/packages/couchbase/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.9.1"
+  changes:
+    - description: Added description to ssl nodes including links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12780
 - version: "1.9.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/couchbase/manifest.yml
+++ b/packages/couchbase/manifest.yml
@@ -83,7 +83,7 @@ vars:
       #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
       #   7RhLQyWn2u00L7/9Omw=
       #   -----END CERTIFICATE-----
-    description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
+    description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
 
     multi: false
     required: false
@@ -151,7 +151,7 @@ policy_templates:
               #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
               #   7RhLQyWn2u00L7/9Omw=
               #   -----END CERTIFICATE-----
-            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/couchbase/manifest.yml
+++ b/packages/couchbase/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: couchbase
 title: Couchbase
-version: "1.9.0"
+version: "1.9.1"
 description: Collect metrics from Couchbase databases with Elastic Agent.
 type: integration
 categories:
@@ -83,7 +83,8 @@ vars:
       #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
       #   7RhLQyWn2u00L7/9Omw=
       #   -----END CERTIFICATE-----
-    description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+    description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
+
     multi: false
     required: false
     show_user: false
@@ -150,7 +151,7 @@ policy_templates:
               #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
               #   7RhLQyWn2u00L7/9Omw=
               #   -----END CERTIFICATE-----
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/couchdb/changelog.yml
+++ b/packages/couchdb/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.1"
+  changes:
+    - description: Added description to ssl nodes including links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12780
 - version: "1.5.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/couchdb/manifest.yml
+++ b/packages/couchdb/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: couchdb
 title: CouchDB
-version: "1.5.0"
+version: "1.5.1"
 description: Collect metrics from CouchDB with Elastic Agent.
 type: integration
 categories:
@@ -74,7 +74,7 @@ policy_templates:
               #     yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
               #     sxSmbIUfc2SGJGCJD4I=
               #     -----END CERTIFICATE-----
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/couchdb/manifest.yml
+++ b/packages/couchdb/manifest.yml
@@ -74,7 +74,7 @@ policy_templates:
               #     yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
               #     sxSmbIUfc2SGJGCJD4I=
               #     -----END CERTIFICATE-----
-            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/golang/changelog.yml
+++ b/packages/golang/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.1"
+  changes:
+    - description: Added description to ssl nodes including links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12780
 - version: "1.7.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/golang/manifest.yml
+++ b/packages/golang/manifest.yml
@@ -71,7 +71,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/golang/manifest.yml
+++ b/packages/golang/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: golang
 title: Golang
-version: "1.7.0"
+version: "1.7.1"
 description: This Elastic integration collects metrics from Golang applications.
 type: integration
 categories:
@@ -71,7 +71,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/ibmmq/changelog.yml
+++ b/packages/ibmmq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.1"
+  changes:
+    - description: Added description to ssl nodes including links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12780
 - version: "1.6.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/ibmmq/manifest.yml
+++ b/packages/ibmmq/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: ibmmq
 title: IBM MQ
-version: "1.6.0"
+version: "1.6.1"
 source:
   license: Elastic-2.0
 description: Collect logs and metrics from IBM MQ with Elastic Agent.
@@ -85,7 +85,7 @@ policy_templates:
               #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
               #   7RhLQyWn2u00L7/9Omw=
               #   -----END CERTIFICATE-----
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/ibmmq/manifest.yml
+++ b/packages/ibmmq/manifest.yml
@@ -85,7 +85,7 @@ policy_templates:
               #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
               #   7RhLQyWn2u00L7/9Omw=
               #   -----END CERTIFICATE-----
-            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/kafka/changelog.yml
+++ b/packages/kafka/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12780
 - version: "1.18.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/kafka/manifest.yml
+++ b/packages/kafka/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: kafka
 title: Kafka
-version: "1.18.0"
+version: "1.18.1"
 description: Collect logs and metrics from Kafka servers with Elastic Agent.
 type: integration
 categories:
@@ -57,27 +57,33 @@ policy_templates:
             title: SSL Certificate Authorities
             multi: true
             show_user: true
+            description: SSL certificate authorities. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-certificate-authorities) for details.
           - name: ssl.certificate
             type: text
             title: SSL Certificate
             show_user: true
+            description: SSL certificate. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-certificate) for details.
           - name: ssl.key
             type: text
             title: SSL Private Key
             show_user: true
+            description: SSL certificate key. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-key) for details.
           - name: ssl.key_passphrase
             type: password
             title: SSL Key Passphrase
             secret: true
             show_user: true
+            description: SSL certificate passphrase. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-key-passphrase) for details.
           - name: ssl.verification_mode
             type: text
             title: SSL Verification Mode
             show_user: true
+            description: SSL verification mode. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-verification-mode) for details.
           - name: ssl.ca_trusted_fingerprint
             type: text
             title: SSL CA Trusted Fingerprint
             show_user: true
+            description: SSL CA trusted fingerprint. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ca_trusted_fingerprint) for details.
 owner:
   github: elastic/obs-infraobs-integrations
   type: elastic

--- a/packages/kafka/manifest.yml
+++ b/packages/kafka/manifest.yml
@@ -57,33 +57,33 @@ policy_templates:
             title: SSL Certificate Authorities
             multi: true
             show_user: true
-            description: SSL certificate authorities. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-certificate-authorities) for details.
+            description: SSL certificate authorities. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
           - name: ssl.certificate
             type: text
             title: SSL Certificate
             show_user: true
-            description: SSL certificate. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-certificate) for details.
+            description: SSL certificate. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
           - name: ssl.key
             type: text
             title: SSL Private Key
             show_user: true
-            description: SSL certificate key. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-key) for details.
+            description: SSL certificate key. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
           - name: ssl.key_passphrase
             type: password
             title: SSL Key Passphrase
             secret: true
             show_user: true
-            description: SSL certificate passphrase. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-key-passphrase) for details.
+            description: SSL certificate passphrase. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
           - name: ssl.verification_mode
             type: text
             title: SSL Verification Mode
             show_user: true
-            description: SSL verification mode. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-verification-mode) for details.
+            description: SSL verification mode. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
           - name: ssl.ca_trusted_fingerprint
             type: text
             title: SSL CA Trusted Fingerprint
             show_user: true
-            description: SSL CA trusted fingerprint. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ca_trusted_fingerprint) for details.
+            description: SSL CA trusted fingerprint. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
 owner:
   github: elastic/obs-infraobs-integrations
   type: elastic

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.19.1"
+  changes:
+    - description: Updated SSL description to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12780
 - version: "1.19.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -1,6 +1,6 @@
 name: mongodb
 title: MongoDB
-version: "1.19.0"
+version: "1.19.1"
 description: Collect logs and metrics from MongoDB instances with Elastic Agent.
 type: integration
 categories:
@@ -51,30 +51,35 @@ policy_templates:
             required: false
             show_user: false
             default: false
+            description: SSL enabled option. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#enabled) for details.
           - name: ssl.verification_mode
             type: text
             title: Mode of verification of server certificate ('none' or 'full')
             multi: false
             required: false
             show_user: false
+            description: SSL verification mode. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-verification-mode) for details.
           - name: ssl.certificate_authorities
             type: text
             title: List of root certificates for TLS server verifications
             multi: true
             required: false
             show_user: false
+            description: SSL certificate authorities. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-certificate-authorities) for details.
           - name: ssl.certificate
             type: text
             title: Certificate for SSL client authentication
             multi: false
             required: false
             show_user: false
+            description: SSL certificate. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-certificate) for details.
           - name: ssl.key
             type: text
             title: Client Certificate Key
             multi: false
             required: false
             show_user: false
+            description: SSL certificate key. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-key) for details.
           - name: username
             type: text
             title: Username

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -51,35 +51,35 @@ policy_templates:
             required: false
             show_user: false
             default: false
-            description: SSL enabled option. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#enabled) for details.
+            description: SSL enabled option. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
           - name: ssl.verification_mode
             type: text
             title: Mode of verification of server certificate ('none' or 'full')
             multi: false
             required: false
             show_user: false
-            description: SSL verification mode. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-verification-mode) for details.
+            description: SSL verification mode. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
           - name: ssl.certificate_authorities
             type: text
             title: List of root certificates for TLS server verifications
             multi: true
             required: false
             show_user: false
-            description: SSL certificate authorities. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-certificate-authorities) for details.
+            description: SSL certificate authorities. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
           - name: ssl.certificate
             type: text
             title: Certificate for SSL client authentication
             multi: false
             required: false
             show_user: false
-            description: SSL certificate. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-certificate) for details.
+            description: SSL certificate. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
           - name: ssl.key
             type: text
             title: Client Certificate Key
             multi: false
             required: false
             show_user: false
-            description: SSL certificate key. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-key) for details.
+            description: SSL certificate key. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
           - name: username
             type: text
             title: Username

--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.26.1"
+  changes:
+    - description: Added description to ssl nodes including links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12780
 - version: 1.26.0
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -62,7 +62,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
             multi: false
             required: false
             show_user: false
@@ -111,7 +111,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: mysql
 title: MySQL
-version: "1.26.0"
+version: "1.26.1"
 description: Collect logs and metrics from MySQL servers with Elastic Agent.
 type: integration
 categories:
@@ -62,7 +62,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false
@@ -111,7 +111,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/nagios_xi/changelog.yml
+++ b/packages/nagios_xi/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.1"
+  changes:
+    - description: Added description to ssl nodes including links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12780
 - version: "1.5.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/nagios_xi/manifest.yml
+++ b/packages/nagios_xi/manifest.yml
@@ -72,7 +72,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/nagios_xi/manifest.yml
+++ b/packages/nagios_xi/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: nagios_xi
 title: "Nagios XI"
-version: "1.5.0"
+version: "1.5.1"
 description: Collect Logs and Metrics from Nagios XI with Elastic Agent.
 type: integration
 categories:
@@ -72,7 +72,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/nginx/changelog.yml
+++ b/packages/nginx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.25.1"
+  changes:
+    - description: Added description to ssl nodes including links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12780
 - version: "1.25.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -80,7 +80,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: nginx
 title: Nginx
-version: "1.25.0"
+version: "1.25.1"
 description: Collect logs and metrics from Nginx HTTP servers with Elastic Agent.
 type: integration
 categories:
@@ -80,7 +80,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/oracle_weblogic/changelog.yml
+++ b/packages/oracle_weblogic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.1"
+  changes:
+    - description: Added description to ssl nodes including links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12780
 - version: "1.9.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/oracle_weblogic/manifest.yml
+++ b/packages/oracle_weblogic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: oracle_weblogic
 title: Oracle WebLogic
-version: "1.9.0"
+version: "1.9.1"
 description: Collect logs and metrics from Oracle WebLogic with Elastic Agent.
 type: integration
 categories:
@@ -88,7 +88,7 @@ policy_templates:
               #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
               #   7RhLQyWn2u00L7/9Omw=
               #   -----END CERTIFICATE-----
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/oracle_weblogic/manifest.yml
+++ b/packages/oracle_weblogic/manifest.yml
@@ -88,7 +88,7 @@ policy_templates:
               #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
               #   7RhLQyWn2u00L7/9Omw=
               #   -----END CERTIFICATE-----
-            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/php_fpm/changelog.yml
+++ b/packages/php_fpm/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.1"
+  changes:
+    - description: Added description to ssl nodes including links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12780
 - version: "1.5.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/php_fpm/manifest.yml
+++ b/packages/php_fpm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: php_fpm
 title: PHP-FPM
-version: "1.5.0"
+version: "1.5.1"
 description: This Elastic integration collects metrics from PHP-FPM.
 type: integration
 categories:
@@ -59,7 +59,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/php_fpm/manifest.yml
+++ b/packages/php_fpm/manifest.yml
@@ -59,7 +59,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/redis/changelog.yml
+++ b/packages/redis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.1"
+  changes:
+    - description: Added description to ssl nodes including links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12780
 - version: "1.19.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/redis/manifest.yml
+++ b/packages/redis/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: redis
 title: Redis
-version: "1.19.0"
+version: "1.19.1"
 description: Collect logs and metrics from Redis servers with Elastic Agent.
 type: integration
 categories:
@@ -117,7 +117,7 @@ policy_templates:
               #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
               #   7RhLQyWn2u00L7/9Omw=
               #   -----END CERTIFICATE-----
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/redis/manifest.yml
+++ b/packages/redis/manifest.yml
@@ -117,7 +117,7 @@ policy_templates:
               #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
               #   7RhLQyWn2u00L7/9Omw=
               #   -----END CERTIFICATE-----
-            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/spring_boot/changelog.yml
+++ b/packages/spring_boot/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: Added description to ssl nodes including links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12780
 - version: "1.8.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/spring_boot/manifest.yml
+++ b/packages/spring_boot/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: spring_boot
 title: Spring Boot
-version: "1.8.0"
+version: "1.8.1"
 description: This Elastic integration collects logs and metrics from Spring Boot integration.
 type: integration
 categories:
@@ -55,7 +55,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false
@@ -103,7 +103,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/spring_boot/manifest.yml
+++ b/packages/spring_boot/manifest.yml
@@ -55,7 +55,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
             multi: false
             required: false
             show_user: false
@@ -103,7 +103,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-common-config) for details.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.67.2"
+  changes:
+    - description: Added description to ssl nodes including links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12780
 - version: "1.67.1"
   changes:
     - description: Fix boolean key in security pipeline.

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: system
 title: System
-version: "1.67.1"
+version: "1.67.2"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:
@@ -128,7 +128,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
             multi: false
             required: false
             show_user: false


### PR DESCRIPTION
## Proposed commit message

Updates description field on ssl nodes in package level manifest.yml file to include links to online documentation and to be consistent with other integrations. This issue tracks changes to integration owned by obs-infraobs-integrations

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

Originally, we updated the descriptions on all the files in integration. This created some issues with so many teams needing to validate the files. This is currently a partial update with files that are owned by obs-infraobs-integrations,

git diff main | grep description: | grep + | sort -u
results in the update fields for the ssl node description and the changelog.yml

## Related issues

- Closes #12708
- Relates #11792

