### PR TITLE
[azure logs] enable event hub processor v2

### DIFF
--- a/packages/azure/_dev/build/docs/events.md
+++ b/packages/azure/_dev/build/docs/events.md
@@ -56,7 +56,7 @@ The processor v2 introduces several changes:
 
 The processor v2 is in preview. Processor v1 is still the default and is recommended for typical use cases.
 
-See the "Processor v2 only" section in the integration settings for more details about enabling the processor v2.
+See the "Event Hub Processor v2 only" section in the integration settings for more details about enabling the processor v2.
 
 ## Data streams
 
@@ -509,15 +509,15 @@ The following settings are **event hub processor v2 only** and available in the 
 
 `processor_version` :
 _string_
-(v2 only) The processor version that the integration should use. Possible values are `v1` and `v2` (preview). The processor v2 is in preview. Using the processor v1 is recommended for typical use cases. Default is `v1`.
+(processor v2 only) The processor version that the integration should use. Possible values are `v1` and `v2` (preview). The processor v2 is in preview. Using the processor v1 is recommended for typical use cases. Default is `v1`.
 
 `processor_update_interval` :
 _string_
-(v2 only) How often the processor should attempt to claim partitions. Default is `10s`.
+(processor v2 only) How often the processor should attempt to claim partitions. Default is `10s`.
 
 `processor_start_position` :
 _string_
-(v2 only) Controls from which position in the event hub the processor should start processing messages for all partitions.
+(processor v2 only) Controls from which position in the event hub the processor should start processing messages for all partitions.
 
 Possible values are `earliest` and `latest`.
 
@@ -526,19 +526,19 @@ Possible values are `earliest` and `latest`.
 
 `migrate_checkpoint` :
 _boolean_
-(v2 only) Flag to control whether the processor should perform the checkpoint information migration from v1 to v2 at startup. The checkpoint migration converts the checkpoint information from the v1 format to the v2 format.
+(processor v2 only) Flag to control whether the processor should perform the checkpoint information migration from v1 to v2 at startup. The checkpoint migration converts the checkpoint information from the v1 format to the v2 format.
 
 Default is `false`, which means the processor will not perform the checkpoint migration.
 
 `partition_receive_timeout` :
 _string_
-(v2 only) Maximum time to wait before processing the messages received from the event hub.
+(processor v2 only) Maximum time to wait before processing the messages received from the event hub.
 
 The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Default is `5` seconds.
 
 `partition_receive_count` :
 _string_
-(v2 only) Maximum number of messages from the event hub to wait for before processing them.
+(processor v2 only) Maximum number of messages from the event hub to wait for before processing them.
 
 The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Default is `100` messages.
 

--- a/packages/azure/_dev/build/docs/events.md
+++ b/packages/azure/_dev/build/docs/events.md
@@ -517,7 +517,7 @@ _string_
 _string_
 (v2 only) Controls from what position in the event hub the input should start processing messages for all partitions.
 
-Possible values are `earliest` and `latest`. 
+Possible values are `earliest` and `latest`.
 
 * `earliest` starts processing messages from the last checkpoint, or the beginning of the event hub if no checkpoint is available.
 * `latest` starts processing messages from the the latest event in the event hub and continues to process new events as they arrive.
@@ -526,17 +526,21 @@ Default is `earliest`.
 
 `migrate_checkpoint` :
 _boolean_
-(v2 only) Whether to migrate the checkpoint information from the input v1 format to v2 format.
+(v2 only) Flag to control if the input should perform the checkpoint information migration from v1 to v2 at startup. The checkpoint migration converts the checkpoint information from the v1 format to the v2 format.
 
-Default is `false`, which means the input will not perform the checkpoint migration and will start processing messages from the beginning or the end of the event hub according to the `processor_start_position` setting.
+Default is `false`, which means the input will not perform the checkpoint migration.
 
 `partition_receive_timeout` :
 _string_
-(v2 only) Max time to wait before processing the messages received from the event hub. Default is `5s`.
+(v2 only) Max time to wait before processing the messages received from the event hub.
+
+The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Default is `5` seconds.
 
 `partition_receive_count` :
 _string_
-(v2 only) Max number of events to wait for before processing the messages received from the event hub. Default is `100`.
+(v2 only) Max number of messages from the event hub to wait for before processing them.
+
+The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Default is `100` messages.
 
 ## Handling Malformed JSON in Azure Logs
 

--- a/packages/azure/_dev/build/docs/events.md
+++ b/packages/azure/_dev/build/docs/events.md
@@ -515,7 +515,7 @@ _string_
 
 `processor_start_position` :
 _string_
-(v2 only) Controls from what position in the event hub the input should start processing messages for all partitions.
+(v2 only) Controls from which position in the event hub the input should start processing messages for all partitions.
 
 Possible values are `earliest` and `latest`.
 
@@ -526,19 +526,19 @@ Default is `earliest`.
 
 `migrate_checkpoint` :
 _boolean_
-(v2 only) Flag to control if the input should perform the checkpoint information migration from v1 to v2 at startup. The checkpoint migration converts the checkpoint information from the v1 format to the v2 format.
+(v2 only) Flag to control whether the input should perform the checkpoint information migration from v1 to v2 at startup. The checkpoint migration converts the checkpoint information from the v1 format to the v2 format.
 
 Default is `false`, which means the input will not perform the checkpoint migration.
 
 `partition_receive_timeout` :
 _string_
-(v2 only) Max time to wait before processing the messages received from the event hub.
+(v2 only) Maximum time to wait before processing the messages received from the event hub.
 
 The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Default is `5` seconds.
 
 `partition_receive_count` :
 _string_
-(v2 only) Max number of messages from the event hub to wait for before processing them.
+(v2 only) Maximum number of messages from the event hub to wait for before processing them.
 
 The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Default is `100` messages.
 

--- a/packages/azure/_dev/build/docs/events.md
+++ b/packages/azure/_dev/build/docs/events.md
@@ -10,6 +10,12 @@ You may also want to plan your Azure capacity better. Send Azure Activity logs t
 
 ## What's new in the integration v2 preview?
 
+The Azure Logs integration v2 preview introduces:
+
+* A new architecture that allows you to collect all logs through a single event hub.
+* Significant efficiency improvements.
+* A new processor (v2) that incorporates the latest Event Hubs SDK.
+
 ### Architecture
 
 The Azure Logs integration (v2 preview) introduces a new architecture that allows you to forward logs from multiple Azure services to the same event hub.
@@ -37,24 +43,20 @@ IMPORTANT: **To use the integration v2 preview, you must turn off all the existi
 
 ### Efficiency
 
