### PR TITLE
[Stack Monitoring] Add compatibility with 9.x

### DIFF
--- a/packages/beat/changelog.yml
+++ b/packages/beat/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Added 9.0.0 constraint
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/xyz
+      link: https://github.com/elastic/integrations/pull/13118
 - version: 1.0.0-beta1
   changes:
     - description: Adding Beats monitoring dashboards

--- a/packages/beat/changelog.yml
+++ b/packages/beat/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.0.1
+  changes:
+    - description: Added 9.0.0 constraint
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/xyz
 - version: 1.0.0-beta1
   changes:
     - description: Adding Beats monitoring dashboards

--- a/packages/beat/manifest.yml
+++ b/packages/beat/manifest.yml
@@ -1,10 +1,10 @@
 name: beat
 title: Beat
-version: 1.0.0-beta1
+version: 1.0.1
 description: Beat Integration
 type: integration
 conditions:
-  kibana.version: ^8.10.2
+  kibana.version: ^8.10.2 || ^9.0.0
   elastic.subscription: basic
 owner:
   github: elastic/stack-monitoring

--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.0"
+  changes:
+    - description: Added 9.0.0 constraint
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/xyz
 - version: "1.17.4"
   changes: 
     - description: Fix formulas for computing tier capacity

--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Added 9.0.0 constraint
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/xyz
+      link: https://github.com/elastic/integrations/pull/13118
 - version: "1.17.4"
   changes: 
     - description: Fix formulas for computing tier capacity

--- a/packages/elasticsearch/elasticsearch/transform/index_pivot/transform.yml
+++ b/packages/elasticsearch/elasticsearch/transform/index_pivot/transform.yml
@@ -119,7 +119,7 @@ pivot:
         script: "Math.max(0, params.end-params.start)"
 dest:
   index: "monitoring-indices"
-  pipeline: "1.17.4-monitoring_indices"
+  pipeline: "1.18.0-monitoring_indices"
 description: This transform runs every 10 minutes to compute extra metrics for the Elasticsearch indices.
 frequency: 10m
 settings:

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 1.17.4
+version: 1.18.0
 description: Elasticsearch Integration
 type: integration
 icons:
@@ -12,7 +12,7 @@ format_version: 2.6.0
 categories: ["elastic_stack", "datastore"]
 conditions:
   elastic.subscription: basic
-  kibana.version: ^8.10.1
+  kibana.version: ^8.10.1 || ^9.0.0
 owner:
   github: elastic/stack-monitoring
 policy_templates:

--- a/packages/kibana/changelog.yml
+++ b/packages/kibana/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Added 9.0.0 constraint
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/xyz
+      link: https://github.com/elastic/integrations/pull/13118
 - version: "2.6.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/kibana/changelog.yml
+++ b/packages/kibana/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.7.0"
+  changes:
+    - description: Added 9.0.0 constraint
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/xyz
 - version: "2.6.1"
   changes:
     - description: Updated SSL description to be uniform and to include links to documentation.

--- a/packages/kibana/manifest.yml
+++ b/packages/kibana/manifest.yml
@@ -1,6 +1,6 @@
 name: kibana
 title: Kibana
-version: 2.6.1
+version: 2.7.0
 description: Collect logs and metrics from Kibana with Elastic Agent.
 type: integration
 icons:
@@ -12,7 +12,7 @@ format_version: 1.0.0
 license: basic
 categories: ["elastic_stack"]
 conditions:
-  kibana.version: ^8.10.1
+  kibana.version: ^8.10.1 || ^9.0.0
 owner:
   github: elastic/stack-monitoring
 policy_templates:


### PR DESCRIPTION
## Proposed commit message

Add constraint for 9.0.0 for Stack Monitoring integrations

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

cc @jamiehynds 