### PR TITLE
Updated description on ssl node in package level manifest.yml to be uniform and include links to online documentation for integrations owned by security-service-integrations

### DIFF
--- a/packages/1password/changelog.yml
+++ b/packages/1password/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.31.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.31.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` set to "pipeline_error".

--- a/packages/1password/manifest.yml
+++ b/packages/1password/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: 1password
 title: "1Password"
-version: "1.31.0"
+version: "1.31.1"
 description: Collect logs from 1Password with Elastic Agent.
 type: integration
 categories:
@@ -73,7 +73,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/abnormal_security/changelog.yml
+++ b/packages/abnormal_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.3.0"
   changes:
     - description: Include `judgementStatus` field in fingerprint.

--- a/packages/abnormal_security/manifest.yml
+++ b/packages/abnormal_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: abnormal_security
 title: Abnormal Security
-version: 1.3.0
+version: 1.3.1
 description: Collect logs from Abnormal Security with Elastic Agent.
 type: integration
 categories:
@@ -73,7 +73,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/authentik/changelog.yml
+++ b/packages/authentik/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.2"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.2.1"
   changes:
     - description: Defensively copy list parameters in 'Set ECS categorization fields' script.

--- a/packages/authentik/manifest.yml
+++ b/packages/authentik/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: authentik
 title: authentik
-version: 1.2.1
+version: 1.2.2
 description: Collect logs from authentik with Elastic Agent.
 type: integration
 categories:
@@ -59,7 +59,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/bitwarden/changelog.yml
+++ b/packages/bitwarden/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.16.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/bitwarden/manifest.yml
+++ b/packages/bitwarden/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: bitwarden
 title: Bitwarden
-version: "1.16.0"
+version: "1.16.1"
 source:
   license: Elastic-2.0
 description: Collect logs from Bitwarden with Elastic Agent.
@@ -87,7 +87,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/blacklens/changelog.yml
+++ b/packages/blacklens/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "0.2.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` set to "pipeline_error".

--- a/packages/blacklens/manifest.yml
+++ b/packages/blacklens/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.0
 name: blacklens
 title: "blacklens.io"
-version: 0.2.0
+version: 0.2.1
 source:
   license: "Elastic-2.0"
 description: "Collect logs from blacklens.io with Elastic Agent"
@@ -76,7 +76,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/carbon_black_cloud/changelog.yml
+++ b/packages/carbon_black_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.8.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "2.8.0"
   changes:
     - description: Add support for Access Point ARN when collecting logs via the AWS S3 Bucket.

--- a/packages/carbon_black_cloud/manifest.yml
+++ b/packages/carbon_black_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: carbon_black_cloud
 title: VMware Carbon Black Cloud
-version: "2.8.0"
+version: "2.8.1"
 description: Collect logs from VMWare Carbon Black Cloud with Elastic Agent.
 type: integration
 categories:
@@ -78,7 +78,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false
@@ -146,7 +146,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/checkpoint_email/changelog.yml
+++ b/packages/checkpoint_email/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "0.4.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/checkpoint_email/manifest.yml
+++ b/packages/checkpoint_email/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.2
 name: checkpoint_email
 title: Check Point Harmony Email & Collaboration
-version: 0.4.0
+version: 0.4.1
 description: Collect logs from Check Point Harmony Email & Collaboration with Elastic Agent.
 type: integration
 categories:
@@ -64,7 +64,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/claroty_ctd/changelog.yml
+++ b/packages/claroty_ctd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.2"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "0.4.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/claroty_ctd/manifest.yml
+++ b/packages/claroty_ctd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.4
 name: claroty_ctd
 title: Claroty CTD
-version: 0.4.1
+version: 0.4.2
 description: Collect logs from Claroty CTD using Elastic Agent.
 type: integration
 categories:
@@ -95,7 +95,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: SSL config for host.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/cloudflare/changelog.yml
+++ b/packages/cloudflare/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.29.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "2.29.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` set to "pipeline_error".

--- a/packages/cloudflare/manifest.yml
+++ b/packages/cloudflare/manifest.yml
@@ -1,6 +1,6 @@
 name: cloudflare
 title: Cloudflare
