### PR TITLE
mimecast: Prevent pageToken from incorrectly reappearing in interval requests in multiple datastreams

### DIFF
--- a/packages/mimecast/changelog.yml
+++ b/packages/mimecast/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.6.1"
+  changes:
+    - description: Prevent pageToken from incorrectly reappearing in interval requests in multiple data streams.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "2.6.0"
   changes:
     - description: Set `event.kind:"alert"` for relevant events.

--- a/packages/mimecast/changelog.yml
+++ b/packages/mimecast/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Prevent pageToken from incorrectly reappearing in interval requests in multiple data streams.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/12936
 - version: "2.6.0"
   changes:
     - description: Set `event.kind:"alert"` for relevant events.

--- a/packages/mimecast/data_stream/archive_search_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/archive_search_logs/agent/stream/cel.yml.hbs
@@ -90,7 +90,7 @@ program: |
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
           bytes(resp.Body).decode_json().as(body, body.?fail.orValue([]).size() == 0 ?
-            {
+            (has(body.?meta.pagination.next) && size(body.data) != 0).as(want_more, {
               "events": body.data.map(e, e[state.data_path].map(l, {"message": l.encode_json()})).flatten(),
               "cursor": {
                 "last": (
@@ -106,19 +106,16 @@ program: |
                   ).format(time_layout.RFC3339)
                 ),
               },
-              ?"last_page": has(body.?meta.pagination.next) && size(body.data) != 0 ?
-                optional.of({
-                  ?"next": body.?meta.pagination.next,
-                  "data": req.data,
-                })
-              :
-                optional.none(),
+              "last_page": {
+                ?"next": want_more ? body.?meta.pagination.next : optional.none(),
+                ?"data": want_more ? req.?data : optional.none(),
+              },
               "token": {
                 "access_token": token.access_token,
                 "expires": token.expires,
               },
-              "want_more": has(body.?meta.pagination.next) && size(body.data) != 0,
-            }
+              "want_more": want_more,
+            })
           :
             // Mimecast can return failure states with a 200. This
             // is detected by a non-empty fail array at the root

--- a/packages/mimecast/data_stream/archive_search_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/archive_search_logs/agent/stream/cel.yml.hbs
@@ -106,10 +106,13 @@ program: |
                   ).format(time_layout.RFC3339)
                 ),
               },
-              "last_page": {
-                ?"next": want_more ? body.?meta.pagination.next : optional.none(),
-                ?"data": want_more ? req.?data : optional.none(),
-              },
+              "last_page": want_more ?
+                dyn({
+                  ?"next": body.?meta.pagination.next,
+                  ?"data": req.?data,
+                })
+              :
+                dyn(null), // required to clear the incoming state
               "token": {
                 "access_token": token.access_token,
                 "expires": token.expires,

--- a/packages/mimecast/data_stream/dlp_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/dlp_logs/agent/stream/cel.yml.hbs
@@ -90,7 +90,7 @@ program: |
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
           bytes(resp.Body).decode_json().as(body, body.?fail.orValue([]).size() == 0 ?
-            {
+            (has(body.?meta.pagination.next) && size(body.data) != 0).as(want_more, {
               "events": body.data.map(e, e[state.data_path].map(l, {"message": l.encode_json()})).flatten(),
               "cursor": {
                 "last": (
@@ -106,19 +106,16 @@ program: |
                   ).format(time_layout.RFC3339)
                 ),
               },
-              ?"last_page": has(body.?meta.pagination.next) && size(body.data) != 0 ?
-                optional.of({
-                  ?"next": body.?meta.pagination.next,
-                  "data": req.data,
-                })
-              :
-                optional.none(),
+              "last_page": {
+                ?"next": want_more ? body.?meta.pagination.next : optional.none(),
+                ?"data": want_more ? req.?data : optional.none(),
+              },
               "token": {
                 "access_token": token.access_token,
                 "expires": token.expires,
               },
-              "want_more": has(body.?meta.pagination.next) && size(body.data) != 0,
-            }
+              "want_more": want_more,
+            })
           :
             // Mimecast can return failure states with a 200. This
             // is detected by a non-empty fail array at the root

--- a/packages/mimecast/data_stream/dlp_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/dlp_logs/agent/stream/cel.yml.hbs
@@ -106,10 +106,13 @@ program: |
                   ).format(time_layout.RFC3339)
                 ),
               },
