### PR TITLE
[AD Entity Analytics] User Object Enrichments

### DIFF
--- a/packages/entityanalytics_ad/changelog.yml
+++ b/packages/entityanalytics_ad/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.11.0"
+  changes:
+    - description: Enrich the user object with account details and security-related settings.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "0.10.1"
   changes:
     - description: Fix user account control value look-ups.

--- a/packages/entityanalytics_ad/changelog.yml
+++ b/packages/entityanalytics_ad/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enrich the user object with account details and security-related settings.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/13174
 - version: "0.10.1"
   changes:
     - description: Fix user account control value look-ups.

--- a/packages/entityanalytics_ad/changelog.yml
+++ b/packages/entityanalytics_ad/changelog.yml
@@ -2,7 +2,7 @@
 - version: "0.11.0"
   changes:
     - description: Enrich the user object with account details and security-related settings.
-      type: bugfix
+      type: enhancement
       link: https://github.com/elastic/integrations/pull/13174
 - version: "0.10.1"
   changes:

--- a/packages/entityanalytics_ad/data_stream/user/_dev/test/pipeline/test-user.json-expected.json
+++ b/packages/entityanalytics_ad/data_stream/user/_dev/test/pipeline/test-user.json-expected.json
@@ -187,6 +187,7 @@
                         "2024-01-22T06:37:40Z",
                         "1601-01-01T18:12:16Z"
                     ],
+                    "enabled": true,
                     "instance_type": "4",
                     "is_critical_system_object": true,
                     "last_logoff": "0",
@@ -212,6 +213,7 @@
                     "object_guid": "09e84591-183c-48bf-9935-ce9469d024d7",
                     "object_sid": "S-1-5-21-372676048-1189045421-4047760665-500",
                     "primary_group_id": "513",
+                    "privileged_group_member": true,
                     "pwd_last_set": "2024-01-22T06:15:39.8703568Z",
                     "sam_account_name": "Administrator",
                     "sam_account_type": "805306368",
@@ -285,6 +287,7 @@
                         "2024-01-22T06:37:40Z",
                         "1601-01-01T00:00:01Z"
                     ],
+                    "enabled": false,
                     "instance_type": "4",
                     "is_critical_system_object": true,
                     "last_logoff": "0",
@@ -302,6 +305,7 @@
                     "object_dn": "CN=Guest,CN=Users,DC=testserver,DC=local",
                     "object_guid": "e37f2b85-c945-4e41-9c7f-e2765e860c1f",
                     "object_sid": "S-1-5-21-372676048-1189045421-4047760665-501",
+                    "password_not_required": true,
                     "primary_group_id": "514",
                     "pwd_last_set": "2185-07-21T23:34:33.709551616Z",
                     "sam_account_name": "Guest",
@@ -419,6 +423,7 @@
                         "2024-01-22T06:37:40Z",
                         "1601-01-01T00:04:16Z"
                     ],
+                    "enabled": false,
                     "instance_type": "4",
                     "is_critical_system_object": true,
                     "last_logoff": "0",
@@ -438,6 +443,7 @@
                     "object_guid": "1736d9ad-aefa-4be0-9de7-64396d35dcee",
                     "object_sid": "S-1-5-21-372676048-1189045421-4047760665-502",
                     "primary_group_id": "513",
+                    "privileged_group_member": false,
                     "pwd_last_set": "2024-01-22T06:37:40.4305135Z",
                     "sam_account_name": "krbtgt",
                     "sam_account_type": "805306368",

--- a/packages/entityanalytics_ad/data_stream/user/elasticsearch/ingest_pipeline/entity.yml
+++ b/packages/entityanalytics_ad/data_stream/user/elasticsearch/ingest_pipeline/entity.yml
@@ -273,6 +273,59 @@ processors:
       field: user.id
       copy_from: activedirectory.user.object_sid
 
