### PR TITLE
[o365_metrics]Update ownership for O365 Metrics integration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -462,26 +462,4 @@
 /packages/zscaler_zpa @elastic/security-service-integrations
 /packages/cisco_meraki_metrics @elastic/obs-infraobs-integrations
 /packages/panw_metrics @elastic/obs-infraobs-integrations
-/packages/o365_metrics @elastic/obs-infraobs-integrations @elastic/security-service-integrations
-/packages/o365_metrics/data_stream/active_users_services_user_counts @elastic/obs-infraobs-integrations
-/packages/o365_metrics/data_stream/groups_activity_group_detail @elastic/security-service-integrations
-/packages/o365_metrics/data_stream/onedrive_usage_account_counts @elastic/obs-infraobs-integrations
-/packages/o365_metrics/data_stream/onedrive_usage_file_counts @elastic/obs-infraobs-integrations
-/packages/o365_metrics/data_stream/onedrive_usage_storage @elastic/obs-infraobs-integrations
-/packages/o365_metrics/data_stream/onedrive_usage_account_detail @elastic/security-service-integrations
-/packages/o365_metrics/data_stream/outlook_activity @elastic/obs-infraobs-integrations
-/packages/o365_metrics/data_stream/outlook_app_usage @elastic/obs-infraobs-integrations
-/packages/o365_metrics/data_stream/sharepoint_site_usage_storage @elastic/obs-infraobs-integrations
-/packages/o365_metrics/data_stream/sharepoint_site_usage_detail @elastic/obs-infraobs-integrations
-/packages/o365_metrics/data_stream/mailbox_usage_detail @elastic/obs-infraobs-integrations
-/packages/o365_metrics/data_stream/mailbox_usage_quota_status @elastic/obs-infraobs-integrations
-/packages/o365_metrics/data_stream/outlook_app_usage_version_counts @elastic/obs-infraobs-integrations
-/packages/o365_metrics/data_stream/teams_device_usage_user_counts @elastic/obs-infraobs-integrations
-/packages/o365_metrics/data_stream/teams_user_activity_user_counts @elastic/obs-infraobs-integrations
-/packages/o365_metrics/data_stream/teams_user_activity_user_detail @elastic/security-service-integrations
-/packages/o365_metrics/data_stream/viva_engage_groups_activity_group_detail @elastic/security-service-integrations
-/packages/o365_metrics/data_stream/yammer_device_usage @elastic/obs-infraobs-integrations
-/packages/o365_metrics/data_stream/service_health @elastic/obs-infraobs-integrations
-/packages/o365_metrics/data_stream/viva_engage_device_usage_user_counts @elastic/obs-infraobs-integrations
-/packages/o365_metrics/data_stream/subscriptions @elastic/obs-infraobs-integrations
-/packages/o365_metrics/data_stream/teams_call_quality @elastic/obs-infraobs-integrations
+/packages/o365_metrics @elastic/obs-infraobs-integrations 


### PR DESCRIPTION
Update ownership for O365 Metrics integration
Currently some of the data streams are owned by the @elastic/security-service-integrations because they were created by one of the team members.
All the data streams that the security team owns:
- /packages/o365_metrics/data_stream/groups_activity_group_detail
- /packages/o365_metrics/data_stream/onedrive_usage_account_detail 
- /packages/o365_metrics/data_stream/teams_user_activity_user_detail
- /packages/o365_metrics/data_stream/viva_engage_groups_activity_group_detail

Based on the integration name and scope and looking at the sample logs:
https://github.com/elastic/integrations/blob/main/packages/o365_metrics/data_stream/groups_activity_group_detail/sample_event.json
https://github.com/elastic/integrations/blob/main/packages/o365_metrics/data_stream/onedrive_usage_account_detail/sample_event.json
https://github.com/elastic/integrations/blob/main/packages/o365_metrics/data_stream/teams_user_activity_user_detail/sample_event.json
https://github.com/elastic/integrations/blob/main/packages/o365_metrics/data_stream/viva_engage_groups_activity_group_detail/sample_event.json

the data streams return exclusively metrics (specifically count and duration) and not logs or security information. 

@kcreddy feel free to chime in here.

@lalit-satapathy do you see any reason the service team should continue owning these data streams?


