### PR TITLE
checkpoint_harmony_endpoint: improve handling of 404 and 503 errors

### DIFF
--- a/packages/checkpoint_harmony_endpoint/changelog.yml
+++ b/packages/checkpoint_harmony_endpoint/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "0.5.0"
+  changes:
+    - description: Improve handling of 404 and 503 API responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
+    - description: Propagate forensics CEL fixes to all data streams.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "0.4.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/checkpoint_harmony_endpoint/changelog.yml
+++ b/packages/checkpoint_harmony_endpoint/changelog.yml
@@ -3,10 +3,10 @@
   changes:
     - description: Improve handling of 404 and 503 API responses.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/13009
     - description: Propagate forensics CEL fixes to all data streams.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/13009
 - version: "0.4.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
@@ -69,7 +69,9 @@ program: |
   			"startTime": state.?cursor.next_startTime.orValue(
   				timestamp(now() - duration(state.initial_interval)).format(time_layout.RFC3339)
   			),
-  			"endTime": timestamp(now() - duration("1m")).format(time_layout.RFC3339),
+  			"endTime": state.?cursor.next_endTime.orValue(
+  				timestamp(now() - duration("1m")).format(time_layout.RFC3339)
+  			),
   		}.as(timeframe,
   			request("POST", state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query").with(
   				{
@@ -116,7 +118,10 @@ program: |
   									"auth_data": auth_data,
   									"task_id": body.data.taskId,
   									"page_token": null,
+  									"current_startTime": timeframe.startTime,
+  									"current_endTime": timeframe.endTime,
   									"next_startTime": timeframe.endTime,
+  									"next_endTime": null,
   								},
   							}
   						)
@@ -144,7 +149,24 @@ program: |
   					}
   				)
   			:
-  			resp.StatusCode == 200 ?
+  			(resp.StatusCode == 404) ?
+  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
+  				state.with(
+  					{
+  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"want_more": true,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
+  							}
+  						),
+  					}
+  				)
+  			:
+  			(resp.StatusCode == 200) ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.state == "Ready") ?
   						// 'Ready' (Results found) - Save the first page token.
@@ -232,7 +254,23 @@ program: |
   					}
   				)
   			:
-  			resp.StatusCode == 200 ?
+  			(resp.StatusCode == 503) ?
+  				// 503 Service Unavailable - Clear the task ID and page token, and end the sequence.
+  				state.with(
+  					{
+  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"want_more": false,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"page_token": null,
+  							}
+  						),
+  					}
+  				)
+  			:
+  			(resp.StatusCode == 200) ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.nextPageToken != "NULL") ?
   						// Not the last page - Save the next page token and continue.

--- a/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
@@ -14,8 +14,7 @@ state:
   limit: {{limit}}
   page_limit: {{page_limit}}
   filter: {{filter}}
-program: |-
-  
+program: |
   (
   	state.?cursor.auth_data.expires.optMap(t,
   		t.parse_time(time_layout.RFC1123) - now() > duration("5m")
@@ -35,15 +34,35 @@ program: |-
   					"accessKey": state.auth_access_key,
   				}.encode_json(),
   			}
-  		).do_request().as(resp,
+  		).do_request().as(resp, resp.StatusCode == 200 ?
   			bytes(resp.Body).decode_json().as(body,
   				{
   					"token": body.data.token,
   					"expires": body.data.expires,
   				}
   			)
+  		:
+  			state.with(
+  				{
+  					"events": {
+  						"error": {
+  							"code": string(resp.StatusCode),
+  							"id": string(resp.Status),
+  							"message": "POST " + state.url.trim_right("/") + "/auth/external: " + (
+  								size(resp.Body) != 0 ?
+  									string(resp.Body)
+  								:
+  									string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  							),
+  						},
+  					},
+  					"want_more": false,
+  				}
+  			)
   		)
-  ).as(auth_data,
+  ).as(v, has(v.?events.error) ?
+    v
+  : v.as(auth_data,
   	(state.?cursor.task_id.orValue(null) == null) ?
   		// No task ID - Submit a query and get its task ID.
   		{
@@ -125,6 +144,7 @@ program: |-
   					}
   				)
   			:
+  			resp.StatusCode == 200 ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.state == "Ready") ?
   						// 'Ready' (Results found) - Save the first page token.
@@ -168,6 +188,24 @@ program: |-
   							}
   						)
   				)
+  			:
+  				state.with(
+  					{
+  						"events": {
+  							"error": {
+  								"code": string(resp.StatusCode),
+  								"id": string(resp.Status),
+  								"message": "GET " + state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query: " + (
+  									size(resp.Body) != 0 ?
+  										string(resp.Body)
+  									:
+  										string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  								),
+  							},
+  						},
+  						"want_more": false,
+  					}
+  				)
   		)
   	:
   		// Task is ready - Use the task ID and page token to retrieve a page of results.
