### PR TITLE
Support stack 9.0 in deployment and devices integrations

### DIFF
--- a/packages/arista_ngfw/changelog.yml
+++ b/packages/arista_ngfw/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.3.0"
   changes:
     - description: ECS version updated to 8.17.0.

--- a/packages/arista_ngfw/manifest.yml
+++ b/packages/arista_ngfw/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: arista_ngfw
 title: "Arista NG Firewall"
-version: "1.3.0"
+version: "1.4.0"
 source:
   license: "Elastic-2.0"
 description: "Collect logs and metrics from Arista NG Firewall."
@@ -10,7 +10,7 @@ categories:
   - network
 conditions:
   kibana:
-    version: "^8.11.0"
+    version: "^8.11.0 || ^9.0.0"
   elastic:
     subscription: "basic"
 icons:

--- a/packages/cef/changelog.yml
+++ b/packages/cef/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.21.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.20.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/cef/manifest.yml
+++ b/packages/cef/manifest.yml
@@ -1,12 +1,12 @@
 name: cef
 title: Common Event Format (CEF)
-version: "2.20.1"
+version: "2.21.0"
 description: Collect logs from CEF Logs with Elastic Agent.
 categories:
   - security
 conditions:
   kibana:
-    version: "^8.6.1"
+    version: "^8.6.1 || ^9.0.0"
 format_version: "3.0.3"
 policy_templates:
   - name: cef

--- a/packages/checkpoint/changelog.yml
+++ b/packages/checkpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.39.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.38.0"
   changes:
     - description: Extend key/value parsing to include numbers in key names and extend supported fields. Map checkpoint.hostname to host.hostname.

--- a/packages/checkpoint/manifest.yml
+++ b/packages/checkpoint/manifest.yml
@@ -1,13 +1,13 @@
 name: checkpoint
 title: Check Point
-version: "1.38.0"
+version: "1.39.0"
 description: Collect logs from Check Point with Elastic Agent.
 type: integration
 format_version: "3.0.3"
 categories: [security, network, firewall_security]
 conditions:
   kibana:
-    version: "^8.11.0"
+    version: "^8.11.0 || ^9.0.0"
 icons:
   - src: /img/checkpoint-logo.svg
     title: Check Point

--- a/packages/cisco_aironet/changelog.yml
+++ b/packages/cisco_aironet/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.15.2"
   changes:
     - description: Properly parse 'CLIENT_ORCH_LOG-6-CLIENT_ADDED_TO_RUN_STATE' log messages

--- a/packages/cisco_aironet/manifest.yml
+++ b/packages/cisco_aironet/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_aironet
 title: "Cisco Aironet"
-version: "1.15.2"
+version: "1.16.0"
 description: "Integration for Cisco Aironet WLC Logs"
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - network
 conditions:
   kibana:
-    version: "^8.11.0"
+    version: "^8.11.0 || ^9.0.0"
   elastic:
     subscription: "basic"
 icons:

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.43.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.42.3"
   changes:
     - description: "Add proper parsing for previously unhandled message types"

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_asa
 title: Cisco ASA
-version: "2.42.3"
+version: "2.43.0"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:
@@ -10,7 +10,7 @@ categories:
   - firewall_security
 conditions:
   kibana:
-    version: "^8.11.0"
+    version: "^8.11.0 || ^9.0.0"
 screenshots:
   - src: /img/kibana-cisco-asa.png
     title: kibana cisco asa

--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.8.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.7.0"
   changes:
     - description: Add parsing for message IDs 109201, 109207, 209210, 111008, 113008, 113009, 113014, 716002, 716058, 716059, 722055, 746012, 746013, and fix patterns for 305012, 602101, 722051.

--- a/packages/cisco_ftd/manifest.yml
+++ b/packages/cisco_ftd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ftd
 title: Cisco FTD
-version: "3.7.0"
+version: "3.8.0"
 description: Collect logs from Cisco FTD with Elastic Agent.
 type: integration
 categories:
