### PR TITLE
removing refs for obscloudnative team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -164,7 +164,7 @@
 /packages/cloudflare @elastic/security-service-integrations
 /packages/cloudflare_logpush @elastic/security-service-integrations
 /packages/cockroachdb @elastic/obs-infraobs-integrations
-/packages/containerd @elastic/obs-cloudnative-monitoring
+/packages/containerd @elastic/obs-ds-hosted-services
 /packages/coredns @elastic/obs-infraobs-integrations
 /packages/corelight @elastic/security-service-integrations
 /packages/couchbase @elastic/obs-infraobs-integrations
@@ -180,7 +180,7 @@
 /packages/ded @elastic/ml-ui @elastic/sec-applied-ml
 /packages/dga @elastic/ml-ui @elastic/sec-applied-ml
 /packages/digital_guardian @elastic/security-service-integrations
-/packages/docker @elastic/obs-cloudnative-monitoring
+/packages/docker @elastic/obs-ds-hosted-services
 /packages/elastic_agent @elastic/elastic-agent
 /packages/elastic_connectors @elastic/search-extract-and-transform
 /packages/elastic_package_registry @elastic/ecosystem
@@ -254,7 +254,7 @@
 /packages/infoblox_bloxone_ddi @elastic/security-service-integrations
 /packages/infoblox_nios @elastic/security-service-integrations
 /packages/iptables @elastic/sec-deployment-and-devices
-/packages/istio @elastic/obs-cloudnative-monitoring
+/packages/istio @elastic/obs-ds-hosted-services
 /packages/jamf_compliance_reporter @elastic/security-service-integrations
 /packages/jamf_pro @elastic/security-service-integrations
 /packages/jamf_protect @elastic/security-service-integrations
@@ -268,9 +268,9 @@
 /packages/kafka_log @elastic/obs-infraobs-integrations
 /packages/keycloak @elastic/security-service-integrations
 /packages/kibana @elastic/stack-monitoring
-/packages/kubernetes @elastic/obs-cloudnative-monitoring
-/packages/kubernetes/kibana @elastic/obs-cloudnative-monitoring
-/packages/kubernetes_otel @elastic/obs-cloudnative-monitoring
+/packages/kubernetes @elastic/obs-ds-hosted-services
+/packages/kubernetes/kibana @elastic/obs-ds-hosted-services
+/packages/kubernetes_otel @elastic/obs-ds-hosted-services
 /packages/lastpass @elastic/security-service-integrations
 /packages/linux @elastic/elastic-agent-data-plane
 /packages/lmd @elastic/ml-ui @elastic/sec-applied-ml
@@ -303,7 +303,7 @@
 /packages/netskope @elastic/security-service-integrations
 /packages/network_traffic @elastic/sec-linux-platform
 /packages/nginx @elastic/obs-infraobs-integrations
-/packages/nginx_ingress_controller @elastic/obs-cloudnative-monitoring
+/packages/nginx_ingress_controller @elastic/obs-ds-hosted-services
 /packages/nginx_ingress_controller_otel @elastic/obs-infraobs-integrations
 /packages/o365 @elastic/security-service-integrations
 /packages/okta @elastic/security-service-integrations
@@ -326,7 +326,7 @@
 /packages/prisma_cloud @elastic/security-service-integrations
 /packages/problemchild @elastic/ml-ui @elastic/sec-applied-ml
 /packages/prometheus @elastic/obs-infraobs-integrations
-/packages/prometheus/data_stream/remote_write @elastic/obs-cloudnative-monitoring
+/packages/prometheus/data_stream/remote_write @elastic/obs-ds-hosted-services
 /packages/prometheus/data_stream/collector @elastic/obs-infraobs-integrations
 /packages/prometheus/data_stream/query @elastic/obs-infraobs-integrations
 /packages/prometheus_input @elastic/obs-infraobs-integrations


### PR DESCRIPTION

## Proposed commit message

Updating the CodeOwners file by removing references to obs-cloudnative team and replacing with obs-ds-hosted-services team
