### PR TITLE
[ti_threatconnect] Update transform version numbers

### DIFF
--- a/packages/ti_threatconnect/elasticsearch/transform/latest/transform.yml
+++ b/packages/ti_threatconnect/elasticsearch/transform/latest/transform.yml
@@ -9,7 +9,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_threatconnect_latest.dest_indicator-3"
+  index: "logs-ti_threatconnect_latest.dest_indicator-4"
   aliases:
     - alias: "logs-ti_threatconnect_latest.indicator"
       move_on_creation: true
@@ -32,4 +32,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.3.0
+  fleet_transform_version: 0.4.0


### PR DESCRIPTION
## Proposed commit message

```
[ti_threatconnect] Update transform version numbers

For the last change[1], which added the
`threat_connect.indicator.tags.data.tactics` field.

[1]: https://github.com/elastic/integrations/pull/13121.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Relates #13121