-version: "2.29.0"
+version: "2.29.1"
 description: Collect logs from Cloudflare with Elastic Agent.
 type: integration
 format_version: "3.0.2"
@@ -56,6 +56,7 @@ policy_templates:
             multi: false
             required: false
             show_user: false
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
           - name: proxy_url
             type: text
             title: Proxy URL

--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.34.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.34.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/cloudflare_logpush/manifest.yml
+++ b/packages/cloudflare_logpush/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cloudflare_logpush
 title: Cloudflare Logpush
-version: "1.34.0"
+version: "1.34.1"
 description: Collect and parse logs from Cloudflare API with Elastic Agent.
 type: integration
 categories:
@@ -71,7 +71,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.51.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.51.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "1.51.0"
+version: "1.51.1"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: "3.0.3"
@@ -99,7 +99,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/cyberark_epm/changelog.yml
+++ b/packages/cyberark_epm/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "0.1.0"
   changes:
     - description: Initial release.

--- a/packages/cyberark_epm/manifest.yml
+++ b/packages/cyberark_epm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.0
 name: cyberark_epm
 title: CyberArk EPM
-version: 0.1.0
+version: 0.1.1
 description: Collect logs from CyberArk EPM with Elastic Agent.
 type: integration
 categories:
@@ -87,7 +87,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/cybereason/changelog.yml
+++ b/packages/cybereason/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.2.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/cybereason/manifest.yml
+++ b/packages/cybereason/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: cybereason
 title: Cybereason
-version: "1.2.0"
+version: "1.2.1"
 description: Collect logs from Cybereason with Elastic Agent.
 type: integration
 categories:
@@ -89,7 +89,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/darktrace/changelog.yml
+++ b/packages/darktrace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.22.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/darktrace/manifest.yml
+++ b/packages/darktrace/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: darktrace
 title: Darktrace
-version: "1.22.0"
+version: "1.22.1"
 description: Collect logs from Darktrace with Elastic Agent.
 type: integration
 categories:
@@ -63,7 +63,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false
@@ -104,7 +104,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/f5_bigip/changelog.yml
+++ b/packages/f5_bigip/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.25.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.25.0"
   changes:
     - description: Allow the usage of deprecated log input and support for stack 9.0

--- a/packages/f5_bigip/manifest.yml
+++ b/packages/f5_bigip/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: f5_bigip
 title: F5 BIG-IP
-version: "1.25.0"
+version: "1.25.1"
 description: Collect logs from F5 BIG-IP with Elastic Agent.
 type: integration
 categories:
@@ -67,7 +67,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/first_epss/changelog.yml
+++ b/packages/first_epss/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.2"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "0.3.1"
   changes:
     - description: Update links to getting started docs

--- a/packages/first_epss/manifest.yml
+++ b/packages/first_epss/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: first_epss
 title: First EPSS
-version: 0.3.1
+version: 0.3.2
 description: Collect exploit prediction score data from the First EPSS API with Elastic Agent.
 type: integration
 categories:
@@ -41,7 +41,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/forgerock/changelog.yml
+++ b/packages/forgerock/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.20.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.20.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/forgerock/manifest.yml
+++ b/packages/forgerock/manifest.yml
@@ -1,6 +1,6 @@
 name: forgerock
 title: "ForgeRock"
-version: "1.20.0"
+version: "1.20.1"
 description: Collect audit logs from ForgeRock with Elastic Agent.
 type: integration
 format_version: "3.0.2"
@@ -51,6 +51,7 @@ policy_templates:
             multi: false
             required: false
             show_user: false
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
           - name: api_key
             type: password
             title: API Key

--- a/packages/google_scc/changelog.yml
+++ b/packages/google_scc/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.7.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/google_scc/manifest.yml
+++ b/packages/google_scc/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: google_scc
 title: Google Security Command Center
-version: "1.7.0"
+version: "1.7.1"
 description: Collect logs from Google Security Command Center with Elastic Agent.
 type: integration
 categories:
@@ -105,7 +105,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/infoblox_bloxone_ddi/changelog.yml
+++ b/packages/infoblox_bloxone_ddi/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.20.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.20.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/infoblox_bloxone_ddi/manifest.yml
+++ b/packages/infoblox_bloxone_ddi/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: infoblox_bloxone_ddi
 title: Infoblox BloxOne DDI
