### PR TITLE
Aligned data pulls to calendar days

### DIFF
--- a/packages/ess_billing/changelog.yml
+++ b/packages/ess_billing/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Aligned billing data pulls to calendar days
+      type: enhancement
+      link: "TODO"
 - version: "1.2.0"
   changes:
     - description: Added Agentless deployment mode

--- a/packages/ess_billing/changelog.yml
+++ b/packages/ess_billing/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Aligned billing data pulls to calendar days
       type: enhancement
-      link: "TODO"
+      link: https://github.com/elastic/integrations/pull/13020
 - version: "1.2.0"
   changes:
     - description: Added Agentless deployment mode

--- a/packages/ess_billing/data_stream/billing/agent/stream/cel.yml.hbs
+++ b/packages/ess_billing/data_stream/billing/agent/stream/cel.yml.hbs
@@ -17,20 +17,22 @@ resource.url: {{url}}/api/v2/billing/organizations/{{organization_id}}/costs/ins
 state:
   api_key: {{api_key}}
   organization_id: "{{organization_id}}"
-  lookbehind: "{{lookbehind}}h"
+  lookbehind: "{{lookbehind}}d"
 redact:
   fields:
     - api_key
 program: |
   state.with({
-    "from": has(state.?cursor.last_to) ?
+    "from": (has(state.?cursor.last_to) ?
         timestamp(state.cursor.last_to)
       :
-        (now().format(time_layout.DateOnly).parse_time(time_layout.DateOnly) - duration(state.lookbehind)),
-    "to": has(state.?cursor.last_to) ?
-        (timestamp(state.cursor.last_to) + duration("24h"))
+        (now() - duration(state.lookbehind))
+    ).format(time_layout.DateOnly).parse_time(time_layout.DateOnly),
+    "to": (has(state.?cursor.last_to) ?
+        (timestamp(state.cursor.last_to) + duration("1d"))
       :
-        (now().format(time_layout.DateOnly).parse_time(time_layout.DateOnly) - duration(state.lookbehind) + duration("24h")),
+        (now() - duration(state.lookbehind) + duration("1d"))
+    ).format(time_layout.DateOnly).parse_time(time_layout.DateOnly),
   }.as(req, (req.to > now()) ?
     // We would fetch data in the future, back off
     {

--- a/packages/ess_billing/data_stream/billing/agent/stream/cel.yml.hbs
+++ b/packages/ess_billing/data_stream/billing/agent/stream/cel.yml.hbs
@@ -16,8 +16,8 @@ resource.timeout: {{http_client_timeout}}
 resource.url: {{url}}/api/v2/billing/organizations/{{organization_id}}/costs/instances
 state:
   api_key: {{api_key}}
-  organization_id: "{{organization_id}}"
-  lookbehind: "{{lookbehind}}d"
+  organization_id: {{organization_id}}
+  lookbehind: {{lookbehind}}
 redact:
   fields:
     - api_key
@@ -26,12 +26,12 @@ program: |
     "from": (has(state.?cursor.last_to) ?
         timestamp(state.cursor.last_to)
       :
-        (now() - duration(state.lookbehind))
+        (now() - duration(string(int(state.lookbehind)*24) + "h"))
     ).format(time_layout.DateOnly).parse_time(time_layout.DateOnly),
     "to": (has(state.?cursor.last_to) ?
-        (timestamp(state.cursor.last_to) + duration("1d"))
+        (timestamp(state.cursor.last_to) + duration("24h"))
       :
-        (now() - duration(state.lookbehind) + duration("1d"))
+        (now() - duration(string(int(state.lookbehind)*24) + "h") + duration("24h"))
     ).format(time_layout.DateOnly).parse_time(time_layout.DateOnly),
   }.as(req, (req.to > now()) ?
     // We would fetch data in the future, back off

--- a/packages/ess_billing/data_stream/billing/manifest.yml
+++ b/packages/ess_billing/data_stream/billing/manifest.yml
@@ -13,8 +13,8 @@ streams:
       - name: lookbehind
         type: integer
         title: Lookbehind
-        description: How far back to fetch data for the first run (in hours), default to 8760 hours (1 year).
-        default: 8760
+        description: How far back to fetch data for the first run (in days), default to 1 year.
+        default: 365
         multi: false
         required: true
         show_user: true

--- a/packages/ess_billing/manifest.yml
+++ b/packages/ess_billing/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ess_billing
 title: "Elasticsearch Service Billing"
-version: 1.2.0
+version: 1.3.0
 source:
   license: "Elastic-2.0"
 description: "Collects billing metrics from Elasticsearch Service billing API"


### PR DESCRIPTION
In the previous implementation of the integration, the billing data was pulled with an offset starting when the integration is first run. This had the side effect of aligning days to whatever current time it was at installation.
IE instead of pulling from 00:00 to 23:59, it could be from 11:00 to 10:59 for instance.

This fixes this behavior, while also changing the lookbehind behavior: it used to be a count of hours, whereas it is now a count of days.