@@ -10,7 +10,7 @@ categories:
   - firewall_security
 conditions:
   kibana:
-    version: "^8.11.0"
+    version: "^8.11.0 || ^9.0.0"
 icons:
   - src: /img/cisco.svg
     title: cisco

--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.30.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.29.2"
   changes:
     - description: Support additional header format and message type.

--- a/packages/cisco_ios/manifest.yml
+++ b/packages/cisco_ios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ios
 title: Cisco IOS
-version: "1.29.2"
+version: "1.30.0"
 description: Collect logs from Cisco IOS with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - security
 conditions:
   kibana:
-    version: "^8.11.0"
+    version: "^8.11.0 || ^9.0.0"
 icons:
   - src: /img/cisco.svg
     title: cisco

--- a/packages/cisco_ise/changelog.yml
+++ b/packages/cisco_ise/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.26.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.25.0"
   changes:
     - description: ECS version updated to 8.17.0.

--- a/packages/cisco_ise/manifest.yml
+++ b/packages/cisco_ise/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ise
 title: Cisco ISE
-version: "1.25.0"
+version: "1.26.0"
 description: Collect logs from Cisco ISE with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - network
 conditions:
   kibana:
-    version: ^8.11.0
+    version: "^8.11.0 || ^9.0.0"
 screenshots:
   - src: /img/cisco-ise-screenshot.png
     title: Cisco ISE dashboard screenshot

--- a/packages/cisco_nexus/changelog.yml
+++ b/packages/cisco_nexus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.3.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/cisco_nexus/manifest.yml
+++ b/packages/cisco_nexus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_nexus
 title: Cisco Nexus
-version: "1.3.1"
+version: "1.4.0"
 description: Collect logs from Cisco Nexus with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - security
 conditions:
   kibana:
-    version: ^8.11.0
+    version: "^8.11.0 || ^9.0.0"
   elastic:
     subscription: basic
 icons:

--- a/packages/cisco_secure_email_gateway/changelog.yml
+++ b/packages/cisco_secure_email_gateway/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.25.1"
+- version: "1.26.0"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.
       type: bugfix

--- a/packages/cisco_secure_email_gateway/manifest.yml
+++ b/packages/cisco_secure_email_gateway/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_secure_email_gateway
 title: Cisco Secure Email Gateway
-version: "1.25.1"
+version: "1.26.0"
 description: Collect logs from Cisco Secure Email Gateway with Elastic Agent.
 type: integration
 categories:
@@ -10,7 +10,7 @@ categories:
   - email_security
 conditions:
   kibana:
-    version: ^8.11.0
+    version: "^8.11.0 || ^9.0.0"
 screenshots:
   - src: /img/cisco-secure-email-gateway-screenshot.png
     title: Cisco Secure Email Gateway dashboard screenshot

--- a/packages/citrix_waf/changelog.yml
+++ b/packages/citrix_waf/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.17.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/citrix_waf/manifest.yml
+++ b/packages/citrix_waf/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: citrix_waf
 title: "Citrix Web App Firewall"
-version: "1.17.1"
+version: "1.18.0"
 description: Ingest events from Citrix Systems Web App Firewall.
 type: integration
 categories:
@@ -10,7 +10,7 @@ categories:
   - web_application_firewall
 conditions:
   kibana:
-    version: "^8.11.0"
+    version: "^8.11.0 || ^9.0.0"
 icons:
   - src: /img/Citrix_Systems_logo.svg
     title: Citrix Systems

--- a/packages/fortinet_fortiedr/changelog.yml
+++ b/packages/fortinet_fortiedr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.17.0"
   changes:
     - description: Allow the usage of deprecated log input and support for stack 9.0

--- a/packages/fortinet_fortiedr/manifest.yml
+++ b/packages/fortinet_fortiedr/manifest.yml
@@ -1,13 +1,13 @@
 name: fortinet_fortiedr
 title: Fortinet FortiEDR Logs
