### PR TITLE
[elastic_connectors][ci] Skip install error elastic connectors

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,6 @@ env:
   YQ_VERSION: 'v4.35.2'
   JQ_VERSION: '1.7'
   GH_CLI_VERSION: "2.29.0"
-  STACK_VERSION: "9.0.0-SNAPSHOT"
 
   # Agent images used in pipeline steps
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,6 +8,7 @@ env:
   YQ_VERSION: 'v4.35.2'
   JQ_VERSION: '1.7'
   GH_CLI_VERSION: "2.29.0"
+  STACK_VERSION: "9.0.0-SNAPSHOT"
 
   # Agent images used in pipeline steps
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -757,7 +757,7 @@ teardown_test_package() {
 }
 
 list_all_directories() {
-    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort |grep -E "^(elastic_connectors|juniper_junos|elsatic_package_registry)$"
+    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort |grep -E "^(elastic_connectors|juniper_junos|elastic_package_registry)$"
 }
 
 check_package() {

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -858,6 +858,12 @@ run_tests_package() {
     if ! skip_installation_step "${package}" ; then
         echo "--- [${package}] test installation"
         if ! install_package "${package}" ; then
+            if [[ "${exit_code}" != 0 && "${package}" == "elastic_connectors" ]]; then
+                # TODO: Remove this skip once elastic_connectors can be installed again
+                # For reference: https://github.com/elastic/kibana/pull/211419
+                echo "[${package}]: Known issue when package is installed - skipped all tests"
+                return 0
+            fi
             return 1
         fi
     fi

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -757,7 +757,7 @@ teardown_test_package() {
 }
 
 list_all_directories() {
-    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort |grep -E "^elastic_connectors$"
+    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort |grep -E "^(elastic_connectors|juniper_junos|elsatic_package_registry)$"
 }
 
 check_package() {

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -757,7 +757,7 @@ teardown_test_package() {
 }
 
 list_all_directories() {
-    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort |grep -E "^(elastic_connectors|juniper_junos|elastic_package_registry)$"
+    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort
 }
 
 check_package() {

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -757,7 +757,7 @@ teardown_test_package() {
 }
 
 list_all_directories() {
-    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort
+    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort |grep -E "^elastic_connectors$"
 }
 
 check_package() {

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -1018,12 +1018,6 @@ process_package() {
     fi
 
     popd > /dev/null
-    if [[ "${package}" == "elastic_connectors" ]]; then
-        # TODO: Remove this skip once elastic_connectors can be installed again
-        # For reference: https://github.com/elastic/kibana/pull/211419
-        echo "[${package}]: Skipped errors in package"
-        exit_code=0
-    fi
     return $exit_code
 }
 

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -858,7 +858,7 @@ run_tests_package() {
     if ! skip_installation_step "${package}" ; then
         echo "--- [${package}] test installation"
         if ! install_package "${package}" ; then
-            if [[ "${exit_code}" != 0 && "${package}" == "elastic_connectors" ]]; then
+            if [[ "${package}" == "elastic_connectors" ]]; then
                 # TODO: Remove this skip once elastic_connectors can be installed again
                 # For reference: https://github.com/elastic/kibana/pull/211419
                 echo "[${package}]: Known issue when package is installed - skipped all tests"

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -1018,6 +1018,12 @@ process_package() {
     fi
 
     popd > /dev/null
+    if [[ "${package}" == "elastic_connectors" ]]; then
+        # TODO: Remove this skip once elastic_connectors can be installed again
+        # For reference: https://github.com/elastic/kibana/pull/211419
+        echo "[${package}]: Skipped errors in package"
+        exit_code=0
+    fi
     return $exit_code
 }
 

--- a/.buildkite/scripts/test_one_package.sh
+++ b/.buildkite/scripts/test_one_package.sh
@@ -39,12 +39,6 @@ exit_code=0
 if ! process_package "${package}" "${from}" "${to}"; then
     echo "[${package}] failed"
     exit_code=1
-    if [[ "${exit_code}" != 0 && "${package}" == "elastic_connectors" ]]; then
-        # TODO: Remove this skip once elastic_connectors can be installed again
-        # For reference: https://github.com/elastic/kibana/pull/211419
-        echo "[${package}]: Skipped errors in package"
-        exit_code=0
-    fi
 fi
 popd > /dev/null
 

--- a/.buildkite/scripts/test_one_package.sh
+++ b/.buildkite/scripts/test_one_package.sh
@@ -35,8 +35,17 @@ with_kubernetes
 use_elastic_package
 
 pushd packages > /dev/null
+exit_code=0
 if ! process_package "${package}" "${from}" "${to}"; then
     echo "[${package}] failed"
-    exit 1
+    exit_code=1
+    if [[ "${exit_code}" != 0 && "${package}" == "elastic_connectors" ]]; then
+        # TODO: Remove this skip once elastic_connectors can be installed again
+        # For reference: https://github.com/elastic/kibana/pull/211419
+        echo "[${package}]: Skipped errors in package"
+        exit_code=0
+    fi
 fi
 popd > /dev/null
+
+exit "${exit_code}"


### PR DESCRIPTION
## Proposed commit message

Skip errors in `elastic_connectors` for now.
https://buildkite.com/elastic/integrations/builds/22711#01953abf-f486-41be-a9db-18ecf5d383ae

Error: 
```
Error: can't install the package: could not zip-install package; API status code = 403; response body = {"statusCode":403,"error":"Forbidden","message":"elastic_connectors installation is not authorized"}
```

As reference: https://github.com/elastic/kibana/pull/211419

Example of a Buildkite build skipping error:
https://buildkite.com/elastic/integrations/builds/22753#019541cc-d460-4651-80fc-db6fcf7a0999/585-608