@@ -194,6 +232,7 @@ program: |-
   					}
   				)
   			:
+  			resp.StatusCode == 200 ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.nextPageToken != "NULL") ?
   						// Not the last page - Save the next page token and continue.
@@ -225,8 +264,26 @@ program: |-
   							}
   						)
   				)
+  			:
+  				state.with(
+  					{
+  						"events": {
+  							"error": {
+  								"code": string(resp.StatusCode),
+  								"id": string(resp.Status),
+  								"message": "POST " + state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query/retrieve: " + (
+  									size(resp.Body) != 0 ?
+  										string(resp.Body)
+  									:
+  										string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  								),
+  							},
+  						},
+  						"want_more": false,
+  					}
+  				)
   		)
-  )
+  ))
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
@@ -258,7 +258,18 @@ program: |
   				// 503 Service Unavailable - Clear the task ID and page token, and end the sequence.
   				state.with(
   					{
-  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"events": {
+  							"error": {
+  								"code": string(resp.StatusCode),
+  								"id": string(resp.Status),
+  								"message": "POST " + state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query/retrieve: " + (
+  									size(resp.Body) != 0 ?
+  										string(resp.Body)
+  									:
+  										string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  								),
+  							},
+  						},
   						"want_more": false,
   						"cursor": state.cursor.with(
   							{

--- a/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
@@ -69,7 +69,9 @@ program: |
   			"startTime": state.?cursor.next_startTime.orValue(
   				timestamp(now() - duration(state.initial_interval)).format(time_layout.RFC3339)
   			),
-  			"endTime": timestamp(now() - duration("1m")).format(time_layout.RFC3339),
+  			"endTime": state.?cursor.next_endTime.orValue(
+  				timestamp(now() - duration("1m")).format(time_layout.RFC3339)
+  			),
   		}.as(timeframe,
   			request("POST", state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query").with(
   				{
@@ -116,7 +118,10 @@ program: |
   									"auth_data": auth_data,
   									"task_id": body.data.taskId,
   									"page_token": null,
+  									"current_startTime": timeframe.startTime,
+  									"current_endTime": timeframe.endTime,
   									"next_startTime": timeframe.endTime,
+  									"next_endTime": null,
   								},
   							}
   						)
@@ -144,7 +149,24 @@ program: |
   					}
   				)
   			:
-  			resp.StatusCode == 200 ?
+  			(resp.StatusCode == 404) ?
+  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
+  				state.with(
+  					{
+  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"want_more": true,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
+  							}
+  						),
+  					}
+  				)
+  			:
+  			(resp.StatusCode == 200) ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.state == "Ready") ?
   						// 'Ready' (Results found) - Save the first page token.
@@ -232,7 +254,23 @@ program: |
   					}
   				)
   			:
-  			resp.StatusCode == 200 ?
+  			(resp.StatusCode == 503) ?
+  				// 503 Service Unavailable - Clear the task ID and page token, and end the sequence.
+  				state.with(
+  					{
+  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"want_more": false,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"page_token": null,
+  							}
+  						),
+  					}
+  				)
+  			:
+  			(resp.StatusCode == 200) ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.nextPageToken != "NULL") ?
   						// Not the last page - Save the next page token and continue.

--- a/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
@@ -14,8 +14,7 @@ state:
   limit: {{limit}}
   page_limit: {{page_limit}}
   filter: {{filter}}
-program: |-
-  
+program: |
   (
   	state.?cursor.auth_data.expires.optMap(t,
   		t.parse_time(time_layout.RFC1123) - now() > duration("5m")
@@ -35,15 +34,35 @@ program: |-
   					"accessKey": state.auth_access_key,
   				}.encode_json(),
   			}
-  		).do_request().as(resp,
+  		).do_request().as(resp, resp.StatusCode == 200 ?
   			bytes(resp.Body).decode_json().as(body,
   				{
   					"token": body.data.token,
   					"expires": body.data.expires,
   				}
   			)
+  		:
+  			state.with(
+  				{
+  					"events": {
+  						"error": {
+  							"code": string(resp.StatusCode),
+  							"id": string(resp.Status),
+  							"message": "POST " + state.url.trim_right("/") + "/auth/external: " + (
+  								size(resp.Body) != 0 ?
+  									string(resp.Body)
+  								:
+  									string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  							),
+  						},
+  					},
+  					"want_more": false,
+  				}
+  			)
   		)