-version: "1.17.0"
+version: "1.18.0"
 description: Collect logs from Fortinet FortiEDR instances with Elastic Agent.
 type: integration
 format_version: "3.0.3"
 categories: ["security", "edr_xdr"]
 conditions:
   kibana:
-    version: "^7.17.0 || ^8.0.0"
+    version: "^7.17.0 || ^8.0.0 || ^9.0.0"
 icons:
   - src: /img/fortinet-logo.svg
     title: Fortinet

--- a/packages/fortinet_fortigate/changelog.yml
+++ b/packages/fortinet_fortigate/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.31.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.30.0"
   changes:
     - description: If url parsing fails, append failure message to error.message.

--- a/packages/fortinet_fortigate/manifest.yml
+++ b/packages/fortinet_fortigate/manifest.yml
@@ -1,13 +1,13 @@
 name: fortinet_fortigate
 title: Fortinet FortiGate Firewall Logs
-version: "1.30.0"
+version: "1.31.0"
 description: Collect logs from Fortinet FortiGate firewalls with Elastic Agent.
 type: integration
 format_version: "3.0.3"
 categories: ["security", "network", "firewall_security"]
 conditions:
   kibana:
-    version: "^8.3.0"
+    version: "^8.3.0 || ^9.0.0"
 icons:
   - src: /img/fortinet-logo.svg
     title: Fortinet

--- a/packages/fortinet_fortimail/changelog.yml
+++ b/packages/fortinet_fortimail/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.15.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.14.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/fortinet_fortimail/manifest.yml
+++ b/packages/fortinet_fortimail/manifest.yml
@@ -1,13 +1,13 @@
 name: fortinet_fortimail
 title: Fortinet FortiMail
-version: "2.14.1"
+version: "2.15.0"
 description: Collect logs from Fortinet FortiMail instances with Elastic Agent.
 type: integration
 format_version: "3.0.3"
 categories: ["security", "email_security"]
 conditions:
   kibana:
-    version: ^8.3.0
+    version: "^8.3.0 || ^9.0.0"
   elastic:
     subscription: basic
 icons:

--- a/packages/fortinet_fortimanager/changelog.yml
+++ b/packages/fortinet_fortimanager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.15.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.14.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/fortinet_fortimanager/manifest.yml
+++ b/packages/fortinet_fortimanager/manifest.yml
@@ -1,13 +1,13 @@
 format_version: "3.0.3"
 name: fortinet_fortimanager
 title: Fortinet FortiManager Logs
-version: "2.14.1"
+version: "2.15.0"
 description: Collect logs from Fortinet FortiManager instances with Elastic Agent.
 type: integration
 categories: ["security", "network", "firewall_security"]
 conditions:
   kibana:
-    version: ^8.3.0
+    version: "^8.3.0 || ^9.0.0"
   elastic:
     subscription: basic
 screenshots:

--- a/packages/fortinet_fortiproxy/changelog.yml
+++ b/packages/fortinet_fortiproxy/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.1.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/fortinet_fortiproxy/manifest.yml
+++ b/packages/fortinet_fortiproxy/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.3
 name: fortinet_fortiproxy
 title: "Fortinet FortiProxy"
-version: "1.1.1"
+version: "1.2.0"
 description: "Collect logs from Fortinet FortiProxy with Elastic Agent."
 type: integration
 categories:
@@ -11,7 +11,7 @@ categories:
   - web
 conditions:
   kibana:
-    version: "^8.12.2"
+    version: "^8.12.2 || ^9.0.0"
   elastic:
     subscription: "basic"
 screenshots:

--- a/packages/goflow2/changelog.yml
+++ b/packages/goflow2/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.3.0"
   changes:
     - description: ECS version updated to 8.17.0.

--- a/packages/goflow2/manifest.yml
+++ b/packages/goflow2/manifest.yml
@@ -1,14 +1,14 @@
 format_version: 3.2.1
 name: goflow2
 title: "GoFlow2 logs"
