### PR TITLE
cisco_duo, anomali, o365: update Kibana constraint to support 9.0.0

### DIFF
--- a/packages/cisco_duo/changelog.yml
+++ b/packages/cisco_duo/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update Kibana constraint to support 9.0.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/13119
 - version: "2.4.0"
   changes:
     - description: Provide option to ignore ingesting API Errors.

--- a/packages/cisco_duo/changelog.yml
+++ b/packages/cisco_duo/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.0"
+  changes:
+    - description: Update Kibana constraint to support 9.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "2.4.0"
   changes:
     - description: Provide option to ignore ingesting API Errors.

--- a/packages/cisco_duo/manifest.yml
+++ b/packages/cisco_duo/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cisco_duo
 title: Cisco Duo
-version: "2.4.0"
+version: "2.5.0"
 description: Collect logs from Cisco Duo with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - iam
 conditions:
   kibana:
-    version: "^8.13.0"
+    version: "^8.13.0 || ^9.0.0"
 screenshots:
   - src: /img/dashboard-activity.png
     title: Cisco Duo trust monitor logs dashboard

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update Kibana constraint to support 9.0.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/13119
 - version: "2.10.0"
   changes:
     - description: Extract ECS fields from Data and AttachmentData.

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.11.0"
+  changes:
+    - description: Update Kibana constraint to support 9.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "2.10.0"
   changes:
     - description: Extract ECS fields from Data and AttachmentData.

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft Office 365
-version: "2.10.0"
+version: "2.11.0"
 description: Collect logs from Microsoft Office 365 with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -7,7 +7,7 @@ format_version: "3.0.2"
 categories: [security, productivity_security]
 conditions:
   kibana:
-    version: "^8.13.0"
+    version: "^8.13.0 || ^9.0.0"
 icons:
   - src: /img/logo-integrations-microsoft-365.svg
     title: Microsoft Office 365

--- a/packages/ti_anomali/changelog.yml
+++ b/packages/ti_anomali/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.26.0"
+  changes:
+    - description: Update Kibana constraint to support 9.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "1.25.2"
   changes:
     - description: Add missing ECS field in intelligence datastream.

--- a/packages/ti_anomali/changelog.yml
+++ b/packages/ti_anomali/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update Kibana constraint to support 9.0.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/13119
 - version: "1.25.2"
   changes:
     - description: Add missing ECS field in intelligence datastream.

--- a/packages/ti_anomali/manifest.yml
+++ b/packages/ti_anomali/manifest.yml
@@ -1,13 +1,13 @@
 name: ti_anomali
 title: Anomali
-version: "1.25.2"
+version: "1.26.0"
 description: Ingest threat intelligence indicators from Anomali with Elastic Agent.
 type: integration
 format_version: 3.0.2
 categories: ["security", "threat_intel"]
 conditions:
   kibana:
-    version: "^8.13.0"
+    version: "^8.13.0 || ^9.0.0"
 screenshots:
   - src: /img/screenshot1.png
     title: "Dashboard: Anomali Overview"


### PR DESCRIPTION
## Proposed commit message

Update Kibana version constraints to support 9.0.0 for Anomali, Cisco Duo, and o365 integrations.

After some discussions at https://github.com/elastic/integrations/issues/11775, it has been decided that these packages will keep their deprecated data streams or inputs.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Install latest elastic-package (currently v0.109.1)
- Run a local 9.0.0 stack with elastic-package stack up -d -v --version=9.0.0-SNAPSHOT
- Run tests in affected packages with elastic-package test
- Install the integration manually and check everything works as expected

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/11775