-Internally, the v2 preview processes logs using only one `azure-eventhub` input per event hub instead of multiple inputs like the v1 architecture.
+The integration v2 preview avoids contention and inefficiencies from using multiple consumers per partition with the same event hub, problems that are typical of the v1 architecture. With the v2 preview, you can still assign the agent policy to multiple Elastic Agents to scale out the logs processing.
 
-The `azure-eventhub` input is the main engine of the integration. It is responsible for fetching the messages from the event hub, processing them, and sending them to the data stream in Elasticsearch.
+### Processor v2 ✨
 
-The integration v2 preview avoids contention and inefficiencies from using multiple inputs with the same event hub, problems that are typical of the v1 architecture. With the v2 preview, you can still assign the agent policy to multiple Elastic Agents to scale out the logs processing.
+The integration v2 preview offers a new processor v2 starting with integration version 1.23.0.
 
-### Input v2 ✨
-
-The integration v2 preview offers a new `azure-eventhub` input v2 starting with integration version 1.23.0.
-
-The input v2 introduces several changes:
+The processor v2 introduces several changes:
 
 * It uses the latest Event Hubs SDK from Azure.
 * It uses a more efficient checkpoint store based on Azure Blob Storage metadata.
 
-The input v2 is in preview. Input v1 is still the default and is recommended for typical use cases.
+The processor v2 is in preview. Processor v1 is still the default and is recommended for typical use cases.
 
-See the "Settings" section for more details about enabling the input v2.
+See the "Processor v2 only" section in the integration settings for more details about enabling the processor v2.
 
 ## Data streams
 
@@ -501,21 +503,21 @@ Examples:
 
 This setting can also be used to define your own endpoints, like for hybrid cloud models.
 
-### Input v2 only
+### Processor v2 only
 
-The following settings are **input v2 only** and available in the advanced section of the integration.
+The following settings are **processor v2 only** and available in the advanced section of the integration.
 
 `processor_version` :
 _string_
-(v2 only) The input version that the integration should use. Possible values are `v1` and `v2` (preview). The input v2 is in preview. Using the input v1 is recommended for typical use cases. Default is `v1`.
+(v2 only) The processor version that the integration should use. Possible values are `v1` and `v2` (preview). The processor v2 is in preview. Using the processor v1 is recommended for typical use cases. Default is `v1`.
 
 `processor_update_interval` :
 _string_
-(v2 only) How often the input should attempt to claim partitions. Default is `10s`.
+(v2 only) How often the processor should attempt to claim partitions. Default is `10s`.
 
 `processor_start_position` :
 _string_
-(v2 only) Controls from which position in the event hub the input should start processing messages for all partitions.
+(v2 only) Controls from which position in the event hub the processor should start processing messages for all partitions.
 
 Possible values are `earliest` and `latest`.
 
@@ -524,9 +526,9 @@ Possible values are `earliest` and `latest`.
 
 `migrate_checkpoint` :
 _boolean_
-(v2 only) Flag to control whether the input should perform the checkpoint information migration from v1 to v2 at startup. The checkpoint migration converts the checkpoint information from the v1 format to the v2 format.
+(v2 only) Flag to control whether the processor should perform the checkpoint information migration from v1 to v2 at startup. The checkpoint migration converts the checkpoint information from the v1 format to the v2 format.
 
-Default is `false`, which means the input will not perform the checkpoint migration.
+Default is `false`, which means the processor will not perform the checkpoint migration.
 
 `partition_receive_timeout` :
 _string_

--- a/packages/azure/_dev/build/docs/events.md
+++ b/packages/azure/_dev/build/docs/events.md
@@ -501,7 +501,7 @@ Examples:
 
 This setting can also be used to define your own endpoints, like for hybrid cloud models.
 
-### Input v2 settings (advanced)
+### Input v2 only
 
 The following settings are **input v2 only** and available in the advanced section of the integration.
 
@@ -519,10 +519,8 @@ _string_
 
 Possible values are `earliest` and `latest`.
 
-* `earliest` starts processing messages from the last checkpoint, or the beginning of the event hub if no checkpoint is available.
-* `latest` starts processing messages from the the latest event in the event hub and continues to process new events as they arrive.
-
-Default is `earliest`.
+* `earliest` (default): starts processing messages from the last checkpoint, or the beginning of the event hub if no checkpoint is available.
+* `latest`: starts processing messages from the the latest event in the event hub and continues to process new events as they arrive.
 
 `migrate_checkpoint` :
 _boolean_

--- a/packages/azure/_dev/build/docs/events.md
+++ b/packages/azure/_dev/build/docs/events.md
@@ -33,15 +33,15 @@ The Azure Logs integration (v2 preview) introduces a new architecture that allow
 
 The integration will automatically detect the log category and forward the logs to the appropriate data stream. When the integration v2 preview cannot find a matching data stream for a log category, it forwards the logs to the platform logs data stream.
 
-IMPORTANT: To use the integrationv2 preview, you must turn off all the existing v1 integrations and turn on only the v2 preview integration.
+IMPORTANT: **To use the integration v2 preview, you must turn off all the existing v1 integrations and turn on only the v2 preview integration.**
 
 ### Efficiency
 
-Under the hood, the v2 preview processes logs using only one `azure-eventhub` input per event hub instead of multiple inputs like the v1 architecture.
+Internally, the v2 preview processes logs using only one `azure-eventhub` input per event hub instead of multiple inputs like the v1 architecture.
 
 The `azure-eventhub` input is the main engine of the integration. It is responsible for fetching the messages from the event hub, processing them, and sending them to the data stream in Elasticsearch.
 
-The integration v2 preview avoids contention and inefficiencies from using multiple inputs with the same event hub, which is typical of the v1 architecture. With the v2 preview, you can still assign the agent policy to multiple Elastic Agents to scale out the logs processing.
+The integration v2 preview avoids contention and inefficiencies from using multiple inputs with the same event hub, problems that are typical of the v1 architecture. With the v2 preview, you can still assign the agent policy to multiple Elastic Agents to scale out the logs processing.
 
 ### Input v2 ✨
 

--- a/packages/azure/_dev/build/docs/events.md
+++ b/packages/azure/_dev/build/docs/events.md
@@ -8,7 +8,9 @@ For example, to detect possible brute force sign-in attacks, you can install the
 
 You may also want to plan your Azure capacity better. Send Azure Activity logs to Elastic to track and visualize when your virtual machines fail to start because they exceed the quota limit.
 
-## What's new in v2 preview?
+## What's new in the integration v2 preview?
+
+### Architecture
 
 The Azure Logs integration (v2 preview) introduces a new architecture that allows you to forward logs from multiple Azure services to the same event hub.
 