-version: "0.3.0"
+version: "0.4.0"
 description: "Collect logs from goflow2 with Elastic Agent."
 type: integration
 categories:
   - network
 conditions:
   kibana:
-    version: "^8.11.0"
+    version: "^8.11.0 || ^9.0.0"
   elastic:
     subscription: "basic"
 icons:

--- a/packages/hashicorp_vault/changelog.yml
+++ b/packages/hashicorp_vault/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.27.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.26.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/hashicorp_vault/manifest.yml
+++ b/packages/hashicorp_vault/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: hashicorp_vault
 title: Hashicorp Vault
-version: "1.26.1"
+version: "1.27.0"
 description: Collect logs and metrics from Hashicorp Vault with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - iam
 conditions:
   kibana:
-    version: "^8.12.0"
+    version: "^8.12.0 || ^9.0.0"
 screenshots:
   - src: /img/hashicorp_vault-audit-dashboard.png
     title: Audit Log Dashboard

--- a/packages/imperva/changelog.yml
+++ b/packages/imperva/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.4.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/imperva/manifest.yml
+++ b/packages/imperva/manifest.yml
@@ -1,13 +1,13 @@
 format_version: 3.0.3
 name: imperva
 title: Imperva
-version: "1.4.1"
+version: "1.5.0"
 description: Collect logs from Imperva devices with Elastic Agent.
 categories: ["network", "security"]
 type: integration
 conditions:
   kibana:
-    version: ^8.10.1
+    version: "^8.10.1 || ^9.0.0"
   elastic:
     subscription: basic
 screenshots:

--- a/packages/iptables/changelog.yml
+++ b/packages/iptables/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.20.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.19.0"
   changes:
     - description: Allow the usage of deprecated log input and support for stack 9.0

--- a/packages/iptables/manifest.yml
+++ b/packages/iptables/manifest.yml
@@ -1,6 +1,6 @@
 name: iptables
 title: Iptables
-version: "1.19.0"
+version: "1.20.0"
 description: Collect logs from Iptables with Elastic Agent.
 type: integration
 icons:
@@ -14,7 +14,7 @@ categories:
   - security
 conditions:
   kibana:
-    version: "^8.7.1"
+    version: "^8.7.1 || ^9.0.0"
 screenshots:
   - src: /img/kibana-iptables.png
     title: kibana iptables

--- a/packages/juniper_srx/changelog.yml
+++ b/packages/juniper_srx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.23.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.22.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/juniper_srx/manifest.yml
+++ b/packages/juniper_srx/manifest.yml
@@ -1,13 +1,13 @@
 format_version: "3.0.3"
 name: juniper_srx
 title: Juniper SRX
-version: "1.22.1"
+version: "1.23.0"
 description: Collect logs from Juniper SRX devices with Elastic Agent.
 categories: ["network", "security", "firewall_security"]
 type: integration
 conditions:
   kibana:
-    version: ^8.0.0
+    version: "^8.0.0 || ^9.0.0"
 policy_templates:
   - name: juniper
     title: Juniper SRX logs

--- a/packages/modsecurity/changelog.yml
+++ b/packages/modsecurity/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.20.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.19.0"
   changes:
     - description: ECS version updated to 8.17.0.

--- a/packages/modsecurity/manifest.yml
+++ b/packages/modsecurity/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: modsecurity
 title: "ModSecurity Audit"
-version: "1.19.0"
+version: "1.20.0"
 description: Collect logs from ModSecurity with Elastic Agent
 type: integration
 categories:
@@ -10,7 +10,7 @@ categories:
   - web_application_firewall
 conditions:
   kibana:
-    version: "^7.16.0 || ^8.0.0"
+    version: "^7.16.0 || ^8.0.0 || ^9.0.0"
 icons:
   - src: /img/modsec.svg
     title: ModSecurity

--- a/packages/netflow/changelog.yml
+++ b/packages/netflow/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.22.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.21.0"
   changes:
     - description: ECS version updated to 8.17.0.

