### PR TITLE
Fix org ID scientific notation

### DIFF
--- a/packages/ess_billing/changelog.yml
+++ b/packages/ess_billing/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.1"
+  changes:
+    - description: Fix organization ID scientific notation issue
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/13126
 - version: "1.4.0"
   changes:
     - description: 9.x integration compatibility

--- a/packages/ess_billing/data_stream/billing/agent/stream/cel.yml.hbs
+++ b/packages/ess_billing/data_stream/billing/agent/stream/cel.yml.hbs
@@ -13,7 +13,7 @@ resource.ssl: {{ssl}}
 {{#if http_client_timeout}}
 resource.timeout: {{http_client_timeout}}
 {{/if}}
-resource.url: {{url}}/api/v2/billing/organizations/{{organization_id}}/costs/instances
+resource.url: "{{url}}/api/v2/billing/organizations/{{organization_id}}/costs/instances"
 state:
   api_key: {{api_key}}
   organization_id: "{{organization_id}}"

--- a/packages/ess_billing/data_stream/billing/agent/stream/cel.yml.hbs
+++ b/packages/ess_billing/data_stream/billing/agent/stream/cel.yml.hbs
@@ -16,7 +16,7 @@ resource.timeout: {{http_client_timeout}}
 resource.url: {{url}}/api/v2/billing/organizations/{{organization_id}}/costs/instances
 state:
   api_key: {{api_key}}
-  organization_id: {{organization_id}}
+  organization_id: "{{organization_id}}"
   lookbehind: {{lookbehind}}
 redact:
   fields:

--- a/packages/ess_billing/manifest.yml
+++ b/packages/ess_billing/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ess_billing
 title: "Elasticsearch Service Billing"
-version: 1.4.0
+version: 1.4.1
 source:
   license: "Elastic-2.0"
 description: "Collects billing metrics from Elasticsearch Service billing API"


### PR DESCRIPTION
## Proposed commit message

The org ID can sometimes be interpreted in scientific notation, which causes issues in the ESS billing dashboard. This fixes it by changing the type of org_id back to a string, directly from the Elastic Agent collection.
