### PR TITLE
Enable zscaler and sentinel one for agentless

### DIFF
--- a/packages/sentinel_one/_dev/build/docs/README.md
+++ b/packages/sentinel_one/_dev/build/docs/README.md
@@ -2,6 +2,11 @@
 
 The [SentinelOne](https://www.sentinelone.com/) integration collects and parses data from SentinelOne REST APIs. This integration also offers the capability to perform response actions on SentinelOne hosts directly through the Elastic Security interface (introduced with v8.12.0). Additional configuration is required; for detailed guidance, refer to [documentation](https://www.elastic.co/guide/en/security/current/response-actions-config.html).
 
+## Agentless Enabled Integration
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Compatibility
 
 This module has been tested against `SentinelOne Management Console API version 2.1`.

--- a/packages/sentinel_one/changelog.yml
+++ b/packages/sentinel_one/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add agentless deployment.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/13107
 - version: "1.29.1"
   changes:
     - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.

--- a/packages/sentinel_one/changelog.yml
+++ b/packages/sentinel_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.30.0"
+  changes:
+    - description: Add agentless deployment.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.29.1"
   changes:
     - description: Updated SSL description in package manifest.yml to be uniform and to include links to documentation.

--- a/packages/sentinel_one/data_stream/activity/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sentinel_one/data_stream/activity/elasticsearch/ingest_pipeline/default.yml
@@ -9,6 +9,11 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/sentinel_one/data_stream/agent/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sentinel_one/data_stream/agent/elasticsearch/ingest_pipeline/default.yml
@@ -18,6 +18,11 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/sentinel_one/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sentinel_one/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
@@ -18,6 +18,11 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/sentinel_one/data_stream/group/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sentinel_one/data_stream/group/elasticsearch/ingest_pipeline/default.yml
@@ -18,6 +18,11 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/sentinel_one/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sentinel_one/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
@@ -12,6 +12,11 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/sentinel_one/docs/README.md
+++ b/packages/sentinel_one/docs/README.md
@@ -2,6 +2,11 @@
 
 The [SentinelOne](https://www.sentinelone.com/) integration collects and parses data from SentinelOne REST APIs. This integration also offers the capability to perform response actions on SentinelOne hosts directly through the Elastic Security interface (introduced with v8.12.0). Additional configuration is required; for detailed guidance, refer to [documentation](https://www.elastic.co/guide/en/security/current/response-actions-config.html).
 
+## Agentless Enabled Integration
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Compatibility
 
 This module has been tested against `SentinelOne Management Console API version 2.1`.

--- a/packages/sentinel_one/manifest.yml
+++ b/packages/sentinel_one/manifest.yml
@@ -1,7 +1,7 @@
-format_version: "3.0.2"
+format_version: "3.2.3"
 name: sentinel_one
 title: SentinelOne
-version: "1.29.1"
+version: "1.30.0"
 description: Collect logs from SentinelOne with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - edr_xdr
 conditions:
   kibana:
-    version: "^8.13.0 || ^9.0.0"
+    version: "^8.18.0 || ^9.0.0"
 screenshots:
   - src: /img/sentinel-one-screenshot.png
     title: SentinelOne Threat Dashboard Screenshot
@@ -24,6 +24,14 @@ policy_templates:
   - name: sentinel_one
     title: SentinelOne
     description: Collect logs from SentinelOne.
+    deployment_modes: 
+      default:
+        enabled: true 
+      agentless:
+        enabled: true
+        organization: security
+        division: engineering
+        team: security-service-integrations
     inputs:
       - type: httpjson
         title: Collect SentinelOne logs via API

--- a/packages/zscaler_zia/_dev/build/docs/README.md
+++ b/packages/zscaler_zia/_dev/build/docs/README.md
@@ -7,21 +7,26 @@ The log message is expected to be in JSON format. The data is mapped to ECS fiel
 
 ## Requirements
 
+### Agentless Enabled Integration
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
 Elastic Agent must be installed. For more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-### Installing and managing an Elastic Agent:
+### Agent-Based Installation
+#### Installing and managing an Elastic Agent:
 
 You have a few options for installing and managing an Elastic Agent:
 
-### Install a Fleet-managed Elastic Agent (recommended):
+#### Install a Fleet-managed Elastic Agent (recommended):
 
 With this approach, you install Elastic Agent and use Fleet in Kibana to define, configure, and manage your agents in a central location. We recommend using Fleet management because it makes the management and upgrade of your agents considerably easier.
 
-### Install Elastic Agent in standalone mode (advanced users):
+#### Install Elastic Agent in standalone mode (advanced users):
 
 With this approach, you install Elastic Agent and manually configure the agent locally on the system where it’s installed. You are responsible for managing and upgrading the agents. This approach is reserved for advanced users only.
 
-### Install Elastic Agent in a containerized environment:
+#### Install Elastic Agent in a containerized environment:
 
 You can run Elastic Agent inside a container, either with Fleet Server or standalone. Docker images for all versions of Elastic Agent are available from the Elastic Docker registry, and we provide deployment manifests for running on Kubernetes.
 

--- a/packages/zscaler_zia/changelog.yml
+++ b/packages/zscaler_zia/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add agentless deployment.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/13107
 - version: "3.7.2"
   changes:
     - description: Added description to ssl nodes in package level manifest.yml file to including links to documentation.

--- a/packages/zscaler_zia/changelog.yml
+++ b/packages/zscaler_zia/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.8.0"
+  changes:
+    - description: Add agentless deployment.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.7.2"
   changes:
     - description: Added description to ssl nodes in package level manifest.yml file to including links to documentation.

--- a/packages/zscaler_zia/docs/README.md
+++ b/packages/zscaler_zia/docs/README.md
@@ -7,21 +7,26 @@ The log message is expected to be in JSON format. The data is mapped to ECS fiel
 
 ## Requirements
 
+### Agentless Enabled Integration
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
 Elastic Agent must be installed. For more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-### Installing and managing an Elastic Agent:
+### Agent-Based Installation
+#### Installing and managing an Elastic Agent:
 
 You have a few options for installing and managing an Elastic Agent:
 
-### Install a Fleet-managed Elastic Agent (recommended):
+#### Install a Fleet-managed Elastic Agent (recommended):
 
 With this approach, you install Elastic Agent and use Fleet in Kibana to define, configure, and manage your agents in a central location. We recommend using Fleet management because it makes the management and upgrade of your agents considerably easier.
 
-### Install Elastic Agent in standalone mode (advanced users):
+#### Install Elastic Agent in standalone mode (advanced users):
 
 With this approach, you install Elastic Agent and manually configure the agent locally on the system where it’s installed. You are responsible for managing and upgrading the agents. This approach is reserved for advanced users only.
 
-### Install Elastic Agent in a containerized environment:
+#### Install Elastic Agent in a containerized environment:
 
 You can run Elastic Agent inside a container, either with Fleet Server or standalone. Docker images for all versions of Elastic Agent are available from the Elastic Docker registry, and we provide deployment manifests for running on Kubernetes.
 

--- a/packages/zscaler_zia/manifest.yml
+++ b/packages/zscaler_zia/manifest.yml
@@ -1,7 +1,7 @@
-format_version: "3.0.3"
+format_version: "3.2.3"
 name: zscaler_zia
 title: Zscaler Internet Access
-version: "3.7.2"
+version: "3.8.0"
 description: Collect logs from Zscaler Internet Access (ZIA) with Elastic Agent.
 type: integration
 categories:
@@ -11,7 +11,7 @@ source:
   license: "Elastic-2.0"
 conditions:
   kibana:
-    version: "^8.13.0 || ^9.0.0"
+    version: "^8.18.0 || ^9.0.0"
   elastic:
     subscription: "basic"
 screenshots:
@@ -60,6 +60,14 @@ policy_templates:
   - name: zscaler_zia
     title: Zscaler Internet Access logs
     description: Collect Zscaler Internet Access logs.
+    deployment_modes: 
+      default:
+        enabled: true 
+      agentless:
+        enabled: true
+        organization: security
+        division: engineering
+        team: security-service-integrations
     inputs:
       - type: tcp
         vars:


### PR DESCRIPTION
Parent Ticket:
https://github.com/elastic/integrations/issues/11810

## Proposed commit message
- Updated the documentation based upon agreed upon language to highlight that the integration now supports Agentless deployment for both sentinel one and zscaler
- Upgraded the `format_version` to latest, 3.2.3
- Updated Kibana version constraints to ^8.18 || ^9.0.0
![Screenshot 2025-03-13 at 11 45 42 AM](https://github.com/user-attachments/assets/94d44042-c1de-4565-9a9c-77fa44dba80f)
![Screenshot 2025-03-13 at 11 47 29 AM](https://github.com/user-attachments/assets/c5c1f3c6-de48-4ec0-bec7-a86772ec790a)

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally (Note: only tested Sentinel One, enabled zscaler)
1. Setup an api token within Sentinel One
2. Fill in the Console URL and API token within the Sentinel One configuration
3. Validated that data gets ingested into ES
4. Validated that the agentless index gets created and populated with the right values
5. Validate that the agent logs do not show any errors after a period of time in operation

Note: I set the start interval was 165d to get as much initial data as possible