--- a/packages/netflow/manifest.yml
+++ b/packages/netflow/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: netflow
 title: NetFlow Records
-version: "2.21.0"
+version: "2.22.0"
 description: Collect flow records from NetFlow and IPFIX exporters with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - security
 conditions:
   kibana:
-    version: ^8.14.0
+    version: "^8.14.0 || ^9.0.0"
 screenshots:
   - src: /img/netflow-overview.png
     title: Netflow Overview Dashboard

--- a/packages/osquery/changelog.yml
+++ b/packages/osquery/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.21.0"
   changes:
     - description: Allow the usage of deprecated log input and support for stack 9.0

--- a/packages/osquery/manifest.yml
+++ b/packages/osquery/manifest.yml
@@ -1,6 +1,6 @@
 name: osquery
 title: Osquery Logs
-version: "1.21.0"
+version: "1.22.0"
 description: Collect logs from Osquery with Elastic Agent.
 type: integration
 icons:
@@ -13,7 +13,7 @@ categories:
   - security
 conditions:
   kibana:
-    version: ^8.7.1
+    version: "^8.7.1 || ^9.0.0"
 screenshots:
   - src: /img/osquery-compliance.png
     title: Osquery Compliance Dashboard

--- a/packages/pfsense/changelog.yml
+++ b/packages/pfsense/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.21.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/pfsense/manifest.yml
+++ b/packages/pfsense/manifest.yml
@@ -1,6 +1,6 @@
 name: pfsense
 title: pfSense
-version: "1.21.1"
+version: "1.22.0"
 description: Collect logs from pfSense and OPNsense with Elastic Agent.
 type: integration
 icons:
@@ -15,7 +15,7 @@ categories:
   - firewall_security
 conditions:
   kibana:
-    version: ^8.7.1
+    version: "^8.7.1 || ^9.0.0"
 screenshots:
   - src: /img/firewall.png
     title: pfSense Firewall Dashboard

--- a/packages/proxysg/changelog.yml
+++ b/packages/proxysg/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.5.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/proxysg/manifest.yml
+++ b/packages/proxysg/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.1
 name: proxysg
 title: "Broadcom ProxySG"
-version: "0.5.1"
+version: "0.6.0"
 source:
   license: "Elastic-2.0"
 description: "Collect access logs from Broadcom ProxySG with Elastic Agent."
@@ -11,7 +11,7 @@ categories:
   - security
 conditions:
   kibana:
-    version: "^8.13.0"
+    version: "^8.13.0 || ^9.0.0"
   elastic:
     subscription: "basic"
 screenshots:

--- a/packages/qnap_nas/changelog.yml
+++ b/packages/qnap_nas/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.21.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/qnap_nas/manifest.yml
+++ b/packages/qnap_nas/manifest.yml
@@ -1,13 +1,13 @@
 name: qnap_nas
 title: QNAP NAS
-version: "1.21.1"
+version: "1.22.0"
 description: Collect logs from QNAP NAS devices with Elastic Agent.
 type: integration
 format_version: "3.0.3"
 categories: ["security"]
 conditions:
   kibana:
-    version: "^8.7.1"
+    version: "^8.7.1 || ^9.0.0"
 icons:
   - src: /img/logo.svg
     title: QNAP logo

--- a/packages/snort/changelog.yml
+++ b/packages/snort/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.17.0"
   changes:
     - description: Allow the usage of deprecated log input and support for stack 9.0

--- a/packages/snort/manifest.yml
+++ b/packages/snort/manifest.yml
@@ -1,6 +1,6 @@
 name: snort
 title: Snort
-version: "1.17.0"
+version: "1.18.0"
 description: Collect logs from Snort with Elastic Agent.
 type: integration
 icons:
@@ -12,7 +12,7 @@ format_version: "3.0.3"
 categories: [ids_ips, security]
 conditions:
   kibana:
