### PR TITLE
jamf_pro: normalize jamf_pro.inventory.operating_system.version and os.version to three-part versions

### DIFF
--- a/packages/jamf_pro/changelog.yml
+++ b/packages/jamf_pro/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Normalize `jamf_pro.inventory.operating_system.version` and `os.version` to three-part versions.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12834
 - version: "0.2.6"
   changes:
     - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.

--- a/packages/jamf_pro/changelog.yml
+++ b/packages/jamf_pro/changelog.yml
@@ -4,6 +4,9 @@
     - description: Normalize `jamf_pro.inventory.operating_system.version` and `os.version` to three-part versions.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12834
+    - description: Add `os.full` for known OS versions.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12834
 - version: "0.2.6"
   changes:
     - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.

--- a/packages/jamf_pro/data_stream/inventory/_dev/test/pipeline/test-inventory.json
+++ b/packages/jamf_pro/data_stream/inventory/_dev/test/pipeline/test-inventory.json
@@ -388,6 +388,70 @@
                 "purchasing": null,
                 "udid": "21ED95A7-FF9D-52BD-A55B-36D54585083A"
             }
+        },
+        {
+            "message": {
+                "applications": [
+                    {
+                        "bundleId": "com.apple.freeform",
+                        "externalVersionId": "0",
+                        "macAppStore": false,
+                        "name": "Freeform.app",
+                        "path": "/System/Applications/Freeform.app",
+                        "sizeMegabytes": 57,
+                        "updateAvailable": false,
+                        "version": "2.4"
+                    }
+                ],
+                "operatingSystem": {
+                    "activeDirectoryStatus": "Not Bound",
+                    "build": "23H311",
+                    "extensionAttributes": [],
+                    "fileVault2Status": "NOT_ENCRYPTED",
+                    "name": "macOS",
+                    "rapidSecurityResponse": null,
+                    "softwareUpdateDeviceId": "J314cAP",
+                    "supplementalBuildVersion": "23H311",
+                    "version": "14.7"
+                },
+                "packageReceipts": null,
+                "plugins": null,
+                "printers": null,
+                "purchasing": null,
+                "udid": "21ED95A7-FF9D-52BD-A55B-36D54585083A"
+            }
+        },
+        {
+            "message": {
+                "applications": [
+                    {
+                        "bundleId": "com.apple.freeform",
+                        "externalVersionId": "0",
+                        "macAppStore": false,
+                        "name": "Freeform.app",
+                        "path": "/System/Applications/Freeform.app",
+                        "sizeMegabytes": 57,
+                        "updateAvailable": false,
+                        "version": "2.4"
+                    }
+                ],
+                "operatingSystem": {
+                    "activeDirectoryStatus": "Not Bound",
+                    "build": "23H311",
+                    "extensionAttributes": [],
+                    "fileVault2Status": "NOT_ENCRYPTED",
+                    "name": "macOS",
+                    "rapidSecurityResponse": null,
+                    "softwareUpdateDeviceId": "J314cAP",
+                    "supplementalBuildVersion": "23H311",
+                    "version": "14"
+                },
+                "packageReceipts": null,
+                "plugins": null,
+                "printers": null,
+                "purchasing": null,
+                "udid": "21ED95A7-FF9D-52BD-A55B-36D54585083A"
+            }
         }
     ]
 }

--- a/packages/jamf_pro/data_stream/inventory/_dev/test/pipeline/test-inventory.json-expected.json
+++ b/packages/jamf_pro/data_stream/inventory/_dev/test/pipeline/test-inventory.json-expected.json
@@ -421,6 +421,7 @@
                 }
             },
             "os": {
+                "full": "sonoma",
                 "name": "macOS",
                 "version": "14.7.2"
             },
@@ -464,6 +465,7 @@
                 }
             },
             "os": {
+                "full": "sonoma",
                 "name": "macOS",
                 "version": "14.7.0"
             },
@@ -507,6 +509,7 @@
                 }
             },
             "os": {
+                "full": "sonoma",
                 "name": "macOS",
                 "version": "14.0.0"
             },

--- a/packages/jamf_pro/data_stream/inventory/_dev/test/pipeline/test-inventory.json-expected.json
+++ b/packages/jamf_pro/data_stream/inventory/_dev/test/pipeline/test-inventory.json-expected.json
@@ -429,6 +429,92 @@
                     ""
                 ]
             }
