### PR TITLE
[CI] Update teams permissions in pull request pipeline

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -61,6 +61,48 @@ spec:
       teams:
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ
+        ecosystem:
+          access_level: MANAGE_BUILD_AND_READ
+        cloud-security-posture:
+          access_level: BUILD_AND_READ
+        customer-architects:
+          access_level: BUILD_AND_READ
+        elastic-agent:
+          access_level: BUILD_AND_READ
+        elastic-agent-data-plane:
+          access_level: BUILD_AND_READ
+        fleet:
+          access_level: BUILD_AND_READ
+        logstash:
+          access_level: BUILD_AND_READ
+        ml-ui:
+          access_level: BUILD_AND_READ
+        obs-ds-hosted-services:
+          access_level: BUILD_AND_READ
+        obs-ds-intake-services:
+          access_level: BUILD_AND_READ
+        obs-infraobs-integrations:
+          access_level: BUILD_AND_READ
+        obs-ux-management-team:
+          access_level: BUILD_AND_READ
+        profiling:
+          access_level: BUILD_AND_READ
+        protections:
+          access_level: BUILD_AND_READ
+        search-extract-and-transform:
+          access_level: BUILD_AND_READ
+        sec-applied-ml:
+          access_level: BUILD_AND_READ
+        sec-deployment-and-devices:
+          access_level: BUILD_AND_READ
+        sec-linux-platform:
+          access_level: BUILD_AND_READ
+        security-asset-management:
+          access_level: BUILD_AND_READ
+        security-service-integrations:
+          access_level: BUILD_AND_READ
+        sec-windows-platform:
+          access_level: BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
 


### PR DESCRIPTION
## Proposed commit message

Update team permissions related to Pull Request pipeline in `catalog-info.yaml`.

Teams added in this PR are the ones found in `.github/CODEOWNERS` file. These are the teams:
```
@elastic/cloud-security-posture
@elastic/customer-architects
@elastic/ecosystem
@elastic/elastic-agent
@elastic/elastic-agent-data-plane
@elastic/fleet
@elastic/logstash
@elastic/ml-ui
@elastic/obs-ds-hosted-services
@elastic/obs-ds-intake-services
@elastic/obs-infraobs-integrations
@elastic/obs-ux-management-team
@elastic/profiling
@elastic/protections
@elastic/search-extract-and-transform
@elastic/sec-applied-ml
@elastic/sec-deployment-and-devices
@elastic/sec-linux-platform
@elastic/security-asset-management
@elastic/security-service-integrations
@elastic/sec-windows-platform
@elastic/stack-monitoring
```