### PR TITLE
Update `fim` Kibana constraint integration to support to 9.0

### DIFF
--- a/packages/fim/changelog.yml
+++ b/packages/fim/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description:  Update Kibana constraint to 9.0
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/9702
+      link: https://github.com/elastic/integrations/pull/13106
 - version: "1.15.1"
   changes:
     - description: Fix default backend to auto

--- a/packages/fim/changelog.yml
+++ b/packages/fim/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.0"
+  changes:
+    - description:  Update Kibana constraint to 9.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9702
 - version: "1.15.1"
   changes:
     - description: Fix default backend to auto

--- a/packages/fim/manifest.yml
+++ b/packages/fim/manifest.yml
@@ -1,14 +1,14 @@
 format_version: "3.0.0"
 name: fim
 title: "File Integrity Monitoring"
-version: "1.15.1"
+version: "1.16.0"
 description: "The File Integrity Monitoring integration reports filesystem changes in real time."
 type: integration
 categories:
   - security
 conditions:
   kibana:
-    version: ^8.7.1
+    version: ^8.7.1 || ^9.0.0
 icons:
   - src: /img/sample-logo.svg
     title: Sample logo


### PR DESCRIPTION
## Proposed commit message

Updates the constraint in the `fim` integration to support the 9.0 stack. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

