### PR TITLE
imperva_cloud_waf: step over non-UTF-8 data work items

### DIFF
--- a/packages/imperva_cloud_waf/changelog.yml
+++ b/packages/imperva_cloud_waf/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.0"
+  changes:
+    - description: Prevent stale compressed data wedging log collection.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/13152
 - version: "1.10.2"
   changes:
     - description: Clarify documentation regarding Imperva file compression configuration.

--- a/packages/imperva_cloud_waf/data_stream/event/agent/stream/cel.yml.hbs
+++ b/packages/imperva_cloud_waf/data_stream/event/agent/stream/cel.yml.hbs
@@ -72,7 +72,22 @@ program: |
         }
       }).do_request().as(resp, resp.StatusCode == 200 ?
         bytes(resp.Body).as(body, {
-          "events": (string(body)+"|==|").split("|==|")[1].split("\n").filter(x,x!="").map(x,{"message":x}),
+          "events": try(string(body), "error").as(body, type(body) == type("") ?
+          	(body+"|==|").split("|==|")[1].split("\n").filter(x,x!="").map(x,{"message":x})
+          :
+            // This is an unrecoverable error for the worklist element; it indicates
+            // most likely that the data was compressed, or was encrypted. We cannot
+            // handle this, so we step past it and log the failure. We are in an
+            // unfortunate position where ideally we would like this to cause a health
+            // status note in fleet to result, but we cannot do this since this would
+            // delete the cursor update and we would still be stuck here, so we just
+            // log into the index in the hope that someone will see it.
+            [{"error":
+              {
+                "message": v.worklist[v.next].filename + ": " + body.error + ": check imperva waf logging is configured correctly",
+              },
+            }]
+          ),
           "cursor": {
             "log_file": (
               has(state.cursor) && has(state.cursor.log_file) && state.cursor.log_file != null

--- a/packages/imperva_cloud_waf/manifest.yml
+++ b/packages/imperva_cloud_waf/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: imperva_cloud_waf
 title: Imperva Cloud WAF
-version: "1.10.2"
+version: "1.11.0"
 description: Collect logs from Imperva Cloud WAF with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

```
imperva_cloud_waf: step over non-UTF-8 data work items

It is possible for users to incorrectly configure their Imperva Cloud
WAF logging to send compressed data (this is the default). This results
in a CEL evaluation failure since we depend on the data being string
CEF. When the non-UTF-8 data is converted to a string, CEL refuses to
peform the conversion by design. When a user has done this, it appears
that logs in the compressed form persist, so the agent is unable to move
past the integration-invalid data. This change tries to perform the
conversion, falling back to an error message being sent to the index
when it is not possible. This helps identify cases where the
configuration is incorrect, and allows the collection to step over the
bodies that are not consumable.

Unfortunately we cannot make use of fleet health notifications since
sending object errors prevents cursor updates, and so would result in
continuing to be stuck.
```

> [!WARNING]
> The CEL input in this integration is not tested in system tests. Please review with extra care.

PoC:
```
mito src.cel
! stderr .
cmp stdout want.txt

-- src.cel --
[
	b"\xc3\x28",
	b"good message",
].map(body,
	{
		"events": try(string(body), "error").as(body, type(body) == type("") ?
			[{"message": body}]
		:
			[{"error": {"message": body.error}}]
		),
	}
)
-- want.txt --
[
	{
		"events": [
			{
				"error": {
					"message": "invalid UTF-8 in bytes, cannot convert to string"
				}
			}
		]
	},
	{
		"events": [
			{
				"message": "good message"
			}
		]
	}
]
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