@@ -31,9 +33,28 @@ The Azure Logs integration (v2 preview) introduces a new architecture that allow
 
 The integration will automatically detect the log category and forward the logs to the appropriate data stream. When the integration v2 preview cannot find a matching data stream for a log category, it forwards the logs to the platform logs data stream.
 
-IMPORTANT: To use the v2 preview, you must turn off all the existing v1 integrations and turn on only the v2 preview integration.
+IMPORTANT: To use the integrationv2 preview, you must turn off all the existing v1 integrations and turn on only the v2 preview integration.
 
-Under the hood, the v2 preview uses only one `azure-eventhub` input per event hub. The v2 preview avoids contention and inefficiencies from using multiple inputs with the same event hub, which is typical of the v1 architecture. With the v2 preview, you can still assign the agent policy to multiple Elastic Agents to scale out the logs processing.
+### Efficiency
+
+Under the hood, the v2 preview processes logs using only one `azure-eventhub` input per event hub instead of multiple inputs like the v1 architecture.
+
+The `azure-eventhub` input is the main engine of the integration. It is responsible for fetching the messages from the event hub, processing them, and sending them to the data stream in Elasticsearch.
+
+The integration v2 preview avoids contention and inefficiencies from using multiple inputs with the same event hub, which is typical of the v1 architecture. With the v2 preview, you can still assign the agent policy to multiple Elastic Agents to scale out the logs processing.
+
+### Input v2 ✨
+
+The integration v2 preview offers a new `azure-eventhub` input v2 starting with integration version 1.23.0.
+
+The input v2 introduces several changes:
+
+* It uses the latest Event Hubs SDK from Azure.
+* It uses a more efficient checkpoint store based on Azure Blob Storage metadata.
+
+The input v2 is in preview. Input v1 is still the default and is recommended for typical use cases.
+
+See the "Settings" section for more details about enabling the input v2.
 
 ## Data streams
 
@@ -479,6 +500,43 @@ Examples:
 * Azure USGovernmentCloud: `https://management.usgovcloudapi.net/`
 
 This setting can also be used to define your own endpoints, like for hybrid cloud models.
+
+### Input v2 settings (advanced)
+
+The following settings are **input v2 only** and available in the advanced section of the integration.
+
+`processor_version` :
+_string_
+(v2 only) The input version that the integration should use. Possible values are `v1` and `v2` (preview). The input v2 is in preview. Using the input v1 is recommended for typical use cases. Default is `v1`.
+
+`processor_update_interval` :
+_string_
+(v2 only) How often the input should attempt to claim partitions. Default is `10s`.
+
+`processor_start_position` :
+_string_
+(v2 only) Controls from what position in the event hub the input should start processing messages for all partitions.
+
+Possible values are `earliest` and `latest`. 
+
+* `earliest` starts processing messages from the last checkpoint, or the beginning of the event hub if no checkpoint is available.
+* `latest` starts processing messages from the the latest event in the event hub and continues to process new events as they arrive.
+
+Default is `earliest`.
+
+`migrate_checkpoint` :
+_boolean_
+(v2 only) Whether to migrate the checkpoint information from the input v1 format to v2 format.
+
+Default is `false`, which means the input will not perform the checkpoint migration and will start processing messages from the beginning or the end of the event hub according to the `processor_start_position` setting.
+
+`partition_receive_timeout` :
+_string_
+(v2 only) Max time to wait before processing the messages received from the event hub. Default is `5s`.
+
+`partition_receive_count` :
+_string_
+(v2 only) Max number of events to wait for before processing the messages received from the event hub. Default is `100`.
 
 ## Handling Malformed JSON in Azure Logs
 

--- a/packages/azure/_dev/build/docs/events.md
+++ b/packages/azure/_dev/build/docs/events.md
@@ -14,7 +14,7 @@ The Azure Logs integration v2 preview introduces:
 
 * A new architecture that allows you to collect all logs through a single event hub.
 * Significant efficiency improvements.
-* A new processor (v2) that incorporates the latest Event Hubs SDK.
+* A new event hub processor (v2) that incorporates the latest Event Hubs SDK.
 
 ### Architecture
 
@@ -45,7 +45,7 @@ IMPORTANT: **To use the integration v2 preview, you must turn off all the existi
 
 The integration v2 preview avoids contention and inefficiencies from using multiple consumers per partition with the same event hub, problems that are typical of the v1 architecture. With the v2 preview, you can still assign the agent policy to multiple Elastic Agents to scale out the logs processing.
 
-### Processor v2 ✨
+### Event Hub Processor v2 ✨
 
 The integration v2 preview offers a new processor v2 starting with integration version 1.23.0.
 
@@ -503,9 +503,9 @@ Examples:
 
 This setting can also be used to define your own endpoints, like for hybrid cloud models.
 
-### Processor v2 only
+### Event Hub Processor v2 only
 
-The following settings are **processor v2 only** and available in the advanced section of the integration.
+The following settings are **event hub processor v2 only** and available in the advanced section of the integration.
 
 `processor_version` :
 _string_

--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,14 +1,19 @@
+- version: "1.23.0"
+  changes:
+    - description: Enable Event Hub processor v2.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12802
 - version: "1.22.2"
   changes:
     - description: Fix Platform Logs pipeline inconsistent casing for subscription_id field.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/12735
-- version: 1.22.1
+- version: "1.22.1"
   changes:
     - description: Fix the custom storage container description for the Azure Logs integration v2.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/12926
-- version: 1.22.0
+- version: "1.22.0"
   changes:
     - description: Add support for Kibana `9.0.0` 
       type: enhancement

