### PR TITLE
[AmazonMQ] Add RabbitMQ metrics dataset

### DIFF
--- a/packages/aws_mq/_dev/build/docs/README.md
+++ b/packages/aws_mq/_dev/build/docs/README.md
@@ -11,15 +11,16 @@ The Amazon MQ integration allows you to efficiently collect and monitor broker p
 
 ## Compatibility
 
-This integration presently supports Amazon MQ for [Apache ActiveMQ](http://activemq.apache.org/) metrics.
+This integration presently supports Amazon MQ for [Apache ActiveMQ](http://activemq.apache.org/) and [RabbitMQ](https://www.rabbitmq.com/) metrics.
 
 ## Data streams
 
-The Amazon MQ integration collects Apache ActiveMQ metrics. 
+The Amazon MQ integration collects Apache ActiveMQ and RabbitMQ metrics. 
 
 
 Data streams:
  - `activemq_metrics`: Collects broker metrics and destination (queue and topic) metrics.
+ - `rabbitmq_metrics`: Collects broker, queue and node metrics.
 
 
 ## Requirements
@@ -48,9 +49,9 @@ documentation](https://docs.elastic.co/integrations/aws#requirements).
 
 ## Metrics
 
-### ActiveMQ Metrics
+### ActiveMQ metrics
 
-Amazon MQ provides a range of broker and queue metrics that help monitor system performance, resource utilization, and message flow. These metrics can be used for various use cases, including:
+AmazonMQ for ActiveMQ provides a range of broker and queue metrics that help monitor system performance, resource utilization, and message flow. These metrics can be used for various use cases, including:
 
 - Tracking broker resource utilization, such as compute, memory, and storage.
 - Monitoring message throughput and queue performance.
@@ -66,3 +67,15 @@ The following metrics are related to [Amazon MQ quotas](https://docs.aws.amazon.
 
 {{event "activemq_metrics"}}
 {{fields "activemq_metrics"}}
+
+
+### RabbitMQ metrics
+
+Amazon MQ for RabbitMQ offers a variety of broker and queue metrics to monitor system performance, resource utilization, and message flow. These metrics are essential for:
+
+- Assessing broker resource usage, including CPU, memory, and storage.
+- Tracking message rates and queue depths to ensure efficient message processing.
+- Analyzing connection counts and consumer activity to optimize messaging workloads.
+
+{{event "rabbitmq_metrics"}}
+{{fields "rabbitmq_metrics"}}

--- a/packages/aws_mq/_dev/build/docs/README.md
+++ b/packages/aws_mq/_dev/build/docs/README.md
@@ -51,7 +51,7 @@ documentation](https://docs.elastic.co/integrations/aws#requirements).
 
 ### ActiveMQ metrics
 
-AmazonMQ for ActiveMQ provides a range of broker and queue metrics that help monitor system performance, resource utilization, and message flow. These metrics can be used for various use cases, including:
+Amazon MQ for ActiveMQ provides a range of broker and queue metrics that help monitor system performance, resource utilization, and message flow. These metrics can be used for various use cases, including:
 
 - Tracking broker resource utilization, such as compute, memory, and storage.
 - Monitoring message throughput and queue performance.

--- a/packages/aws_mq/changelog.yml
+++ b/packages/aws_mq/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.3.0"
+  changes:
+    - description: Add rabbitmq_metrics dataset for RabbitMQ metrics.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.2.0"
   changes:
     - description: Add ActiveMQ overview dashboard.

--- a/packages/aws_mq/changelog.yml
+++ b/packages/aws_mq/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add rabbitmq_metrics dataset for RabbitMQ metrics.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/12924
 - version: "0.2.0"
   changes:
     - description: Add ActiveMQ overview dashboard.

--- a/packages/aws_mq/data_stream/rabbitmq_metrics/agent/stream/stream.yml.hbs
+++ b/packages/aws_mq/data_stream/rabbitmq_metrics/agent/stream/stream.yml.hbs
@@ -1,0 +1,74 @@
+metricsets: ["cloudwatch"]
+period: {{period}}
+{{#if data_granularity}}
+data_granularity: {{data_granularity}}
+{{/if}}
+{{#if include_linked_accounts}}
+include_linked_accounts: {{include_linked_accounts}}
+{{#if owning_account}}
+owning_account: "{{owning_account}}"
+{{/if}}
+{{/if}}
+{{#if access_key_id}}
+access_key_id: {{access_key_id}}
+{{/if}}
+{{#if secret_access_key}}
+secret_access_key: {{secret_access_key}}
+{{/if}}
+{{#if session_token}}
+session_token: {{session_token}}
+{{/if}}
+{{#if credential_profile_name}}
+credential_profile_name: {{credential_profile_name}}
+{{/if}}
+{{#if shared_credential_file}}
+shared_credential_file: {{shared_credential_file}}
+{{/if}}
+{{#if role_arn}}
+role_arn: {{role_arn}}
+{{/if}}
+{{#if default_region}}
+default_region: {{default_region}}
+{{/if}}
+{{#if regions}}
+regions:
+{{#each regions as |region|}}
+- {{region}}
+{{/each}}
+{{/if}}
+{{#if latency}}
+latency: {{latency}}
+{{/if}}
+{{#if tags_filter}}
+tags_filter: {{tags_filter}}
+{{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}
+metrics:
+- namespace: AWS/AmazonMQ
+  statistic: ["Maximum"]
+  name:
+  - ExchangeCount
+  - QueueCount
+  - ConnectionCount
+  - ChannelCount
+  - ConsumerCount
+  - MessageCount
+  - MessageReadyCount
+  - MessageUnacknowledgedCount
+  - PublishRate
+  - ConfirmRate
+  - AckRate
+  - SystemCpuUtilization	
+  - RabbitMQMemLimit
+  - RabbitMQMemUsed
+  - RabbitMQDiskFreeLimit
+  - RabbitMQDiskFree
+  - RabbitMQFdUsed
+  - RabbitMQIOReadAverageTime
+  - RabbitMQIOWriteAverageTime

--- a/packages/aws_mq/data_stream/rabbitmq_metrics/agent/stream/stream.yml.hbs
+++ b/packages/aws_mq/data_stream/rabbitmq_metrics/agent/stream/stream.yml.hbs
@@ -73,4 +73,5 @@ metrics:
   - RabbitMQIOWriteAverageTime
 - namespace: AWS/AmazonMQ
   statistic: ["Maximum"]
+  name:
   - RabbitMQDiskFree

--- a/packages/aws_mq/data_stream/rabbitmq_metrics/agent/stream/stream.yml.hbs
+++ b/packages/aws_mq/data_stream/rabbitmq_metrics/agent/stream/stream.yml.hbs
@@ -68,7 +68,9 @@ metrics:
   - RabbitMQMemLimit
   - RabbitMQMemUsed
   - RabbitMQDiskFreeLimit
-  - RabbitMQDiskFree
   - RabbitMQFdUsed
   - RabbitMQIOReadAverageTime
   - RabbitMQIOWriteAverageTime
+- namespace: AWS/AmazonMQ
+  statistic: ["Maximum"]
+  - RabbitMQDiskFree

--- a/packages/aws_mq/data_stream/rabbitmq_metrics/agent/stream/stream.yml.hbs
+++ b/packages/aws_mq/data_stream/rabbitmq_metrics/agent/stream/stream.yml.hbs
@@ -72,6 +72,6 @@ metrics:
   - RabbitMQIOReadAverageTime
   - RabbitMQIOWriteAverageTime
 - namespace: AWS/AmazonMQ
-  statistic: ["Maximum"]
+  statistic: ["Minimum"]
   name:
   - RabbitMQDiskFree

--- a/packages/aws_mq/data_stream/rabbitmq_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws_mq/data_stream/rabbitmq_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,45 @@
+---
+description: Pipeline of RabbitMQ metrics
+processors:
+  - dot_expander:
+      field: "*"
+      ignore_failure: true
+  - drop:
+      description: "To drop the documents having RabbitMQ metrics"
+      if: >
+        ctx.aws?.amazonmq?.metrics?.size() == 1 &&
+        ctx.aws.amazonmq.metrics.ConsumerCount?.max != null
+      ignore_failure: true
+  - rename:
+      field: "aws.amazonmq.metrics"
+      target_field: "aws.amazonmq.metrics.rabbitmq.broker"
+      ignore_missing: true
+      if: >
+        ctx.aws?.dimensions?.Broker != null &&
+        (ctx.aws?.dimensions?.Node == null && ctx.aws?.dimensions?.Queue == null )
+  - rename:
+      field: "aws.amazonmq.metrics"
+      target_field: "aws.amazonmq.metrics.rabbitmq.node"
+      ignore_missing: true
+      if: >
+        ctx.aws?.dimensions?.Broker != null &&
+        (ctx.aws?.dimensions?.Node != null )
+  - rename:
+      field: "aws.amazonmq.metrics"
+      target_field: "aws.amazonmq.metrics.rabbitmq.queue"
+      ignore_missing: true
+      if: >
+        ctx.aws?.dimensions?.Broker != null &&
+        (ctx.aws?.dimensions?.Queue != null )
+
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+  - set:
+      field: error.message
+      value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'

--- a/packages/aws_mq/data_stream/rabbitmq_metrics/fields/base-fields.yml
+++ b/packages/aws_mq/data_stream/rabbitmq_metrics/fields/base-fields.yml
@@ -1,0 +1,16 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.
+- name: '@timestamp'
+  type: date
+  description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  external: ecs
+  value: aws

--- a/packages/aws_mq/data_stream/rabbitmq_metrics/fields/ecs.yml
+++ b/packages/aws_mq/data_stream/rabbitmq_metrics/fields/ecs.yml
@@ -1,0 +1,9 @@
+- external: ecs
+  name: cloud.account.id
+  dimension: true
+- external: ecs
+  name: cloud.region
+  dimension: true
+- name: agent.id
+  external: ecs
+  dimension: true

--- a/packages/aws_mq/data_stream/rabbitmq_metrics/fields/fields.yml
+++ b/packages/aws_mq/data_stream/rabbitmq_metrics/fields/fields.yml
@@ -1,0 +1,176 @@
+- name: aws
+  type: group
+  fields:
+    - name: dimensions
+      type: group
+      fields:
+        - name: Broker
+          description: The name of the broker.
+          type: keyword
+          dimension: true
+        - name: Node
+          description: The name of the node.
+          type: keyword
+          dimension: true
+        - name: Queue
+          description: The name of the queue.
+          type: keyword
+          dimension: true
+        - name: VirtualHost
+          description: The name of the virtual host.
+          type: keyword
+          dimension: true
+    - name: cloudwatch.namespace
+      type: keyword
+      description: The namespace specified when query cloudwatch api.
+    - name: amazonmq.metrics.rabbitmq
+      type: group
+      fields:
+        - name: broker
+          type: group
+          fields:
+            - name: ExchangeCount.max
+              metric_type: gauge
+              type: long
+              description: The total number of exchanges configured on the broker.
+            - name: QueueCount.max
+              metric_type: gauge
+              type: long
+              description: The total number of queues configured on the broker.
+            - name: ConnectionCount.max
+              metric_type: gauge
+              type: long
+              description: The total number of connections established on the broker.
+            - name: ChannelCount.max
+              metric_type: gauge
+              type: long
+              description: The total number of channels established on the broker.
+            - name: ConsumerCount.max
+              metric_type: gauge
+              type: long
+              description: The total number of consumers connected to the broker.
+            - name: MessageCount.max
+              metric_type: gauge
+              type: long
+              description: The total number of messages in the queues.
+            - name: MessageReadyCount.max
+              metric_type: gauge
+              type: long
+              description: The total number of ready messages in the queues.
+            - name: MessageUnacknowledgedCount.max
+              metric_type: gauge
+              type: long
+              description: The total number of unacknowledged messages in the queues.
+            - name: PublishRate.max
+              metric_type: gauge
+              type: long
+              description: The rate at which messages are published to the broker.
+            - name: ConfirmRate.max
+              metric_type: gauge
+              type: long
+              description: The rate at which the RabbitMQ server is confirming published messages.
+            - name: AckRate.max
+              metric_type: gauge
+              type: long
+              description: The rate at which messages are being acknowledged by consumers.
+            - name: SystemCpuUtilization.max
+              metric_type: gauge
+              type: long
+              unit: percent
+              description: The percentage of allocated Amazon EC2 compute units that the broker currently uses. For cluster deployments, this value represents the aggregate of all three RabbitMQ nodes' corresponding metric values.
+            - name: RabbitMQMemLimit.max
+              metric_type: gauge
+              type: long
+              unit: byte
+              description: The RAM limit for a RabbitMQ broker. For cluster deployments, this value represents the aggregate of all RabbitMQ nodes' corresponding metric values.
+            - name: RabbitMQMemUsed.max
+              metric_type: gauge
+              type: long
+              unit: byte
+              description: The volume of RAM used by a RabbitMQ broker. For cluster deployments, this value represents the aggregate of all RabbitMQ nodes' corresponding metric values.
+            - name: RabbitMQDiskFreeLimit.max
+              metric_type: gauge
+              type: long
+              unit: byte
+              description: The disk limit for a RabbitMQ broker. For cluster deployments, this value represents the aggregate of all RabbitMQ nodes' corresponding metric values.
+            - name: RabbitMQDiskFree.max
+              metric_type: gauge
+              type: long
+              unit: byte
+              description: The total volume of free disk space available in a RabbitMQ broker. For cluster deployments, this value represents the aggregate of all RabbitMQ nodes' corresponding metric values.
+            - name: RabbitMQFdUsed.max
+              metric_type: gauge
+              type: long
+              description: The number of file descriptors used. For cluster deployments, this value represents the aggregate of all RabbitMQ nodes' corresponding metric values.
+            - name: RabbitMQIOReadAverageTime.max
+              metric_type: gauge
+              type: long
+              unit: ms
+              description: The average time for RabbitMQ to perform one read operation.
+            - name: RabbitMQIOWriteAverageTime.max
+              metric_type: gauge
+              type: long
+              unit: ms
+              description: The average time for RabbitMQ to perform one write operation.
+        - name: node
+          type: group
+          fields:
+            - name: SystemCpuUtilization.max
+              metric_type: gauge
+              type: long
+              unit: percent
+              description: The percentage of allocated Amazon EC2 compute units that the broker currently uses.
+            - name: RabbitMQMemLimit.max
+              metric_type: gauge
+              type: long
+              unit: byte
+              description: The RAM limit for a RabbitMQ node.
+            - name: RabbitMQMemUsed.max
+              metric_type: gauge
+              type: long
+              unit: byte
+              description: The volume of RAM used by a RabbitMQ node.
+            - name: RabbitMQDiskFreeLimit.max
+              metric_type: gauge
+              type: long
+              unit: byte
+              description: The disk limit for a RabbitMQ node.
+            - name: RabbitMQDiskFree.max
+              metric_type: gauge
+              type: long
+              unit: byte
+              description: The total volume of free disk space available in a RabbitMQ node.
+            - name: RabbitMQFdUsed.max
+              metric_type: gauge
+              type: long
+              unit: byte
+              description: Number of file descriptors used.
+            - name: RabbitMQIOReadAverageTime.max
+              metric_type: gauge
+              type: long
+              unit: ms
+              description: The average time for RabbitMQ to perform one read operation.
+            - name: RabbitMQIOWriteAverageTime.max
+              metric_type: gauge
+              type: long
+              unit: ms
+              description: The average time for RabbitMQ to perform one write operation.
+        - name: queue
+          type: group
+          fields:
+            - name: ConsumerCount.max
+              metric_type: gauge
+              type: long
+              description: The number of consumers subscribed to the queue.
+            - name: MessageReadyCount.max
+              metric_type: gauge
+              type: long
+              description: The number of messages that are currently available to be delivered.
+            - name: MessageUnacknowledgedCount.max
+              metric_type: gauge
+              type: long
+              description: The number of messages for which the server is awaiting acknowledgement.
+            - name: MessageCount.max
+              metric_type: gauge
+              type: long
+              description: The total number of MessageReadyCount and MessageUnacknowledgedCount, referred to as queue depth.

--- a/packages/aws_mq/data_stream/rabbitmq_metrics/fields/fields.yml
+++ b/packages/aws_mq/data_stream/rabbitmq_metrics/fields/fields.yml
@@ -135,7 +135,7 @@
               type: long
               unit: byte
               description: The disk limit for a RabbitMQ node.
-            - name: RabbitMQDiskFree.max
+            - name: RabbitMQDiskFree.min
               metric_type: gauge
               type: long
               unit: byte

--- a/packages/aws_mq/data_stream/rabbitmq_metrics/fields/fields.yml
+++ b/packages/aws_mq/data_stream/rabbitmq_metrics/fields/fields.yml
@@ -93,7 +93,7 @@
               type: long
               unit: byte
               description: The disk limit for a RabbitMQ broker. For cluster deployments, this value represents the aggregate of all RabbitMQ nodes' corresponding metric values.
-            - name: RabbitMQDiskFree.max
+            - name: RabbitMQDiskFree.min
               metric_type: gauge
               type: long
               unit: byte

--- a/packages/aws_mq/data_stream/rabbitmq_metrics/manifest.yml
+++ b/packages/aws_mq/data_stream/rabbitmq_metrics/manifest.yml
@@ -1,0 +1,67 @@
+title: "RabbitMQ Metrics"
+type: metrics
+streams:
+  - input: aws/metrics
+    title: RabbitMQ metrics
+    description: Collect RabbitMQ metrics
+    vars:
+      - name: period
+        type: text
+        title: Collection Period
+        multi: false
+        required: true
+        show_user: true
+        default: 5m
+      - name: data_granularity
+        type: text
+        title: Data Granularity
+        multi: false
+        required: false
+        show_user: false
+      - name: regions
+        type: text
+        title: Regions
+        multi: true
+        required: false
+        show_user: true
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
+      - name: tags_filter
+        type: yaml
+        title: Tags Filter
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          # - key: "created-by"
+            # value: "foo"
+      - name: include_linked_accounts
+        type: bool
+        title: Include Linked Accounts
+        multi: false
+        required: false
+        show_user: false
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
+      - name: owning_account
+        type: integer
+        title: Owning Account
+        multi: false
+        required: false
+        show_user: false
+        description: Accepts an AWS account ID linked to the monitoring account. Works only if include_linked_accounts is set to true. If set, monitoring data will only include data from the given account.
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
+elasticsearch:
+  index_mode: time_series

--- a/packages/aws_mq/data_stream/rabbitmq_metrics/sample_event.json
+++ b/packages/aws_mq/data_stream/rabbitmq_metrics/sample_event.json
@@ -1,0 +1,97 @@
+{
+    "@timestamp": "2025-02-28T10:05:00.000Z",
+    "agent": {
+        "ephemeral_id": "fc4c4367-978d-456e-8738-d7cae2319a83",
+        "id": "151607dd-a8d5-462b-995f-752c336930d8",
+        "name": "elastic-agent-97629",
+        "type": "metricbeat",
+        "version": "8.16.2"
+    },
+    "aws": {
+        "amazonmq": {
+            "metrics": {
+                "rabbitmq": {
+                    "queue": {
+                        "ConsumerCount": {
+                            "max": 0
+                        },
+                        "MessageCount": {
+                            "max": 0
+                        },
+                        "MessageReadyCount": {
+                            "max": 0
+                        },
+                        "MessageUnacknowledgedCount": {
+                            "max": 0
+                        }
+                    }
+                }
+            }
+        },
+        "cloudwatch": {
+            "namespace": "AWS/AmazonMQ"
+        },
+        "dimensions": {
+            "Broker": "ObsIntegrations-RabbitMQ",
+            "Queue": "obs-infra queue",
+            "VirtualHost": "/"
+        }
+    },
+    "cloud": {
+        "account": {
+            "id": "11111111111",
+            "name": "MonitoringAccount"
+        },
+        "provider": "aws",
+        "region": "ap-south-1"
+    },
+    "data_stream": {
+        "dataset": "aws_mq.rabbitmq_metrics",
+        "namespace": "16654",
+        "type": "metrics"
+    },
+    "ecs": {
+        "version": "8.0.0"
+    },
+    "elastic_agent": {
+        "id": "151607dd-a8d5-462b-995f-752c336930d8",
+        "snapshot": false,
+        "version": "8.16.2"
+    },
+    "event": {
+        "agent_id_status": "verified",
+        "dataset": "aws_mq.rabbitmq_metrics",
+        "duration": 117138104,
+        "ingested": "2025-02-28T10:10:52Z",
+        "module": "aws"
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": true,
+        "hostname": "elastic-agent-97629",
+        "ip": [
+            "192.168.192.2",
+            "192.168.0.4"
+        ],
+        "mac": [
+            "02-42-C0-A8-00-04",
+            "02-42-C0-A8-C0-02"
+        ],
+        "name": "elastic-agent-97629",
+        "os": {
+            "family": "",
+            "kernel": "5.4.0-1106-gcp",
+            "name": "Wolfi",
+            "platform": "wolfi",
+            "type": "linux",
+            "version": "20230201"
+        }
+    },
+    "metricset": {
+        "name": "cloudwatch",
+        "period": 300000
+    },
+    "service": {
+        "type": "aws"
+    }
+}

--- a/packages/aws_mq/docs/README.md
+++ b/packages/aws_mq/docs/README.md
@@ -11,15 +11,16 @@ The Amazon MQ integration allows you to efficiently collect and monitor broker p
 
 ## Compatibility
 
-This integration presently supports Amazon MQ for [Apache ActiveMQ](http://activemq.apache.org/) metrics.
+This integration presently supports Amazon MQ for [Apache ActiveMQ](http://activemq.apache.org/) and [RabbitMQ](https://www.rabbitmq.com/) metrics.
 
 ## Data streams
 
-The Amazon MQ integration collects Apache ActiveMQ metrics. 
+The Amazon MQ integration collects Apache ActiveMQ and RabbitMQ metrics. 
 
 
 Data streams:
  - `activemq_metrics`: Collects broker metrics and destination (queue and topic) metrics.
+ - `rabbitmq_metrics`: Collects broker, queue and node metrics.
 
 
 ## Requirements
@@ -48,9 +49,9 @@ documentation](https://docs.elastic.co/integrations/aws#requirements).
 
 ## Metrics
 
-### ActiveMQ Metrics
+### ActiveMQ metrics
 
-Amazon MQ provides a range of broker and queue metrics that help monitor system performance, resource utilization, and message flow. These metrics can be used for various use cases, including:
+AmazonMQ for ActiveMQ provides a range of broker and queue metrics that help monitor system performance, resource utilization, and message flow. These metrics can be used for various use cases, including:
 
 - Tracking broker resource utilization, such as compute, memory, and storage.
 - Monitoring message throughput and queue performance.
@@ -275,6 +276,166 @@ An example event for `activemq` looks as following:
 | aws.dimensions.NetworkConnector | The name of the network connector. | keyword |  |  |
 | aws.dimensions.Queue | The name of the queue. | keyword |  |  |
 | aws.dimensions.Topic | The name of the topic. | keyword |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | constant_keyword |  |  |
+
+
+
+### RabbitMQ metrics
+
+Amazon MQ for RabbitMQ offers a variety of broker and queue metrics to monitor system performance, resource utilization, and message flow. These metrics are essential for:
+
+- Assessing broker resource usage, including CPU, memory, and storage.
+- Tracking message rates and queue depths to ensure efficient message processing.
+- Analyzing connection counts and consumer activity to optimize messaging workloads.
+
+An example event for `rabbitmq` looks as following:
+
+```json
+{
+    "@timestamp": "2025-02-28T10:05:00.000Z",
+    "agent": {
+        "ephemeral_id": "fc4c4367-978d-456e-8738-d7cae2319a83",
+        "id": "151607dd-a8d5-462b-995f-752c336930d8",
+        "name": "elastic-agent-97629",
+        "type": "metricbeat",
+        "version": "8.16.2"
+    },
+    "aws": {
+        "amazonmq": {
+            "metrics": {
+                "rabbitmq": {
+                    "queue": {
+                        "ConsumerCount": {
+                            "max": 0
+                        },
+                        "MessageCount": {
+                            "max": 0
+                        },
+                        "MessageReadyCount": {
+                            "max": 0
+                        },
+                        "MessageUnacknowledgedCount": {
+                            "max": 0
+                        }
+                    }
+                }
+            }
+        },
+        "cloudwatch": {
+            "namespace": "AWS/AmazonMQ"
+        },
+        "dimensions": {
+            "Broker": "ObsIntegrations-RabbitMQ",
+            "Queue": "obs-infra queue",
+            "VirtualHost": "/"
+        }
+    },
+    "cloud": {
+        "account": {
+            "id": "11111111111",
+            "name": "MonitoringAccount"
+        },
+        "provider": "aws",
+        "region": "ap-south-1"
+    },
+    "data_stream": {
+        "dataset": "aws_mq.rabbitmq_metrics",
+        "namespace": "16654",
+        "type": "metrics"
+    },
+    "ecs": {
+        "version": "8.0.0"
+    },
+    "elastic_agent": {
+        "id": "151607dd-a8d5-462b-995f-752c336930d8",
+        "snapshot": false,
+        "version": "8.16.2"
+    },
+    "event": {
+        "agent_id_status": "verified",
+        "dataset": "aws_mq.rabbitmq_metrics",
+        "duration": 117138104,
+        "ingested": "2025-02-28T10:10:52Z",
+        "module": "aws"
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": true,
+        "hostname": "elastic-agent-97629",
+        "ip": [
+            "192.168.192.2",
+            "192.168.0.4"
+        ],
+        "mac": [
+            "02-42-C0-A8-00-04",
+            "02-42-C0-A8-C0-02"
+        ],
+        "name": "elastic-agent-97629",
+        "os": {
+            "family": "",
+            "kernel": "5.4.0-1106-gcp",
+            "name": "Wolfi",
+            "platform": "wolfi",
+            "type": "linux",
+            "version": "20230201"
+        }
+    },
+    "metricset": {
+        "name": "cloudwatch",
+        "period": 300000
+    },
+    "service": {
+        "type": "aws"
+    }
+}
+```
+**Exported fields**
+
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |  |
+| aws.amazonmq.metrics.rabbitmq.broker.AckRate.max | The rate at which messages are being acknowledged by consumers. | long |  | gauge |
+| aws.amazonmq.metrics.rabbitmq.broker.ChannelCount.max | The total number of channels established on the broker. | long |  | gauge |
+| aws.amazonmq.metrics.rabbitmq.broker.ConfirmRate.max | The rate at which the RabbitMQ server is confirming published messages. | long |  | gauge |
+| aws.amazonmq.metrics.rabbitmq.broker.ConnectionCount.max | The total number of connections established on the broker. | long |  | gauge |
+| aws.amazonmq.metrics.rabbitmq.broker.ConsumerCount.max | The total number of consumers connected to the broker. | long |  | gauge |
+| aws.amazonmq.metrics.rabbitmq.broker.ExchangeCount.max | The total number of exchanges configured on the broker. | long |  | gauge |
+| aws.amazonmq.metrics.rabbitmq.broker.MessageCount.max | The total number of messages in the queues. | long |  | gauge |
+| aws.amazonmq.metrics.rabbitmq.broker.MessageReadyCount.max | The total number of ready messages in the queues. | long |  | gauge |
+| aws.amazonmq.metrics.rabbitmq.broker.MessageUnacknowledgedCount.max | The total number of unacknowledged messages in the queues. | long |  | gauge |
+| aws.amazonmq.metrics.rabbitmq.broker.PublishRate.max | The rate at which messages are published to the broker. | long |  | gauge |
+| aws.amazonmq.metrics.rabbitmq.broker.QueueCount.max | The total number of queues configured on the broker. | long |  | gauge |
+| aws.amazonmq.metrics.rabbitmq.broker.RabbitMQDiskFree.max | The total volume of free disk space available in a RabbitMQ broker. For cluster deployments, this value represents the aggregate of all RabbitMQ nodes' corresponding metric values. | long | byte | gauge |
+| aws.amazonmq.metrics.rabbitmq.broker.RabbitMQDiskFreeLimit.max | The disk limit for a RabbitMQ broker. For cluster deployments, this value represents the aggregate of all RabbitMQ nodes' corresponding metric values. | long | byte | gauge |
+| aws.amazonmq.metrics.rabbitmq.broker.RabbitMQFdUsed.max | The number of file descriptors used. For cluster deployments, this value represents the aggregate of all RabbitMQ nodes' corresponding metric values. | long |  | gauge |
+| aws.amazonmq.metrics.rabbitmq.broker.RabbitMQIOReadAverageTime.max | The average time for RabbitMQ to perform one read operation. | long | ms | gauge |
+| aws.amazonmq.metrics.rabbitmq.broker.RabbitMQIOWriteAverageTime.max | The average time for RabbitMQ to perform one write operation. | long | ms | gauge |
+| aws.amazonmq.metrics.rabbitmq.broker.RabbitMQMemLimit.max | The RAM limit for a RabbitMQ broker. For cluster deployments, this value represents the aggregate of all RabbitMQ nodes' corresponding metric values. | long | byte | gauge |
+| aws.amazonmq.metrics.rabbitmq.broker.RabbitMQMemUsed.max | The volume of RAM used by a RabbitMQ broker. For cluster deployments, this value represents the aggregate of all RabbitMQ nodes' corresponding metric values. | long | byte | gauge |
+| aws.amazonmq.metrics.rabbitmq.broker.SystemCpuUtilization.max | The percentage of allocated Amazon EC2 compute units that the broker currently uses. For cluster deployments, this value represents the aggregate of all three RabbitMQ nodes' corresponding metric values. | long | percent | gauge |
+| aws.amazonmq.metrics.rabbitmq.node.RabbitMQDiskFree.max | The total volume of free disk space available in a RabbitMQ node. | long | byte | gauge |
+| aws.amazonmq.metrics.rabbitmq.node.RabbitMQDiskFreeLimit.max | The disk limit for a RabbitMQ node. | long | byte | gauge |
+| aws.amazonmq.metrics.rabbitmq.node.RabbitMQFdUsed.max | Number of file descriptors used. | long | byte | gauge |
+| aws.amazonmq.metrics.rabbitmq.node.RabbitMQIOReadAverageTime.max | The average time for RabbitMQ to perform one read operation. | long | ms | gauge |
+| aws.amazonmq.metrics.rabbitmq.node.RabbitMQIOWriteAverageTime.max | The average time for RabbitMQ to perform one write operation. | long | ms | gauge |
+| aws.amazonmq.metrics.rabbitmq.node.RabbitMQMemLimit.max | The RAM limit for a RabbitMQ node. | long | byte | gauge |
+| aws.amazonmq.metrics.rabbitmq.node.RabbitMQMemUsed.max | The volume of RAM used by a RabbitMQ node. | long | byte | gauge |
+| aws.amazonmq.metrics.rabbitmq.node.SystemCpuUtilization.max | The percentage of allocated Amazon EC2 compute units that the broker currently uses. | long | percent | gauge |
+| aws.amazonmq.metrics.rabbitmq.queue.ConsumerCount.max | The number of consumers subscribed to the queue. | long |  | gauge |
+| aws.amazonmq.metrics.rabbitmq.queue.MessageCount.max | The total number of MessageReadyCount and MessageUnacknowledgedCount, referred to as queue depth. | long |  | gauge |
+| aws.amazonmq.metrics.rabbitmq.queue.MessageReadyCount.max | The number of messages that are currently available to be delivered. | long |  | gauge |
+| aws.amazonmq.metrics.rabbitmq.queue.MessageUnacknowledgedCount.max | The number of messages for which the server is awaiting acknowledgement. | long |  | gauge |
+| aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |  |
+| aws.dimensions.Broker | The name of the broker. | keyword |  |  |
+| aws.dimensions.Node | The name of the node. | keyword |  |  |
+| aws.dimensions.Queue | The name of the queue. | keyword |  |  |
+| aws.dimensions.VirtualHost | The name of the virtual host. | keyword |  |  |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
 | cloud.region | Region in which this host, resource, or service is located. | keyword |  |  |
 | data_stream.dataset | Data stream dataset. | constant_keyword |  |  |

--- a/packages/aws_mq/docs/README.md
+++ b/packages/aws_mq/docs/README.md
@@ -419,7 +419,7 @@ An example event for `rabbitmq` looks as following:
 | aws.amazonmq.metrics.rabbitmq.broker.RabbitMQMemLimit.max | The RAM limit for a RabbitMQ broker. For cluster deployments, this value represents the aggregate of all RabbitMQ nodes' corresponding metric values. | long | byte | gauge |
 | aws.amazonmq.metrics.rabbitmq.broker.RabbitMQMemUsed.max | The volume of RAM used by a RabbitMQ broker. For cluster deployments, this value represents the aggregate of all RabbitMQ nodes' corresponding metric values. | long | byte | gauge |
 | aws.amazonmq.metrics.rabbitmq.broker.SystemCpuUtilization.max | The percentage of allocated Amazon EC2 compute units that the broker currently uses. For cluster deployments, this value represents the aggregate of all three RabbitMQ nodes' corresponding metric values. | long | percent | gauge |
-| aws.amazonmq.metrics.rabbitmq.node.RabbitMQDiskFree.max | The total volume of free disk space available in a RabbitMQ node. | long | byte | gauge |
+| aws.amazonmq.metrics.rabbitmq.node.RabbitMQDiskFree.min | The total volume of free disk space available in a RabbitMQ node. | long | byte | gauge |
 | aws.amazonmq.metrics.rabbitmq.node.RabbitMQDiskFreeLimit.max | The disk limit for a RabbitMQ node. | long | byte | gauge |
 | aws.amazonmq.metrics.rabbitmq.node.RabbitMQFdUsed.max | Number of file descriptors used. | long | byte | gauge |
 | aws.amazonmq.metrics.rabbitmq.node.RabbitMQIOReadAverageTime.max | The average time for RabbitMQ to perform one read operation. | long | ms | gauge |

--- a/packages/aws_mq/docs/README.md
+++ b/packages/aws_mq/docs/README.md
@@ -411,7 +411,7 @@ An example event for `rabbitmq` looks as following:
 | aws.amazonmq.metrics.rabbitmq.broker.MessageUnacknowledgedCount.max | The total number of unacknowledged messages in the queues. | long |  | gauge |
 | aws.amazonmq.metrics.rabbitmq.broker.PublishRate.max | The rate at which messages are published to the broker. | long |  | gauge |
 | aws.amazonmq.metrics.rabbitmq.broker.QueueCount.max | The total number of queues configured on the broker. | long |  | gauge |
-| aws.amazonmq.metrics.rabbitmq.broker.RabbitMQDiskFree.max | The total volume of free disk space available in a RabbitMQ broker. For cluster deployments, this value represents the aggregate of all RabbitMQ nodes' corresponding metric values. | long | byte | gauge |
+| aws.amazonmq.metrics.rabbitmq.broker.RabbitMQDiskFree.min | The total volume of free disk space available in a RabbitMQ broker. For cluster deployments, this value represents the aggregate of all RabbitMQ nodes' corresponding metric values. | long | byte | gauge |
 | aws.amazonmq.metrics.rabbitmq.broker.RabbitMQDiskFreeLimit.max | The disk limit for a RabbitMQ broker. For cluster deployments, this value represents the aggregate of all RabbitMQ nodes' corresponding metric values. | long | byte | gauge |
 | aws.amazonmq.metrics.rabbitmq.broker.RabbitMQFdUsed.max | The number of file descriptors used. For cluster deployments, this value represents the aggregate of all RabbitMQ nodes' corresponding metric values. | long |  | gauge |
 | aws.amazonmq.metrics.rabbitmq.broker.RabbitMQIOReadAverageTime.max | The average time for RabbitMQ to perform one read operation. | long | ms | gauge |

--- a/packages/aws_mq/docs/README.md
+++ b/packages/aws_mq/docs/README.md
@@ -51,7 +51,7 @@ documentation](https://docs.elastic.co/integrations/aws#requirements).
 
 ### ActiveMQ metrics
 
-AmazonMQ for ActiveMQ provides a range of broker and queue metrics that help monitor system performance, resource utilization, and message flow. These metrics can be used for various use cases, including:
+Amazon MQ for ActiveMQ provides a range of broker and queue metrics that help monitor system performance, resource utilization, and message flow. These metrics can be used for various use cases, including:
 
 - Tracking broker resource utilization, such as compute, memory, and storage.
 - Monitoring message throughput and queue performance.

--- a/packages/aws_mq/manifest.yml
+++ b/packages/aws_mq/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.1
 name: aws_mq
 title: "Amazon MQ"
-version: 0.2.0
+version: 0.3.0
 description: "Collect Amazon MQ metrics with Elastic Agent"
 type: integration
 categories:


### PR DESCRIPTION
- Enhancement

## Proposed commit message

- Add support for RabbitMQ metrics.
- Add minor documentation updates.


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

- [x] Integration testing with producer clients and consumer clients
- [x] Comparison of values with RabbitMQ console metrics
- [x] Metrics dependencies on dimensions and adjustments
- [x] TSDS enablement testing

## How to test this PR locally

- `elastic-package build`
- `elastic-package stack up -v -d --services package-registry`


## Screenshots

![image](https://github.com/user-attachments/assets/fb65058e-f84f-477d-92da-397004a562dc)