+  - set:
+      field: activedirectory.user.logon_script_enabled
+      value: true
+      if: "ctx.activedirectory?.user?.uac_list?.contains('SCRIPT')"
+  - set:
+      field: activedirectory.user.enabled
+      value: true
+      if: "!ctx.activedirectory?.user?.uac_list?.contains('ACCOUNTDISABLE')"
+  - set:
+      field: activedirectory.user.enabled
+      value: false
+      if: "ctx.activedirectory?.user?.uac_list?.contains('ACCOUNTDISABLE')"
+
+  - set:
+      field: activedirectory.user.locked
+      value: true
+      if: "ctx.activedirectory?.user?.uac_list?.contains('LOCKOUT')"
+
+  - set:
+      field: activedirectory.user.password_not_required
+      value: true
+      if: "ctx.activedirectory?.user?.uac_list?.contains('PASSWD_NOTREQD')"
+
+  - set:
+      field: activedirectory.user.reversible_encryption_password
+      value: true
+      if: "ctx.activedirectory?.user?.uac_list?.contains('ENCRYPTED_TEXT_PWD_ALLOWED')"
+
+  - set:
+      field: activedirectory.user.unconstrained_delegation
+      value: true
+      if: "ctx.activedirectory?.user?.uac_list?.contains('TRUSTED_FOR_DELEGATION')"
+
+  - set:
+      field: activedirectory.user.sensitive_object
+      value: true
+      if: "ctx.activedirectory?.user?.uac_list?.contains('NOT_DELEGATED')"
+
+  - set:
+      field: activedirectory.user.use_des_key_only
+      value: true
+      if: "ctx.activedirectory?.user?.uac_list?.contains('USE_DES_KEY_ONLY')"
+
+  - set:
+      field: activedirectory.user.dont_require_preauth
+      value: true
+      if: "ctx.activedirectory?.user?.uac_list?.contains('DONT_REQUIRE_PREAUTH')"
+
+  - set:
+      field: activedirectory.user.constrained_delegation
+      value: true
+      if: "ctx.activedirectory?.user?.uac_list?.contains('TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION')"
+
   - foreach:
       tag: foreach_group_id
       field: activedirectory.groups
@@ -282,6 +335,54 @@ processors:
           tag: set_group_id
           field: "_ingest._value.id"
           value: "{{{_ingest._value.object_sid}}}"
+
+  - script:
+      lang: painless
+      ignore_failure: true
+      tag: set_privileged_group_member
+      description: Set privileged_group_member flag based on group membership.
+      # Well-known SIDs - Name to SID mapping
+      # https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers#well-known-sids
+      source: >
+        if (ctx.activedirectory?.groups == null) {
+          return;
+        }
+        ctx.activedirectory.user.privileged_group_member = false;
+        for (def group : ctx.activedirectory?.groups) {
+          if (group?.object_sid != null && (
+            // Domain Admins
+            group.object_sid.endsWith('-512') ||
+            // Domain Controllers
+            group.object_sid.endsWith('-516') ||
+            // Schema Admins
+            group.object_sid.endsWith('-518') ||
+            // Enterprise Admins
+            group.object_sid.endsWith('-519') ||
+            // Group Policy Creator Owners
+            group.object_sid.endsWith('-520') ||
+            // Protected Users
+            group.object_sid.endsWith('-525') ||
+            // Key Admins
+            group.object_sid.endsWith('-526') ||
+            // Enterprise Key Admins
+            group.object_sid.endsWith('-527') ||
+            // Administrators
+            group.object_sid.endsWith('-544') ||
+            // Account Operators
+            group.object_sid.endsWith('-548') ||
+            // Server Operators
+            group.object_sid.endsWith('-549') ||
+            // Backup Operators
+            group.object_sid.endsWith('-551'))) {
+              ctx.activedirectory.user.privileged_group_member = true;
+              break; // Stop at a match
+          }
+        }
+
+  - set:
+      field: activedirectory.user.account_never_expires
+      value: true
+      if: ctx.activedirectory?.user?.account_expires == "0" || ctx.activedirectory?.user?.account_expires == "9223372036854775807"
 
   - append:
       field: related.user

--- a/packages/entityanalytics_ad/data_stream/user/elasticsearch/ingest_pipeline/entity.yml
+++ b/packages/entityanalytics_ad/data_stream/user/elasticsearch/ingest_pipeline/entity.yml
@@ -276,55 +276,55 @@ processors:
   - set:
       field: activedirectory.user.logon_script_enabled
       value: true
-      if: "ctx.activedirectory?.user?.uac_list?.contains('SCRIPT')"
+      if: ctx.activedirectory?.user?.uac_list?.contains('SCRIPT') == true
   - set:
       field: activedirectory.user.enabled
       value: true
-      if: "!ctx.activedirectory?.user?.uac_list?.contains('ACCOUNTDISABLE')"
+      if: ctx.activedirectory?.user?.uac_list?.contains('ACCOUNTDISABLE') == false
   - set:
       field: activedirectory.user.enabled
       value: false