-  ).as(auth_data,
+  ).as(v, has(v.?events.error) ?
+    v
+  : v.as(auth_data,
   	(state.?cursor.task_id.orValue(null) == null) ?
   		// No task ID - Submit a query and get its task ID.
   		{
@@ -125,6 +144,7 @@ program: |-
   					}
   				)
   			:
+  			resp.StatusCode == 200 ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.state == "Ready") ?
   						// 'Ready' (Results found) - Save the first page token.
@@ -168,6 +188,24 @@ program: |-
   							}
   						)
   				)
+  			:
+  				state.with(
+  					{
+  						"events": {
+  							"error": {
+  								"code": string(resp.StatusCode),
+  								"id": string(resp.Status),
+  								"message": "GET " + state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query: " + (
+  									size(resp.Body) != 0 ?
+  										string(resp.Body)
+  									:
+  										string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  								),
+  							},
+  						},
+  						"want_more": false,
+  					}
+  				)
   		)
   	:
   		// Task is ready - Use the task ID and page token to retrieve a page of results.
@@ -194,6 +232,7 @@ program: |-
   					}
   				)
   			:
+  			resp.StatusCode == 200 ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.nextPageToken != "NULL") ?
   						// Not the last page - Save the next page token and continue.
@@ -225,8 +264,26 @@ program: |-
   							}
   						)
   				)
+  			:
+  				state.with(
+  					{
+  						"events": {
+  							"error": {
+  								"code": string(resp.StatusCode),
+  								"id": string(resp.Status),
+  								"message": "POST " + state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query/retrieve: " + (
+  									size(resp.Body) != 0 ?
+  										string(resp.Body)
+  									:
+  										string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  								),
+  							},
+  						},
+  						"want_more": false,
+  					}
+  				)
   		)
-  )
+  ))
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
@@ -258,7 +258,18 @@ program: |
   				// 503 Service Unavailable - Clear the task ID and page token, and end the sequence.
   				state.with(
   					{
-  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"events": {
+  							"error": {
+  								"code": string(resp.StatusCode),
+  								"id": string(resp.Status),
+  								"message": "POST " + state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query/retrieve: " + (
+  									size(resp.Body) != 0 ?
+  										string(resp.Body)
+  									:
+  										string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  								),
+  							},
+  						},
   						"want_more": false,
   						"cursor": state.cursor.with(
   							{

--- a/packages/checkpoint_harmony_endpoint/data_stream/forensics/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/forensics/agent/stream/cel.yml.hbs
@@ -69,7 +69,9 @@ program: |
   			"startTime": state.?cursor.next_startTime.orValue(
   				timestamp(now() - duration(state.initial_interval)).format(time_layout.RFC3339)
   			),
-  			"endTime": timestamp(now() - duration("1m")).format(time_layout.RFC3339),
+  			"endTime": state.?cursor.next_endTime.orValue(
+  				timestamp(now() - duration("1m")).format(time_layout.RFC3339)
+  			),
   		}.as(timeframe,
   			request("POST", state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query").with(
   				{
@@ -116,7 +118,10 @@ program: |
   									"auth_data": auth_data,
   									"task_id": body.data.taskId,
   									"page_token": null,
+  									"current_startTime": timeframe.startTime,
+  									"current_endTime": timeframe.endTime,
   									"next_startTime": timeframe.endTime,
+  									"next_endTime": null,
   								},
   							}
   						)
@@ -144,7 +149,24 @@ program: |
   					}
   				)
   			:
-  			resp.StatusCode == 200 ?
+  			(resp.StatusCode == 404) ?
+  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
+  				state.with(
+  					{
+  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"want_more": true,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
+  							}
+  						),
+  					}
+  				)
+  			:
+  			(resp.StatusCode == 200) ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.state == "Ready") ?
   						// 'Ready' (Results found) - Save the first page token.
@@ -232,7 +254,23 @@ program: |
   					}
   				)
   			:
-  			resp.StatusCode == 200 ?
+  			(resp.StatusCode == 503) ?
+  				// 503 Service Unavailable - Clear the task ID and page token, and end the sequence.
+  				state.with(
+  					{
+  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"want_more": false,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"page_token": null,
+  							}
+  						),
+  					}
+  				)
+  			:
+  			(resp.StatusCode == 200) ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.nextPageToken != "NULL") ?
   						// Not the last page - Save the next page token and continue.