--- a/packages/azure/data_stream/events/agent/stream/stream.yml.hbs
+++ b/packages/azure/data_stream/events/agent/stream/stream.yml.hbs
@@ -20,9 +20,33 @@ storage_account: {{storage_account}}
 {{#if storage_account_key}}
 storage_account_key: {{storage_account_key}}
 {{/if}}
+{{#if storage_account_connection_string}}
+ : {{storage_account_connection_string}}
+{{else}}
+storage_account_connection_string: DefaultEndpointsProtocol=https;AccountName={{storage_account}};AccountKey={{storage_account_key}};EndpointSuffix=core.windows.net
+{{/if}}
 {{#if resource_manager_endpoint}}
 resource_manager_endpoint: {{resource_manager_endpoint}}
 {{/if}}
+{{#if processor_version}}
+processor_version: {{processor_version}}
+{{/if}}
+{{#if migrate_checkpoint}}
+migrate_checkpoint: {{migrate_checkpoint}}
+{{/if}}
+{{#if processor_update_interval}}
+processor_update_interval: {{processor_update_interval}}
+{{/if}}
+{{#if processor_start_position}}
+processor_start_position: {{processor_start_position}}
+{{/if}}
+{{#if partition_receive_timeout}}
+partition_receive_timeout: {{partition_receive_timeout}}
+{{/if}}
+{{#if partition_receive_count}}
+partition_receive_count: {{partition_receive_count}}
+{{/if}}
+
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/azure/data_stream/events/agent/stream/stream.yml.hbs
+++ b/packages/azure/data_stream/events/agent/stream/stream.yml.hbs
@@ -19,10 +19,6 @@ storage_account: {{storage_account}}
 {{/if}}
 {{#if storage_account_key}}
 storage_account_key: {{storage_account_key}}
-{{/if}}
-{{#if storage_account_connection_string}}
- : {{storage_account_connection_string}}
-{{else}}
 storage_account_connection_string: DefaultEndpointsProtocol=https;AccountName={{storage_account}};AccountKey={{storage_account_key}};EndpointSuffix=core.windows.net
 {{/if}}
 {{#if resource_manager_endpoint}}

--- a/packages/azure/data_stream/events/manifest.yml
+++ b/packages/azure/data_stream/events/manifest.yml
@@ -80,6 +80,75 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: processor_version
+        type: text
+        title: Processor version
+        multi: false
+        required: false
+        show_user: false
+        default: v1
+        description: >-
+          The Processor version option controls the processor version to use.
+          Possible values are `v1` and `v2`. Default is `v1`.
+      - name: migrate_checkpoint
+        type: bool
+        title: Migrate checkpoint information
+        multi: false
+        required: false
+        show_user: false
+        default: false
+        description: >-
+          (Processor v2 only) The Migrate checkpoint information option controls if the input 
+          should perform the checkpoint information migration from v1 to v2. Default is `false`.
+      - name: processor_update_interval
+        type: text
+        title: Processor update interval
+        multi: false
+        required: false
+        show_user: false
+        default: 10s
+        description: >-
+          (Processor v2 only) The Processor update interval option controls how often attempt to claim
+          partitions. Default is `10` seconds.
+      - name: processor_start_position
+        type: text
+        title: Processor start position
+        multi: false
+        required: false
+        show_user: false
+        default: earliest
+        description: >-
+          (Processor v2 only) The Processor start position option controls the start position for all partitions.
+          Possible values are `earliest` and `latest`. Default is `earliest`.
+      - name: partition_receive_timeout
+        type: text
+        title: Partition receive timeout
+        multi: false
+        required: false
+        show_user: false
+        default: 5m
+        description: >-
+          (Processor v2 only) The Partition receive timeout option controls the batching of incoming
+          messages together with Partition receive count. Default is `5m`.
+
+          The partition client waits up to Partition receive timeout or
+          for at least Partition receive count events, then it returns
+          the events it has received.
+      - name: partition_receive_count
+        type: text
+        title: Partition receive count
+        multi: false
+        required: false
+        show_user: false
+        default: 100
+        description: >-
+          (Processor v2 only) The Partition receive count option controls the batching of
+          incoming messages together with Partition receive timeout. Default is `100`.
+
+          The partition client waits up to Partition receive timeout or
+          for at least Partition receive count events, then it returns
+          the events it has received.
+
 # Ensures agents have permissions to write data to `logs-*-*`
 elasticsearch:
   dynamic_dataset: true

--- a/packages/azure/data_stream/events/manifest.yml
+++ b/packages/azure/data_stream/events/manifest.yml
@@ -88,7 +88,8 @@ streams:
         show_user: false
         default: v1
         description: >-
-          The Processor version option controls the processor version to use.
+          The "processor version" option controls which processor version to use.
+          
           Possible values are `v1` and `v2`. Default is `v1`.
       - name: migrate_checkpoint
         type: bool
@@ -98,8 +99,12 @@ streams:
         show_user: false
         default: false
         description: >-
-          (Processor v2 only) The Migrate checkpoint information option controls if the input 
-          should perform the checkpoint information migration from v1 to v2. Default is `false`.
+          (Processor v2 only) The "migrate checkpoint information" option
+          controls if the input should perform the checkpoint information
+          migration from v1 to v2 at startup.
+          
+          Default is `false`.
+
       - name: processor_update_interval
         type: text
         title: Processor update interval
@@ -108,8 +113,10 @@ streams:
         show_user: false
         default: 10s
         description: >-
-          (Processor v2 only) The Processor update interval option controls how often attempt to claim
-          partitions. Default is `10` seconds.
+          (Processor v2 only) The Processor update interval option controls how
+          often attempt to claim partitions.
+          
+          Default is `10` seconds.
       - name: processor_start_position
         type: text
         title: Processor start position
@@ -118,22 +125,39 @@ streams:
         show_user: false
         default: earliest
         description: >-
-          (Processor v2 only) The Processor start position option controls the start position for all partitions.
-          Possible values are `earliest` and `latest`. Default is `earliest`.
+          (Processor v2 only) The "processor start position" option controls
+          from what position in the event hub the input should start processing
+          messages for all partitions.
+          
+          Possible values are `earliest` and `latest`.
+          
+          `earliest` starts processing messages from the last checkpoint, or the
+          beginning of the event hub if no checkpoint is available.
+
+          `latest` starts processing messages from the end of the event hub.
+          
+          Default is `earliest`.
+
       - name: partition_receive_timeout
         type: text
         title: Partition receive timeout
         multi: false
         required: false
         show_user: false
-        default: 5m
+        default: 5s
         description: >-
-          (Processor v2 only) The Partition receive timeout option controls the batching of incoming
-          messages together with Partition receive count. Default is `5m`.
-
-          The partition client waits up to Partition receive timeout or
-          for at least Partition receive count events, then it returns
+          (Processor v2 only) Max time to wait before processing the
+          messages received from the event hub.
+          
+          The partition client waits up to "partition receive timeout" or
+          for at least "partition receive count events", then it returns
           the events it has received.
+
+          The Partition receive timeout option controls the batching
+          of incoming messages together with Partition receive count.
+
+          Default is `5` seconds.
+
       - name: partition_receive_count
         type: text
         title: Partition receive count
@@ -142,12 +166,17 @@ streams:
         show_user: false
         default: 100
         description: >-
-          (Processor v2 only) The Partition receive count option controls the batching of
-          incoming messages together with Partition receive timeout. Default is `100`.
+          (Processor v2 only) Max number of events to wait for before processing
+          the messages received from the event hub.
+          
+          The "partition receive count" option controls the batching of
+          incoming messages together with Partition receive timeout. 
 
-          The partition client waits up to Partition receive timeout or
-          for at least Partition receive count events, then it returns
+          The partition client waits up to "partition receive timeout" or
+          for at least "partition receive count" events, then it returns
           the events it has received.
+
+          Default is `100` messages.
 
 # Ensures agents have permissions to write data to `logs-*-*`
 elasticsearch:

--- a/packages/azure/data_stream/events/manifest.yml
+++ b/packages/azure/data_stream/events/manifest.yml
@@ -91,7 +91,7 @@ streams:
           The processor version that the integration should use.
           Possible values are `v1` and `v2` (preview). 
           
-          The v2 processor is in preview, so using the v1 processor
+          The v2 event hub processor is in preview, so using the v1 processor
           is recommended for typical use cases.
           
           Default is `v1`.

--- a/packages/azure/data_stream/events/manifest.yml
+++ b/packages/azure/data_stream/events/manifest.yml
@@ -95,22 +95,7 @@ streams:
           is recommended for typical use cases.
           
           Default is `v1`.
-          
-      - name: migrate_checkpoint
-        type: bool
-        title: Migrate checkpoint information
-        multi: false
-        required: false
-        show_user: false
-        default: false
-        description: >-
-          (Processor v2 only) The "migrate checkpoint information" option
-          controls if the input should perform the checkpoint information
-          migration from v1 to v2 at startup.
-          
-          Default is `false`, which means the input will not perform the
-          checkpoint migration.
-
+       
       - name: processor_update_interval
         type: text
         title: Processor update interval
@@ -131,9 +116,8 @@ streams:
         show_user: false
         default: earliest
         description: >-
-          (Processor v2 only) The "processor start position" option controls
-          from what position in the event hub the input should start processing
-          messages for all partitions.
+          (Processor v2 only) Controls from what position in the event hub
+          the input should start processing messages for all partitions.
           
           Possible values are `earliest` and `latest`.
           
@@ -144,6 +128,23 @@ streams:
           event hub and continues to process new events as they arrive.
           
           Default is `earliest`.
+
+      - name: migrate_checkpoint
+        type: bool
+        title: Migrate checkpoint information
+        multi: false
+        required: false
+        show_user: false
+        default: false
+        description: >-
+          (Processor v2 only) Flag to control if the input should perform the
+          checkpoint information migration from v1 to v2 at startup.
+          
+          The checkpoint migration converts the checkpoint information
+          from the v1 format to the v2 format.
+
+          Default is `false`, which means the input will not perform the
+          checkpoint migration.
 
       - name: partition_receive_timeout
         type: text
@@ -156,12 +157,8 @@ streams:
           (Processor v2 only) Max time to wait before processing the
           messages received from the event hub.
           
-          The partition client waits up to "partition receive timeout" or
-          for at least "partition receive count events", then it returns
-          the events it has received.
-
-          The Partition receive timeout option controls the batching
-          of incoming messages together with Partition receive count.
+          The partition consumer waits up to a "receive count" or a
+          "receive timeout", whichever comes first.
 
           Default is `5` seconds.
 
@@ -173,15 +170,11 @@ streams:
         show_user: false
         default: 100
         description: >-
-          (Processor v2 only) Max number of events to wait for before processing
-          the messages received from the event hub.
+          (Processor v2 only) Max number of messages from the event hub
+          to wait for before processing them.
           
-          The "partition receive count" option controls the batching of
-          incoming messages together with Partition receive timeout. 
-
-          The partition client waits up to "partition receive timeout" or
-          for at least "partition receive count" events, then it returns
-          the events it has received.
+          The partition consumer waits up to a "receive count" or a
+          "receive timeout", whichever comes first.
 
           Default is `100` messages.
 

--- a/packages/azure/data_stream/events/manifest.yml
+++ b/packages/azure/data_stream/events/manifest.yml
@@ -88,9 +88,14 @@ streams:
         show_user: false
         default: v1
         description: >-
-          The "processor version" option controls which processor version to use.
+          The processor version that the integration should use.
+          Possible values are `v1` and `v2` (preview). 
           
-          Possible values are `v1` and `v2`. Default is `v1`.
+          The v2 processor is in preview, so using the v1 processor
+          is recommended for typical use cases.
+          
+          Default is `v1`.
+          
       - name: migrate_checkpoint
         type: bool
         title: Migrate checkpoint information
@@ -103,7 +108,8 @@ streams:
           controls if the input should perform the checkpoint information
           migration from v1 to v2 at startup.
           
-          Default is `false`.
+          Default is `false`, which means the input will not perform the
+          checkpoint migration.
 
       - name: processor_update_interval
         type: text
@@ -113,8 +119,8 @@ streams:
         show_user: false
         default: 10s
         description: >-
-          (Processor v2 only) The Processor update interval option controls how
-          often attempt to claim partitions.
+          (Processor v2 only) How often the input should attempt to claim
+          partitions.
           
           Default is `10` seconds.
       - name: processor_start_position
@@ -134,7 +140,8 @@ streams:
           `earliest` starts processing messages from the last checkpoint, or the
           beginning of the event hub if no checkpoint is available.
 
-          `latest` starts processing messages from the end of the event hub.
+          `latest` starts processing messages from the the latest event in the
+          event hub and continues to process new events as they arrive.
           
           Default is `earliest`.
 

--- a/packages/azure/data_stream/events/manifest.yml
+++ b/packages/azure/data_stream/events/manifest.yml
@@ -104,7 +104,7 @@ streams:
         show_user: false
         default: 10s
         description: >-
-          (Processor v2 only) How often the input should attempt to claim
+          (Processor v2 only) How often the processor should attempt to claim
           partitions.
           
           Default is `10` seconds.
@@ -117,7 +117,7 @@ streams:
         default: earliest
         description: >-
           (Processor v2 only) Controls from what position in the event hub
-          the input should start processing messages for all partitions.
+          the processor should start processing messages for all partitions.
           
           Possible values are `earliest` and `latest`.
           
@@ -137,13 +137,14 @@ streams:
         show_user: false
         default: false
         description: >-
-          (Processor v2 only) Flag to control if the input should perform the
-          checkpoint information migration from v1 to v2 at startup.
+          (Processor v2 only) Flag to control if the processor should perform 
+          the checkpoint information migration from processor v1 to v2
+          at startup.
           
           The checkpoint migration converts the checkpoint information
           from the v1 format to the v2 format.
 
-          Default is `false`, which means the input will not perform the
+          Default is `false`, which means the processor will not perform the
           checkpoint migration.
 
       - name: partition_receive_timeout

--- a/packages/azure/data_stream/events/manifest.yml
+++ b/packages/azure/data_stream/events/manifest.yml
@@ -154,7 +154,7 @@ streams:
         show_user: false
         default: 5s
         description: >-
-          (Processor v2 only) Max time to wait before processing the
+          (Processor v2 only) Maximum time to wait before processing the
           messages received from the event hub.
           
           The partition consumer waits up to a "receive count" or a
@@ -170,7 +170,7 @@ streams:
         show_user: false
         default: 100
         description: >-
-          (Processor v2 only) Max number of messages from the event hub
+          (Processor v2 only) Maximum number of messages from the event hub
           to wait for before processing them.
           
           The partition consumer waits up to a "receive count" or a

--- a/packages/azure/docs/events.md
+++ b/packages/azure/docs/events.md
@@ -33,15 +33,15 @@ The Azure Logs integration (v2 preview) introduces a new architecture that allow
 
 The integration will automatically detect the log category and forward the logs to the appropriate data stream. When the integration v2 preview cannot find a matching data stream for a log category, it forwards the logs to the platform logs data stream.
 
-IMPORTANT: To use the integrationv2 preview, you must turn off all the existing v1 integrations and turn on only the v2 preview integration.
+IMPORTANT: **To use the integration v2 preview, you must turn off all the existing v1 integrations and turn on only the v2 preview integration.**
 
 ### Efficiency
 
-Under the hood, the v2 preview processes logs using only one `azure-eventhub` input per event hub instead of multiple inputs like the v1 architecture.
+Internally, the v2 preview processes logs using only one `azure-eventhub` input per event hub instead of multiple inputs like the v1 architecture.
 
 The `azure-eventhub` input is the main engine of the integration. It is responsible for fetching the messages from the event hub, processing them, and sending them to the data stream in Elasticsearch.
 
-The integration v2 preview avoids contention and inefficiencies from using multiple inputs with the same event hub, which is typical of the v1 architecture. With the v2 preview, you can still assign the agent policy to multiple Elastic Agents to scale out the logs processing.
+The integration v2 preview avoids contention and inefficiencies from using multiple inputs with the same event hub, problems that are typical of the v1 architecture. With the v2 preview, you can still assign the agent policy to multiple Elastic Agents to scale out the logs processing.
 
 ### Input v2 ✨
 
@@ -501,7 +501,7 @@ Examples:
 
 This setting can also be used to define your own endpoints, like for hybrid cloud models.
 
-### Input v2 settings (advanced)
+### Input v2 only
 
 The following settings are **input v2 only** and available in the advanced section of the integration.
 
@@ -515,30 +515,28 @@ _string_
 
 `processor_start_position` :
 _string_
-(v2 only) Controls from what position in the event hub the input should start processing messages for all partitions.
+(v2 only) Controls from which position in the event hub the input should start processing messages for all partitions.
 
 Possible values are `earliest` and `latest`.
 
-* `earliest` starts processing messages from the last checkpoint, or the beginning of the event hub if no checkpoint is available.
-* `latest` starts processing messages from the the latest event in the event hub and continues to process new events as they arrive.
-
-Default is `earliest`.
+* `earliest` (default): starts processing messages from the last checkpoint, or the beginning of the event hub if no checkpoint is available.
+* `latest`: starts processing messages from the the latest event in the event hub and continues to process new events as they arrive.
 
 `migrate_checkpoint` :
 _boolean_
-(v2 only) Flag to control if the input should perform the checkpoint information migration from v1 to v2 at startup. The checkpoint migration converts the checkpoint information from the v1 format to the v2 format.
+(v2 only) Flag to control whether the input should perform the checkpoint information migration from v1 to v2 at startup. The checkpoint migration converts the checkpoint information from the v1 format to the v2 format.
 
 Default is `false`, which means the input will not perform the checkpoint migration.
 
 `partition_receive_timeout` :
 _string_
-(v2 only) Max time to wait before processing the messages received from the event hub.
+(v2 only) Maximum time to wait before processing the messages received from the event hub.
 
 The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Default is `5` seconds.
 
 `partition_receive_count` :
 _string_
-(v2 only) Max number of messages from the event hub to wait for before processing them.
+(v2 only) Maximum number of messages from the event hub to wait for before processing them.
 
 The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Default is `100` messages.
 

--- a/packages/azure/docs/events.md
+++ b/packages/azure/docs/events.md
@@ -517,7 +517,7 @@ _string_
 _string_
 (v2 only) Controls from what position in the event hub the input should start processing messages for all partitions.
 
-Possible values are `earliest` and `latest`. 
+Possible values are `earliest` and `latest`.
 
 * `earliest` starts processing messages from the last checkpoint, or the beginning of the event hub if no checkpoint is available.
 * `latest` starts processing messages from the the latest event in the event hub and continues to process new events as they arrive.
@@ -526,17 +526,21 @@ Default is `earliest`.
 
 `migrate_checkpoint` :
 _boolean_
-(v2 only) Whether to migrate the checkpoint information from the input v1 format to v2 format.
+(v2 only) Flag to control if the input should perform the checkpoint information migration from v1 to v2 at startup. The checkpoint migration converts the checkpoint information from the v1 format to the v2 format.
 
-Default is `false`, which means the input will not perform the checkpoint migration and will start processing messages from the beginning or the end of the event hub according to the `processor_start_position` setting.
+Default is `false`, which means the input will not perform the checkpoint migration.
 
 `partition_receive_timeout` :
 _string_
-(v2 only) Max time to wait before processing the messages received from the event hub. Default is `5s`.
+(v2 only) Max time to wait before processing the messages received from the event hub.
+
+The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Default is `5` seconds.
 
 `partition_receive_count` :
 _string_
-(v2 only) Max number of events to wait for before processing the messages received from the event hub. Default is `100`.
+(v2 only) Max number of messages from the event hub to wait for before processing them.
+
+The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Default is `100` messages.
 
 ## Handling Malformed JSON in Azure Logs
 

--- a/packages/azure/docs/events.md
+++ b/packages/azure/docs/events.md
@@ -10,6 +10,12 @@ You may also want to plan your Azure capacity better. Send Azure Activity logs t
 
 ## What's new in the integration v2 preview?
 
+The Azure Logs integration v2 preview introduces:
+
+* A new architecture that allows you to collect all logs through a single event hub.
+* Significant efficiency improvements.
+* A new processor (v2) that incorporates the latest Event Hubs SDK.
+
 ### Architecture
 
 The Azure Logs integration (v2 preview) introduces a new architecture that allows you to forward logs from multiple Azure services to the same event hub.
@@ -37,24 +43,20 @@ IMPORTANT: **To use the integration v2 preview, you must turn off all the existi
 
 ### Efficiency
 
-Internally, the v2 preview processes logs using only one `azure-eventhub` input per event hub instead of multiple inputs like the v1 architecture.
+The integration v2 preview avoids contention and inefficiencies from using multiple consumers per partition with the same event hub, problems that are typical of the v1 architecture. With the v2 preview, you can still assign the agent policy to multiple Elastic Agents to scale out the logs processing.
 
-The `azure-eventhub` input is the main engine of the integration. It is responsible for fetching the messages from the event hub, processing them, and sending them to the data stream in Elasticsearch.
+### Processor v2 ✨
 
-The integration v2 preview avoids contention and inefficiencies from using multiple inputs with the same event hub, problems that are typical of the v1 architecture. With the v2 preview, you can still assign the agent policy to multiple Elastic Agents to scale out the logs processing.
+The integration v2 preview offers a new processor v2 starting with integration version 1.23.0.
 
-### Input v2 ✨
-
-The integration v2 preview offers a new `azure-eventhub` input v2 starting with integration version 1.23.0.
-
-The input v2 introduces several changes:
+The processor v2 introduces several changes:
 
 * It uses the latest Event Hubs SDK from Azure.
 * It uses a more efficient checkpoint store based on Azure Blob Storage metadata.
 
-The input v2 is in preview. Input v1 is still the default and is recommended for typical use cases.
+The processor v2 is in preview. Processor v1 is still the default and is recommended for typical use cases.
 
-See the "Settings" section for more details about enabling the input v2.
+See the "Processor v2 only" section in the integration settings for more details about enabling the processor v2.
 
 ## Data streams
 
@@ -501,21 +503,21 @@ Examples:
 
 This setting can also be used to define your own endpoints, like for hybrid cloud models.
 
-### Input v2 only
+### Processor v2 only
 
-The following settings are **input v2 only** and available in the advanced section of the integration.
+The following settings are **processor v2 only** and available in the advanced section of the integration.
 
 `processor_version` :
 _string_
-(v2 only) The input version that the integration should use. Possible values are `v1` and `v2` (preview). The input v2 is in preview. Using the input v1 is recommended for typical use cases. Default is `v1`.
+(v2 only) The processor version that the integration should use. Possible values are `v1` and `v2` (preview). The processor v2 is in preview. Using the processor v1 is recommended for typical use cases. Default is `v1`.
 
 `processor_update_interval` :
 _string_
-(v2 only) How often the input should attempt to claim partitions. Default is `10s`.
+(v2 only) How often the processor should attempt to claim partitions. Default is `10s`.
 
 `processor_start_position` :
 _string_
-(v2 only) Controls from which position in the event hub the input should start processing messages for all partitions.
+(v2 only) Controls from which position in the event hub the processor should start processing messages for all partitions.
 
 Possible values are `earliest` and `latest`.
 
@@ -524,9 +526,9 @@ Possible values are `earliest` and `latest`.
 
 `migrate_checkpoint` :
 _boolean_
-(v2 only) Flag to control whether the input should perform the checkpoint information migration from v1 to v2 at startup. The checkpoint migration converts the checkpoint information from the v1 format to the v2 format.
+(v2 only) Flag to control whether the processor should perform the checkpoint information migration from v1 to v2 at startup. The checkpoint migration converts the checkpoint information from the v1 format to the v2 format.
 
-Default is `false`, which means the input will not perform the checkpoint migration.
+Default is `false`, which means the processor will not perform the checkpoint migration.
 
 `partition_receive_timeout` :
 _string_

--- a/packages/azure/docs/events.md
+++ b/packages/azure/docs/events.md
@@ -8,7 +8,9 @@ For example, to detect possible brute force sign-in attacks, you can install the
 
 You may also want to plan your Azure capacity better. Send Azure Activity logs to Elastic to track and visualize when your virtual machines fail to start because they exceed the quota limit.
 
-## What's new in v2 preview?
+## What's new in the integration v2 preview?
+
+### Architecture
 
 The Azure Logs integration (v2 preview) introduces a new architecture that allows you to forward logs from multiple Azure services to the same event hub.
 
@@ -31,9 +33,28 @@ The Azure Logs integration (v2 preview) introduces a new architecture that allow
 
 The integration will automatically detect the log category and forward the logs to the appropriate data stream. When the integration v2 preview cannot find a matching data stream for a log category, it forwards the logs to the platform logs data stream.
 
-IMPORTANT: To use the v2 preview, you must turn off all the existing v1 integrations and turn on only the v2 preview integration.
+IMPORTANT: To use the integrationv2 preview, you must turn off all the existing v1 integrations and turn on only the v2 preview integration.
 
-Under the hood, the v2 preview uses only one `azure-eventhub` input per event hub. The v2 preview avoids contention and inefficiencies from using multiple inputs with the same event hub, which is typical of the v1 architecture. With the v2 preview, you can still assign the agent policy to multiple Elastic Agents to scale out the logs processing.
+### Efficiency
+
+Under the hood, the v2 preview processes logs using only one `azure-eventhub` input per event hub instead of multiple inputs like the v1 architecture.
+
+The `azure-eventhub` input is the main engine of the integration. It is responsible for fetching the messages from the event hub, processing them, and sending them to the data stream in Elasticsearch.
+
+The integration v2 preview avoids contention and inefficiencies from using multiple inputs with the same event hub, which is typical of the v1 architecture. With the v2 preview, you can still assign the agent policy to multiple Elastic Agents to scale out the logs processing.
+
+### Input v2 ✨
+
+The integration v2 preview offers a new `azure-eventhub` input v2 starting with integration version 1.23.0.
+
+The input v2 introduces several changes:
+
+* It uses the latest Event Hubs SDK from Azure.
+* It uses a more efficient checkpoint store based on Azure Blob Storage metadata.
+
+The input v2 is in preview. Input v1 is still the default and is recommended for typical use cases.
+
+See the "Settings" section for more details about enabling the input v2.
 
 ## Data streams
 
@@ -479,6 +500,43 @@ Examples:
 * Azure USGovernmentCloud: `https://management.usgovcloudapi.net/`
 
 This setting can also be used to define your own endpoints, like for hybrid cloud models.
+
+### Input v2 settings (advanced)
+
+The following settings are **input v2 only** and available in the advanced section of the integration.
+
+`processor_version` :
+_string_
+(v2 only) The input version that the integration should use. Possible values are `v1` and `v2` (preview). The input v2 is in preview. Using the input v1 is recommended for typical use cases. Default is `v1`.
+
+`processor_update_interval` :
+_string_
+(v2 only) How often the input should attempt to claim partitions. Default is `10s`.
+
+`processor_start_position` :
+_string_
+(v2 only) Controls from what position in the event hub the input should start processing messages for all partitions.
+
+Possible values are `earliest` and `latest`. 
+
+* `earliest` starts processing messages from the last checkpoint, or the beginning of the event hub if no checkpoint is available.
+* `latest` starts processing messages from the the latest event in the event hub and continues to process new events as they arrive.
+
+Default is `earliest`.
+
+`migrate_checkpoint` :
+_boolean_
+(v2 only) Whether to migrate the checkpoint information from the input v1 format to v2 format.
+
+Default is `false`, which means the input will not perform the checkpoint migration and will start processing messages from the beginning or the end of the event hub according to the `processor_start_position` setting.
+
+`partition_receive_timeout` :
+_string_
+(v2 only) Max time to wait before processing the messages received from the event hub. Default is `5s`.
+
+`partition_receive_count` :
+_string_
+(v2 only) Max number of events to wait for before processing the messages received from the event hub. Default is `100`.
 
 ## Handling Malformed JSON in Azure Logs
 

--- a/packages/azure/docs/events.md
+++ b/packages/azure/docs/events.md
@@ -14,7 +14,7 @@ The Azure Logs integration v2 preview introduces:
 
 * A new architecture that allows you to collect all logs through a single event hub.
 * Significant efficiency improvements.
-* A new processor (v2) that incorporates the latest Event Hubs SDK.
+* A new event hub processor (v2) that incorporates the latest Event Hubs SDK.
 
 ### Architecture
 
@@ -45,7 +45,7 @@ IMPORTANT: **To use the integration v2 preview, you must turn off all the existi
 
 The integration v2 preview avoids contention and inefficiencies from using multiple consumers per partition with the same event hub, problems that are typical of the v1 architecture. With the v2 preview, you can still assign the agent policy to multiple Elastic Agents to scale out the logs processing.
 
-### Processor v2 ✨
+### Event Hub Processor v2 ✨
 
 The integration v2 preview offers a new processor v2 starting with integration version 1.23.0.
 
@@ -56,7 +56,7 @@ The processor v2 introduces several changes:
 
 The processor v2 is in preview. Processor v1 is still the default and is recommended for typical use cases.
 
-See the "Processor v2 only" section in the integration settings for more details about enabling the processor v2.
+See the "Event Hub Processor v2 only" section in the integration settings for more details about enabling the processor v2.
 
 ## Data streams
 
@@ -503,21 +503,21 @@ Examples:
 
 This setting can also be used to define your own endpoints, like for hybrid cloud models.
 
-### Processor v2 only
+### Event Hub Processor v2 only
 
-The following settings are **processor v2 only** and available in the advanced section of the integration.
+The following settings are **event hub processor v2 only** and available in the advanced section of the integration.
 
 `processor_version` :
 _string_
-(v2 only) The processor version that the integration should use. Possible values are `v1` and `v2` (preview). The processor v2 is in preview. Using the processor v1 is recommended for typical use cases. Default is `v1`.
+(processor v2 only) The processor version that the integration should use. Possible values are `v1` and `v2` (preview). The processor v2 is in preview. Using the processor v1 is recommended for typical use cases. Default is `v1`.
 
 `processor_update_interval` :
 _string_
-(v2 only) How often the processor should attempt to claim partitions. Default is `10s`.
+(processor v2 only) How often the processor should attempt to claim partitions. Default is `10s`.
 
 `processor_start_position` :
 _string_
-(v2 only) Controls from which position in the event hub the processor should start processing messages for all partitions.
+(processor v2 only) Controls from which position in the event hub the processor should start processing messages for all partitions.
 
 Possible values are `earliest` and `latest`.
 
@@ -526,19 +526,19 @@ Possible values are `earliest` and `latest`.
 
 `migrate_checkpoint` :
 _boolean_
-(v2 only) Flag to control whether the processor should perform the checkpoint information migration from v1 to v2 at startup. The checkpoint migration converts the checkpoint information from the v1 format to the v2 format.
+(processor v2 only) Flag to control whether the processor should perform the checkpoint information migration from v1 to v2 at startup. The checkpoint migration converts the checkpoint information from the v1 format to the v2 format.
 
 Default is `false`, which means the processor will not perform the checkpoint migration.
 
 `partition_receive_timeout` :
 _string_
-(v2 only) Maximum time to wait before processing the messages received from the event hub.
+(processor v2 only) Maximum time to wait before processing the messages received from the event hub.
 
 The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Default is `5` seconds.
 
 `partition_receive_count` :
 _string_
-(v2 only) Maximum number of messages from the event hub to wait for before processing them.
+(processor v2 only) Maximum number of messages from the event hub to wait for before processing them.
 
 The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Default is `100` messages.
 

--- a/packages/azure/manifest.yml
+++ b/packages/azure/manifest.yml
@@ -1,6 +1,6 @@
 name: azure
 title: Azure Logs
-version: "1.22.2"
+version: "1.23.0"
 description: This Elastic integration collects logs from Azure
 type: integration
 icons:
@@ -15,7 +15,7 @@ categories:
   - observability
 conditions:
   kibana:
-    version: "^8.13.0 || ^9.0.0"
+    version: "^8.15.1 || ^9.0.0"
   elastic:
     subscription: basic
 screenshots:
@@ -71,6 +71,7 @@ vars:
     multi: false
     required: false
     show_user: false
+
 policy_templates:
   - name: events
     title: Azure Logs (v2 preview)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

The PR adds the new `processor_version` configuration option (an related ones) to enable the azure-eventhub processor v2 in the Azure Logs integration v2 preview.

- We increase the min stack version to 8.15.1.
- processor v2 is only available to for integration v2 preview (no integration v1 support)
- Add `storage_account_connection_string` config option (required for processor v2); the policy template builds a default value using the `storage_account_key` but also offers an override option.

The processor v2 uses the modern Event Hub SDK.

## Notes for reviewers

In this PR, I am adding the processor v2 settings to the advanced section of the integration v2 only (`events` data stream).

The goal is to enable only processor v2 for the data stream that can avoid contention among event hub partition consumers. 

However, nothing can stop users from enabling v2 AND one or more v1 integrations. So, adding the processor v2 settings to the global scope is better for simplicity.

I would love to hear your thoughts about placing the processor v2 settings:  data stream vs. global level.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Update the integration docs

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

- Bootstrap a local stack using `elastic-package` (min stack version 8.15.1)
- Build the Azure Logs package
- Install the Azure Logs integration v2 preview
- In the integration settings > advanced > set `processor_version` to `v2`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #12800

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->

![CleanShot 2025-03-10 at 22 15 01@2x](https://github.com/user-attachments/assets/9b737160-d0b6-43a1-89ab-8e9632df8f5b)

![CleanShot 2025-03-10 at 22 18 54@2x](https://github.com/user-attachments/assets/8db11db6-5f5b-4311-8935-3a1cbe42f085)

![CleanShot 2025-03-10 at 22 21 10@2x](https://github.com/user-attachments/assets/62ed5cb8-7d95-45f7-b9bf-f3e118aa5257)
