### PR TITLE
#11810 - Enabling google_scc with Agentless deployment

### DIFF
--- a/packages/google_scc/_dev/build/docs/README.md
+++ b/packages/google_scc/_dev/build/docs/README.md
@@ -24,29 +24,35 @@ This module has been tested against the latest Google SCC API version **v1**.
 
 ## Requirements
 
-- Elastic Agent must be installed.
+### Agentless Enabled Integration
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
+### Agent Based Installation
+- Elastic Agent must be installed
 - You can install only one Elastic Agent per host.
 - Elastic Agent is required to stream data from the GCP Pub/Sub or REST API and ship the data to Elastic, where the events will then be processed via the integration's ingest pipelines.
 
-### Installing and managing an Elastic Agent:
+#### Installing and managing an Elastic Agent:
 
 You have a few options for installing and managing an Elastic Agent:
 
-### Install a Fleet-managed Elastic Agent (recommended):
+#### Install a Fleet-managed Elastic Agent (recommended):
 
 With this approach, you install Elastic Agent and use Fleet in Kibana to define, configure, and manage your agents in a central location. We recommend using Fleet management because it makes the management and upgrade of your agents considerably easier.
 
-### Install Elastic Agent in standalone mode (advanced users):
+#### Install Elastic Agent in standalone mode (advanced users):
 
 With this approach, you install Elastic Agent and manually configure the agent locally on the system where it’s installed. You are responsible for managing and upgrading the agents. This approach is reserved for advanced users only.
 
-### Install Elastic Agent in a containerized environment:
+#### Install Elastic Agent in a containerized environment:
 
 You can run Elastic Agent inside a container, either with Fleet Server or standalone. Docker images for all versions of Elastic Agent are available from the Elastic Docker registry and we provide deployment manifests for running on Kubernetes.
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-The minimum **kibana.version** required is **8.8.0**.
+The minimum **kibana.version** required is **8.18.0**.
 
 ## Prerequisites
 

--- a/packages/google_scc/changelog.yml
+++ b/packages/google_scc/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.0"
+  changes:
+    - description: Enable Agentless deployment.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.7.1"
   changes:
     - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.

--- a/packages/google_scc/data_stream/asset/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_scc/data_stream/asset/elasticsearch/ingest_pipeline/default.yml
@@ -23,6 +23,11 @@ processors:
       tag: rename_message
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       tag: 'json_decoding'

--- a/packages/google_scc/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_scc/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -11,6 +11,11 @@ processors:
       tag: rename_message
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - set:
       field: event.kind
       tag: set_event_kind

--- a/packages/google_scc/data_stream/finding/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_scc/data_stream/finding/elasticsearch/ingest_pipeline/default.yml
@@ -11,6 +11,11 @@ processors:
       tag: rename_message
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       tag: 'json_decoding'

--- a/packages/google_scc/data_stream/source/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_scc/data_stream/source/elasticsearch/ingest_pipeline/default.yml
@@ -11,6 +11,11 @@ processors:
       tag: rename_message
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - set:
       field: event.kind
       tag: set_event_kind

--- a/packages/google_scc/docs/README.md
+++ b/packages/google_scc/docs/README.md
@@ -24,29 +24,35 @@ This module has been tested against the latest Google SCC API version **v1**.
 
 ## Requirements
 
-- Elastic Agent must be installed.
+### Agentless Enabled Integration
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
+### Agent Based Installation
+- Elastic Agent must be installed
 - You can install only one Elastic Agent per host.
 - Elastic Agent is required to stream data from the GCP Pub/Sub or REST API and ship the data to Elastic, where the events will then be processed via the integration's ingest pipelines.
 
-### Installing and managing an Elastic Agent:
+#### Installing and managing an Elastic Agent:
 
 You have a few options for installing and managing an Elastic Agent:
 
-### Install a Fleet-managed Elastic Agent (recommended):
+#### Install a Fleet-managed Elastic Agent (recommended):
 
 With this approach, you install Elastic Agent and use Fleet in Kibana to define, configure, and manage your agents in a central location. We recommend using Fleet management because it makes the management and upgrade of your agents considerably easier.
 
-### Install Elastic Agent in standalone mode (advanced users):
+#### Install Elastic Agent in standalone mode (advanced users):
 
 With this approach, you install Elastic Agent and manually configure the agent locally on the system where it’s installed. You are responsible for managing and upgrading the agents. This approach is reserved for advanced users only.
 
-### Install Elastic Agent in a containerized environment:
+#### Install Elastic Agent in a containerized environment:
 
 You can run Elastic Agent inside a container, either with Fleet Server or standalone. Docker images for all versions of Elastic Agent are available from the Elastic Docker registry and we provide deployment manifests for running on Kubernetes.
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-The minimum **kibana.version** required is **8.8.0**.
+The minimum **kibana.version** required is **8.18.0**.
 
 ## Prerequisites
 

--- a/packages/google_scc/manifest.yml
+++ b/packages/google_scc/manifest.yml
@@ -1,7 +1,7 @@
-format_version: "3.0.3"
+format_version: "3.2.3"
 name: google_scc
 title: Google Security Command Center
-version: "1.7.1"
+version: "1.8.0"
 description: Collect logs from Google Security Command Center with Elastic Agent.
 type: integration
 categories:
@@ -10,7 +10,7 @@ categories:
   - cloudsecurity_cdr
 conditions:
   kibana:
-    version: "^8.13.0"
+    version: "^8.18.0 || ^9.0.0"
   elastic:
     subscription: basic
 screenshots:
@@ -43,6 +43,14 @@ policy_templates:
   - name: google_scc
     title: Google SCC logs
     description: Collect logs from Google SCC.
+    deployment_modes: 
+      default:
+        enabled: true 
+      agentless:
+        enabled: true
+        organization: security
+        division: engineering
+        team: security-service-integrations
     inputs:
       - type: httpjson
         title: Collect Google SCC logs via API


### PR DESCRIPTION
Parent Ticket:
https://github.com/elastic/integrations/issues/11810

## Proposed commit message
- Updated the documentation based upon agreed upon language to highlight that the integration now supports Agentless deployment
![screencapture-m365-defender-testing-kb-eastus2-staging-azure-foundit-no-app-integrations-detail-google-scc-1-8-0-overview-2025-02-26-14_29_48](https://github.com/user-attachments/assets/6a84742e-f90d-4a34-8b69-eb6bf2c5fc4f)

- Upgraded the `format_version` to latest, 3.2.3
- Updated Kibana version constraints to ^8.18 || ^9.0.0
- Update the default.yml datastream to follow package-spec 3.2.3

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Testing
1. Followed the onboarding to setup a new service account within google with the proper permissions and downloaded the key-json file
2. Enabled Security Command Center API through the activation link
3. Setup the integration to fetch assets through the api
4. Validated that data flowed to ES
5. Validated no noticeable errors were found within the agent diagnostics