### PR TITLE
update `audit_manager` Kibana constraint integration to support to 9.0

### DIFF
--- a/packages/auditd_manager/changelog.yml
+++ b/packages/auditd_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.0"
+  changes:
+    - description: Update Kibana constraint to 9.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12542
 - version: "1.18.3"
   changes:
     - description: "Updated field definitions for `auditd.data.*` fields"

--- a/packages/auditd_manager/changelog.yml
+++ b/packages/auditd_manager/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update Kibana constraint to 9.0
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/12542
+      link: https://github.com/elastic/integrations/pull/13067
 - version: "1.18.3"
   changes:
     - description: "Updated field definitions for `auditd.data.*` fields"

--- a/packages/auditd_manager/manifest.yml
+++ b/packages/auditd_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: auditd_manager
 title: "Auditd Manager"
-version: "1.18.3"
+version: "1.19.0"
 description: "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel."
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - auditd
 conditions:
   kibana:
-    version: "^8.16.0"
+    version: ^8.16.0 || ^9.0.0
 screenshots:
   - src: /img/overview.png
     title: Overview Dashboard

--- a/packages/auditd_manager/manifest.yml
+++ b/packages/auditd_manager/manifest.yml
@@ -9,7 +9,7 @@ categories:
   - auditd
 conditions:
   kibana:
-    version: ^8.16.0 || ^9.0.0
+    version: "^8.16.0 || ^9.0.0"
 screenshots:
   - src: /img/overview.png
     title: Overview Dashboard


### PR DESCRIPTION

## Proposed commit message

Updates the constraint to support the 9.0 stack. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
