### PR TITLE
ti_anomali: Fix lower bound query parameter in Threatstream API.

### DIFF
--- a/packages/ti_anomali/_dev/deploy/docker/files/intelligence-api-config.yml
+++ b/packages/ti_anomali/_dev/deploy/docker/files/intelligence-api-config.yml
@@ -7,7 +7,7 @@ rules:
       order_by: update_id
       modified_ts__lt: "{modified_ts__lt:.*}"
       limit: "3"
-      search_after: "100000006"
+      update_id__gt: "100000006"
     responses:
       - status_code: 200
         body: |-
@@ -33,7 +33,7 @@ rules:
       order_by: update_id
       modified_ts__lt: "{modified_ts__lt:.*}"
       limit: "3"
-      search_after: "100000003"
+      update_id__gt: "100000003"
     responses:
       - status_code: 200
         body: |-
@@ -47,7 +47,7 @@ rules:
               "offset": 0,
               "limit": 3,
               "total_count": 6,
-              "next": "/api/v2/intelligence/?limit=3&modified_ts__lt=2099-01-01T00%3A00%3A01Z&order_by=update_id&search_after=100000006",
+              "next": "/api/v2/intelligence/?limit=3&modified_ts__lt=2099-01-01T00%3A00%3A01Z&order_by=update_id&update_id__gt=100000006",
               "took": 1
             }
           }
@@ -59,7 +59,7 @@ rules:
       order_by: update_id
       modified_ts__lt: "{modified_ts__lt:.*}"
       limit: "3"
-      # search_after: null
+      # update_id__gt: null
     responses:
       - status_code: 200
         body: |-
@@ -73,7 +73,7 @@ rules:
               "offset": 0,
               "limit": 3,
               "total_count": 9,
-              "next": "/api/v2/intelligence/?limit=3&modified_ts__lt=2099-01-01T00%3A00%3A01Z&order_by=update_id&search_after=100000003",
+              "next": "/api/v2/intelligence/?limit=3&modified_ts__lt=2099-01-01T00%3A00%3A01Z&order_by=update_id&update_id__gt=100000003",
               "took": 1
             }
           }

--- a/packages/ti_anomali/changelog.yml
+++ b/packages/ti_anomali/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.26.1"
+  changes:
+    - description: Fix lower bound query parameter in Threatstream API.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.26.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/ti_anomali/data_stream/intelligence/agent/stream/cel.yml.hbs
+++ b/packages/ti_anomali/data_stream/intelligence/agent/stream/cel.yml.hbs
@@ -39,7 +39,7 @@ program: |-
   			"order_by": ["update_id"],
   			"modified_ts__lt": [(now - duration(state.delay)).format(time_layout.RFC3339)],
   			"limit": [string(state.page_size)],
-  			?"search_after": state.?cursor.last_update_id.optMap(id, [string(int(id))]),
+  			?"update_id__gt": state.?cursor.last_update_id.optMap(id, [string(int(id))]),
   			?"remote_api": state.remote_api_true ? optional.of(["true"]) : optional.none(), // never set remote_api=false, only true or absent
   		}.format_query()
   	).with(

--- a/packages/ti_anomali/manifest.yml
+++ b/packages/ti_anomali/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_anomali
 title: Anomali
-version: "1.26.0"
+version: "1.26.1"
 description: Ingest threat intelligence indicators from Anomali with Elastic Agent.
 type: integration
 format_version: 3.0.2


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
API doc doesn't have any reference to the 
query parameter search_after, which is supposed to handle
the lower bound on searching indicators. Without this, the 
integration always fetches all indicators every call because 
modified_ts__lt : now-1m. There are cases Anomali revoked 
API keys because of this requesting for proper lower bounding 
the requests.

Based on API doc, this PR updates the query parameter to be
update_id__gt which lower bounds based on last received 
update_id.
```

> [!NOTE]
> Not tested against live API, but only based on API doc. 
> DM me for the API doc.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Updated system tests pass. Not tested against live API.
```
--- Test results for package: ti_anomali - START ---
╭────────────┬──────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE    │ DATA STREAM  │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├────────────┼──────────────┼───────────┼───────────┼────────┼───────────────┤
│ ti_anomali │ intelligence │ system    │ default   │ PASS   │ 44.176397125s │
╰────────────┴──────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: ti_anomali - END   ---
Done
```