-version: "1.20.0"
+version: "1.20.1"
 description: Collect logs from Infoblox BloxOne DDI with Elastic Agent.
 type: integration
 categories:
@@ -63,7 +63,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/infoblox_nios/changelog.yml
+++ b/packages/infoblox_nios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.27.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.27.0"
   changes:
     - description: Allow the usage of deprecated log input and support for stack 9.0

--- a/packages/infoblox_nios/manifest.yml
+++ b/packages/infoblox_nios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: infoblox_nios
 title: Infoblox NIOS
-version: "1.27.0"
+version: "1.27.1"
 description: Collect logs from Infoblox NIOS with Elastic Agent.
 type: integration
 categories:
@@ -57,7 +57,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/jamf_pro/changelog.yml
+++ b/packages/jamf_pro/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.6"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "0.2.5"
   changes:
     - description: Make `host.mac` in inventory data stream conform to ECS definition.

--- a/packages/jamf_pro/manifest.yml
+++ b/packages/jamf_pro/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.5
 name: jamf_pro
 title: "Jamf Pro"
-version: 0.2.5
+version: 0.2.6
 source:
   license: "Elastic-2.0"
 description: "Collect logs and inventory data from Jamf Pro with Elastic Agent"
@@ -68,7 +68,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/jamf_protect/changelog.yml
+++ b/packages/jamf_protect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.9.2"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "2.9.1"
   changes:
     - description: Update links to getting started docs

--- a/packages/jamf_protect/manifest.yml
+++ b/packages/jamf_protect/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: jamf_protect
 title: Jamf Protect
-version: "2.9.1"
+version: "2.9.2"
 description: Receives events from Jamf Protect with Elastic Agent.
 type: integration
 categories:
@@ -61,7 +61,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: TLS
-            description: Options for enabling TLS for the listening webhook endpoint. See the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html) for a list of all options.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/lastpass/changelog.yml
+++ b/packages/lastpass/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.19.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/lastpass/manifest.yml
+++ b/packages/lastpass/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: lastpass
 title: LastPass
-version: "1.19.0"
+version: "1.19.1"
 description: Collect logs from LastPass with Elastic Agent.
 type: integration
 categories:
@@ -67,7 +67,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/m365_defender/changelog.yml
+++ b/packages/m365_defender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.22.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "2.22.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/m365_defender/manifest.yml
+++ b/packages/m365_defender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: m365_defender
 title: Microsoft M365 Defender
-version: "2.22.0"
+version: "2.22.1"
 description: Collect logs from Microsoft M365 Defender with Elastic Agent.
 categories:
   - "security"
@@ -75,7 +75,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/menlo/changelog.yml
+++ b/packages/menlo/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.4.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/menlo/manifest.yml
+++ b/packages/menlo/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: menlo
 title: "Menlo Security"
-version: "1.4.0"
+version: "1.4.1"
 source:
   license: "Elastic-2.0"
 description: "Collect logs from Menlo Security products with Elastic Agent"
@@ -54,7 +54,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/microsoft_exchange_online_message_trace/changelog.yml
+++ b/packages/microsoft_exchange_online_message_trace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.26.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.26.0"
   changes:
     - description: Allow the usage of deprecated log input and support for stack 9.0

--- a/packages/microsoft_exchange_online_message_trace/manifest.yml
+++ b/packages/microsoft_exchange_online_message_trace/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: microsoft_exchange_online_message_trace
 title: "Microsoft Exchange Online Message Trace"
-version: "1.26.0"
+version: "1.26.1"
 description: "Microsoft Exchange Online Message Trace Integration"
 type: integration
 categories:
@@ -170,7 +170,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/microsoft_sentinel/changelog.yml
+++ b/packages/microsoft_sentinel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "0.3.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/microsoft_sentinel/manifest.yml
+++ b/packages/microsoft_sentinel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: microsoft_sentinel
 title: Microsoft Sentinel
-version: 0.3.0
+version: 0.3.1
 description: Collect logs from Microsoft Sentinel with Elastic Agent.
 type: integration
 categories:
@@ -108,7 +108,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/netskope/changelog.yml
+++ b/packages/netskope/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.22.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/netskope/manifest.yml
+++ b/packages/netskope/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: netskope
 title: "Netskope"
