### PR TITLE
[cisco_aironet] Properly parse CLIENT_ORCH_LOG-6-CLIENT_ADDED_TO_RUN_STATE messages

### DIFF
--- a/packages/cisco_aironet/changelog.yml
+++ b/packages/cisco_aironet/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.2"
+  changes:
+    - description: Add support for parsing 'CLIENT_ORCH_LOG-6-CLIENT_ADDED_TO_RUN_STATE' log messages
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9999999
 - version: "1.15.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/cisco_aironet/changelog.yml
+++ b/packages/cisco_aironet/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "1.15.2"
   changes:
-    - description: Add support for parsing 'CLIENT_ORCH_LOG-6-CLIENT_ADDED_TO_RUN_STATE' log messages
+    - description: Properly parse 'CLIENT_ORCH_LOG-6-CLIENT_ADDED_TO_RUN_STATE' log messages
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/9999999
+      link: https://github.com/elastic/integrations/pull/12975
 - version: "1.15.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log
+++ b/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log
@@ -30,6 +30,7 @@
 <132>WLC001: *bcastReceiveTask: Aug 20 14:55:28.577: %BCAST-4-MLD_INVALID_IPV6_PKT: bcastMld.c:2594  Received IPV6 packet which is not a valid MLD packet
 <132>WLC001: *apfReceiveTask: Aug 22 10:24:20.959: %APF-4-MOBILESTATION_NOT_FOUND: apf_ms.c:8467 Could not find the mobile cc:73:14:61:b0:8f in internal database
 <190>201477: Jan 4 17:25:42.866: %CLIENT_ORCH_LOG-6-CLIENT_ADDED_TO_RUN_STATE: Chassis 2 R0/0: wncd: Username entry (00-00-00-00-00-00) joined with ssid (System-110) for device with MAC: 0000.0000.0000
+<190>201477: Jan 4 17:25:42.866: %CLIENT_ORCH_LOG-6-CLIENT_ADDED_TO_RUN_STATE: Chassis 1 R0/0: wncd: Username entry (RND-UN) joined with ssid (System-110) for device with MAC: abcd.ef12.3456
 <132>WLC001: *spamReceiveTask: Dec 17 19:59:10.223: %LOG-3-Q_IND: mm_aplist.c:734 Could not delete an AP from the AP list.
 <132>WLC001: *spamApTask4: Jun 08 04:26:43.773: %LOG-3-Q_IND: spam_lrad.c:11366 Country code (CN ) not configured for AP 6c:99:89:b0:XX:XX[…It occurred 2 times.!]
 <132>WLC001: *emWeb: Jan 22 11:42:50.501: %LOG-3-Q_IND: spam_lrad.c:52448 The system is unable to find WLAN 1 to be deleted; AP XX:XX:XX:XX:XX:XX[...It occurred 3 times.!]