-      if: "ctx.activedirectory?.user?.uac_list?.contains('ACCOUNTDISABLE')"
+      if: ctx.activedirectory?.user?.uac_list?.contains('ACCOUNTDISABLE') == true
 
   - set:
       field: activedirectory.user.locked
       value: true
-      if: "ctx.activedirectory?.user?.uac_list?.contains('LOCKOUT')"
+      if: ctx.activedirectory?.user?.uac_list?.contains('LOCKOUT') == true
 
   - set:
       field: activedirectory.user.password_not_required
       value: true
-      if: "ctx.activedirectory?.user?.uac_list?.contains('PASSWD_NOTREQD')"
+      if: ctx.activedirectory?.user?.uac_list?.contains('PASSWD_NOTREQD') == true
 
   - set:
       field: activedirectory.user.reversible_encryption_password
       value: true
-      if: "ctx.activedirectory?.user?.uac_list?.contains('ENCRYPTED_TEXT_PWD_ALLOWED')"
+      if: ctx.activedirectory?.user?.uac_list?.contains('ENCRYPTED_TEXT_PWD_ALLOWED') == true
 
   - set:
       field: activedirectory.user.unconstrained_delegation
       value: true
-      if: "ctx.activedirectory?.user?.uac_list?.contains('TRUSTED_FOR_DELEGATION')"
+      if: ctx.activedirectory?.user?.uac_list?.contains('TRUSTED_FOR_DELEGATION') == true
 
   - set:
       field: activedirectory.user.sensitive_object
       value: true
-      if: "ctx.activedirectory?.user?.uac_list?.contains('NOT_DELEGATED')"
+      if: ctx.activedirectory?.user?.uac_list?.contains('NOT_DELEGATED') == true
 
   - set:
       field: activedirectory.user.use_des_key_only
       value: true
-      if: "ctx.activedirectory?.user?.uac_list?.contains('USE_DES_KEY_ONLY')"
+      if: ctx.activedirectory?.user?.uac_list?.contains('USE_DES_KEY_ONLY') == true
 
   - set:
       field: activedirectory.user.dont_require_preauth
       value: true
-      if: "ctx.activedirectory?.user?.uac_list?.contains('DONT_REQUIRE_PREAUTH')"
+      if: ctx.activedirectory?.user?.uac_list?.contains('DONT_REQUIRE_PREAUTH') == true
 
   - set:
       field: activedirectory.user.constrained_delegation
       value: true
-      if: "ctx.activedirectory?.user?.uac_list?.contains('TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION')"
+      if: ctx.activedirectory?.user?.uac_list?.contains('TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION') == true
 
   - foreach:
       tag: foreach_group_id
@@ -341,43 +341,38 @@ processors:
       ignore_failure: true
       tag: set_privileged_group_member
       description: Set privileged_group_member flag based on group membership.
+      if: ctx.activedirectory?.groups instanceof List
       # Well-known SIDs - Name to SID mapping
       # https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers#well-known-sids