--- a/packages/checkpoint_harmony_endpoint/data_stream/forensics/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/forensics/agent/stream/cel.yml.hbs
@@ -258,7 +258,18 @@ program: |
   				// 503 Service Unavailable - Clear the task ID and page token, and end the sequence.
   				state.with(
   					{
-  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"events": {
+  							"error": {
+  								"code": string(resp.StatusCode),
+  								"id": string(resp.Status),
+  								"message": "POST " + state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query/retrieve: " + (
+  									size(resp.Body) != 0 ?
+  										string(resp.Body)
+  									:
+  										string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  								),
+  							},
+  						},
   						"want_more": false,
   						"cursor": state.cursor.with(
   							{

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
@@ -69,7 +69,9 @@ program: |
   			"startTime": state.?cursor.next_startTime.orValue(
   				timestamp(now() - duration(state.initial_interval)).format(time_layout.RFC3339)
   			),
-  			"endTime": timestamp(now() - duration("1m")).format(time_layout.RFC3339),
+  			"endTime": state.?cursor.next_endTime.orValue(
+  				timestamp(now() - duration("1m")).format(time_layout.RFC3339)
+  			),
   		}.as(timeframe,
   			request("POST", state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query").with(
   				{
@@ -116,7 +118,10 @@ program: |
   									"auth_data": auth_data,
   									"task_id": body.data.taskId,
   									"page_token": null,
+  									"current_startTime": timeframe.startTime,
+  									"current_endTime": timeframe.endTime,
   									"next_startTime": timeframe.endTime,
+  									"next_endTime": null,
   								},
   							}
   						)
@@ -144,7 +149,24 @@ program: |
   					}
   				)
   			:
-  			resp.StatusCode == 200 ?
+  			(resp.StatusCode == 404) ?
+  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
+  				state.with(
+  					{
+  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"want_more": true,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
+  							}
+  						),
+  					}
+  				)
+  			:
+  			(resp.StatusCode == 200) ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.state == "Ready") ?
   						// 'Ready' (Results found) - Save the first page token.
@@ -232,7 +254,23 @@ program: |
   					}
   				)
   			:
-  			resp.StatusCode == 200 ?
+  			(resp.StatusCode == 503) ?
+  				// 503 Service Unavailable - Clear the task ID and page token, and end the sequence.
+  				state.with(
+  					{
+  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"want_more": false,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"page_token": null,
+  							}
+  						),
+  					}
+  				)
+  			:
+  			(resp.StatusCode == 200) ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.nextPageToken != "NULL") ?
   						// Not the last page - Save the next page token and continue.

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
@@ -14,8 +14,7 @@ state:
   limit: {{limit}}
   page_limit: {{page_limit}}
   filter: {{filter}}
-program: |-
-  
+program: |
   (
   	state.?cursor.auth_data.expires.optMap(t,
   		t.parse_time(time_layout.RFC1123) - now() > duration("5m")
@@ -35,15 +34,35 @@ program: |-
   					"accessKey": state.auth_access_key,
   				}.encode_json(),
   			}
-  		).do_request().as(resp,
+  		).do_request().as(resp, resp.StatusCode == 200 ?
   			bytes(resp.Body).decode_json().as(body,
   				{
   					"token": body.data.token,
   					"expires": body.data.expires,
   				}
   			)
+  		:
+  			state.with(
+  				{
+  					"events": {
+  						"error": {
+  							"code": string(resp.StatusCode),
+  							"id": string(resp.Status),
+  							"message": "POST " + state.url.trim_right("/") + "/auth/external: " + (
+  								size(resp.Body) != 0 ?
+  									string(resp.Body)
+  								:
+  									string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  							),
+  						},
+  					},
+  					"want_more": false,
+  				}
+  			)
   		)
-  ).as(auth_data,
+  ).as(v, has(v.?events.error) ?
+    v
+  : v.as(auth_data,
   	(state.?cursor.task_id.orValue(null) == null) ?
   		// No task ID - Submit a query and get its task ID.
   		{
@@ -125,6 +144,7 @@ program: |-
   					}
   				)
   			:
+  			resp.StatusCode == 200 ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.state == "Ready") ?
   						// 'Ready' (Results found) - Save the first page token.
@@ -168,6 +188,24 @@ program: |-
   							}
   						)
   				)
+  			:
+  				state.with(
+  					{
+  						"events": {
+  							"error": {
+  								"code": string(resp.StatusCode),
+  								"id": string(resp.Status),
+  								"message": "GET " + state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query: " + (
+  									size(resp.Body) != 0 ?
+  										string(resp.Body)
+  									:
+  										string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  								),
+  							},
+  						},
+  						"want_more": false,
+  					}
+  				)
   		)
   	:
   		// Task is ready - Use the task ID and page token to retrieve a page of results.
@@ -194,6 +232,7 @@ program: |-
   					}
   				)
   			:
