### PR TITLE
Make filestream available in 9.X

### DIFF
--- a/packages/filestream/changelog.yml
+++ b/packages/filestream/changelog.yml
@@ -1,5 +1,10 @@
 - version: "0.1.0"
   changes:
+    - description: Make it available in 9.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12837
+- version: "0.0.1"
+  changes:
     - description: Initial Release
       type: enhancement
       link: https://github.com/elastic/integrations/pull/11332

--- a/packages/filestream/changelog.yml
+++ b/packages/filestream/changelog.yml
@@ -1,4 +1,4 @@
-- version: "0.0.1"
+- version: "0.1.0"
   changes:
     - description: Initial Release
       type: enhancement

--- a/packages/filestream/manifest.yml
+++ b/packages/filestream/manifest.yml
@@ -3,10 +3,10 @@ name: filestream
 title: Custom Filestream Logs
 description: Collect log data using filestream with Elastic Agent.
 type: integration
-version: 0.0.1
+version: 0.1.0
 conditions:
   kibana:
-    version: ^8.15.0
+    version: "^8.15.0 || ^9.0.0"
 categories:
   - custom
   - custom_logs


### PR DESCRIPTION
Update Kibana constraint and add a new changelog entry to make filestream integration available on 9.0