### PR TITLE
[CI] Update timeout for serverless pipeline

### DIFF
--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -60,7 +60,7 @@ steps:
   - label: "Check integrations in serverless"
     key: "test-integrations-serverless-project"
     command: ".buildkite/scripts/test_integrations_with_serverless.sh"
-    timeout_in_minutes: 240
+    timeout_in_minutes: 360
     env:
       FORCE_CHECK_ALL: true
       UPLOAD_SAFE_LOGS: 1


### PR DESCRIPTION
## Proposed commit message

Latest daily CI builds have failed due to a timeout. Currently, this timeout is set to 4 hours. This PR increases that timeout up to 6 hours.

https://buildkite.com/elastic/integrations-serverless/builds?branch=main

Example:
https://buildkite.com/elastic/integrations-serverless/builds/1004#01956916-4d67-4104-bab7-fcae6791f78e