### PR TITLE
[CI] Remove deps from with_mage

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -126,8 +126,6 @@ with_mage() {
 
     local install_packages=(
             "github.com/magefile/mage"
-            "github.com/elastic/go-licenser"
-            "golang.org/x/tools/cmd/goimports"
             "github.com/jstemmer/go-junit-report"
             "gotest.tools/gotestsum"
     )


### PR DESCRIPTION
## Proposed commit message

Remove dependencies that are already defined in `go.mod` when calling `with_mage` in buildkite scripts.

Applied same change as #11143 

Relates #13077