### PR TITLE
MS Defender for Endpoint - add support for Kibana `9.0.0`

### DIFF
--- a/packages/microsoft_defender_endpoint/changelog.yml
+++ b/packages/microsoft_defender_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.29.0"
+  changes:
+    - description: Add support for Kibana `9.0.0`
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/<PR_NUMBER>
 - version: "2.28.0"
   changes:
     - description: Allow the usage of deprecated log input and support for stack 9.0

--- a/packages/microsoft_defender_endpoint/changelog.yml
+++ b/packages/microsoft_defender_endpoint/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add support for Kibana `9.0.0`
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/<PR_NUMBER>
+      link: https://github.com/elastic/integrations/pull/12886
 - version: "2.28.0"
   changes:
     - description: Allow the usage of deprecated log input and support for stack 9.0

--- a/packages/microsoft_defender_endpoint/manifest.yml
+++ b/packages/microsoft_defender_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: microsoft_defender_endpoint
 title: Microsoft Defender for Endpoint
-version: "2.28.0"
+version: "2.29.0"
 description: Collect logs from Microsoft Defender for Endpoint with Elastic Agent.
 categories:
   - "security"
@@ -9,7 +9,7 @@ categories:
 type: integration
 conditions:
   kibana:
-    version: "^8.13.0"
+    version: "^8.13.0 || ^9.0.0"
 policy_templates:
   - name: microsoft_defender_endpoint
     title: Microsoft Defender for Endpoint


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

This change is needed as currently on Kibana (main/9.0.0) the MS Defender integration doesn't show.
![Screenshot 2025-02-25 at 09 47 10](https://github.com/user-attachments/assets/48eb336b-680c-450f-a7eb-5a93375a680b)

related checks for integration package versions https://github.com/elastic/kibana/pull/208169

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- https://github.com/elastic/integrations/pull/12821