+        },
+        {
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "kind": "asset"
+            },
+            "jamf_pro": {
+                "inventory": {
+                    "applications": [
+                        {
+                            "bundle_id": "com.apple.freeform",
+                            "external_version_id": "0",
+                            "mac_app_store": false,
+                            "name": "Freeform.app",
+                            "path": "/System/Applications/Freeform.app",
+                            "size_megabytes": 57,
+                            "update_available": false,
+                            "version": "2.4"
+                        }
+                    ],
+                    "operating_system": {
+                        "active_directory_status": "Not Bound",
+                        "build": "23H311",
+                        "file_vault2status": "NOT_ENCRYPTED",
+                        "name": "macOS",
+                        "software_update_device_id": "J314cAP",
+                        "supplemental_build_version": "23H311",
+                        "version": "14.7.0"
+                    },
+                    "udid": "21ED95A7-FF9D-52BD-A55B-36D54585083A"
+                }
+            },
+            "os": {
+                "name": "macOS",
+                "version": "14.7.0"
+            },
+            "related": {
+                "user": [
+                    ""
+                ]
+            }
+        },
+        {
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "kind": "asset"
+            },
+            "jamf_pro": {
+                "inventory": {
+                    "applications": [
+                        {
+                            "bundle_id": "com.apple.freeform",
+                            "external_version_id": "0",
+                            "mac_app_store": false,
+                            "name": "Freeform.app",
+                            "path": "/System/Applications/Freeform.app",
+                            "size_megabytes": 57,
+                            "update_available": false,
+                            "version": "2.4"
+                        }
+                    ],
+                    "operating_system": {
+                        "active_directory_status": "Not Bound",
+                        "build": "23H311",
+                        "file_vault2status": "NOT_ENCRYPTED",
+                        "name": "macOS",
+                        "software_update_device_id": "J314cAP",
+                        "supplemental_build_version": "23H311",
+                        "version": "14.0.0"
+                    },
+                    "udid": "21ED95A7-FF9D-52BD-A55B-36D54585083A"
+                }
+            },
+            "os": {
+                "name": "macOS",
+                "version": "14.0.0"
+            },
+            "related": {
+                "user": [
+                    ""
+                ]
+            }
         }
     ]
 }

--- a/packages/jamf_pro/data_stream/inventory/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/jamf_pro/data_stream/inventory/elasticsearch/ingest_pipeline/default.yml
@@ -149,7 +149,53 @@ processors:
         }
         return s + ".0.0";
       }
+      String full_name(String s) {
+        if (s.startsWith('15.')) {
+          return 'sequoia';
+        }
+        if (s.startsWith('14.')) {
+          return 'sonoma';
+        }
+        if (s.startsWith('13.')) {
+          return 'ventura';
+        }
+        if (s.startsWith('12.')) {
+          return 'monterey';
+        }
+        if (s.startsWith('11.')) {
+          return 'big sur';
+        }
+        if (s.startsWith('10.15.')) {
+          return 'catalina';
+        }
+        if (s.startsWith('10.14.')) {
+          return 'mojave';
+        }
+        if (s.startsWith('10.13.')) {
+          return 'high sierra';
+        }
+        if (s.startsWith('10.12.')) {
+          return 'sierra';
+        }
+        if (s.startsWith('10.11.')) {
+          return 'el capitan';
+        }
+        if (s.startsWith('10.10.')) {
+          return 'yosemite';
+        }
+        if (s.startsWith('10.9.')) {
+          return 'mavericks';
+        }
+        return '';
+      }
       ctx.jamf_pro.inventory.operating_system.version = normalize(ctx.jamf_pro.inventory.operating_system.version);
+      String name = full_name(ctx.jamf_pro.inventory.operating_system.version);
+      if (name != '') {
+        if (ctx.os == null) {
+          ctx.os = [:];
+        }
+        ctx.os.full = name;
+      }
 - set:
     field: os.version
     copy_from: jamf_pro.inventory.operating_system.version

--- a/packages/jamf_pro/data_stream/inventory/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/jamf_pro/data_stream/inventory/elasticsearch/ingest_pipeline/default.yml
@@ -123,6 +123,33 @@ processors:
     field: os.name
     copy_from: jamf_pro.inventory.operating_system.name
     ignore_empty_value: true
+- script:
+    tag: script_normalize_operating_system_version
+    lang: painless
+    if: ctx.jamf_pro?.inventory?.operating_system?.version != null && ctx.jamf_pro.inventory.operating_system.version != ''
+    source: |-
+      String normalize(String s) {
+        int n = 0;
+        for (int i = 0; i < s.length(); i++){
+            char c = s.charAt(i);
+            if (c == (char)'.') {
+              n++;
+              continue;
+            }
+            if (c < (char)'0' || (char)'9' < c) {
+              // If we have non-numeric parts, bail.
+              return s;
+            }
+        }
+        if (n >= 2) {
+            return s;
+        }
+        if (n == 1) {
+            return s + ".0";
+        }
+        return s + ".0.0";
+      }
+      ctx.jamf_pro.inventory.operating_system.version = normalize(ctx.jamf_pro.inventory.operating_system.version);
 - set:
     field: os.version
     copy_from: jamf_pro.inventory.operating_system.version

--- a/packages/jamf_pro/manifest.yml
+++ b/packages/jamf_pro/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.5
 name: jamf_pro
 title: "Jamf Pro"
-version: 0.2.6
+version: 0.3.0
 source:
   license: "Elastic-2.0"
 description: "Collect logs and inventory data from Jamf Pro with Elastic Agent"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

```
jamf_pro: normalize jamf_pro.inventory.operating_system.version and os.version to three-part versions

Depending on the source of the Jamf data, we may receive two-part (e.g.
15.1) or three-part (e.g. 15.1.0) versions for versions where the last
part is zero. This leads to multiplication of the numbers of
semantically identical versions in search results and dashboards. So
normalise all OS versions to the three-part form, unless there are other
syntax components (this should never happen).
```

> [!NOTE]
> The dashboard uses `jamf_pro.inventory.operating_system.version`, so this why we need to change both.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #12799

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