-              "last_page": {
-                ?"next": want_more ? body.?meta.pagination.next : optional.none(),
-                ?"data": want_more ? req.?data : optional.none(),
-              },
+              "last_page": want_more ?
+                dyn({
+                  ?"next": body.?meta.pagination.next,
+                  ?"data": req.?data,
+                })
+              :
+                dyn(null), // required to clear the incoming state
               "token": {
                 "access_token": token.access_token,
                 "expires": token.expires,

--- a/packages/mimecast/data_stream/message_release_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/message_release_logs/agent/stream/cel.yml.hbs
@@ -90,7 +90,7 @@ program: |
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
           bytes(resp.Body).decode_json().as(body, body.?fail.orValue([]).size() == 0 ?
-            {
+            (has(body.?meta.pagination.next) && size(body.data) != 0).as(want_more, {
               "events": body.data.map(e, e[state.data_path].map(l, {"message": l.encode_json()})).flatten(),
               "cursor": {
                 "last": (
@@ -106,19 +106,16 @@ program: |
                   ).format(time_layout.RFC3339)
                 ),
               },
-              ?"last_page": has(body.?meta.pagination.next) && size(body.data) != 0 ?
-                optional.of({
-                  ?"next": body.?meta.pagination.next,
-                  "data": req.data,
-                })
-              :
-                optional.none(),
+              "last_page": {
+                ?"next": want_more ? body.?meta.pagination.next : optional.none(),
+                ?"data": want_more ? req.?data : optional.none(),
+              },
               "token": {
                 "access_token": token.access_token,
                 "expires": token.expires,
               },
-              "want_more": has(body.?meta.pagination.next) && size(body.data) != 0,
-            }
+              "want_more": want_more,
+            })
           :
             // Mimecast can return failure states with a 200. This
             // is detected by a non-empty fail array at the root

--- a/packages/mimecast/data_stream/message_release_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/message_release_logs/agent/stream/cel.yml.hbs
@@ -106,10 +106,13 @@ program: |
                   ).format(time_layout.RFC3339)
                 ),
               },
-              "last_page": {
-                ?"next": want_more ? body.?meta.pagination.next : optional.none(),
-                ?"data": want_more ? req.?data : optional.none(),
-              },
+              "last_page": want_more ?
+                dyn({
+                  ?"next": body.?meta.pagination.next,
+                  ?"data": req.?data,
+                })
+              :
+                dyn(null), // required to clear the incoming state
               "token": {
                 "access_token": token.access_token,
                 "expires": token.expires,

--- a/packages/mimecast/data_stream/ttp_ap_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/ttp_ap_logs/agent/stream/cel.yml.hbs
@@ -90,7 +90,7 @@ program: |
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
           bytes(resp.Body).decode_json().as(body, body.?fail.orValue([]).size() == 0 ?
-            {
+            (has(body.?meta.pagination.next) && size(body.data) != 0).as(want_more, {
               "events": body.data.map(e, e[state.data_path].map(l, {"message": l.encode_json()})).flatten(),
               "cursor": {
                 "last": (
@@ -106,19 +106,16 @@ program: |
                   ).format(time_layout.RFC3339)
                 ),
               },
-              ?"last_page": has(body.?meta.pagination.next) && size(body.data) != 0 ?
-                optional.of({
-                  ?"next": body.?meta.pagination.next,
-                  "data": req.data,
-                })
-              :
-                optional.none(),
+              "last_page": {
+                ?"next": want_more ? body.?meta.pagination.next : optional.none(),
+                ?"data": want_more ? req.?data : optional.none(),
+              },
               "token": {
                 "access_token": token.access_token,
                 "expires": token.expires,
               },
-              "want_more": has(body.?meta.pagination.next) && size(body.data) != 0,
-            }
+              "want_more": want_more,
+            })
           :
             // Mimecast can return failure states with a 200. This
             // is detected by a non-empty fail array at the root

--- a/packages/mimecast/data_stream/ttp_ap_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/ttp_ap_logs/agent/stream/cel.yml.hbs
@@ -106,10 +106,13 @@ program: |
                   ).format(time_layout.RFC3339)
                 ),
               },