-version: "1.22.0"
+version: "1.22.1"
 description: Collect logs from Netskope with Elastic Agent.
 type: integration
 categories:
@@ -42,7 +42,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.4.2"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "3.4.1"
   changes:
     - description: Fix ECS event.category and event.type mappings.

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -1,6 +1,6 @@
 name: okta
 title: Okta
-version: "3.4.1"
+version: "3.4.2"
 description: Collect and parse event logs from Okta API with Elastic Agent.
 type: integration
 format_version: "3.1.0"
@@ -147,6 +147,7 @@ policy_templates:
             multi: false
             required: false
             show_user: true
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
           - name: proxy_url
             type: text
             title: Proxy URL

--- a/packages/ping_one/changelog.yml
+++ b/packages/ping_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.18.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/ping_one/manifest.yml
+++ b/packages/ping_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: ping_one
 title: PingOne
-version: "1.18.0"
+version: "1.18.1"
 description: Collect logs from PingOne with Elastic-Agent.
 type: integration
 categories:
@@ -40,7 +40,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false
@@ -121,7 +121,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/pps/changelog.yml
+++ b/packages/pps/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "0.4.0"
   changes:
     - description: Allow the usage of deprecated log input and support for stack 9.0

--- a/packages/pps/manifest.yml
+++ b/packages/pps/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: pps
 title: "Pleasant Password Server"
-version: "0.4.0"
+version: "0.4.1"
 source:
   license: "Apache-2.0"
 description: "Integration for Pleasant Password Server Syslog Messages"
@@ -56,7 +56,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/prisma_cloud/changelog.yml
+++ b/packages/prisma_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.0.2"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "2.0.1"
   changes:
     - description: Fix ingest pipeline processors with tags `create_user_name_and_user_domain` and `convert_ip_address_to_ip` that fails for some values.

--- a/packages/prisma_cloud/manifest.yml
+++ b/packages/prisma_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: prisma_cloud
 title: "Palo Alto Prisma Cloud"
-version: "2.0.1"
+version: "2.0.2"
 description: "Collect logs from Prisma Cloud with Elastic Agent."
 type: integration
 categories:
@@ -72,7 +72,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false
@@ -105,7 +105,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/proofpoint_tap/changelog.yml
+++ b/packages/proofpoint_tap/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.26.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.26.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/proofpoint_tap/manifest.yml
+++ b/packages/proofpoint_tap/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: proofpoint_tap
 title: Proofpoint TAP
-version: "1.26.0"
+version: "1.26.1"
 description: Collect logs from Proofpoint TAP with Elastic Agent.
 type: integration
 categories:
@@ -62,7 +62,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/rapid7_insightvm/changelog.yml
+++ b/packages/rapid7_insightvm/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.15.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/rapid7_insightvm/manifest.yml
+++ b/packages/rapid7_insightvm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: rapid7_insightvm
 title: Rapid7 InsightVM
-version: "1.15.0"
+version: "1.15.1"
 source:
   license: "Elastic-2.0"
 description: Collect logs from Rapid7 InsightVM with Elastic Agent.
@@ -69,7 +69,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/sentinel_one/changelog.yml
+++ b/packages/sentinel_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.29.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.29.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/sentinel_one/manifest.yml
+++ b/packages/sentinel_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: sentinel_one
 title: SentinelOne
-version: "1.29.0"
+version: "1.29.1"
 description: Collect logs from SentinelOne with Elastic Agent.
 type: integration
 categories:
@@ -57,7 +57,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/sentinel_one_cloud_funnel/changelog.yml
+++ b/packages/sentinel_one_cloud_funnel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.2"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.8.1"
   changes:
     - description: Fix missing event.action in network events.

--- a/packages/sentinel_one_cloud_funnel/manifest.yml
+++ b/packages/sentinel_one_cloud_funnel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: sentinel_one_cloud_funnel
 title: SentinelOne Cloud Funnel
-version: "1.8.1"
+version: "1.8.2"
 description: Collect logs from SentinelOne Cloud Funnel with Elastic Agent.
 type: integration
 categories: ["security", "edr_xdr"]
