### PR TITLE
crowdstrike.fdr: Increase field limits in FDR data-streams to avoid unindexed ECS fields

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Increase field limits in FDR data-streams to avoid unindexed ECS fields.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/13056
 - version: "1.54.0"
   changes:
     - description: Enable request trace log removal.
@@ -19,7 +19,7 @@
       link: https://github.com/elastic/integrations/pull/12973
 - version: "1.52.1"
   changes:
-    - description: Fixed parsing of RawProcessIDs in edge case scenarios. 
+    - description: Fixed parsing of RawProcessIDs in edge case scenarios.
       type: bugfix
       link: http://github.com/elastic/integrations/pull/12860
 - version: "1.52.0"

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.55.0"
+  changes:
+    - description: Increase field limits in FDR data-streams to avoid unindexed ECS fields.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.54.0"
   changes:
     - description: Enable request trace log removal.

--- a/packages/crowdstrike/data_stream/fdr/manifest.yml
+++ b/packages/crowdstrike/data_stream/fdr/manifest.yml
@@ -1,5 +1,12 @@
 title: "Falcon Data Replicator"
 type: logs
+elasticsearch:
+  index_template:
+    settings:
+      index:
+        mapping:
+          total_fields:
+            limit: 2000
 streams:
   - input: aws-s3
     template_path: aws-s3.yml.hbs

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "1.54.0"
+version: "1.55.0"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: "3.3.1"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
Crowdstrike FDR data stream can collect more than 1000 fields
and the data stream explicitly defines more than 500 fields.
In such cases, the total_fields.limit is automatically updated to 
10000[1] from the default 1000. 
Having such dynamic resizing could be detrimental when some of 
these explicitly mapped fields are later removed and the limit goes 
back to 1000. If it goes back to 1000, then it could end up not 
indexing all fields, even the ECS fields.

This PR sets the field limit to 2000 to facilitate 
indexing of all fields, especially ECS.

Ref: 
- [1] https://www.elastic.co/guide/en/integrations-developer/current/general-guidelines.html#_field_limits
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Current (1.54.0) version:
`GET .ds-logs-crowdstrike.fdr-default-2025.03.11-000001/_settings`
```json
{
  ".ds-logs-crowdstrike.fdr-default-2025.03.11-000001": {
    "settings": {
      "index": {
        "mapping": {
          "total_fields": {
            "limit": "10000",
            "ignore_dynamic_beyond_limit": "true"
          },
          "ignore_malformed": "true"
        },
```

With new PR change
`GET .ds-logs-crowdstrike.fdr-default-2025.03.11-000001/_settings`
```json
{
  ".ds-logs-crowdstrike.fdr-default-2025.03.11-000001": {
    "settings": {
      "index": {
        "mapping": {
          "total_fields": {
            "limit": "2000",
            "ignore_dynamic_beyond_limit": "true"
          },
          "ignore_malformed": "true"
        },
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
