### PR TITLE
checkpoint_harmony_endpoint: fix assignment of endTime query parameter

### DIFF
--- a/packages/checkpoint_harmony_endpoint/changelog.yml
+++ b/packages/checkpoint_harmony_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.1"
+  changes:
+    - description: Fix endTime query parameter assignment.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "0.5.0"
   changes:
     - description: Improve handling of 404 and 503 API responses.

--- a/packages/checkpoint_harmony_endpoint/changelog.yml
+++ b/packages/checkpoint_harmony_endpoint/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix endTime query parameter assignment.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/13200
 - version: "0.5.0"
   changes:
     - description: Improve handling of 404 and 503 API responses.

--- a/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
@@ -69,9 +69,10 @@ program: |
   			"startTime": state.?cursor.next_startTime.orValue(
   				timestamp(now() - duration(state.initial_interval)).format(time_layout.RFC3339)
   			),
-  			"endTime": state.?cursor.next_endTime.orValue(
-  				timestamp(now() - duration("1m")).format(time_layout.RFC3339)
-  			),
+  			"endTime": state.?cursor.next_endTime.orValue(null) == null ?
+  				optional.of(timestamp(now() - duration("1m")).format(time_layout.RFC3339))
+  			:
+  				optional.of(state.cursor.next_endTime),
   		}.as(timeframe,
   			request("POST", state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query").with(
   				{

--- a/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
@@ -70,9 +70,9 @@ program: |
   				timestamp(now() - duration(state.initial_interval)).format(time_layout.RFC3339)
   			),
   			"endTime": state.?cursor.next_endTime.orValue(null) == null ?
-  				optional.of(timestamp(now() - duration("1m")).format(time_layout.RFC3339))
+  				timestamp(now() - duration("1m")).format(time_layout.RFC3339)
   			:
-  				optional.of(state.cursor.next_endTime),
+  				state.cursor.next_endTime,
   		}.as(timeframe,
   			request("POST", state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query").with(
   				{

--- a/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
@@ -69,9 +69,10 @@ program: |
   			"startTime": state.?cursor.next_startTime.orValue(
   				timestamp(now() - duration(state.initial_interval)).format(time_layout.RFC3339)
   			),
-  			"endTime": state.?cursor.next_endTime.orValue(
-  				timestamp(now() - duration("1m")).format(time_layout.RFC3339)
-  			),
+  			"endTime": state.?cursor.next_endTime.orValue(null) == null ?
+  				optional.of(timestamp(now() - duration("1m")).format(time_layout.RFC3339))
+  			:
+  				optional.of(state.cursor.next_endTime),
   		}.as(timeframe,
   			request("POST", state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query").with(
   				{

--- a/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
@@ -70,9 +70,9 @@ program: |
   				timestamp(now() - duration(state.initial_interval)).format(time_layout.RFC3339)
   			),
   			"endTime": state.?cursor.next_endTime.orValue(null) == null ?
-  				optional.of(timestamp(now() - duration("1m")).format(time_layout.RFC3339))
+  				timestamp(now() - duration("1m")).format(time_layout.RFC3339)
   			:
-  				optional.of(state.cursor.next_endTime),
+  				state.cursor.next_endTime,
   		}.as(timeframe,
   			request("POST", state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query").with(
   				{

--- a/packages/checkpoint_harmony_endpoint/data_stream/forensics/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/forensics/agent/stream/cel.yml.hbs
@@ -69,9 +69,10 @@ program: |
   			"startTime": state.?cursor.next_startTime.orValue(
   				timestamp(now() - duration(state.initial_interval)).format(time_layout.RFC3339)
   			),
-  			"endTime": state.?cursor.next_endTime.orValue(
-  				timestamp(now() - duration("1m")).format(time_layout.RFC3339)
-  			),
+  			"endTime": state.?cursor.next_endTime.orValue(null) == null ?
+  				optional.of(timestamp(now() - duration("1m")).format(time_layout.RFC3339))
+  			:
+  				optional.of(state.cursor.next_endTime),
   		}.as(timeframe,
   			request("POST", state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query").with(
   				{

--- a/packages/checkpoint_harmony_endpoint/data_stream/forensics/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/forensics/agent/stream/cel.yml.hbs
@@ -70,9 +70,9 @@ program: |
   				timestamp(now() - duration(state.initial_interval)).format(time_layout.RFC3339)
   			),
   			"endTime": state.?cursor.next_endTime.orValue(null) == null ?
-  				optional.of(timestamp(now() - duration("1m")).format(time_layout.RFC3339))
+  				timestamp(now() - duration("1m")).format(time_layout.RFC3339)
   			:
-  				optional.of(state.cursor.next_endTime),
+  				state.cursor.next_endTime,
   		}.as(timeframe,
   			request("POST", state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query").with(
   				{

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
@@ -69,9 +69,10 @@ program: |
   			"startTime": state.?cursor.next_startTime.orValue(
   				timestamp(now() - duration(state.initial_interval)).format(time_layout.RFC3339)
   			),
-  			"endTime": state.?cursor.next_endTime.orValue(
-  				timestamp(now() - duration("1m")).format(time_layout.RFC3339)
-  			),
+  			"endTime": state.?cursor.next_endTime.orValue(null) == null ?
+  				optional.of(timestamp(now() - duration("1m")).format(time_layout.RFC3339))
+  			:
+  				optional.of(state.cursor.next_endTime),
   		}.as(timeframe,
   			request("POST", state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query").with(
   				{

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
@@ -70,9 +70,9 @@ program: |
   				timestamp(now() - duration(state.initial_interval)).format(time_layout.RFC3339)
   			),
   			"endTime": state.?cursor.next_endTime.orValue(null) == null ?
-  				optional.of(timestamp(now() - duration("1m")).format(time_layout.RFC3339))
+  				timestamp(now() - duration("1m")).format(time_layout.RFC3339)
   			:
-  				optional.of(state.cursor.next_endTime),
+  				state.cursor.next_endTime,
   		}.as(timeframe,
   			request("POST", state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query").with(
   				{

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
@@ -69,9 +69,10 @@ program: |
   			"startTime": state.?cursor.next_startTime.orValue(
   				timestamp(now() - duration(state.initial_interval)).format(time_layout.RFC3339)
   			),
-  			"endTime": state.?cursor.next_endTime.orValue(
-  				timestamp(now() - duration("1m")).format(time_layout.RFC3339)
-  			),
+  			"endTime": state.?cursor.next_endTime.orValue(null) == null ?
+  				optional.of(timestamp(now() - duration("1m")).format(time_layout.RFC3339))
+  			:
+  				optional.of(state.cursor.next_endTime),
   		}.as(timeframe,
   			request("POST", state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query").with(
   				{

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
@@ -70,9 +70,9 @@ program: |
   				timestamp(now() - duration(state.initial_interval)).format(time_layout.RFC3339)
   			),
   			"endTime": state.?cursor.next_endTime.orValue(null) == null ?
-  				optional.of(timestamp(now() - duration("1m")).format(time_layout.RFC3339))
+  				timestamp(now() - duration("1m")).format(time_layout.RFC3339)
   			:
-  				optional.of(state.cursor.next_endTime),
+  				state.cursor.next_endTime,
   		}.as(timeframe,
   			request("POST", state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query").with(
   				{

--- a/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
@@ -69,9 +69,10 @@ program: |
   			"startTime": state.?cursor.next_startTime.orValue(
   				timestamp(now() - duration(state.initial_interval)).format(time_layout.RFC3339)
   			),
-  			"endTime": state.?cursor.next_endTime.orValue(
-  				timestamp(now() - duration("1m")).format(time_layout.RFC3339)
-  			),
+  			"endTime": state.?cursor.next_endTime.orValue(null) == null ?
+  				optional.of(timestamp(now() - duration("1m")).format(time_layout.RFC3339))
+  			:
+  				optional.of(state.cursor.next_endTime),
   		}.as(timeframe,
   			request("POST", state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query").with(
   				{

--- a/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
@@ -70,9 +70,9 @@ program: |
   				timestamp(now() - duration(state.initial_interval)).format(time_layout.RFC3339)
   			),
   			"endTime": state.?cursor.next_endTime.orValue(null) == null ?
-  				optional.of(timestamp(now() - duration("1m")).format(time_layout.RFC3339))
+  				timestamp(now() - duration("1m")).format(time_layout.RFC3339)
   			:
-  				optional.of(state.cursor.next_endTime),
+  				state.cursor.next_endTime,
   		}.as(timeframe,
   			request("POST", state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query").with(
   				{

--- a/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
@@ -69,9 +69,10 @@ program: |
   			"startTime": state.?cursor.next_startTime.orValue(
   				timestamp(now() - duration(state.initial_interval)).format(time_layout.RFC3339)
   			),
-  			"endTime": state.?cursor.next_endTime.orValue(
-  				timestamp(now() - duration("1m")).format(time_layout.RFC3339)
-  			),
+  			"endTime": state.?cursor.next_endTime.orValue(null) == null ?
+  				optional.of(timestamp(now() - duration("1m")).format(time_layout.RFC3339))
+  			:
+  				optional.of(state.cursor.next_endTime),
   		}.as(timeframe,
   			request("POST", state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query").with(
   				{

--- a/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
@@ -70,9 +70,9 @@ program: |
   				timestamp(now() - duration(state.initial_interval)).format(time_layout.RFC3339)
   			),
   			"endTime": state.?cursor.next_endTime.orValue(null) == null ?
-  				optional.of(timestamp(now() - duration("1m")).format(time_layout.RFC3339))
+  				timestamp(now() - duration("1m")).format(time_layout.RFC3339)
   			:
-  				optional.of(state.cursor.next_endTime),
+  				state.cursor.next_endTime,
   		}.as(timeframe,
   			request("POST", state.url.trim_right("/") + "/app/laas-logs-api/api/logs_query").with(
   				{

--- a/packages/checkpoint_harmony_endpoint/manifest.yml
+++ b/packages/checkpoint_harmony_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: checkpoint_harmony_endpoint
 title: "Check Point Harmony Endpoint"
-version: "0.5.0"
+version: "0.5.1"
 source:
   license: "Elastic-2.0"
 description: "Collect logs from Check Point Harmony Endpoint"


### PR DESCRIPTION
## Proposed commit message

Fixing a CEL condition that made the `endTime` query parameter being null when `state.cursor.next_endTime` is also null, leading to the following error:
```
 {"success":false,"error":{"status":400,"name":"Bad Request","details":["endTime should not be empty"]}}
```

> [!NOTE]
> All data streams have identical `cel.yml.hbs` files.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