@@ -141,7 +141,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/slack/changelog.yml
+++ b/packages/slack/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.24.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.24.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/slack/manifest.yml
+++ b/packages/slack/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: slack
 title: "Slack Logs"
-version: "1.24.0"
+version: "1.24.1"
 description: "Slack Logs Integration"
 type: integration
 categories:
@@ -45,6 +45,7 @@ policy_templates:
             multi: false
             required: false
             show_user: false
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
           - name: proxy_url
             type: text
             title: Proxy URL

--- a/packages/snyk/changelog.yml
+++ b/packages/snyk/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.27.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.27.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/snyk/manifest.yml
+++ b/packages/snyk/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: snyk
 title: "Snyk"
-version: "1.27.0"
+version: "1.27.1"
 description: Collect logs from Snyk with Elastic Agent.
 type: integration
 categories:
@@ -63,7 +63,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false
@@ -110,7 +110,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/sophos_central/changelog.yml
+++ b/packages/sophos_central/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.18.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/sophos_central/manifest.yml
+++ b/packages/sophos_central/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: sophos_central
 title: Sophos Central
-version: "1.18.0"
+version: "1.18.1"
 description: This Elastic integration collects logs from Sophos Central with Elastic Agent.
 type: integration
 categories:
@@ -89,7 +89,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/spycloud/changelog.yml
+++ b/packages/spycloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.2.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/spycloud/manifest.yml
+++ b/packages/spycloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: spycloud
 title: SpyCloud Enterprise Protection
-version: 1.2.0
+version: 1.2.1
 description: Collect data from SpyCloud Enterprise Protection with Elastic Agent.
 type: integration
 categories:
@@ -63,7 +63,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/sublime_security/changelog.yml
+++ b/packages/sublime_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.5.0"
   changes:
     - description: Improve `file_selectors` documentation.

--- a/packages/sublime_security/manifest.yml
+++ b/packages/sublime_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: sublime_security
 title: Sublime Security
-version: 1.5.0
+version: 1.5.1
 description: Collect logs from Sublime Security with Elastic Agent.
 type: integration
 categories:
@@ -70,7 +70,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false
@@ -194,7 +194,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/symantec_edr_cloud/changelog.yml
+++ b/packages/symantec_edr_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.8.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/symantec_edr_cloud/manifest.yml
+++ b/packages/symantec_edr_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: symantec_edr_cloud
 title: Symantec EDR Cloud (Deprecated)
-version: "1.8.0"
+version: "1.8.1"
 source:
   license: Elastic-2.0
 description: Deprecated. Use the Symantec Endpoint Security package instead.
@@ -72,7 +72,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/symantec_endpoint_security/changelog.yml
+++ b/packages/symantec_endpoint_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.7.0"
   changes:
     - description: Support ISO8601 timestamps.

--- a/packages/symantec_endpoint_security/manifest.yml
+++ b/packages/symantec_endpoint_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: symantec_endpoint_security
 title: Symantec Endpoint Security
-version: "1.7.0"
+version: "1.7.1"
 description: Collect logs from Symantec Endpoint Security with Elastic Agent.
 type: integration
 categories:
@@ -95,7 +95,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/tanium/changelog.yml
+++ b/packages/tanium/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.14.0"
   changes:
     - description: Add support for Access Point ARN when collecting logs via the AWS S3 Bucket.

--- a/packages/tanium/manifest.yml
+++ b/packages/tanium/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: tanium
 title: Tanium
-version: "1.14.0"
+version: "1.14.1"
 description: This Elastic integration collects logs from Tanium with Elastic Agent.
 type: integration
 categories:
@@ -168,7 +168,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false
@@ -209,7 +209,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/tenable_io/changelog.yml
+++ b/packages/tenable_io/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.6.2"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "3.6.1"
   changes:
     - description: Add "vulnerability_management" category.

--- a/packages/tenable_io/manifest.yml
+++ b/packages/tenable_io/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: tenable_io
 title: Tenable Vulnerability Management
-version: "3.6.1"
+version: "3.6.2"
 description: Collect logs from Tenable Vulnerability Management with Elastic Agent.
 type: integration
 categories:
@@ -69,7 +69,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/tenable_sc/changelog.yml
+++ b/packages/tenable_sc/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.28.2"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.28.1"
   changes:
     - description: Add "vulnerability_management" category.