+  			resp.StatusCode == 200 ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.nextPageToken != "NULL") ?
   						// Not the last page - Save the next page token and continue.
@@ -225,8 +264,26 @@ program: |-
   							}
   						)
   				)
+  			:
+  				state.with(
+  					{
+  						"events": {
+  							"error": {
+  								"code": string(resp.StatusCode),
+  								"id": string(resp.Status),
+  								"message": "POST " + state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query/retrieve: " + (
+  									size(resp.Body) != 0 ?
+  										string(resp.Body)
+  									:
+  										string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  								),
+  							},
+  						},
+  						"want_more": false,
+  					}
+  				)
   		)
-  )
+  ))
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
@@ -258,7 +258,18 @@ program: |
   				// 503 Service Unavailable - Clear the task ID and page token, and end the sequence.
   				state.with(
   					{
-  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"events": {
+  							"error": {
+  								"code": string(resp.StatusCode),
+  								"id": string(resp.Status),
+  								"message": "POST " + state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query/retrieve: " + (
+  									size(resp.Body) != 0 ?
+  										string(resp.Body)
+  									:
+  										string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  								),
+  							},
+  						},
   						"want_more": false,
   						"cursor": state.cursor.with(
   							{

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
@@ -69,7 +69,9 @@ program: |
   			"startTime": state.?cursor.next_startTime.orValue(
   				timestamp(now() - duration(state.initial_interval)).format(time_layout.RFC3339)
   			),
-  			"endTime": timestamp(now() - duration("1m")).format(time_layout.RFC3339),
+  			"endTime": state.?cursor.next_endTime.orValue(
+  				timestamp(now() - duration("1m")).format(time_layout.RFC3339)
+  			),
   		}.as(timeframe,
   			request("POST", state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query").with(
   				{
@@ -116,7 +118,10 @@ program: |
   									"auth_data": auth_data,
   									"task_id": body.data.taskId,
   									"page_token": null,
+  									"current_startTime": timeframe.startTime,
+  									"current_endTime": timeframe.endTime,
   									"next_startTime": timeframe.endTime,
+  									"next_endTime": null,
   								},
   							}
   						)
@@ -144,7 +149,24 @@ program: |
   					}
   				)
   			:
-  			resp.StatusCode == 200 ?
+  			(resp.StatusCode == 404) ?
+  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
+  				state.with(
+  					{
+  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"want_more": true,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
+  							}
+  						),
+  					}
+  				)
+  			:
+  			(resp.StatusCode == 200) ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.state == "Ready") ?
   						// 'Ready' (Results found) - Save the first page token.
@@ -232,7 +254,23 @@ program: |
   					}
   				)
   			:
-  			resp.StatusCode == 200 ?
+  			(resp.StatusCode == 503) ?
+  				// 503 Service Unavailable - Clear the task ID and page token, and end the sequence.
+  				state.with(
+  					{
+  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"want_more": false,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"page_token": null,
+  							}
+  						),
+  					}
+  				)
+  			:
+  			(resp.StatusCode == 200) ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.nextPageToken != "NULL") ?
   						// Not the last page - Save the next page token and continue.

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
@@ -14,8 +14,7 @@ state:
   limit: {{limit}}
   page_limit: {{page_limit}}
   filter: {{filter}}
-program: |-
-  
+program: |
   (
   	state.?cursor.auth_data.expires.optMap(t,
   		t.parse_time(time_layout.RFC1123) - now() > duration("5m")
@@ -35,15 +34,35 @@ program: |-
   					"accessKey": state.auth_access_key,
   				}.encode_json(),
   			}
-  		).do_request().as(resp,
+  		).do_request().as(resp, resp.StatusCode == 200 ?
   			bytes(resp.Body).decode_json().as(body,
   				{
   					"token": body.data.token,
   					"expires": body.data.expires,
   				}
   			)
+  		:
+  			state.with(
+  				{
+  					"events": {
+  						"error": {
+  							"code": string(resp.StatusCode),
+  							"id": string(resp.Status),
+  							"message": "POST " + state.url.trim_right("/") + "/auth/external: " + (
+  								size(resp.Body) != 0 ?
+  									string(resp.Body)
+  								:
+  									string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  							),
+  						},
+  					},
+  					"want_more": false,
+  				}
+  			)
   		)
-  ).as(auth_data,
+  ).as(v, has(v.?events.error) ?
+    v
+  : v.as(auth_data,
   	(state.?cursor.task_id.orValue(null) == null) ?
   		// No task ID - Submit a query and get its task ID.
   		{
@@ -125,6 +144,7 @@ program: |-
   					}
   				)
   			:
+  			resp.StatusCode == 200 ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.state == "Ready") ?
   						// 'Ready' (Results found) - Save the first page token.
