### PR TITLE
[cisco_asa] Trim quotes from user.name

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.42.2"
+  changes:
+    - description: "Trim quotes from user.name field."
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.42.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: "Trim quotes from user.name field."
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/12877
 - version: "2.42.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-fix.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-fix.log
@@ -13,3 +13,4 @@ Jun 21 2022 11:47:08: %ASA-6-302015: Built inbound UDP connection 7 for outside:
 Jun 21 2022 11:47:08: %ASA-6-302015: Built inbound UDP connection 7 for outside:81.2.69.142/3424 (81.2.69.142/3424)(LOCAL\alice) to inside:89.160.20.112/9803 (89.160.20.112/9803) (bob)
 Jun 21 2022 11:47:09: %ASA-6-302015: Built inbound UDP connection 7 for outside:81.2.69.142/3424 (81.2.69.142/3424)(LOCAL\alice, 123) to inside:89.160.20.112/9803 (89.160.20.112/9803)(LOCAL\dave, 246) (bob)
 Apr 27 2020 02:03:03 dev01: %ASA-5-434004: SFR requested device to bypass further packet redirection and process TCP flow from sourceInterfaceName:81.2.69.144/8888 to destinationInterfaceName:192.168.2.2/123123 locally
+<140>Feb 02 2025 14:02:35: %ASA-4-106103: access-list TEST_ACL_LIST denied tcp for user 'username' outside/81.2.69.142(51950) -> inside/89.160.20.112(443) hit-cnt 1 first hit [0xd3e666fa, 0x0]

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
@@ -1259,6 +1259,122 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2025-02-02T14:02:35.000Z",
+            "cisco": {
+                "asa": {
+                    "destination_interface": "inside",
+                    "rule_name": "TEST_ACL_LIST",
+                    "source_interface": "outside"
+                }
+            },
+            "destination": {
+                "address": "89.160.20.112",
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.112",
+                "port": 443
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "106103",
+                "kind": "event",
+                "original": "<140>Feb 02 2025 14:02:35: %ASA-4-106103: access-list TEST_ACL_LIST denied tcp for user 'username' outside/81.2.69.142(51950) -> inside/89.160.20.112(443) hit-cnt 1 first hit [0xd3e666fa, 0x0]",
+                "outcome": "failure",
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "denied"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "network": {
+                "community_id": "1:j9VGmcL6owBe84RhzGdmyxXoL8w=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
+                "ingress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "ip": [
+                    "81.2.69.142",
+                    "89.160.20.112"
+                ],
+                "user": [
+                    "username"
+                ]
+            },
+            "source": {
+                "address": "81.2.69.142",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.142",
+                "port": 51950
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "username"
+            }
         }
     ]
 }

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -2950,6 +2950,13 @@ processors:
       value: "{{{destination.user.name}}}"
       ignore_empty_value: true
       if: ctx?.user?.name == null
+  # Remove quotes from fields
+  - gsub:
+      if: ctx.user?.name != null
+      tag: trim_user_name_whitespace
+      pattern: "^['\"]|['\"]$"
+      replacement: ""
+      field: user.name
 
   # Configures observer fields with a copy from cisco and host fields. Later on these might replace host.hostname.
   - set:

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_asa
 title: Cisco ASA
-version: "2.42.1"
+version: "2.42.2"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- Add gsub processor to trim extra quotes from beginning and end of user.name field.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

## How to test this PR locally

```
cd packages/cisco_asa
elastic-package test
```

## Related issues

- Closes #12576