--- a/packages/tenable_sc/manifest.yml
+++ b/packages/tenable_sc/manifest.yml
@@ -2,7 +2,7 @@ format_version: "3.0.2"
 name: tenable_sc
 title: Tenable Security Center
 # The version must be updated in the input configuration templates as well, in order to set the correct User-Agent header. Until elastic/kibana#121310 is implemented we will have to manually sync these.
-version: "1.28.1"
+version: "1.28.2"
 description: |
   Collect data from Tenable Security Center with Elastic Agent.
 type: integration
@@ -87,7 +87,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/ti_crowdstrike/changelog.yml
+++ b/packages/ti_crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "2.3.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/ti_crowdstrike/manifest.yml
+++ b/packages/ti_crowdstrike/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_crowdstrike
 title: CrowdStrike Falcon Intelligence
-version: "2.3.0"
+version: "2.3.1"
 description: Collect logs from CrowdStrike Falcon Intelligence with Elastic Agent.
 type: integration
 categories:
@@ -75,7 +75,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/ti_eclecticiq/changelog.yml
+++ b/packages/ti_eclecticiq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.2"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.3.1"
   changes:
     - description: Update links to getting started docs

--- a/packages/ti_eclecticiq/manifest.yml
+++ b/packages/ti_eclecticiq/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_eclecticiq
 title: EclecticIQ
-version: "1.3.1"
+version: "1.3.2"
 description: Ingest threat intelligence from EclecticIQ with Elastic Agent
 type: integration
 categories:
@@ -41,9 +41,8 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: |
-              Add SSL client configuration options such as 'certificate_authorities', 'certificate', 'verification_mode', etc.
-              See https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-client-config
+            description: |-
+              SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/ti_opencti/changelog.yml
+++ b/packages/ti_opencti/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "2.5.0"
   changes:
     - description: Allow proxy configuration.

--- a/packages/ti_opencti/manifest.yml
+++ b/packages/ti_opencti/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: ti_opencti
 title: OpenCTI
-version: "2.5.0"
+version: "2.5.1"
 description: "Ingest threat intelligence indicators from OpenCTI with Elastic Agent."
 type: integration
 source:
@@ -72,7 +72,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate, key, certificate_authorities, and [other SSL options](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html).
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false
@@ -106,6 +106,7 @@ policy_templates:
             show_user: false
             description: >
               URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>. Please ensure your username and password are in URL encoded format.
+
 owner:
   github: elastic/security-service-integrations
   type: elastic

--- a/packages/ti_rapid7_threat_command/changelog.yml
+++ b/packages/ti_rapid7_threat_command/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "2.3.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/ti_rapid7_threat_command/manifest.yml
+++ b/packages/ti_rapid7_threat_command/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: ti_rapid7_threat_command
 title: Rapid7 Threat Command
-version: "2.3.0"
+version: "2.3.1"
 description: Collect threat intelligence from Threat Command API with Elastic Agent.
 type: integration
 categories: ["security", "threat_intel"]
@@ -88,7 +88,7 @@ policy_templates:
             type: yaml
             title: SSL Configuration
             description: >-
-              i.e. certificate_authorities, supported_protocols, verification_mode etc.
+              SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/ti_threatconnect/changelog.yml
+++ b/packages/ti_threatconnect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.7.0"
   changes:
     - description: Add in filter for dashboard to only show latest indicators.

--- a/packages/ti_threatconnect/manifest.yml
+++ b/packages/ti_threatconnect/manifest.yml
@@ -2,7 +2,7 @@
 format_version: 3.0.3
 name: ti_threatconnect
 title: ThreatConnect
-version: "1.7.0"
+version: "1.7.1"
 description: Collects Indicators from ThreatConnect using the Elastic Agent and saves them as logs inside Elastic
 type: integration
 categories:
@@ -64,7 +64,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: Configuration for SSL communication if needed.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/trellix_edr_cloud/changelog.yml
+++ b/packages/trellix_edr_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.6.0"
   changes:
     - description: Add support for Access Point ARN when collecting logs via the AWS S3 Bucket.

--- a/packages/trellix_edr_cloud/manifest.yml
+++ b/packages/trellix_edr_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: trellix_edr_cloud
 title: Trellix EDR Cloud