@@ -168,6 +188,24 @@ program: |-
   							}
   						)
   				)
+  			:
+  				state.with(
+  					{
+  						"events": {
+  							"error": {
+  								"code": string(resp.StatusCode),
+  								"id": string(resp.Status),
+  								"message": "GET " + state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query: " + (
+  									size(resp.Body) != 0 ?
+  										string(resp.Body)
+  									:
+  										string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  								),
+  							},
+  						},
+  						"want_more": false,
+  					}
+  				)
   		)
   	:
   		// Task is ready - Use the task ID and page token to retrieve a page of results.
@@ -194,6 +232,7 @@ program: |-
   					}
   				)
   			:
+  			resp.StatusCode == 200 ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.nextPageToken != "NULL") ?
   						// Not the last page - Save the next page token and continue.
@@ -225,8 +264,26 @@ program: |-
   							}
   						)
   				)
+  			:
+  				state.with(
+  					{
+  						"events": {
+  							"error": {
+  								"code": string(resp.StatusCode),
+  								"id": string(resp.Status),
+  								"message": "POST " + state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query/retrieve: " + (
+  									size(resp.Body) != 0 ?
+  										string(resp.Body)
+  									:
+  										string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  								),
+  							},
+  						},
+  						"want_more": false,
+  					}
+  				)
   		)
-  )
+  ))
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
@@ -258,7 +258,18 @@ program: |
   				// 503 Service Unavailable - Clear the task ID and page token, and end the sequence.
   				state.with(
   					{
-  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"events": {
+  							"error": {
+  								"code": string(resp.StatusCode),
+  								"id": string(resp.Status),
+  								"message": "POST " + state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query/retrieve: " + (
+  									size(resp.Body) != 0 ?
+  										string(resp.Body)
+  									:
+  										string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  								),
+  							},
+  						},
   						"want_more": false,
   						"cursor": state.cursor.with(
   							{

--- a/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
@@ -69,7 +69,9 @@ program: |
   			"startTime": state.?cursor.next_startTime.orValue(
   				timestamp(now() - duration(state.initial_interval)).format(time_layout.RFC3339)
   			),
-  			"endTime": timestamp(now() - duration("1m")).format(time_layout.RFC3339),
+  			"endTime": state.?cursor.next_endTime.orValue(
+  				timestamp(now() - duration("1m")).format(time_layout.RFC3339)
+  			),
   		}.as(timeframe,
   			request("POST", state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query").with(
   				{
@@ -116,7 +118,10 @@ program: |
   									"auth_data": auth_data,
   									"task_id": body.data.taskId,
   									"page_token": null,
+  									"current_startTime": timeframe.startTime,
+  									"current_endTime": timeframe.endTime,
   									"next_startTime": timeframe.endTime,
+  									"next_endTime": null,
   								},
   							}
   						)
@@ -144,7 +149,24 @@ program: |
   					}
   				)
   			:
-  			resp.StatusCode == 200 ?
+  			(resp.StatusCode == 404) ?
+  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
+  				state.with(
+  					{
+  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"want_more": true,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
+  							}
+  						),
+  					}
+  				)
+  			:
+  			(resp.StatusCode == 200) ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.state == "Ready") ?
   						// 'Ready' (Results found) - Save the first page token.
@@ -232,7 +254,23 @@ program: |
   					}
   				)
   			:
-  			resp.StatusCode == 200 ?
+  			(resp.StatusCode == 503) ?
+  				// 503 Service Unavailable - Clear the task ID and page token, and end the sequence.
+  				state.with(
+  					{
+  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"want_more": false,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"page_token": null,
+  							}
+  						),
+  					}
+  				)
+  			:
+  			(resp.StatusCode == 200) ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.nextPageToken != "NULL") ?
   						// Not the last page - Save the next page token and continue.

--- a/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
@@ -14,8 +14,7 @@ state:
   limit: {{limit}}
   page_limit: {{page_limit}}
   filter: {{filter}}
-program: |-
-  
+program: |
   (
   	state.?cursor.auth_data.expires.optMap(t,
   		t.parse_time(time_layout.RFC1123) - now() > duration("5m")
@@ -35,15 +34,35 @@ program: |-
   					"accessKey": state.auth_access_key,
   				}.encode_json(),
   			}
