### PR TITLE
Enablement & Sanity test run for evoyproxy OBS integration package for 9.0.0

### DIFF
--- a/packages/envoyproxy/changelog.yml
+++ b/packages/envoyproxy/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.3.0"
+  changes:
+    - description: Add support for Kibana `9.0.0`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1 #FIX ME
 - version: "0.2.0"
   changes:
     - description: Add field definitions for envoy.thread_local_cluster_manager

--- a/packages/envoyproxy/changelog.yml
+++ b/packages/envoyproxy/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add support for Kibana `9.0.0`.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1 #FIX ME
+      link: https://github.com/elastic/integrations/pull/12788
 - version: "0.2.0"
   changes:
     - description: Add field definitions for envoy.thread_local_cluster_manager

--- a/packages/envoyproxy/data_stream/log/fields/beats.yml
+++ b/packages/envoyproxy/data_stream/log/fields/beats.yml
@@ -13,6 +13,9 @@
     - name: device_id
       type: keyword
       description: ID of the device containing the filesystem where the file resides.
+    - name: fingerprint
+      type: keyword
+      description: The sha256 fingerprint identity of the file when fingerprinting is enabled.
     - name: inode
       type: keyword
       description: Inode number of the log file.

--- a/packages/envoyproxy/data_stream/log/sample_event.json
+++ b/packages/envoyproxy/data_stream/log/sample_event.json
@@ -1,15 +1,15 @@
 {
     "@timestamp": "2019-04-08T16:16:55.931Z",
     "agent": {
-        "ephemeral_id": "b251a806-74d2-4f75-bb84-142e7f931c17",
-        "id": "c3ca3082-b848-456d-b798-5b7c6044cec3",
-        "name": "elastic-agent-33100",
+        "ephemeral_id": "ee68951f-ee1f-45ae-8e2b-47fadcd1aa7d",
+        "id": "75199e22-366d-48f5-95d2-29840b5c0730",
+        "name": "elastic-agent-18673",
         "type": "filebeat",
-        "version": "8.15.1"
+        "version": "9.0.0"
     },
     "data_stream": {
         "dataset": "envoyproxy.log",
-        "namespace": "34940",
+        "namespace": "46375",
         "type": "logs"
     },
     "destination": {
@@ -21,9 +21,9 @@
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "c3ca3082-b848-456d-b798-5b7c6044cec3",
-        "snapshot": false,
-        "version": "8.15.1"
+        "id": "75199e22-366d-48f5-95d2-29840b5c0730",
+        "snapshot": true,
+        "version": "9.0.0"
     },
     "envoyproxy": {
         "log": {
@@ -39,10 +39,10 @@
         "category": [
             "network"
         ],
-        "created": "2024-11-14T14:19:50.685Z",
+        "created": "2025-02-11T12:38:13.677Z",
         "dataset": "envoyproxy.log",
         "duration": 5000000,
-        "ingested": "2024-11-14T14:19:51Z",
+        "ingested": "2025-02-11T12:38:14Z",
         "kind": "event",
         "original": "[2019-04-08T16:16:55.931Z] \"GET /service/1 HTTP/1.1\" 200 - 0 89 5 4 \"-\" \"curl/7.54.0\" \"c219f6da-2b7f-483e-9ced-ec323d9330a9\" \"localhost:8000\" \"172.27.0.3:80\"",
         "outcome": "success",
@@ -71,8 +71,9 @@
     },
     "log": {
         "file": {
-            "device_id": "30",
-            "inode": "57",
+            "device_id": "64768",
+            "fingerprint": "64a922ed2775bc79e703cb91d8c21d2b5fa2924b41167308d87dfdcb05962d51",
+            "inode": "273536519",
             "path": "/tmp/service_logs/envoy.log"
         },
         "offset": 82

--- a/packages/envoyproxy/docs/README.md
+++ b/packages/envoyproxy/docs/README.md
@@ -46,15 +46,15 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2019-04-08T16:16:55.931Z",
     "agent": {
-        "ephemeral_id": "b251a806-74d2-4f75-bb84-142e7f931c17",
-        "id": "c3ca3082-b848-456d-b798-5b7c6044cec3",
-        "name": "elastic-agent-33100",
+        "ephemeral_id": "ee68951f-ee1f-45ae-8e2b-47fadcd1aa7d",
+        "id": "75199e22-366d-48f5-95d2-29840b5c0730",
+        "name": "elastic-agent-18673",
         "type": "filebeat",
-        "version": "8.15.1"
+        "version": "9.0.0"
     },
     "data_stream": {
         "dataset": "envoyproxy.log",
-        "namespace": "34940",
+        "namespace": "46375",
         "type": "logs"
     },
     "destination": {
@@ -66,9 +66,9 @@ An example event for `log` looks as following:
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "c3ca3082-b848-456d-b798-5b7c6044cec3",
-        "snapshot": false,
-        "version": "8.15.1"
+        "id": "75199e22-366d-48f5-95d2-29840b5c0730",
+        "snapshot": true,
+        "version": "9.0.0"
     },
     "envoyproxy": {
         "log": {
@@ -84,10 +84,10 @@ An example event for `log` looks as following:
         "category": [
             "network"
         ],
-        "created": "2024-11-14T14:19:50.685Z",
+        "created": "2025-02-11T12:38:13.677Z",
         "dataset": "envoyproxy.log",
         "duration": 5000000,
-        "ingested": "2024-11-14T14:19:51Z",
+        "ingested": "2025-02-11T12:38:14Z",
         "kind": "event",
         "original": "[2019-04-08T16:16:55.931Z] \"GET /service/1 HTTP/1.1\" 200 - 0 89 5 4 \"-\" \"curl/7.54.0\" \"c219f6da-2b7f-483e-9ced-ec323d9330a9\" \"localhost:8000\" \"172.27.0.3:80\"",
         "outcome": "success",
@@ -116,8 +116,9 @@ An example event for `log` looks as following:
     },
     "log": {
         "file": {
-            "device_id": "30",
-            "inode": "57",
+            "device_id": "64768",
+            "fingerprint": "64a922ed2775bc79e703cb91d8c21d2b5fa2924b41167308d87dfdcb05962d51",
+            "inode": "273536519",
             "path": "/tmp/service_logs/envoy.log"
         },
         "offset": 82
@@ -173,6 +174,7 @@ An example event for `log` looks as following:
 | kubernetes.pod.uid | Kubernetes pod UID | keyword |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
 | log.file.device_id | ID of the device containing the filesystem where the file resides. | keyword |
+| log.file.fingerprint | The sha256 fingerprint identity of the file when fingerprinting is enabled. | keyword |
 | log.file.inode | Inode number of the log file. | keyword |
 | log.flags | Flags for the log file. | keyword |
 | log.offset | Log offset. | long |

--- a/packages/envoyproxy/manifest.yml
+++ b/packages/envoyproxy/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.3
 name: envoyproxy
 title: Envoyproxy
-version: 0.2.0
+version: 0.3.0
 source:
   license: "Elastic-2.0"
 description: Envoyproxy Integration
@@ -10,7 +10,7 @@ categories:
   - observability
 conditions:
   kibana:
-    version: ^8.15.0
+    version: "^8.15.0 || ^9.0.0"
 icons:
   - src: /img/envoy.svg
     title: Sample logo
@@ -36,7 +36,7 @@ policy_templates:
             multi: false
             required: true
             show_user: true
-            default:
+            default: 
               - localhost
           - name: port
             type: text


### PR DESCRIPTION
- Enhancement

# Description
- OBS package for 9.0.0 enablement activities of O11y `envoyproxy` integration.
- Fix `envoyproxy` fingerprint issue

# Steps performed for the testing
1. update manifest.yml, package minor version upgrade and kibana dependency addition ` || ^9.0.0`.
2. build package
3. run package tests
4. install integration from kibana
5. check for any issues

## List of non-cloud packages and results of sanity

Pass: Successfully Passed
Pending: Either permission issue or agent will stuck on 0 hits
Failed: Failed because of beats and integration changes are not in sync
Not Available: Tests are not available

No. | Packages | build & check | pipeline | system | asset | static
-- | -- | -- | -- | -- | -- | --
1 | envoyproxy | Pass | Pass | Pass | Pass | Pass

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 



## Related issues

- Relates https://github.com/elastic/obs-integration-team/issues/148
- Closes https://github.com/elastic/integrations/issues/12548