-      source: >
-        if (ctx.activedirectory?.groups == null) {
-          return;
-        }
-        ctx.activedirectory.user.privileged_group_member = false;
-        for (def group : ctx.activedirectory?.groups) {
-          if (group?.object_sid != null && (
-            // Domain Admins
-            group.object_sid.endsWith('-512') ||
-            // Domain Controllers
-            group.object_sid.endsWith('-516') ||
-            // Schema Admins
-            group.object_sid.endsWith('-518') ||
-            // Enterprise Admins
-            group.object_sid.endsWith('-519') ||
-            // Group Policy Creator Owners
-            group.object_sid.endsWith('-520') ||
-            // Protected Users
-            group.object_sid.endsWith('-525') ||
-            // Key Admins
-            group.object_sid.endsWith('-526') ||
-            // Enterprise Key Admins
-            group.object_sid.endsWith('-527') ||
-            // Administrators
-            group.object_sid.endsWith('-544') ||
-            // Account Operators
-            group.object_sid.endsWith('-548') ||
-            // Server Operators
-            group.object_sid.endsWith('-549') ||
-            // Backup Operators
-            group.object_sid.endsWith('-551'))) {
-              ctx.activedirectory.user.privileged_group_member = true;
-              break; // Stop at a match
+      params:
+        '512': true
+        '516': true
+        '518': true
+        '519': true
+        '520': true
+        '525': true
+        '526': true
+        '527': true
+        '544': true
+        '548': true
+        '549': true
+        '551': true
+      source: |-
+        for (def group : ctx.activedirectory.groups) {
+          if (group?.object_sid == null) {
+            continue;
+          }
+          int idx = group.object_sid.lastIndexOf('-');
+          if (idx < 0) {
+            continue;
+          }
+          def priv = params.get(group.object_sid.substring(idx+1));
+          if (priv != null) {
+            ctx.activedirectory.user.privileged_group_member = priv;
+            return;
           }
         }
+        ctx.activedirectory.user.privileged_group_member = false;
 
   - set:
       field: activedirectory.user.account_never_expires

--- a/packages/entityanalytics_ad/data_stream/user/fields/fields.yml
+++ b/packages/entityanalytics_ad/data_stream/user/fields/fields.yml
@@ -8,6 +8,9 @@
       fields:
         - name: account_expires
           type: keyword
+        - name: account_never_expires
+          type: boolean
+          description: True if the account is set to never expire.
         - name: admin_count
           type: keyword
         - name: bad_password_time
@@ -18,14 +21,23 @@
           type: keyword
         - name: code_page
           type: keyword
+        - name: constrained_delegation
+          type: boolean
+          description: True if the account is trusted for constrained delegation.
         - name: country_code
           type: keyword
         - name: description
           type: keyword
         - name: distinguished_name
           type: keyword
+        - name: dont_require_preauth
+          type: boolean
+          description: True if the account does not require Kerberos pre-authentication.
         - name: ds_core_propagation_data
           type: date
+        - name: enabled
+          type: boolean
+          description: If the account is enabled.
         - name: instance_type
           type: keyword
         - name: is_critical_system_object
@@ -36,8 +48,14 @@
           type: date
         - name: last_logon_timestamp
           type: date
+        - name: locked
+          type: boolean
+          description: True if the account is locked out.
         - name: logon_count
           type: keyword
+        - name: logon_script_enabled
+          type: boolean
+          description: True if a logon script is configured for the account.
         - name: member_of
           type: keyword
         - name: msDS-*
@@ -54,20 +72,38 @@
           type: keyword
         - name: object_sid
           type: keyword
+        - name: password_not_required
+          type: boolean
+          description: True if the account does not require a password.
         - name: primary_group_id
           type: keyword
+        - name: privileged_group_member
+          type: boolean
+          description: True if the user is a member of a privileged group.
         - name: pwd_last_set
           type: date
+        - name: reversible_encryption_password
+          type: boolean
+          description: True if the user password is stored with reversible encryption.
         - name: sam_account_name
           type: keyword
         - name: sam_account_type
           type: keyword
+        - name: sensitive_object
+          type: boolean
+          description: True if the account cannot be delegated
         - name: service_principal_name
           type: keyword
         - name: show_in_advanced_view_only
           type: boolean
         - name: uac_list
           type: keyword
+        - name: unconstrained_delegation
+          type: boolean
+          description: True if the account is trusted for unconstrained delegation.
+        - name: use_des_key_only
+          type: boolean
+          description: True if the account is configured to only use DES encryption.
         - name: user_account_control
           type: keyword
         - name: usn_changed

--- a/packages/entityanalytics_ad/data_stream/user/fields/fields.yml
+++ b/packages/entityanalytics_ad/data_stream/user/fields/fields.yml
@@ -91,7 +91,7 @@
           type: keyword
         - name: sensitive_object
           type: boolean
-          description: True if the account cannot be delegated
+          description: True if the account cannot be delegated.
         - name: service_principal_name
           type: keyword
         - name: show_in_advanced_view_only

--- a/packages/entityanalytics_ad/docs/README.md
+++ b/packages/entityanalytics_ad/docs/README.md
@@ -161,21 +161,27 @@ An example event for `user` looks as following:
 | entityanalytics_ad.groups.when_created |  | date |
 | entityanalytics_ad.id |  | keyword |
 | entityanalytics_ad.user.account_expires |  | keyword |
+| entityanalytics_ad.user.account_never_expires | True if the account is set to never expire. | boolean |
 | entityanalytics_ad.user.admin_count |  | keyword |
 | entityanalytics_ad.user.bad_password_time |  | keyword |
 | entityanalytics_ad.user.bad_pwd_count |  | keyword |
 | entityanalytics_ad.user.cn |  | keyword |
 | entityanalytics_ad.user.code_page |  | keyword |
+| entityanalytics_ad.user.constrained_delegation | True if the account is trusted for constrained delegation. | boolean |
 | entityanalytics_ad.user.country_code |  | keyword |
 | entityanalytics_ad.user.description |  | keyword |
 | entityanalytics_ad.user.distinguished_name |  | keyword |
+| entityanalytics_ad.user.dont_require_preauth | True if the account does not require Kerberos pre-authentication. | boolean |
 | entityanalytics_ad.user.ds_core_propagation_data |  | date |
+| entityanalytics_ad.user.enabled | If the account is enabled. | boolean |
 | entityanalytics_ad.user.instance_type |  | keyword |
 | entityanalytics_ad.user.is_critical_system_object |  | boolean |
 | entityanalytics_ad.user.last_logoff |  | keyword |
 | entityanalytics_ad.user.last_logon |  | date |
 | entityanalytics_ad.user.last_logon_timestamp |  | date |
+| entityanalytics_ad.user.locked | True if the account is locked out. | boolean |
 | entityanalytics_ad.user.logon_count |  | keyword |
+| entityanalytics_ad.user.logon_script_enabled | True if a logon script is configured for the account. | boolean |
 | entityanalytics_ad.user.member_of |  | keyword |
 | entityanalytics_ad.user.msDS-\* |  | keyword |
 | entityanalytics_ad.user.name |  | keyword |
@@ -184,13 +190,19 @@ An example event for `user` looks as following:
 | entityanalytics_ad.user.object_dn |  | keyword |
 | entityanalytics_ad.user.object_guid |  | keyword |
 | entityanalytics_ad.user.object_sid |  | keyword |
+| entityanalytics_ad.user.password_not_required | True if the account does not require a password. | boolean |
 | entityanalytics_ad.user.primary_group_id |  | keyword |
+| entityanalytics_ad.user.privileged_group_member | True if the user is a member of a privileged group. | boolean |
 | entityanalytics_ad.user.pwd_last_set |  | date |
+| entityanalytics_ad.user.reversible_encryption_password | True if the user password is stored with reversible encryption. | boolean |
 | entityanalytics_ad.user.sam_account_name |  | keyword |
 | entityanalytics_ad.user.sam_account_type |  | keyword |
+| entityanalytics_ad.user.sensitive_object | True if the account cannot be delegated | boolean |
 | entityanalytics_ad.user.service_principal_name |  | keyword |
 | entityanalytics_ad.user.show_in_advanced_view_only |  | boolean |
 | entityanalytics_ad.user.uac_list |  | keyword |
+| entityanalytics_ad.user.unconstrained_delegation | True if the account is trusted for unconstrained delegation. | boolean |
+| entityanalytics_ad.user.use_des_key_only | True if the account is configured to only use DES encryption. | boolean |
 | entityanalytics_ad.user.user_account_control |  | keyword |
 | entityanalytics_ad.user.usn_changed |  | keyword |
 | entityanalytics_ad.user.usn_created |  | keyword |

--- a/packages/entityanalytics_ad/docs/README.md
+++ b/packages/entityanalytics_ad/docs/README.md
@@ -197,7 +197,7 @@ An example event for `user` looks as following:
 | entityanalytics_ad.user.reversible_encryption_password | True if the user password is stored with reversible encryption. | boolean |
 | entityanalytics_ad.user.sam_account_name |  | keyword |
 | entityanalytics_ad.user.sam_account_type |  | keyword |
-| entityanalytics_ad.user.sensitive_object | True if the account cannot be delegated | boolean |
+| entityanalytics_ad.user.sensitive_object | True if the account cannot be delegated. | boolean |
 | entityanalytics_ad.user.service_principal_name |  | keyword |
 | entityanalytics_ad.user.show_in_advanced_view_only |  | boolean |
 | entityanalytics_ad.user.uac_list |  | keyword |

--- a/packages/entityanalytics_ad/manifest.yml
+++ b/packages/entityanalytics_ad/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: entityanalytics_ad
 title: Active Directory Entity Analytics
-version: "0.10.1"
+version: "0.11.0"
 description: "Collect User Identities from Active Directory Entity with Elastic Agent."
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
entityanalytics_ad: enrich the user object with AD security-related settings.
```

## Summary

Adds boolean fields for account settings that are relevant to identify misconfigurations and security risks.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## How to test this PR locally

`elastic-package test pipeline -v`

## Related issues

Part of https://github.com/elastic/ia-trade-team/issues/537