-  		).do_request().as(resp,
+  		).do_request().as(resp, resp.StatusCode == 200 ?
   			bytes(resp.Body).decode_json().as(body,
   				{
   					"token": body.data.token,
   					"expires": body.data.expires,
   				}
   			)
+  		:
+  			state.with(
+  				{
+  					"events": {
+  						"error": {
+  							"code": string(resp.StatusCode),
+  							"id": string(resp.Status),
+  							"message": "POST " + state.url.trim_right("/") + "/auth/external: " + (
+  								size(resp.Body) != 0 ?
+  									string(resp.Body)
+  								:
+  									string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  							),
+  						},
+  					},
+  					"want_more": false,
+  				}
+  			)
   		)
-  ).as(auth_data,
+  ).as(v, has(v.?events.error) ?
+    v
+  : v.as(auth_data,
   	(state.?cursor.task_id.orValue(null) == null) ?
   		// No task ID - Submit a query and get its task ID.
   		{
@@ -125,6 +144,7 @@ program: |-
   					}
   				)
   			:
+  			resp.StatusCode == 200 ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.state == "Ready") ?
   						// 'Ready' (Results found) - Save the first page token.
@@ -168,6 +188,24 @@ program: |-
   							}
   						)
   				)
+  			:
+  				state.with(
+  					{
+  						"events": {
+  							"error": {
+  								"code": string(resp.StatusCode),
+  								"id": string(resp.Status),
+  								"message": "GET " + state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query: " + (
+  									size(resp.Body) != 0 ?
+  										string(resp.Body)
+  									:
+  										string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  								),
+  							},
+  						},
+  						"want_more": false,
+  					}
+  				)
   		)
   	:
   		// Task is ready - Use the task ID and page token to retrieve a page of results.
@@ -194,6 +232,7 @@ program: |-
   					}
   				)
   			:
+  			resp.StatusCode == 200 ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.nextPageToken != "NULL") ?
   						// Not the last page - Save the next page token and continue.
@@ -225,8 +264,26 @@ program: |-
   							}
   						)
   				)
+  			:
+  				state.with(
+  					{
+  						"events": {
+  							"error": {
+  								"code": string(resp.StatusCode),
+  								"id": string(resp.Status),
+  								"message": "POST " + state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query/retrieve: " + (
+  									size(resp.Body) != 0 ?
+  										string(resp.Body)
+  									:
+  										string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  								),
+  							},
+  						},
+  						"want_more": false,
+  					}
+  				)
   		)
-  )
+  ))
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
@@ -258,7 +258,18 @@ program: |
   				// 503 Service Unavailable - Clear the task ID and page token, and end the sequence.
   				state.with(
   					{
-  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"events": {
+  							"error": {
+  								"code": string(resp.StatusCode),
+  								"id": string(resp.Status),
+  								"message": "POST " + state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query/retrieve: " + (
+  									size(resp.Body) != 0 ?
+  										string(resp.Body)
+  									:
+  										string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  								),
+  							},
+  						},
   						"want_more": false,
   						"cursor": state.cursor.with(
   							{

--- a/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
@@ -69,7 +69,9 @@ program: |
   			"startTime": state.?cursor.next_startTime.orValue(
   				timestamp(now() - duration(state.initial_interval)).format(time_layout.RFC3339)
   			),
-  			"endTime": timestamp(now() - duration("1m")).format(time_layout.RFC3339),
+  			"endTime": state.?cursor.next_endTime.orValue(
+  				timestamp(now() - duration("1m")).format(time_layout.RFC3339)
+  			),
   		}.as(timeframe,
   			request("POST", state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query").with(
   				{
@@ -116,7 +118,10 @@ program: |
   									"auth_data": auth_data,
   									"task_id": body.data.taskId,
   									"page_token": null,
+  									"current_startTime": timeframe.startTime,
+  									"current_endTime": timeframe.endTime,
   									"next_startTime": timeframe.endTime,
+  									"next_endTime": null,
   								},
   							}
   						)
@@ -144,7 +149,24 @@ program: |
   					}
   				)
   			:
-  			resp.StatusCode == 200 ?
+  			(resp.StatusCode == 404) ?
+  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
+  				state.with(
+  					{
+  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"want_more": true,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
+  							}
+  						),
+  					}
+  				)
+  			:
+  			(resp.StatusCode == 200) ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.state == "Ready") ?
   						// 'Ready' (Results found) - Save the first page token.
@@ -232,7 +254,23 @@ program: |
   					}
   				)
   			:
-  			resp.StatusCode == 200 ?
+  			(resp.StatusCode == 503) ?
+  				// 503 Service Unavailable - Clear the task ID and page token, and end the sequence.
+  				state.with(
+  					{
+  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"want_more": false,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"page_token": null,
+  							}
+  						),
+  					}
+  				)
+  			:
+  			(resp.StatusCode == 200) ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.nextPageToken != "NULL") ?
   						// Not the last page - Save the next page token and continue.

