### PR TITLE
Universal Profiling: Add Kibana constraint to support 9.0.0

### DIFF
--- a/packages/universal_profiling_agent/changelog.yml
+++ b/packages/universal_profiling_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 8.17.3
+  changes:
+    - description: Update Kibana constraint to support 9.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/13163
 - version: 8.17.2
   changes:
     - description: Update ownership

--- a/packages/universal_profiling_agent/manifest.yml
+++ b/packages/universal_profiling_agent/manifest.yml
@@ -1,11 +1,11 @@
 name: profiler_agent
 title: Universal Profiling Agent
-version: 8.17.2
+version: 8.17.3
 categories: ["elastic_stack", "monitoring"]
 description: Fleet-wide, whole-system, continuous profiling with zero instrumentation.
 conditions:
   kibana:
-    version: ^8.17.1
+    version: "^8.17.3 || ^9.0.0"
   elastic:
     subscription: basic
 format_version: 3.0.2

--- a/packages/universal_profiling_collector/changelog.yml
+++ b/packages/universal_profiling_collector/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 8.17.3
+  changes:
+    - description: Update Kibana constraint to support 9.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/13163
 - version: 8.14.1
   changes:
     - description: Don't use secret variables

--- a/packages/universal_profiling_collector/manifest.yml
+++ b/packages/universal_profiling_collector/manifest.yml
@@ -1,10 +1,10 @@
 name: profiler_collector
 title: Universal Profiling Collector
-version: 8.14.1
+version: 8.17.3
 categories: ["elastic_stack", "monitoring"]
 description: Fleet-wide, whole-system, continuous profiling with zero instrumentation.
 conditions:
-  kibana.version: ^8.12.0
+  kibana.version: "^8.17.3 || ^9.0.0"
   elastic.subscription: basic
 format_version: 2.8.0
 icons:

--- a/packages/universal_profiling_symbolizer/changelog.yml
+++ b/packages/universal_profiling_symbolizer/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 8.17.3
+  changes:
+    - description: Update Kibana constraint to support 9.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/13163
 - version: 8.14.1
   changes:
     - description: Don't use secret variables

--- a/packages/universal_profiling_symbolizer/manifest.yml
+++ b/packages/universal_profiling_symbolizer/manifest.yml
@@ -1,10 +1,10 @@
 name: profiler_symbolizer
 title: Universal Profiling Symbolizer
-version: 8.14.1
+version: 8.17.3
 categories: ["elastic_stack", "monitoring"]
 description: Fleet-wide, whole-system, continuous profiling with zero instrumentation.
 conditions:
-  kibana.version: ^8.12.0
+  kibana.version: "^8.17.3 || ^9.0.0"
   elastic.subscription: basic
 format_version: 2.8.0
 icons:


### PR DESCRIPTION
## Proposed commit message

Universal Profiling: Add Kibana constraint to support 9.0.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

