### PR TITLE
[CI] Set daily jobs to run 7.17.28 instead of snapshot

### DIFF
--- a/.buildkite/pipeline.schedule-daily.yml
+++ b/.buildkite/pipeline.schedule-daily.yml
@@ -21,7 +21,7 @@ steps:
       env:
         SERVERLESS: "false"
         FORCE_CHECK_ALL: "true"
-        STACK_VERSION: 7.17.28-SNAPSHOT
+        STACK_VERSION: 7.17.28
     depends_on:
       - step: "check"
         allow_failure: false

--- a/.github/workflows/updatecli/updatecli.d/bump-latest-7x-version.yml
+++ b/.github/workflows/updatecli/updatecli.d/bump-latest-7x-version.yml
@@ -27,9 +27,14 @@ scms:
 sources:
   latest7xSnapshot:
     name: Get latest 7.x snapshot
-    kind: json
+    kind: file
     spec:
       file: https://storage.googleapis.com/artifacts-api/releases/current/7.17
+    transformers:
+      # Get only the version to avoid spaces and newlines.
+      - findsubmatch:
+          pattern: '([0-9\.]+)'
+          captureindex: 1
 
 targets:
   update-7x-version:

--- a/.github/workflows/updatecli/updatecli.d/bump-latest-7x-version.yml
+++ b/.github/workflows/updatecli/updatecli.d/bump-latest-7x-version.yml
@@ -29,7 +29,7 @@ sources:
     name: Get latest 7.x snapshot
     kind: json
     spec:
-      file: https://storage.googleapis.com/artifacts-api/snapshots/7.17.json
+      file: https://storage.googleapis.com/artifacts-api/releases/current/7.17
       key: .version
 
 targets:

--- a/.github/workflows/updatecli/updatecli.d/bump-latest-7x-version.yml
+++ b/.github/workflows/updatecli/updatecli.d/bump-latest-7x-version.yml
@@ -30,7 +30,6 @@ sources:
     kind: json
     spec:
       file: https://storage.googleapis.com/artifacts-api/releases/current/7.17
-      key: .version
 
 targets:
   update-7x-version:


### PR DESCRIPTION
## Proposed commit message

Set 7.17.28 for the corresponding CI step in daily jobs.

Example of Github Action run updating this step:
https://github.com/elastic/integrations/actions/runs/13542068394/job/37845169395?pr=12899
