### PR TITLE
[infoblox_nios] Remove event.created from the default pipeline for ECS conformity

### DIFF
--- a/packages/infoblox_nios/changelog.yml
+++ b/packages/infoblox_nios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.27.2"
+  changes:
+    - description: Remove incorrect `event.created` mapping from default pipeline.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "1.27.1"
   changes:
     - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -12,9 +12,9 @@ processors:
   - grok:
       field: event.original
       patterns:
-        - "^<%{NUMBER:log.syslog.priority:long}>%{SYSLOGTIMESTAMP:event.created}\\s+%{NOTSPACE:host.domain}\\s+%{IP:_tmp.host.ip}\\s+%{DATA:infoblox_nios.log.service_name}\\[?%{NUMBER:process.pid:long}?\\]?:\\s+%{GREEDYDATA:message}$"
-        - "^<%{NUMBER:log.syslog.priority:long}>%{SYSLOGTIMESTAMP:event.created}\\s+(%{IP:_tmp.host.ip}|%{NOTSPACE:host.domain})\\s+%{DATA:infoblox_nios.log.service_name}\\[?%{NUMBER:process.pid:long}?\\]?:\\s+%{GREEDYDATA:message}$"
-        - "^<%{NUMBER:log.syslog.priority:long}>%{SYSLOGTIMESTAMP:event.created}\\s+%{IP:_tmp.host.ip}\\s+%{GREEDYDATA:message}$"
+        - "^<%{NUMBER:log.syslog.priority:long}>%{SYSLOGTIMESTAMP:_tmp.timestamp}\\s+%{NOTSPACE:host.domain}\\s+%{IP:_tmp.host.ip}\\s+%{DATA:infoblox_nios.log.service_name}\\[?%{NUMBER:process.pid:long}?\\]?:\\s+%{GREEDYDATA:message}$"
+        - "^<%{NUMBER:log.syslog.priority:long}>%{SYSLOGTIMESTAMP:_tmp.timestamp}\\s+(%{IP:_tmp.host.ip}|%{NOTSPACE:host.domain})\\s+%{DATA:infoblox_nios.log.service_name}\\[?%{NUMBER:process.pid:long}?\\]?:\\s+%{GREEDYDATA:message}$"
+        - "^<%{NUMBER:log.syslog.priority:long}>%{SYSLOGTIMESTAMP:_tmp.timestamp}\\s+%{IP:_tmp.host.ip}\\s+%{GREEDYDATA:message}$"
         - "^%{GREEDYDATA:message}$"
   - rename:
       field: _conf.tz_offset
@@ -23,10 +23,10 @@ processors:
       ignore_missing: true
       ignore_failure: true
   - date:
-      field: event.created
+      field: _tmp.timestamp
       timezone: '{{{event.timezone}}}'
-      if: ctx.event?.timezone != null && ctx.event.created != null
-      target_field: event.created
+      if: ctx.event?.timezone != null && ctx._tmp.timestamp != null
+      target_field: _tmp.timestamp
       formats:
         - MMM  d HH:mm:ss
         - MMM dd HH:mm:ss
@@ -34,15 +34,15 @@ processors:
         - dd-MMM-yyyy HH:mm:ss.SSS
       on_failure:
         - remove:
-            field: event.created
+            field: _tmp.timestamp
             ignore_missing: true
         - append:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - date:
-      field: event.created
+      field: _tmp.timestamp
       if: ctx.event?.timezone == null && ctx.event?.created != null
-      target_field: event.created
+      target_field: _tmp.timestamp
       formats:
         - MMM  d HH:mm:ss
         - MMM dd HH:mm:ss
@@ -50,7 +50,7 @@ processors:
         - dd-MMM-yyyy HH:mm:ss.SSS
       on_failure:
         - remove:
-            field: event.created
+            field: _tmp.timestamp
             ignore_missing: true
         - append:
             field: error.message
@@ -77,12 +77,7 @@ processors:
       name: '{{ IngestPipeline "pipeline_dns" }}'
       if: ctx.infoblox_nios?.log?.type == 'DNS'
   # Since logstash sets the @timestamp if not present, `override: true` is required to overwrite the value with event timestamp.
-  - set:
-      field: '@timestamp'
-      value: '{{{event.created}}}'
-      if: ctx.event?.created != null
-      override: true
-  # If individual pipelines has timestamp, they should take priority. This makes @timestamp < event.created conforming to ECS.
+  # If individual pipelines have a timestamp, they will take priority. This makes @timestamp < event.created, conforming to ECS.
   - set:
       field: '@timestamp'
       value: '{{{_tmp.timestamp}}}'

--- a/packages/infoblox_nios/manifest.yml
+++ b/packages/infoblox_nios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: infoblox_nios
 title: Infoblox NIOS
-version: "1.27.1"
+version: "1.27.2"
 description: Collect logs from Infoblox NIOS with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Updates the default pipeline to _not_ set the `event.created` field from the event timestamp, as this should be reserved for the date/time when the event was first read by an agent or pipeline. This change uses the `_tmp.timestamp` instead, which is cleaned up with the existing remove processor. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
