### PR TITLE
[teleport] Ensure to wait for all test docs in system tests

### DIFF
--- a/packages/teleport/data_stream/audit/_dev/test/system/test-filestream-config.yml
+++ b/packages/teleport/data_stream/audit/_dev/test/system/test-filestream-config.yml
@@ -11,3 +11,5 @@ numeric_keyword_fields:
   - log.file.idxhi
   - log.file.idxlo
   - log.file.vol
+assert:
+  hit_count: 270


### PR DESCRIPTION
## Proposed commit message

Ensure to wait for all test docs defined in the package before running any validation.
It is ensured by adding `assert.hit_count` in the system test configuration file.


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 
