### PR TITLE
packages/openai: Change default bucket_width and improve documentation and field descriptions

### DIFF
--- a/packages/openai/_dev/build/docs/README.md
+++ b/packages/openai/_dev/build/docs/README.md
@@ -39,7 +39,7 @@ To generate an Admin key, please generate a key or use an existing one from the 
 
 ## Collection behavior
 
-There are two advanced configuration options for the OpenAI integration: "Initial interval" and "Bucket width".
+Among the configuration options for the OpenAI integration, two settings are particularly important to understand: "Initial interval" and "Bucket width".
 
 ### Initial interval
 

--- a/packages/openai/_dev/build/docs/README.md
+++ b/packages/openai/_dev/build/docs/README.md
@@ -49,7 +49,9 @@ There are two advanced configuration options for the OpenAI integration: "Initia
 
 ### Bucket width
 
-- Controls the time-based aggregation of metrics (e.g., [bucket_width](https://platform.openai.com/docs/api-reference/usage/completions#usage-completions-bucket_width))
+A "bucket" refers to a time interval where OpenAI usage data is grouped together for reporting purposes. For example, with a 1-minute bucket width, usage metrics are aggregated minute by minute. With a 1-hour bucket width, all activity during that hour is consolidated into a single bucket. The [bucket width](https://platform.openai.com/docs/api-reference/usage/completions#usage-completions-bucket_width) determines your data's granularity and level of detail in your usage reporting.
+
+- Controls the time-based aggregation of metrics
 - Default: `1m` (1 minute)
 - Options: `1m`, `1h`, `1d`
 - Affects API request frequency and data resolution
@@ -75,9 +77,13 @@ Example: For 100 API calls to a particular model per hour:
 
 #### API request impact
 
-"Bucket width" and "Initial interval" directly affect API request frequency. Here's the technical breakdown:
+"Bucket width" and "Initial interval" directly affect API request frequency. When using a 1-minute bucket width, it's strongly recommended to set the "Initial interval" to a shorter duration—optimally 1 day—to ensure smooth performance. While our extensive testing demonstrates excellent results with a 6-month initial interval paired with a 1-day bucket width, the same level of success isn't achievable with 1-minute or 1-hour bucket widths. This is because the OpenAI Usage API returns different bucket quantities based on width (60 buckets per call for 1-minute, 24 for 1-hour, and 7 for 1-day widths). To achieve the best results when gathering historical data over long periods, using 1-day bucket widths is the most effective method, ensuring a balance between data granularity and API limitations.
 
-OpenAI Usage API returns different numbers of buckets based on the bucket width:
+For optimal results with historical data, use 1-day bucket widths for long periods (15+ days), 1-hour for medium periods (1-14 days), and 1-minute only for the most recent 24 hours of data.
+
+Here's an example technical breakdown:
+
+The OpenAI Usage API returns different numbers of buckets based on the bucket width:
 - 1-minute buckets: 60 buckets per API call
 - 1-hour buckets: 24 buckets per API call
 - 1-day buckets: 7 buckets per API call
@@ -93,7 +99,7 @@ Technical calculation example with a 6-month initial interval and 1-minute bucke
 - API calls per stream: 259,200 / 60 = 4,320 calls
 - Total API calls across 8 streams: 4,320 × 8 = 34,560 API calls
 
-Making 34,560 API calls in a brief period will likely trigger OpenAI's rate limits, resulting in API errors. When using a 1-minute bucket width, it's strongly recommended to set the "Initial interval" to a shorter duration - optimally 1 day - to ensure smooth performance. While our extensive testing demonstrates excellent results with a 6-month initial interval paired with a 1-day bucket width, the same level of success isn't achievable with 1-minute or 1-hour bucket widths due to OpenAI's API rate limitations. To achieve the best results when gathering historical data over long periods, using 1-day bucket widths is the most effective method, ensuring a balance between data granularity and API limitations.
+Making 34,560 API calls in a brief period will likely trigger OpenAI's rate limits, resulting in API errors.
 
 ### Collection process
 

--- a/packages/openai/_dev/build/docs/README.md
+++ b/packages/openai/_dev/build/docs/README.md
@@ -57,7 +57,7 @@ There are two advanced configuration options for the OpenAI integration: "Initia
 #### Impact on data resolution
 
 Granularity relationship: `1m` > `1h` > `1d`
-- `1m` buckets provide the highest resolution metrics, with data arriving nearly in real-time (1-minute delay)
+- `1m` buckets provide the highest resolution metrics, with data arriving in near real-time (1-minute delay)
 - `1h` buckets aggregate 60-minute intervals, with data arriving less frequently (1-hour delay)
 - `1d` buckets consolidate full 24-hour periods, with data arriving daily (24-hour delay)
 
@@ -87,13 +87,13 @@ Formula for API calls:
 2. Total buckets / buckets per API call = API calls per data stream
 3. Total API calls = API calls per data stream × 8 data streams
 
-Technical calculation example with 6-month initial interval and 1-minute buckets:
+Technical calculation example with a 6-month initial interval and 1-minute buckets:
 - "Initial interval" conversion: 6 months = (6 × 30 × 24) = 4,320 hours
 - Total buckets needed: 4,320 hours × 60 minutes = 259,200 buckets
 - API calls per stream: 259,200 / 60 = 4,320 calls
 - Total API calls across 8 streams: 4,320 × 8 = 34,560 API calls
 
-Making 34,560 API calls in a brief period will likely trigger OpenAI's rate limits, resulting in API errors. When using a 1-minute bucket width, it's strongly recommended to set the "Initial interval" to a shorter duration - optimally 1 day - to ensure smooth performance. While our extensive testing demonstrates excellent results with a 6-month initial interval paired with a 1-day bucket width, the same level of success isn't achievable with 1-minute or 1-hour bucket widths due to OpenAI's API rate limitations. For optimal results when collecting historical data over extended periods, implementing 1-day bucket widths proves to be the most effective approach, balancing data granularity with API constraints.
+Making 34,560 API calls in a brief period will likely trigger OpenAI's rate limits, resulting in API errors. When using a 1-minute bucket width, it's strongly recommended to set the "Initial interval" to a shorter duration - optimally 1 day - to ensure smooth performance. While our extensive testing demonstrates excellent results with a 6-month initial interval paired with a 1-day bucket width, the same level of success isn't achievable with 1-minute or 1-hour bucket widths due to OpenAI's API rate limitations. To achieve the best results when gathering historical data over long periods, using 1-day bucket widths is the most effective method, ensuring a balance between data granularity and API limitations.
 
 ### Collection process
 
@@ -109,10 +109,7 @@ With default settings (Interval: 5m, Bucket width: 1m, Initial interval: 24h), t
 
 With default settings (Interval: 5m, Bucket width: 1m, Initial interval: 24h):
 
-1. Integration starts at 10:00 AM
-2. Collects data from 10:00 AM previous day
-3. Continues until 9:59 AM current day
-4. Next collection starts at 10:05 AM from the 10:00 AM bucket to 10:04 AM as the "Interval" is 5 minutes.
+The integration starts at 10:00 AM, collects data from 10:00 AM the previous day, and continues until 9:59 AM the current day. The next collection starts at 10:05 AM, collecting from the 10:00 AM bucket to the 10:04 AM bucket, as the "Interval" is 5 minutes.
 
 ## Logs reference
 

--- a/packages/openai/_dev/build/docs/README.md
+++ b/packages/openai/_dev/build/docs/README.md
@@ -57,9 +57,9 @@ There are two advanced configuration options for the OpenAI integration: "Initia
 #### Impact on data resolution
 
 Granularity relationship: `1m` > `1h` > `1d`
-- `1m` buckets provide the highest resolution metrics
-- `1h` buckets aggregate 60-minute intervals
-- `1d` buckets consolidate full 24-hour periods
+- `1m` buckets provide the highest resolution metrics, with data arriving nearly in real-time (1-minute delay)
+- `1h` buckets aggregate 60-minute intervals, with data arriving less frequently (1-hour delay)
+- `1d` buckets consolidate full 24-hour periods, with data arriving daily (24-hour delay)
 
 #### Storage considerations
 

--- a/packages/openai/_dev/build/docs/README.md
+++ b/packages/openai/_dev/build/docs/README.md
@@ -93,7 +93,7 @@ Technical calculation example with 6-month initial interval and 1-minute buckets
 - API calls per stream: 259,200 / 60 = 4,320 calls
 - Total API calls across 8 streams: 4,320 × 8 = 34,560 API calls
 
-The number of API calls varies significantly based on both the bucket width configuration and its corresponding buckets-per-call value from the OpenAI API. For example, making 34,560 API calls in a brief period will likely trigger OpenAI's rate limits, resulting in API errors. When using a 1-minute bucket width, it's highly recommended to set the "Initial interval" to a shorter duration - ideally 1 day - to optimize performance. Our testing has confirmed successful operation with a 6-month initial interval combined with a 1-day bucket width, but this same success does not extend to 1-minute or 1-hour bucket widths.
+Making 34,560 API calls in a brief period will likely trigger OpenAI's rate limits, resulting in API errors. When using a 1-minute bucket width, it's strongly recommended to set the "Initial interval" to a shorter duration - optimally 1 day - to ensure smooth performance. While our extensive testing demonstrates excellent results with a 6-month initial interval paired with a 1-day bucket width, the same level of success isn't achievable with 1-minute or 1-hour bucket widths due to OpenAI's API rate limitations. For optimal results when collecting historical data over extended periods, implementing 1-day bucket widths proves to be the most effective approach, balancing data granularity with API constraints.
 
 ### Collection process
 

--- a/packages/openai/_dev/build/docs/README.md
+++ b/packages/openai/_dev/build/docs/README.md
@@ -81,27 +81,7 @@ Example: For 100 API calls to a particular model per hour:
 
 "Bucket width" and "Initial interval" directly affect API request frequency. When using a 1-minute bucket width, it's strongly recommended to set the "Initial interval" to a shorter duration—optimally 1 day—to ensure smooth performance. While our extensive testing demonstrates excellent results with a 6-month initial interval paired with a 1-day bucket width, the same level of success isn't achievable with 1-minute or 1-hour bucket widths. This is because the OpenAI Usage API returns different bucket quantities based on width (60 buckets per call for 1-minute, 24 for 1-hour, and 7 for 1-day widths). To achieve the best results when gathering historical data over long periods, using 1-day bucket widths is the most effective method, ensuring a balance between data granularity and API limitations.
 
-For optimal results with historical data, use 1-day bucket widths for long periods (15+ days), 1-hour for medium periods (1-15 days), and 1-minute only for the most recent 24 hours of data.
-
-Here's an example technical breakdown:
-
-The OpenAI Usage API returns different numbers of buckets based on the bucket width:
-- 1-minute buckets: 60 buckets per API call
-- 1-hour buckets: 24 buckets per API call
-- 1-day buckets: 7 buckets per API call
-
-Formula for API calls:
-1. Hours in initial interval × (60 minutes / bucket size) = Total buckets needed
-2. Total buckets / buckets per API call = API calls per data stream
-3. Total API calls = API calls per data stream × 8 data streams
-
-Technical calculation example with a 6-month initial interval and 1-minute buckets:
-- "Initial interval" conversion: 6 months = (6 × 30 × 24) = 4,320 hours
-- Total buckets needed: 4,320 hours × 60 minutes = 259,200 buckets
-- API calls per stream: 259,200 / 60 = 4,320 calls
-- Total API calls across 8 streams: 4,320 × 8 = 34,560 API calls
-
-Making 34,560 API calls in a brief period will likely trigger OpenAI's rate limits, resulting in API errors.
+> For optimal results with historical data, use 1-day bucket widths for long periods (15+ days), 1-hour for medium periods (1-15 days), and 1-minute only for the most recent 24 hours of data.
 
 ### Collection process
 

--- a/packages/openai/_dev/build/docs/README.md
+++ b/packages/openai/_dev/build/docs/README.md
@@ -39,7 +39,7 @@ To generate an Admin key, please generate a key or use an existing one from the 
 
 ## Collection behavior
 
-By default, the OpenAI integration fetches metrics with a bucket width of 1 day (`1d`), which means metrics are aggregated by day. metrics are collected from the initial start time until the current time, excluding the current bucket since it is incomplete. So, based on configured bucket width, the integration collects metrics from the initial start time until the current time minus the bucket width.
+By default, the OpenAI integration fetches metrics with a bucket width of 1 day (`1d`), which means metrics are aggregated by day. Metrics are collected from the initial start time until the current time, excluding the current bucket since it is incomplete. So, based on configured bucket width, the integration collects metrics from the initial start time until the current time minus the bucket width.
 
 ## Logs reference
 

--- a/packages/openai/_dev/build/docs/README.md
+++ b/packages/openai/_dev/build/docs/README.md
@@ -53,22 +53,24 @@ A "bucket" refers to a time interval where OpenAI usage data is grouped together
 
 - Controls the time-based aggregation of metrics
 - Default: `1m` (1 minute)
-- Options: `1m`, `1h`, `1d`
+- Options: `1m` (1 minute), `1h` (1 hour), `1d` (1 day)
 - Affects API request frequency and data resolution
 
 #### Impact on data resolution
 
-Granularity relationship: `1m` > `1h` > `1d`
 - `1m` buckets provide the highest resolution metrics, with data arriving in near real-time (1-minute delay)
-- `1h` buckets aggregate 60-minute intervals, with data arriving less frequently (1-hour delay)
-- `1d` buckets consolidate full 24-hour periods, with data arriving daily (24-hour delay)
+- `1h` buckets aggregate hourly, with data arriving less frequently (1-hour delay)
+- `1d` buckets aggregate daily, with data arriving once per day (24-hour delay)
+
+Data granularity relationship: `1m` > `1h` > `1d`
 
 #### Storage considerations
 
-Bucket width choice affects storage usage and data resolution:
-- `1m`: Maximum granularity, higher storage needs
-- `1h`: Aggregates 60 one-minute intervals
-- `1d`: Most efficient storage, suitable for long-term analysis
+Bucket width choice affects storage usage (in Elasticsearch) and data resolution:
+
+- `1m`: Maximum granularity, higher storage needs, ideal for detailed analysis.
+- `1h`: Medium granularity, moderate storage needs, good for hourly patterns.
+- `1d`: Minimum granularity, lowest storage needs, suitable for long-term analysis.
 
 Example: For 100 API calls to a particular model per hour:
 - `1m` buckets: Up to 100 documents
@@ -79,7 +81,7 @@ Example: For 100 API calls to a particular model per hour:
 
 "Bucket width" and "Initial interval" directly affect API request frequency. When using a 1-minute bucket width, it's strongly recommended to set the "Initial interval" to a shorter duration—optimally 1 day—to ensure smooth performance. While our extensive testing demonstrates excellent results with a 6-month initial interval paired with a 1-day bucket width, the same level of success isn't achievable with 1-minute or 1-hour bucket widths. This is because the OpenAI Usage API returns different bucket quantities based on width (60 buckets per call for 1-minute, 24 for 1-hour, and 7 for 1-day widths). To achieve the best results when gathering historical data over long periods, using 1-day bucket widths is the most effective method, ensuring a balance between data granularity and API limitations.
 
-For optimal results with historical data, use 1-day bucket widths for long periods (15+ days), 1-hour for medium periods (1-14 days), and 1-minute only for the most recent 24 hours of data.
+For optimal results with historical data, use 1-day bucket widths for long periods (15+ days), 1-hour for medium periods (1-15 days), and 1-minute only for the most recent 24 hours of data.
 
 Here's an example technical breakdown:
 
@@ -103,7 +105,7 @@ Making 34,560 API calls in a brief period will likely trigger OpenAI's rate limi
 
 ### Collection process
 
-With default settings (Interval: 5m, Bucket width: 1m, Initial interval: 24h), the OpenAI integration follows this collection pattern:
+With default settings (Interval: `5m`, Bucket width: `1m`, Initial interval: `24h`), the OpenAI integration follows this collection pattern:
 
 1. Starts collection from (current_time - initial_interval)
 2. Collects data up to (current_time - bucket_width)
@@ -113,7 +115,7 @@ With default settings (Interval: 5m, Bucket width: 1m, Initial interval: 24h), t
 
 #### Example timeline
 
-With default settings (Interval: 5m, Bucket width: 1m, Initial interval: 24h):
+With default settings (Interval: `5m`, Bucket width: `1m`, Initial interval: `24h`):
 
 The integration starts at 10:00 AM, collects data from 10:00 AM the previous day, and continues until 9:59 AM the current day. The next collection starts at 10:05 AM, collecting from the 10:00 AM bucket to the 10:04 AM bucket, as the "Interval" is 5 minutes.
 

--- a/packages/openai/_dev/build/docs/README.md
+++ b/packages/openai/_dev/build/docs/README.md
@@ -39,7 +39,7 @@ To generate an Admin key, please generate a key or use an existing one from the 
 
 ## Collection behavior
 
-Among the configuration options for the OpenAI integration, two settings are particularly important to understand: "Initial interval" and "Bucket width".
+Among the configuration options for the OpenAI integration, the following settings are particularly relevant: "Initial interval" and "Bucket width".
 
 ### Initial interval
 

--- a/packages/openai/changelog.yml
+++ b/packages/openai/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.1"
+  changes:
+    - description: Improve the documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12837
 - version: "0.2.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/openai/changelog.yml
+++ b/packages/openai/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Change the defaults and improve the documentation.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/12837
+      link: https://github.com/elastic/integrations/pull/12838
 - version: "0.2.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/openai/changelog.yml
+++ b/packages/openai/changelog.yml
@@ -1,7 +1,8 @@
 # newer versions go on top
 - version: "0.3.0"
   changes:
-    - description: Change the defaults and improve the documentation.
+    - description: Update default values and improve documentation and field descriptions.
+
       type: enhancement
       link: https://github.com/elastic/integrations/pull/12838
 - version: "0.2.0"

--- a/packages/openai/changelog.yml
+++ b/packages/openai/changelog.yml
@@ -1,8 +1,8 @@
 # newer versions go on top
-- version: "0.2.1"
+- version: "0.3.0"
   changes:
-    - description: Improve the documentation.
-      type: bugfix
+    - description: Change the defaults and improve the documentation.
+      type: enhancement
       link: https://github.com/elastic/integrations/pull/12837
 - version: "0.2.0"
   changes:

--- a/packages/openai/data_stream/audio_speeches/manifest.yml
+++ b/packages/openai/data_stream/audio_speeches/manifest.yml
@@ -28,7 +28,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval for the first API call. Defaults to 24 hours (`24h`). Supported units for this parameter are h/m/s.
+        description: Initial interval controls the historical data collection window at startup. This parameter determines how far back in time the integration will collect data when first initialized. Default is 24 hours (`24h`). Longer intervals retrieve more historical data but increase API calls. When using smaller bucket width (e.g., 1m), keep this interval shorter to avoid rate limiting. Supported units are h/m/s.
         default: 24h
       - name: bucket_width
         type: text

--- a/packages/openai/data_stream/audio_speeches/manifest.yml
+++ b/packages/openai/data_stream/audio_speeches/manifest.yml
@@ -28,7 +28,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval for the first API call. Defaults to 24 hours. Supported units for this parameter are h/m/s.
+        description: Initial interval for the first API call. Defaults to 24 hours (`24h`). Supported units for this parameter are h/m/s.
         default: 24h
       - name: bucket_width
         type: text
@@ -36,8 +36,8 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Bucket width to decide the width of each bucket in response from the OpenAI API. Defaults to 1d. Supported values for this parameter are 1m, 1h and 1d only.
-        default: 1d
+        description: Bucket width to decide the width of each bucket in response from the OpenAI API. Defaults to 1m. Supported values for this parameter are 1m, 1h and 1d only.
+        default: 1m
       - name: tags
         type: text
         title: Tags

--- a/packages/openai/data_stream/audio_transcriptions/manifest.yml
+++ b/packages/openai/data_stream/audio_transcriptions/manifest.yml
@@ -28,7 +28,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval for the first API call. Defaults to 24 hours (`24h`). Supported units for this parameter are h/m/s.
+        description: Initial interval controls the historical data collection window at startup. This parameter determines how far back in time the integration will collect data when first initialized. Default is 24 hours (`24h`). Longer intervals retrieve more historical data but increase API calls. When using smaller bucket width (e.g., 1m), keep this interval shorter to avoid rate limiting. Supported units are h/m/s.
         default: 24h
       - name: bucket_width
         type: text

--- a/packages/openai/data_stream/audio_transcriptions/manifest.yml
+++ b/packages/openai/data_stream/audio_transcriptions/manifest.yml
@@ -28,7 +28,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval for the first API call. Defaults to 24 hours. Supported units for this parameter are h/m/s.
+        description: Initial interval for the first API call. Defaults to 24 hours (`24h`). Supported units for this parameter are h/m/s.
         default: 24h
       - name: bucket_width
         type: text
@@ -36,8 +36,8 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Bucket width to decide the width of each bucket in response from the OpenAI API. Defaults to 1d. Supported values for this parameter are 1m, 1h and 1d only.
-        default: 1d
+        description: Bucket width to decide the width of each bucket in response from the OpenAI API. Defaults to 1m. Supported values for this parameter are 1m, 1h and 1d only.
+        default: 1m
       - name: tags
         type: text
         title: Tags

--- a/packages/openai/data_stream/code_interpreter_sessions/manifest.yml
+++ b/packages/openai/data_stream/code_interpreter_sessions/manifest.yml
@@ -28,7 +28,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval for the first API call. Defaults to 24 hours (`24h`). Supported units for this parameter are h/m/s.
+        description: Initial interval controls the historical data collection window at startup. This parameter determines how far back in time the integration will collect data when first initialized. Default is 24 hours (`24h`). Longer intervals retrieve more historical data but increase API calls. When using smaller bucket width (e.g., 1m), keep this interval shorter to avoid rate limiting. Supported units are h/m/s.
         default: 24h
       - name: bucket_width
         type: text

--- a/packages/openai/data_stream/code_interpreter_sessions/manifest.yml
+++ b/packages/openai/data_stream/code_interpreter_sessions/manifest.yml
@@ -28,7 +28,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval for the first API call. Defaults to 24 hours. Supported units for this parameter are h/m/s.
+        description: Initial interval for the first API call. Defaults to 24 hours (`24h`). Supported units for this parameter are h/m/s.
         default: 24h
       - name: bucket_width
         type: text
@@ -36,8 +36,8 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Bucket width to decide the width of each bucket in response from the OpenAI API. Defaults to 1d. Supported values for this parameter are 1m, 1h and 1d only.
-        default: 1d
+        description: Bucket width to decide the width of each bucket in response from the OpenAI API. Defaults to 1m. Supported values for this parameter are 1m, 1h and 1d only.
+        default: 1m
       - name: tags
         type: text
         title: Tags

--- a/packages/openai/data_stream/completions/manifest.yml
+++ b/packages/openai/data_stream/completions/manifest.yml
@@ -28,7 +28,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval for the first API call. Defaults to 24 hours (`24h`). Supported units for this parameter are h/m/s.
+        description: Initial interval controls the historical data collection window at startup. This parameter determines how far back in time the integration will collect data when first initialized. Default is 24 hours (`24h`). Longer intervals retrieve more historical data but increase API calls. When using smaller bucket width (e.g., 1m), keep this interval shorter to avoid rate limiting. Supported units are h/m/s.
         default: 24h
       - name: bucket_width
         type: text

--- a/packages/openai/data_stream/completions/manifest.yml
+++ b/packages/openai/data_stream/completions/manifest.yml
@@ -28,7 +28,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval for the first API call. Defaults to 24 hours. Supported units for this parameter are h/m/s.
+        description: Initial interval for the first API call. Defaults to 24 hours (`24h`). Supported units for this parameter are h/m/s.
         default: 24h
       - name: bucket_width
         type: text
@@ -36,8 +36,8 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Bucket width to decide the width of each bucket in response from the OpenAI API. Defaults to 1d. Supported values for this parameter are 1m, 1h and 1d only.
-        default: 1d
+        description: Bucket width to decide the width of each bucket in response from the OpenAI API. Defaults to 1m. Supported values for this parameter are 1m, 1h and 1d only.
+        default: 1m
       - name: tags
         type: text
         title: Tags

--- a/packages/openai/data_stream/embeddings/manifest.yml
+++ b/packages/openai/data_stream/embeddings/manifest.yml
@@ -28,7 +28,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval for the first API call. Defaults to 24 hours (`24h`). Supported units for this parameter are h/m/s.
+        description: Initial interval controls the historical data collection window at startup. This parameter determines how far back in time the integration will collect data when first initialized. Default is 24 hours (`24h`). Longer intervals retrieve more historical data but increase API calls. When using smaller bucket width (e.g., 1m), keep this interval shorter to avoid rate limiting. Supported units are h/m/s.
         default: 24h
       - name: bucket_width
         type: text

--- a/packages/openai/data_stream/embeddings/manifest.yml
+++ b/packages/openai/data_stream/embeddings/manifest.yml
@@ -28,7 +28,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval for the first API call. Defaults to 24 hours. Supported units for this parameter are h/m/s.
+        description: Initial interval for the first API call. Defaults to 24 hours (`24h`). Supported units for this parameter are h/m/s.
         default: 24h
       - name: bucket_width
         type: text
@@ -36,8 +36,8 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Bucket width to decide the width of each bucket in response from the OpenAI API. Defaults to 1d. Supported values for this parameter are 1m, 1h and 1d only.
-        default: 1d
+        description: Bucket width to decide the width of each bucket in response from the OpenAI API. Defaults to 1m. Supported values for this parameter are 1m, 1h and 1d only.
+        default: 1m
       - name: tags
         type: text
         title: Tags

--- a/packages/openai/data_stream/images/manifest.yml
+++ b/packages/openai/data_stream/images/manifest.yml
@@ -28,7 +28,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval for the first API call. Defaults to 24 hours (`24h`). Supported units for this parameter are h/m/s.
+        description: Initial interval controls the historical data collection window at startup. This parameter determines how far back in time the integration will collect data when first initialized. Default is 24 hours (`24h`). Longer intervals retrieve more historical data but increase API calls. When using smaller bucket width (e.g., 1m), keep this interval shorter to avoid rate limiting. Supported units are h/m/s.
         default: 24h
       - name: bucket_width
         type: text

--- a/packages/openai/data_stream/images/manifest.yml
+++ b/packages/openai/data_stream/images/manifest.yml
@@ -28,7 +28,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval for the first API call. Defaults to 24 hours. Supported units for this parameter are h/m/s.
+        description: Initial interval for the first API call. Defaults to 24 hours (`24h`). Supported units for this parameter are h/m/s.
         default: 24h
       - name: bucket_width
         type: text
@@ -36,8 +36,8 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Bucket width to decide the width of each bucket in response from the OpenAI API. Defaults to 1d. Supported values for this parameter are 1m, 1h and 1d only.
-        default: 1d
+        description: Bucket width to decide the width of each bucket in response from the OpenAI API. Defaults to 1m. Supported values for this parameter are 1m, 1h and 1d only.
+        default: 1m
       - name: tags
         type: text
         title: Tags

--- a/packages/openai/data_stream/moderations/manifest.yml
+++ b/packages/openai/data_stream/moderations/manifest.yml
@@ -28,7 +28,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval for the first API call. Defaults to 24 hours (`24h`). Supported units for this parameter are h/m/s.
+        description: Initial interval controls the historical data collection window at startup. This parameter determines how far back in time the integration will collect data when first initialized. Default is 24 hours (`24h`). Longer intervals retrieve more historical data but increase API calls. When using smaller bucket width (e.g., 1m), keep this interval shorter to avoid rate limiting. Supported units are h/m/s.
         default: 24h
       - name: bucket_width
         type: text

--- a/packages/openai/data_stream/moderations/manifest.yml
+++ b/packages/openai/data_stream/moderations/manifest.yml
@@ -28,7 +28,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval for the first API call. Defaults to 24 hours. Supported units for this parameter are h/m/s.
+        description: Initial interval for the first API call. Defaults to 24 hours (`24h`). Supported units for this parameter are h/m/s.
         default: 24h
       - name: bucket_width
         type: text
@@ -36,8 +36,8 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Bucket width to decide the width of each bucket in response from the OpenAI API. Defaults to 1d. Supported values for this parameter are 1m, 1h and 1d only.
-        default: 1d
+        description: Bucket width to decide the width of each bucket in response from the OpenAI API. Defaults to 1m. Supported values for this parameter are 1m, 1h and 1d only.
+        default: 1m
       - name: tags
         type: text
         title: Tags

--- a/packages/openai/data_stream/vector_stores/manifest.yml
+++ b/packages/openai/data_stream/vector_stores/manifest.yml
@@ -28,7 +28,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval for the first API call. Defaults to 24 hours (`24h`). Supported units for this parameter are h/m/s.
+        description: Initial interval controls the historical data collection window at startup. This parameter determines how far back in time the integration will collect data when first initialized. Default is 24 hours (`24h`). Longer intervals retrieve more historical data but increase API calls. When using smaller bucket width (e.g., 1m), keep this interval shorter to avoid rate limiting. Supported units are h/m/s.
         default: 24h
       - name: bucket_width
         type: text

--- a/packages/openai/data_stream/vector_stores/manifest.yml
+++ b/packages/openai/data_stream/vector_stores/manifest.yml
@@ -28,7 +28,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval for the first API call. Defaults to 24 hours. Supported units for this parameter are h/m/s.
+        description: Initial interval for the first API call. Defaults to 24 hours (`24h`). Supported units for this parameter are h/m/s.
         default: 24h
       - name: bucket_width
         type: text
@@ -36,8 +36,8 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Bucket width to decide the width of each bucket in response from the OpenAI API. Defaults to 1d. Supported values for this parameter are 1m, 1h and 1d only.
-        default: 1d
+        description: Bucket width to decide the width of each bucket in response from the OpenAI API. Defaults to 1m. Supported values for this parameter are 1m, 1h and 1d only.
+        default: 1m
       - name: tags
         type: text
         title: Tags

--- a/packages/openai/docs/README.md
+++ b/packages/openai/docs/README.md
@@ -39,7 +39,7 @@ To generate an Admin key, please generate a key or use an existing one from the 
 
 ## Collection behavior
 
-There are two advanced configuration options for the OpenAI integration: "Initial interval" and "Bucket width".
+Among the configuration options for the OpenAI integration, two settings are particularly important to understand: "Initial interval" and "Bucket width".
 
 ### Initial interval
 

--- a/packages/openai/docs/README.md
+++ b/packages/openai/docs/README.md
@@ -49,7 +49,9 @@ There are two advanced configuration options for the OpenAI integration: "Initia
 
 ### Bucket width
 
-- Controls the time-based aggregation of metrics (e.g., [bucket_width](https://platform.openai.com/docs/api-reference/usage/completions#usage-completions-bucket_width))
+A "bucket" refers to a time interval where OpenAI usage data is grouped together for reporting purposes. For example, with a 1-minute bucket width, usage metrics are aggregated minute by minute. With a 1-hour bucket width, all activity during that hour is consolidated into a single bucket. The [bucket width](https://platform.openai.com/docs/api-reference/usage/completions#usage-completions-bucket_width) determines your data's granularity and level of detail in your usage reporting.
+
+- Controls the time-based aggregation of metrics
 - Default: `1m` (1 minute)
 - Options: `1m`, `1h`, `1d`
 - Affects API request frequency and data resolution
@@ -75,9 +77,13 @@ Example: For 100 API calls to a particular model per hour:
 
 #### API request impact
 
-"Bucket width" and "Initial interval" directly affect API request frequency. Here's the technical breakdown:
+"Bucket width" and "Initial interval" directly affect API request frequency. When using a 1-minute bucket width, it's strongly recommended to set the "Initial interval" to a shorter duration—optimally 1 day—to ensure smooth performance. While our extensive testing demonstrates excellent results with a 6-month initial interval paired with a 1-day bucket width, the same level of success isn't achievable with 1-minute or 1-hour bucket widths. This is because the OpenAI Usage API returns different bucket quantities based on width (60 buckets per call for 1-minute, 24 for 1-hour, and 7 for 1-day widths). To achieve the best results when gathering historical data over long periods, using 1-day bucket widths is the most effective method, ensuring a balance between data granularity and API limitations.
 
-OpenAI Usage API returns different numbers of buckets based on the bucket width:
+For optimal results with historical data, use 1-day bucket widths for long periods (15+ days), 1-hour for medium periods (1-14 days), and 1-minute only for the most recent 24 hours of data.
+
+Here's an example technical breakdown:
+
+The OpenAI Usage API returns different numbers of buckets based on the bucket width:
 - 1-minute buckets: 60 buckets per API call
 - 1-hour buckets: 24 buckets per API call
 - 1-day buckets: 7 buckets per API call
@@ -93,7 +99,7 @@ Technical calculation example with a 6-month initial interval and 1-minute bucke
 - API calls per stream: 259,200 / 60 = 4,320 calls
 - Total API calls across 8 streams: 4,320 × 8 = 34,560 API calls
 
-Making 34,560 API calls in a brief period will likely trigger OpenAI's rate limits, resulting in API errors. When using a 1-minute bucket width, it's strongly recommended to set the "Initial interval" to a shorter duration - optimally 1 day - to ensure smooth performance. While our extensive testing demonstrates excellent results with a 6-month initial interval paired with a 1-day bucket width, the same level of success isn't achievable with 1-minute or 1-hour bucket widths due to OpenAI's API rate limitations. To achieve the best results when gathering historical data over long periods, using 1-day bucket widths is the most effective method, ensuring a balance between data granularity and API limitations.
+Making 34,560 API calls in a brief period will likely trigger OpenAI's rate limits, resulting in API errors.
 
 ### Collection process
 

--- a/packages/openai/docs/README.md
+++ b/packages/openai/docs/README.md
@@ -57,7 +57,7 @@ There are two advanced configuration options for the OpenAI integration: "Initia
 #### Impact on data resolution
 
 Granularity relationship: `1m` > `1h` > `1d`
-- `1m` buckets provide the highest resolution metrics, with data arriving nearly in real-time (1-minute delay)
+- `1m` buckets provide the highest resolution metrics, with data arriving in near real-time (1-minute delay)
 - `1h` buckets aggregate 60-minute intervals, with data arriving less frequently (1-hour delay)
 - `1d` buckets consolidate full 24-hour periods, with data arriving daily (24-hour delay)
 
@@ -87,13 +87,13 @@ Formula for API calls:
 2. Total buckets / buckets per API call = API calls per data stream
 3. Total API calls = API calls per data stream × 8 data streams
 
-Technical calculation example with 6-month initial interval and 1-minute buckets:
+Technical calculation example with a 6-month initial interval and 1-minute buckets:
 - "Initial interval" conversion: 6 months = (6 × 30 × 24) = 4,320 hours
 - Total buckets needed: 4,320 hours × 60 minutes = 259,200 buckets
 - API calls per stream: 259,200 / 60 = 4,320 calls
 - Total API calls across 8 streams: 4,320 × 8 = 34,560 API calls
 
-Making 34,560 API calls in a brief period will likely trigger OpenAI's rate limits, resulting in API errors. When using a 1-minute bucket width, it's strongly recommended to set the "Initial interval" to a shorter duration - optimally 1 day - to ensure smooth performance. While our extensive testing demonstrates excellent results with a 6-month initial interval paired with a 1-day bucket width, the same level of success isn't achievable with 1-minute or 1-hour bucket widths due to OpenAI's API rate limitations. For optimal results when collecting historical data over extended periods, implementing 1-day bucket widths proves to be the most effective approach, balancing data granularity with API constraints.
+Making 34,560 API calls in a brief period will likely trigger OpenAI's rate limits, resulting in API errors. When using a 1-minute bucket width, it's strongly recommended to set the "Initial interval" to a shorter duration - optimally 1 day - to ensure smooth performance. While our extensive testing demonstrates excellent results with a 6-month initial interval paired with a 1-day bucket width, the same level of success isn't achievable with 1-minute or 1-hour bucket widths due to OpenAI's API rate limitations. To achieve the best results when gathering historical data over long periods, using 1-day bucket widths is the most effective method, ensuring a balance between data granularity and API limitations.
 
 ### Collection process
 
@@ -109,10 +109,7 @@ With default settings (Interval: 5m, Bucket width: 1m, Initial interval: 24h), t
 
 With default settings (Interval: 5m, Bucket width: 1m, Initial interval: 24h):
 
-1. Integration starts at 10:00 AM
-2. Collects data from 10:00 AM previous day
-3. Continues until 9:59 AM current day
-4. Next collection starts at 10:05 AM from the 10:00 AM bucket to 10:04 AM as the "Interval" is 5 minutes.
+The integration starts at 10:00 AM, collects data from 10:00 AM the previous day, and continues until 9:59 AM the current day. The next collection starts at 10:05 AM, collecting from the 10:00 AM bucket to the 10:04 AM bucket, as the "Interval" is 5 minutes.
 
 ## Logs reference
 

--- a/packages/openai/docs/README.md
+++ b/packages/openai/docs/README.md
@@ -57,9 +57,9 @@ There are two advanced configuration options for the OpenAI integration: "Initia
 #### Impact on data resolution
 
 Granularity relationship: `1m` > `1h` > `1d`
-- `1m` buckets provide the highest resolution metrics
-- `1h` buckets aggregate 60-minute intervals
-- `1d` buckets consolidate full 24-hour periods
+- `1m` buckets provide the highest resolution metrics, with data arriving nearly in real-time (1-minute delay)
+- `1h` buckets aggregate 60-minute intervals, with data arriving less frequently (1-hour delay)
+- `1d` buckets consolidate full 24-hour periods, with data arriving daily (24-hour delay)
 
 #### Storage considerations
 

--- a/packages/openai/docs/README.md
+++ b/packages/openai/docs/README.md
@@ -93,7 +93,7 @@ Technical calculation example with 6-month initial interval and 1-minute buckets
 - API calls per stream: 259,200 / 60 = 4,320 calls
 - Total API calls across 8 streams: 4,320 × 8 = 34,560 API calls
 
-The number of API calls varies significantly based on both the bucket width configuration and its corresponding buckets-per-call value from the OpenAI API. For example, making 34,560 API calls in a brief period will likely trigger OpenAI's rate limits, resulting in API errors. When using a 1-minute bucket width, it's highly recommended to set the "Initial interval" to a shorter duration - ideally 1 day - to optimize performance. Our testing has confirmed successful operation with a 6-month initial interval combined with a 1-day bucket width, but this same success does not extend to 1-minute or 1-hour bucket widths.
+Making 34,560 API calls in a brief period will likely trigger OpenAI's rate limits, resulting in API errors. When using a 1-minute bucket width, it's strongly recommended to set the "Initial interval" to a shorter duration - optimally 1 day - to ensure smooth performance. While our extensive testing demonstrates excellent results with a 6-month initial interval paired with a 1-day bucket width, the same level of success isn't achievable with 1-minute or 1-hour bucket widths due to OpenAI's API rate limitations. For optimal results when collecting historical data over extended periods, implementing 1-day bucket widths proves to be the most effective approach, balancing data granularity with API constraints.
 
 ### Collection process
 

--- a/packages/openai/docs/README.md
+++ b/packages/openai/docs/README.md
@@ -81,27 +81,7 @@ Example: For 100 API calls to a particular model per hour:
 
 "Bucket width" and "Initial interval" directly affect API request frequency. When using a 1-minute bucket width, it's strongly recommended to set the "Initial interval" to a shorter duration—optimally 1 day—to ensure smooth performance. While our extensive testing demonstrates excellent results with a 6-month initial interval paired with a 1-day bucket width, the same level of success isn't achievable with 1-minute or 1-hour bucket widths. This is because the OpenAI Usage API returns different bucket quantities based on width (60 buckets per call for 1-minute, 24 for 1-hour, and 7 for 1-day widths). To achieve the best results when gathering historical data over long periods, using 1-day bucket widths is the most effective method, ensuring a balance between data granularity and API limitations.
 
-For optimal results with historical data, use 1-day bucket widths for long periods (15+ days), 1-hour for medium periods (1-15 days), and 1-minute only for the most recent 24 hours of data.
-
-Here's an example technical breakdown:
-
-The OpenAI Usage API returns different numbers of buckets based on the bucket width:
-- 1-minute buckets: 60 buckets per API call
-- 1-hour buckets: 24 buckets per API call
-- 1-day buckets: 7 buckets per API call
-
-Formula for API calls:
-1. Hours in initial interval × (60 minutes / bucket size) = Total buckets needed
-2. Total buckets / buckets per API call = API calls per data stream
-3. Total API calls = API calls per data stream × 8 data streams
-
-Technical calculation example with a 6-month initial interval and 1-minute buckets:
-- "Initial interval" conversion: 6 months = (6 × 30 × 24) = 4,320 hours
-- Total buckets needed: 4,320 hours × 60 minutes = 259,200 buckets
-- API calls per stream: 259,200 / 60 = 4,320 calls
-- Total API calls across 8 streams: 4,320 × 8 = 34,560 API calls
-
-Making 34,560 API calls in a brief period will likely trigger OpenAI's rate limits, resulting in API errors.
+> For optimal results with historical data, use 1-day bucket widths for long periods (15+ days), 1-hour for medium periods (1-15 days), and 1-minute only for the most recent 24 hours of data.
 
 ### Collection process
 

--- a/packages/openai/docs/README.md
+++ b/packages/openai/docs/README.md
@@ -39,7 +39,7 @@ To generate an Admin key, please generate a key or use an existing one from the 
 
 ## Collection behavior
 
-By default, the OpenAI integration fetches metrics with a bucket width of 1 day (`1d`), which means metrics are aggregated by day. metrics are collected from the initial start time until the current time, excluding the current bucket since it is incomplete. So, based on configured bucket width, the integration collects metrics from the initial start time until the current time minus the bucket width.
+By default, the OpenAI integration fetches metrics with a bucket width of 1 day (`1d`), which means metrics are aggregated by day. Metrics are collected from the initial start time until the current time, excluding the current bucket since it is incomplete. So, based on configured bucket width, the integration collects metrics from the initial start time until the current time minus the bucket width.
 
 ## Logs reference
 

--- a/packages/openai/docs/README.md
+++ b/packages/openai/docs/README.md
@@ -53,22 +53,24 @@ A "bucket" refers to a time interval where OpenAI usage data is grouped together
 
 - Controls the time-based aggregation of metrics
 - Default: `1m` (1 minute)
-- Options: `1m`, `1h`, `1d`
+- Options: `1m` (1 minute), `1h` (1 hour), `1d` (1 day)
 - Affects API request frequency and data resolution
 
 #### Impact on data resolution
 
-Granularity relationship: `1m` > `1h` > `1d`
 - `1m` buckets provide the highest resolution metrics, with data arriving in near real-time (1-minute delay)
-- `1h` buckets aggregate 60-minute intervals, with data arriving less frequently (1-hour delay)
-- `1d` buckets consolidate full 24-hour periods, with data arriving daily (24-hour delay)
+- `1h` buckets aggregate hourly, with data arriving less frequently (1-hour delay)
+- `1d` buckets aggregate daily, with data arriving once per day (24-hour delay)
+
+Data granularity relationship: `1m` > `1h` > `1d`
 
 #### Storage considerations
 
-Bucket width choice affects storage usage and data resolution:
-- `1m`: Maximum granularity, higher storage needs
-- `1h`: Aggregates 60 one-minute intervals
-- `1d`: Most efficient storage, suitable for long-term analysis
+Bucket width choice affects storage usage (in Elasticsearch) and data resolution:
+
+- `1m`: Maximum granularity, higher storage needs, ideal for detailed analysis.
+- `1h`: Medium granularity, moderate storage needs, good for hourly patterns.
+- `1d`: Minimum granularity, lowest storage needs, suitable for long-term analysis.
 
 Example: For 100 API calls to a particular model per hour:
 - `1m` buckets: Up to 100 documents
@@ -79,7 +81,7 @@ Example: For 100 API calls to a particular model per hour:
 
 "Bucket width" and "Initial interval" directly affect API request frequency. When using a 1-minute bucket width, it's strongly recommended to set the "Initial interval" to a shorter duration—optimally 1 day—to ensure smooth performance. While our extensive testing demonstrates excellent results with a 6-month initial interval paired with a 1-day bucket width, the same level of success isn't achievable with 1-minute or 1-hour bucket widths. This is because the OpenAI Usage API returns different bucket quantities based on width (60 buckets per call for 1-minute, 24 for 1-hour, and 7 for 1-day widths). To achieve the best results when gathering historical data over long periods, using 1-day bucket widths is the most effective method, ensuring a balance between data granularity and API limitations.
 
-For optimal results with historical data, use 1-day bucket widths for long periods (15+ days), 1-hour for medium periods (1-14 days), and 1-minute only for the most recent 24 hours of data.
+For optimal results with historical data, use 1-day bucket widths for long periods (15+ days), 1-hour for medium periods (1-15 days), and 1-minute only for the most recent 24 hours of data.
 
 Here's an example technical breakdown:
 
@@ -103,7 +105,7 @@ Making 34,560 API calls in a brief period will likely trigger OpenAI's rate limi
 
 ### Collection process
 
-With default settings (Interval: 5m, Bucket width: 1m, Initial interval: 24h), the OpenAI integration follows this collection pattern:
+With default settings (Interval: `5m`, Bucket width: `1m`, Initial interval: `24h`), the OpenAI integration follows this collection pattern:
 
 1. Starts collection from (current_time - initial_interval)
 2. Collects data up to (current_time - bucket_width)
@@ -113,7 +115,7 @@ With default settings (Interval: 5m, Bucket width: 1m, Initial interval: 24h), t
 
 #### Example timeline
 
-With default settings (Interval: 5m, Bucket width: 1m, Initial interval: 24h):
+With default settings (Interval: `5m`, Bucket width: `1m`, Initial interval: `24h`):
 
 The integration starts at 10:00 AM, collects data from 10:00 AM the previous day, and continues until 9:59 AM the current day. The next collection starts at 10:05 AM, collecting from the 10:00 AM bucket to the 10:04 AM bucket, as the "Interval" is 5 minutes.
 

--- a/packages/openai/docs/README.md
+++ b/packages/openai/docs/README.md
@@ -39,7 +39,7 @@ To generate an Admin key, please generate a key or use an existing one from the 
 
 ## Collection behavior
 
-Among the configuration options for the OpenAI integration, two settings are particularly important to understand: "Initial interval" and "Bucket width".
+Among the configuration options for the OpenAI integration, the following settings are particularly relevant: "Initial interval" and "Bucket width".
 
 ### Initial interval
 

--- a/packages/openai/manifest.yml
+++ b/packages/openai/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.0
 name: openai
 title: OpenAI
-version: 0.2.0
+version: 0.2.1
 description: |
   Collect OpenAI usage metrics with Elastic Agent.
 type: integration

--- a/packages/openai/manifest.yml
+++ b/packages/openai/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.0
 name: openai
 title: OpenAI
-version: 0.2.1
+version: 0.3.0
 description: |
   Collect OpenAI usage metrics with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Reduce data granularity by changing the default bucket width of 1d to 1m (1 day to 1 minute). Have also updated the documentation to clearly mention the collection behaviour, storage implications, how granularity affects, etc.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 