### PR TITLE
[Cloud Security] Fix GCP Organization Agentless validation

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -12,6 +12,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "1.13.0-preview05"
+  changes:
+    - description: Fix GCP Organization Agentless validation
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/13045
 - version: "1.13.0-preview04"
   changes:
     - description: Remove azure.credentials.client_certificate_password from required_vars

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -16,7 +16,7 @@
   changes:
     - description: Fix GCP Organization Agentless validation
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/13045
+      link: https://github.com/elastic/integrations/pull/13048
 - version: "1.13.0-preview04"
   changes:
     - description: Remove azure.credentials.client_certificate_password from required_vars

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -224,7 +224,6 @@ streams:
         - name: gcp.credentials.type
           value: credentials-json
         - name: gcp.organization_id
-        - name: gcp.project_id
         - name: gcp.credentials.json
       single_account_cloud_shell:
         - name: gcp.account_type

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.13.0-preview04"
+version: "1.13.0-preview05"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
## Proposed commit message
Removed the validation requiring a project ID for CSPM GCP integration when the account type is `organization`

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally
Start Kibana

1. Load CSPM integration with the preview mode on (cloud_security_posture-1.13.0-preview05)
2. Select GCP
3. Select Organization account
4. Select Agentless
5. Enter the Organization ID
6. Enter the JSON Blob
7. Save button should be enabled


## Related issues
closes https://github.com/elastic/security-team/issues/12087


## Screenshots

https://github.com/user-attachments/assets/8c0f99b3-c65b-47c0-8f35-673e36ac245d