-              "last_page": {
-                ?"next": want_more ? body.?meta.pagination.next : optional.none(),
-                ?"data": want_more ? req.?data : optional.none(),
-              },
+              "last_page": want_more ?
+                dyn({
+                  ?"next": body.?meta.pagination.next,
+                  ?"data": req.?data,
+                })
+              :
+                dyn(null), // required to clear the incoming state
               "token": {
                 "access_token": token.access_token,
                 "expires": token.expires,

--- a/packages/mimecast/data_stream/ttp_ip_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/ttp_ip_logs/agent/stream/cel.yml.hbs
@@ -90,7 +90,7 @@ program: |
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
           bytes(resp.Body).decode_json().as(body, body.?fail.orValue([]).size() == 0 ?
-            {
+            (has(body.?meta.pagination.next) && size(body.data) != 0).as(want_more, {
               "events": body.data.map(e, e[state.data_path].map(l, {"message": l.encode_json()})).flatten(),
               "cursor": {
                 "last": (
@@ -106,19 +106,16 @@ program: |
                   ).format(time_layout.RFC3339)
                 ),
               },
-              ?"last_page": has(body.?meta.pagination.next) && size(body.data) != 0 ?
-                optional.of({
-                  ?"next": body.?meta.pagination.next,
-                  "data": req.data,
-                })
-              :
-                optional.none(),
+              "last_page": {
+                ?"next": want_more ? body.?meta.pagination.next : optional.none(),
+                ?"data": want_more ? req.?data : optional.none(),
+              },
               "token": {
                 "access_token": token.access_token,
                 "expires": token.expires,
               },
-              "want_more": has(body.?meta.pagination.next) && size(body.data) != 0,
-            }
+              "want_more": want_more,
+            })
           :
             // Mimecast can return failure states with a 200. This
             // is detected by a non-empty fail array at the root

--- a/packages/mimecast/data_stream/ttp_ip_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/ttp_ip_logs/agent/stream/cel.yml.hbs
@@ -106,10 +106,13 @@ program: |
                   ).format(time_layout.RFC3339)
                 ),
               },
-              "last_page": {
-                ?"next": want_more ? body.?meta.pagination.next : optional.none(),
-                ?"data": want_more ? req.?data : optional.none(),
-              },
+              "last_page": want_more ?
+                dyn({
+                  ?"next": body.?meta.pagination.next,
+                  ?"data": req.?data,
+                })
+              :
+                dyn(null), // required to clear the incoming state
               "token": {
                 "access_token": token.access_token,
                 "expires": token.expires,

--- a/packages/mimecast/data_stream/ttp_url_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/ttp_url_logs/agent/stream/cel.yml.hbs
@@ -90,7 +90,7 @@ program: |
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
           bytes(resp.Body).decode_json().as(body, body.?fail.orValue([]).size() == 0 ?
-            {
+            (has(body.?meta.pagination.next) && size(body.data) != 0).as(want_more, {
               "events": body.data.map(e, e[state.data_path].map(l, {"message": l.encode_json()})).flatten(),
               "cursor": {
                 "last": (
@@ -106,19 +106,16 @@ program: |
                   ).format(time_layout.RFC3339)
                 ),
               },
-              ?"last_page": has(body.?meta.pagination.next) && size(body.data) != 0 ?
-                optional.of({
-                  ?"next": body.?meta.pagination.next,
-                  "data": req.data,
-                })
-              :
-                optional.none(),
+              "last_page": {
+                ?"next": want_more ? body.?meta.pagination.next : optional.none(),
+                ?"data": want_more ? req.?data : optional.none(),
+              },
               "token": {
                 "access_token": token.access_token,
                 "expires": token.expires,
               },
-              "want_more": has(body.?meta.pagination.next) && size(body.data) != 0,
-            }
+              "want_more": want_more,
+            })
           :
             // Mimecast can return failure states with a 200. This
             // is detected by a non-empty fail array at the root

--- a/packages/mimecast/data_stream/ttp_url_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/ttp_url_logs/agent/stream/cel.yml.hbs
@@ -106,10 +106,13 @@ program: |
                   ).format(time_layout.RFC3339)
                 ),
               },
-              "last_page": {
-                ?"next": want_more ? body.?meta.pagination.next : optional.none(),
-                ?"data": want_more ? req.?data : optional.none(),
-              },
+              "last_page": want_more ?
+                dyn({
+                  ?"next": body.?meta.pagination.next,
+                  ?"data": req.?data,
+                })
+              :
+                dyn(null), // required to clear the incoming state
               "token": {
                 "access_token": token.access_token,
                 "expires": token.expires,

--- a/packages/mimecast/manifest.yml
+++ b/packages/mimecast/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: mimecast
 title: "Mimecast"
-version: "2.6.0"
+version: "2.6.1"
 description: Collect logs from Mimecast with Elastic Agent.
 type: integration
 categories: ["security", "email_security"]


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
last_page is stored at the root-level of state. As it is enclosed 
in state.with(), this leads to last_page.next incorrectly getting 
carried into subsequent interval requests whenever last_page 
evaluates to optional.none().

This change removes last_page assignment to optional.none(), 
thus removing last_page.next it from interval requests. 
```

> [!NOTE]
> This fix is similar to audit events in #12770.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