--- a/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log-expected.json
+++ b/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log-expected.json
@@ -1217,6 +1217,12 @@
         },
         {
             "@timestamp": "2025-01-04T17:25:42.866Z",
+            "cisco": {
+                "ssid": "System-110"
+            },
+            "client": {
+                "mac": "00-00-00-00-00-00"
+            },
             "ecs": {
                 "version": "8.17.0"
             },
@@ -1241,7 +1247,47 @@
             "message": "Chassis 2 R0/0: wncd: Username entry (00-00-00-00-00-00) joined with ssid (System-110) for device with MAC: 0000.0000.0000",
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "user": {
+                "name": "00-00-00-00-00-00"
+            }
+        },
+        {
+            "@timestamp": "2025-01-04T17:25:42.866Z",
+            "cisco": {
+                "ssid": "System-110"
+            },
+            "client": {
+                "mac": "AB-CD-EF-12-34-56"
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "CLIENT_ADDED_TO_RUN_STATE",
+                "original": "<190>201477: Jan 4 17:25:42.866: %CLIENT_ORCH_LOG-6-CLIENT_ADDED_TO_RUN_STATE: Chassis 1 R0/0: wncd: Username entry (RND-UN) joined with ssid (System-110) for device with MAC: abcd.ef12.3456",
+                "provider": "CLIENT_ORCH_LOG",
+                "severity": 6
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 23
+                    },
+                    "priority": 190,
+                    "severity": {
+                        "code": 6
+                    }
+                }
+            },
+            "message": "Chassis 1 R0/0: wncd: Username entry (RND-UN) joined with ssid (System-110) for device with MAC: abcd.ef12.3456",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "RND-UN"
+            }
         },
         {
             "@timestamp": "2025-12-17T19:59:10.223Z",

--- a/packages/cisco_aironet/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_aironet/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -217,6 +217,13 @@ processors:
       patterns:
         - "STA\\(Target MAC Address\\) \\[%{MAC:client.mac}.*?\\] %{DATA:event.reason}\\(Source IP Address\\) %{IP:client.ip}%{DATA}\\(Destination IP Address\\) %{IP:server.ip}"
       ignore_failure: false
+  - grok:
+      description: CLIENT_ORCH_LOG-6-CLIENT_ADDED_TO_RUN_STATE
+      field: message
+      if: ctx._temp_?.reason == 'CLIENT_ORCH_LOG-6-CLIENT_ADDED_TO_RUN_STATE'
+      patterns:
+        - "R0/0: wncd: Username entry \\(%{DATA:user.name}\\) joined with ssid \\(%{DATA:cisco.ssid}\\) for device with MAC: %{MAC:client.mac}"
+      ignore_failure: false
   ###
   # Client MAC
   - grok:
@@ -234,6 +241,18 @@ processors:
       pattern: '[:.]'
       replacement: '-'
       ignore_missing: true
+  - script:
+      lang: painless
+      if: ctx.client?.mac != null
+      description: 'Convert Cisco style mac to standard format (XXXX-XXXX-XXXX to XX-XX-XX-XX-XX-XX)'
+      source: |
+        def mac = ctx.client.mac;
+        def pattern = /^[A-F0-9]{4}(-[A-F0-9]{4}){2}$/;
+        def matcher = pattern.matcher(mac);
+        if (matcher.matches()) {
+           ctx.client.mac = mac.substring(0,2) + "-" + mac.substring(2,4) + "-" + mac.substring(5,7) + "-" + mac.substring(7,9) + "-" + mac.substring(10,12) + "-" + mac.substring(12,14);
+        }
+
   - uppercase:
       field: source.mac
       ignore_missing: true

--- a/packages/cisco_aironet/data_stream/log/fields/aironet-fields.yml
+++ b/packages/cisco_aironet/data_stream/log/fields/aironet-fields.yml
@@ -25,3 +25,6 @@
 - name: cisco.eapol.version
   type: short
   description: Cisco eapol version
+- name: cisco.ssid
+  type: keyword
+  description: Cisco SSID

--- a/packages/cisco_aironet/docs/README.md
+++ b/packages/cisco_aironet/docs/README.md
@@ -97,6 +97,7 @@ An example event for `log` looks as following:
 | cisco.eapol.type | Cisco eapol type | short |
 | cisco.eapol.version | Cisco eapol version | short |
 | cisco.interface.type | Cisco interface type | keyword |
+| cisco.ssid | Cisco SSID | keyword |
 | cisco.wps.channel | Cisco WPS channel | short |
 | cisco.wps.hits | Cisco WPS hits | short |
 | cisco.wps.preced | Cisco WPS precedence | short |

--- a/packages/cisco_aironet/manifest.yml
+++ b/packages/cisco_aironet/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_aironet
 title: "Cisco Aironet"
-version: "1.15.1"
+version: "1.15.2"
 description: "Integration for Cisco Aironet WLC Logs"
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->


Properly parse CLIENT_ORCH_LOG-6-CLIENT_ADDED_TO_RUN_STATE messages in cisco_aironet. The pipeline will now parse out all values from this message type: user name, SSID, and client MAC.

The client MAC will also be reformatted to follow the standard format specified in ECS.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- ~~[ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~


---

The format of this message was found here: https://bst.cisco.com/quickview/bug/CSCwj11043