-version: "1.6.0"
+version: "1.6.1"
 description: Collect logs from Trellix EDR Cloud with Elastic Agent.
 type: integration
 categories:
@@ -130,7 +130,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/trellix_epo_cloud/changelog.yml
+++ b/packages/trellix_epo_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.14.0"
   changes:
     - description: Add "preserve_original_event" tag to documents with `event.kind` manually set to "pipeline_error".

--- a/packages/trellix_epo_cloud/manifest.yml
+++ b/packages/trellix_epo_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: trellix_epo_cloud
 title: Trellix ePO Cloud
-version: "1.14.0"
+version: "1.14.1"
 source:
   license: Elastic-2.0
 description: Collect logs from Trellix ePO Cloud with Elastic Agent.
@@ -88,7 +88,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/trend_micro_vision_one/changelog.yml
+++ b/packages/trend_micro_vision_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.25.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.25.0"
   changes:
     - description: Add configurable additional look-back time option to all the data streams.

--- a/packages/trend_micro_vision_one/manifest.yml
+++ b/packages/trend_micro_vision_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: trend_micro_vision_one
 title: Trend Micro Vision One
-version: "1.25.0"
+version: "1.25.1"
 description: Collect logs from Trend Micro Vision One with Elastic Agent.
 type: integration
 categories:
@@ -57,7 +57,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/wiz/changelog.yml
+++ b/packages/wiz/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.8.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "2.8.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/wiz/manifest.yml
+++ b/packages/wiz/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: wiz
 title: Wiz
-version: "2.8.0"
+version: "2.8.1"
 description: Collect logs from Wiz with Elastic Agent.
 type: integration
 categories:
@@ -91,7 +91,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/zeronetworks/changelog.yml
+++ b/packages/zeronetworks/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.17.2"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.17.1"
   changes:
     - description: Update links to getting started docs

--- a/packages/zeronetworks/manifest.yml
+++ b/packages/zeronetworks/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: zeronetworks
 title: "Zero Networks"
-version: "1.17.1"
+version: "1.17.2"
 source:
   license: "Elastic-2.0"
 description: "Zero Networks Logs integration"
@@ -50,6 +50,7 @@ policy_templates:
             multi: false
             required: false
             show_user: false
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
           - name: proxy_url
             type: text
             title: Proxy URL

--- a/packages/zscaler_zia/changelog.yml
+++ b/packages/zscaler_zia/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.7.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "3.7.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/zscaler_zia/manifest.yml
+++ b/packages/zscaler_zia/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: zscaler_zia
 title: Zscaler Internet Access
-version: "3.7.0"
+version: "3.7.1"
 description: Collect logs from Zscaler Internet Access (ZIA) with Elastic Agent.
 type: integration
 categories:
@@ -74,7 +74,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false
@@ -208,7 +208,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false

--- a/packages/zscaler_zpa/changelog.yml
+++ b/packages/zscaler_zpa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.20.1"
+  changes:
+    - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12781
 - version: "1.20.0"
   changes:
     - description: Do not remove `event.original` in main ingest pipeline.

--- a/packages/zscaler_zpa/manifest.yml
+++ b/packages/zscaler_zpa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: zscaler_zpa
 title: Zscaler Private Access
-version: "1.20.0"
+version: "1.20.1"
 source:
   license: Elastic-2.0
 description: Collect logs from Zscaler Private Access (ZPA) with Elastic Agent.
@@ -43,7 +43,7 @@ policy_templates:
           - name: ssl
             type: yaml
             title: SSL Configuration
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
             multi: false
             required: false
             show_user: false


### PR DESCRIPTION
## Proposed commit message

Updates description field on ssl nodes in package level manifest.yml file to include links to online documentation and to be consistent with other integrations. Changes are for integrations owned by security-service-integrations

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

# How to test this PR locally

Originally, we updated the descriptions on all the files in integration. This created some issues with so many teams needing to validate the files. This is currently a partial update with files that are owned by security-service-integrations.

git diff main | grep description: | grep + | sort -u
results in the update fields for the ssl node description and the changelog.yml

## Related issues

- Closes #12705
- Relates #11792
- Requires #123
- Supersedes #123
