### PR TITLE
[docs] Clean up cross-repo links

### DIFF
--- a/docs/extend/developer-tsds-guidelines.md
+++ b/docs/extend/developer-tsds-guidelines.md
@@ -44,7 +44,7 @@ To set a field as a dimension simply add `dimension: true` to its mapping:
 ```
 
 ::::{note}
-A field having type [flattened](elasticsearch://docs/reference/elasticsearch/mapping-reference/flattened.md) cannot be selected as a dimension field. If the field that you are choosing as a dimension is too long or is of type flattened, consider hashing the value of this field and using the result as a dimension. [Fingerprint processor](elasticsearch://docs/reference/ingestion-tools/enrich-processor/fingerprint-processor.md) can be used for this purpose.
+A field having type [flattened](elasticsearch://reference/elasticsearch/mapping-reference/flattened.md) cannot be selected as a dimension field. If the field that you are choosing as a dimension is too long or is of type flattened, consider hashing the value of this field and using the result as a dimension. [Fingerprint processor](elasticsearch://reference/ingestion-tools/enrich-processor/fingerprint-processor.md) can be used for this purpose.
 
 You can find an example in [Oracle Integration TSDS Enablement Example](https://github.com/elastic/integrations/blob/8a57d6ba96d391afc33da20c80ec51280d22f009/packages/oracle/data_stream/performance/elasticsearch/ingest_pipeline/default.yml#LL127C4-L131C29)
 
@@ -163,7 +163,7 @@ elasticsearch:
 
 * Use [Lens](docs-content://explore-analyze/visualize/lens.md) as the preferred visualisation type.
 * Always assess the number of unique values the field that is selected to be a dimension would hold, especially if it is a numeric field. A field that holds millions of unique values may not be an ideal candidate for becoming a dimension field.
-* If the dimension field value length is very long (max limit is 1024B), consider transforming the value to hash value representation. [Fingerprint processor](elasticsearch://docs/reference/ingestion-tools/enrich-processor/fingerprint-processor.md) can be used for this purpose.
+* If the dimension field value length is very long (max limit is 1024B), consider transforming the value to hash value representation. [Fingerprint processor](elasticsearch://reference/ingestion-tools/enrich-processor/fingerprint-processor.md) can be used for this purpose.
 * In the field mapping files above each dimension field, add in-line comments stating the reason for selecting the field as a dimension field.
 * As part of TSDS migration testing, you may discover other errors which may be unrelated to TSDS migration. Keep the pull request for TSDS migration free from such changes. This helps in obtaining quick PR approval.
 

--- a/docs/extend/edit-ingest-pipeline.md
+++ b/docs/extend/edit-ingest-pipeline.md
@@ -52,4 +52,4 @@ processors:
 
 Open each `elasticsearch/ingest_pipeline/default.yml` file created for each data stream. Edit each ingest pipeline to match your needs.
 
-The [processor reference](elasticsearch://docs/reference/ingestion-tools/enrich-processor/index.md) provides a list of all available processors and their configurations.
+The [processor reference](elasticsearch://reference/ingestion-tools/enrich-processor/index.md) provides a list of all available processors and their configurations.

--- a/docs/extend/general-guidelines.md
+++ b/docs/extend/general-guidelines.md
@@ -57,7 +57,7 @@ As part of the field definition, there are two settings that add metadata which 
 * `unit` applies to all data types, defines the units of the field. Examples of units are `byte` and `ms`. When using `percent` for percentages, the convention is to use 1 for 100%. You can find the full list of supported units in the [package spec](https://github.com/elastic/package-spec/blob/ff8286d0c40ad76bb082e9c8ea78f4551c2519c1/spec/integration/data_stream/fields/fields.spec.yml#L103).
 * `metric_type` applies to metric events only, to be added to metric fields. It defines their metric type. It can be of type `gauge` or `counter`. Counters are used for metrics that always increase over time, such as number of page visits. Gauges are used for amounts that can increase or decrease over time, such as the amount of memory being used.
 
-The Elasticsearch documentation details the [expected values for these two fields](elasticsearch://docs/reference/elasticsearch/mapping-reference/mapping-field-meta.md).
+The Elasticsearch documentation details the [expected values for these two fields](elasticsearch://reference/elasticsearch/mapping-reference/mapping-field-meta.md).
 
 Other applications, including Kibana, can use the information provided by this metadata when accessing these fields. The `unit` is used when formatting the values of the field, and the `metric_type` can be used to provide better defaults when quering the data.
 

--- a/docs/extend/quick-start.md
+++ b/docs/extend/quick-start.md
@@ -138,7 +138,7 @@ You’ve now built an integration package, but it does not contain any assets. F
 
         The command creates the required data in the `/data_stream/log` directory. If you pick `log` as data stream name, the dataset is called `sample.log` and the final data stream created will be `logs-sample.log-default` as an example.
 
-3. To not have to worry about mappings, you can pull in all [Elastic Common Schema (ECS) fields][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). To do this, create the file `_dev/build/build.yml` under the root directory and add the following content:
+3. To not have to worry about mappings, you can pull in all [Elastic Common Schema (ECS) fields][Elastic Common Schema (ECS)](ecs://reference/index.md)). To do this, create the file `_dev/build/build.yml` under the root directory and add the following content:
 
     ```yaml
     dependencies:


### PR DESCRIPTION
Follow up to https://github.com/elastic/integrations/pull/12905

When using cross-repo links, the path should be relative to the `docset.yml` not the full path within the repo ([updated docs-builder docs](https://elastic.github.io/docs-builder/syntax/links/#cross-repository-links)).