### PR TITLE
Fix fleet transform version for DED

### DIFF
--- a/packages/ded/changelog.yml
+++ b/packages/ded/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Fix transform version number
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/12940
+      link: https://github.com/elastic/integrations/pull/13194
 - version: "2.3.0"
   changes:
     - description: Add support for Kibana `9.0.0`

--- a/packages/ded/changelog.yml
+++ b/packages/ded/changelog.yml
@@ -1,3 +1,8 @@
+- version: "2.3.1"
+  changes:
+    - description: Fix transform version number
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12940
 - version: "2.3.0"
   changes:
     - description: Add support for Kibana `9.0.0`

--- a/packages/ded/elasticsearch/transform/pivot_transform/transform.yml
+++ b/packages/ded/elasticsearch/transform/pivot_transform/transform.yml
@@ -88,5 +88,5 @@ sync:
     delay: 120s
     field: "@timestamp"
 _meta:
-  fleet_transform_version: 2.2.0
+  fleet_transform_version: 2.3.1
   run_as_kibana_system: false

--- a/packages/ded/manifest.yml
+++ b/packages/ded/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: ded
 title: "Data Exfiltration Detection"
-version: 2.3.0
+version: 2.3.1
 source:
   license: "Elastic-2.0"
 description: "ML package to detect data exfiltration in your network and file data."


### PR DESCRIPTION
## Proposed commit message

The fleet transform version was incorrect for DED.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] ~I have verified that all data streams collect metrics or logs.~
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] ~I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~

## How to test this PR locally

Tested with `elastic-package`.