-    version: "^7.16.0 || ^8.0.0"
+    version: "^7.16.0 || ^8.0.0 || ^9.0.0"
 policy_templates:
   - name: snort
     title: Snort logs

--- a/packages/sonicwall_firewall/changelog.yml
+++ b/packages/sonicwall_firewall/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.17.0"
   changes:
     - description: ECS version updated to 8.17.0.

--- a/packages/sonicwall_firewall/manifest.yml
+++ b/packages/sonicwall_firewall/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: sonicwall_firewall
 title: "SonicWall Firewall"
-version: "1.17.0"
+version: "1.18.0"
 description: "Integration for SonicWall firewall logs"
 type: integration
 categories:
@@ -10,7 +10,7 @@ categories:
   - firewall_security
 conditions:
   kibana:
-    version: "^8.2.0"
+    version: "^8.2.0 || ^9.0.0"
 screenshots:
   - src: /img/dashboard.png
     title: Sample dashboard

--- a/packages/sophos/changelog.yml
+++ b/packages/sophos/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.13.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.12.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/sophos/manifest.yml
+++ b/packages/sophos/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: sophos
 title: Sophos
-version: "3.12.1"
+version: "3.13.0"
 description: Collect logs from Sophos with Elastic Agent.
 categories:
   - "security"
@@ -10,7 +10,7 @@ categories:
 type: integration
 conditions:
   kibana:
-    version: ^8.6.1
+    version: "^8.6.1 || ^9.0.0"
 policy_templates:
   - name: sophos
     title: Sophos logs

--- a/packages/squid/changelog.yml
+++ b/packages/squid/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.1.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/squid/manifest.yml
+++ b/packages/squid/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: squid
 title: Squid Proxy
-version: "1.1.1"
+version: "1.2.0"
 description: Collect and parse logs from Squid devices with Elastic Agent.
 categories:
   - network
@@ -11,7 +11,7 @@ categories:
 type: integration
 conditions:
   kibana:
-    version: "^8.14.1"
+    version: "^8.14.1 || ^9.0.0"
   elastic:
     subscription: "basic"
 icons:

--- a/packages/stormshield/changelog.yml
+++ b/packages/stormshield/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.1.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/stormshield/manifest.yml
+++ b/packages/stormshield/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.1
 name: stormshield
 title: "StormShield SNS"
-version: "1.1.1"
+version: "1.2.0"
 source:
   license: "Elastic-2.0"
 description: "Stormshield SNS integration."
@@ -12,7 +12,7 @@ categories:
   - firewall_security
 conditions:
   kibana:
-    version: "^8.11.4"
+    version: "^8.11.4 || ^9.0.0"
   elastic:
     subscription: "basic"
 screenshots:

--- a/packages/suricata/changelog.yml
+++ b/packages/suricata/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.24.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.23.0"
   changes:
     - description: Allow the usage of deprecated log input and support for stack 9.0

--- a/packages/suricata/manifest.yml
+++ b/packages/suricata/manifest.yml
@@ -1,6 +1,6 @@
 name: suricata
 title: Suricata
-version: "2.23.0"
+version: "2.24.0"
 description: Collect logs from Suricata with Elastic Agent.
 type: integration
 icons:
@@ -12,7 +12,7 @@ format_version: "3.0.3"
 categories: [network, security, ids_ips]
 conditions:
   kibana:
-    version: ^8.7.1
+    version: "^8.7.1 || ^9.0.0"
 screenshots:
   - src: /img/suricata-events.png
     title: suricata events dashboard

--- a/packages/syslog_router/changelog.yml
+++ b/packages/syslog_router/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.1.2"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/syslog_router/manifest.yml
+++ b/packages/syslog_router/manifest.yml
@@ -1,14 +1,14 @@
 format_version: 3.2.1
 name: syslog_router
 title: "Syslog Router"
-version: 0.1.2
+version: 0.2.0
 description: "Route syslog events to integrations with Elastic Agent."
 type: integration
 categories:
   - custom
 conditions:
   kibana:
-    version: "^8.14.3"
+    version: "^8.14.3 || ^9.0.0"
   elastic:
     subscription: "basic"
 icons:

--- a/packages/tcp/changelog.yml
+++ b/packages/tcp/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.21.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.20.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/tcp/manifest.yml
+++ b/packages/tcp/manifest.yml
@@ -3,10 +3,10 @@ name: tcp
 title: Custom TCP Logs
 description: Collect raw TCP data from listening TCP port with Elastic Agent.
 type: integration
-version: "1.20.1"
+version: "1.21.0"
 conditions:
   kibana:
-    version: "^8.2.1"
+    version: "^8.2.1 || ^9.0.0"
 categories:
   - custom
   - custom_logs

--- a/packages/tetragon/changelog.yml
+++ b/packages/tetragon/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.2.0
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: 0.1.0
   changes:
     - description: Initial Version

--- a/packages/tetragon/manifest.yml
+++ b/packages/tetragon/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.4
 name: cilium_tetragon
 title: Cilium Tetragon
-version: 0.1.0
+version: 0.2.0
 description: >-
   Collect Cilium Tetragon logs from Kubernetes environments.
 type: integration
@@ -14,7 +14,7 @@ categories:
   - kubernetes
 conditions:
   kibana:
-    version: ^8.13.0
+    version: "^8.13.0 || ^9.0.0"
   elastic:
     subscription: "basic"
 policy_templates:

--- a/packages/udp/changelog.yml
+++ b/packages/udp/changelog.yml
@@ -1,3 +1,8 @@
+- version: "2.2.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.1.0"
   changes:
     - description: ECS version updated to 8.17.0.

--- a/packages/udp/manifest.yml
+++ b/packages/udp/manifest.yml
@@ -3,10 +3,10 @@ name: udp
 title: Custom UDP Logs
 description: Collect raw UDP data from listening UDP port with Elastic Agent.
 type: input
-version: "2.1.0"
+version: "2.2.0"
 conditions:
   kibana:
-    version: "^8.13.0"
+    version: "^8.13.0 || ^9.0.0"
 categories:
   - custom
   - custom_logs

--- a/packages/watchguard_firebox/changelog.yml
+++ b/packages/watchguard_firebox/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.2.0"
   changes:
     - description: Support email addresses in 2500-0000 and 2500-0001 events.

--- a/packages/watchguard_firebox/manifest.yml
+++ b/packages/watchguard_firebox/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.4
 name: watchguard_firebox
 title: WatchGuard Firebox
-version: "1.2.0"
+version: "1.3.0"
 description: Collect logs from WatchGuard Firebox with Elastic Agent.
 type: integration
 categories:
@@ -10,7 +10,7 @@ categories:
   - firewall_security
 conditions:
   kibana:
-    version: ^8.13.0
+    version: "^8.13.0 || ^9.0.0"
   elastic:
     subscription: basic
 screenshots:

--- a/packages/zeek/changelog.yml
+++ b/packages/zeek/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.28.0"
+  changes:
+    - description: Support stack version 9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.27.0"
   changes:
     - description: Allow the usage of deprecated log input and support for stack 9.0

--- a/packages/zeek/manifest.yml
+++ b/packages/zeek/manifest.yml
@@ -1,6 +1,6 @@
 name: zeek
 title: Zeek
-version: "2.27.0"
+version: "2.28.0"
 description: Collect logs from Zeek with Elastic Agent.
 type: integration
 icons:
@@ -12,7 +12,7 @@ format_version: "3.0.3"
 categories: [network, security]
 conditions:
   kibana:
-    version: ^8.12.0
+    version: "^8.12.0 || ^9.0.0"
 screenshots:
   - src: /img/kibana-zeek.png
     title: kibana zeek


### PR DESCRIPTION
## Proposed commit message

- Support stack 9.0 in integrations owned by deployment and devices

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

## Related issues

- Closes #13040 
