### PR TITLE
Fixed transform job definition that was inflating ingest volume

### DIFF
--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fixed transform job definition that was inflating ingest volume
       type: bugfix
-      link: TODO
+      link: https://github.com/elastic/integrations/pull/13158
 - version: "1.18.0"
   changes:
     - description: Added 9.0.0 constraint

--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,11 +1,16 @@
 # newer versions go on top
+- version: "1.18.1"
+  changes:
+    - description: Fixed transform job definition that was inflating ingest volume
+      type: bugfix
+      link: TODO
 - version: "1.18.0"
   changes:
     - description: Added 9.0.0 constraint
       type: enhancement
       link: https://github.com/elastic/integrations/pull/13118
 - version: "1.17.4"
-  changes: 
+  changes:
     - description: Fix formulas for computing tier capacity
       type: bugfix
       link: https://github.com/elastic/integrations/pull/11480

--- a/packages/elasticsearch/elasticsearch/transform/index_pivot/transform.yml
+++ b/packages/elasticsearch/elasticsearch/transform/index_pivot/transform.yml
@@ -80,19 +80,19 @@ pivot:
         buckets_path:
           start: "start[elasticsearch.index.primaries.docs.count]"
           end: "end[elasticsearch.index.primaries.docs.count]"
-        script: "Math.max(0, params.end-params.start)"
+        script: "params.end-params.start"
     elasticsearch.index.primaries.store.total_data_set_size_in_bytes_delta:
       bucket_script:
         buckets_path:
           start: "start[elasticsearch.index.primaries.store.total_data_set_size_in_bytes]"
           end: "end[elasticsearch.index.primaries.store.total_data_set_size_in_bytes]"
-        script: "Math.max(0, params.end-params.start)"
+        script: "params.end-params.start"
     elasticsearch.index.total.store.size_in_bytes_delta:
       bucket_script:
         buckets_path:
           start: "start[elasticsearch.index.total.store.size_in_bytes]"
           end: "end[elasticsearch.index.total.store.size_in_bytes]"
-        script: "Math.max(0, params.end-params.start)"
+        script: "params.end-params.start"
     elasticsearch.index.total.search.query_total_delta:
       bucket_script:
         buckets_path:
@@ -119,7 +119,7 @@ pivot:
         script: "Math.max(0, params.end-params.start)"
 dest:
   index: "monitoring-indices"
-  pipeline: "1.18.0-monitoring_indices"
+  pipeline: "1.18.1-monitoring_indices"
 description: This transform runs every 10 minutes to compute extra metrics for the Elasticsearch indices.
 frequency: 10m
 settings:
@@ -131,5 +131,5 @@ sync:
     delay: 60s
     field: '@timestamp'
 _meta:
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0
   run_as_kibana_system: false

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 1.18.0
+version: 1.18.1
 description: Elasticsearch Integration
 type: integration
 icons:


### PR DESCRIPTION

## Proposed commit message

Negative values were cut from the calculation of the delta between the start and end values of the metrics. This was causing the ingest volume to be inflated.

Values can be negative when a merge, or document deletion occurs.

This deletes the `Math.max(0, XX)` in the transform job bucket scripts where relevant (ie where the metrics aren't ever-increasing gauges that are reset upon node restart or shard migration)

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 