--- a/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
@@ -14,8 +14,7 @@ state:
   limit: {{limit}}
   page_limit: {{page_limit}}
   filter: {{filter}}
-program: |-
-  
+program: |
   (
   	state.?cursor.auth_data.expires.optMap(t,
   		t.parse_time(time_layout.RFC1123) - now() > duration("5m")
@@ -35,15 +34,35 @@ program: |-
   					"accessKey": state.auth_access_key,
   				}.encode_json(),
   			}
-  		).do_request().as(resp,
+  		).do_request().as(resp, resp.StatusCode == 200 ?
   			bytes(resp.Body).decode_json().as(body,
   				{
   					"token": body.data.token,
   					"expires": body.data.expires,
   				}
   			)
+  		:
+  			state.with(
+  				{
+  					"events": {
+  						"error": {
+  							"code": string(resp.StatusCode),
+  							"id": string(resp.Status),
+  							"message": "POST " + state.url.trim_right("/") + "/auth/external: " + (
+  								size(resp.Body) != 0 ?
+  									string(resp.Body)
+  								:
+  									string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  							),
+  						},
+  					},
+  					"want_more": false,
+  				}
+  			)
   		)
-  ).as(auth_data,
+  ).as(v, has(v.?events.error) ?
+    v
+  : v.as(auth_data,
   	(state.?cursor.task_id.orValue(null) == null) ?
   		// No task ID - Submit a query and get its task ID.
   		{
@@ -125,6 +144,7 @@ program: |-
   					}
   				)
   			:
+  			resp.StatusCode == 200 ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.state == "Ready") ?
   						// 'Ready' (Results found) - Save the first page token.
@@ -168,6 +188,24 @@ program: |-
   							}
   						)
   				)
+  			:
+  				state.with(
+  					{
+  						"events": {
+  							"error": {
+  								"code": string(resp.StatusCode),
+  								"id": string(resp.Status),
+  								"message": "GET " + state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query: " + (
+  									size(resp.Body) != 0 ?
+  										string(resp.Body)
+  									:
+  										string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  								),
+  							},
+  						},
+  						"want_more": false,
+  					}
+  				)
   		)
   	:
   		// Task is ready - Use the task ID and page token to retrieve a page of results.
@@ -194,6 +232,7 @@ program: |-
   					}
   				)
   			:
+  			resp.StatusCode == 200 ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.nextPageToken != "NULL") ?
   						// Not the last page - Save the next page token and continue.
@@ -225,8 +264,26 @@ program: |-
   							}
   						)
   				)
+  			:
+  				state.with(
+  					{
+  						"events": {
+  							"error": {
+  								"code": string(resp.StatusCode),
+  								"id": string(resp.Status),
+  								"message": "POST " + state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query/retrieve: " + (
+  									size(resp.Body) != 0 ?
+  										string(resp.Body)
+  									:
+  										string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  								),
+  							},
+  						},
+  						"want_more": false,
+  					}
+  				)
   		)
-  )
+  ))
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
@@ -258,7 +258,18 @@ program: |
   				// 503 Service Unavailable - Clear the task ID and page token, and end the sequence.
   				state.with(
   					{
-  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"events": {
+  							"error": {
+  								"code": string(resp.StatusCode),
+  								"id": string(resp.Status),
+  								"message": "POST " + state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query/retrieve: " + (
+  									size(resp.Body) != 0 ?
+  										string(resp.Body)
+  									:
+  										string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+  								),
+  							},
+  						},
   						"want_more": false,
   						"cursor": state.cursor.with(
   							{

--- a/packages/checkpoint_harmony_endpoint/manifest.yml
+++ b/packages/checkpoint_harmony_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: checkpoint_harmony_endpoint
 title: "Check Point Harmony Endpoint"
-version: "0.4.0"
+version: "0.5.0"
 source:
   license: "Elastic-2.0"
 description: "Collect logs from Check Point Harmony Endpoint"


### PR DESCRIPTION
## Proposed commit message

```
Changes in the error handling:

- When receiving a 503 Service Unavailable response, the sequence is restarted gratefully, cleaning the task ID and page token and waiting for the next interval.
- When receiving a 404 Not Found, the task ID is requested again for the same timeframe.
```

> [!TIP]
> Review commit by commit for a better understanding. The first one just propagates improvements from https://github.com/elastic/integrations/pull/12795 and https://github.com/elastic/integrations/pull/12158 to the rest of the data streams, while the second contains the new changes.

> [!NOTE]
> All data streams have identical `cel.yml.hbs` files.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
