### PR TITLE
imperva_cloud_waf: Handle multiple IPs in `cef.extensions.xff`

### DIFF
--- a/packages/imperva_cloud_waf/changelog.yml
+++ b/packages/imperva_cloud_waf/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Handle multiple IPs in `extensions.xff`.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/13244
 - version: "1.11.1"
   changes:
     - description: Fix type issue in CEL program.

--- a/packages/imperva_cloud_waf/changelog.yml
+++ b/packages/imperva_cloud_waf/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.2"
+  changes:
+    - description: Handle multiple IPs in `extensions.xff`.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.11.1"
   changes:
     - description: Fix type issue in CEL program.

--- a/packages/imperva_cloud_waf/data_stream/event/_dev/test/pipeline/test-event.json
+++ b/packages/imperva_cloud_waf/data_stream/event/_dev/test/pipeline/test-event.json
@@ -125,6 +125,132 @@
             "url": {
                 "original": "site123.abcd.info/"
             }
+        },
+        {
+            "@timestamp": "2023-12-15T05:38:35.570Z",
+            "log": {
+                "offset": 0
+            },
+            "event": {
+                "end": "2019-08-20T11:31:10.892Z",
+                "original": "CEF:0|Incapsula|SIEMintegration|1|1|Normal|3| fileid=3412341160002518171 sourceServiceName=site123.abcd.info sip=10.1.0.1 spt=80 siteid=1509732 suid=50005477 requestClientApplication=Mozilla/6.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0 deviceFacility=mia cs2=true cs2Label=Javascript Support cs3=true cs3Label=CO Support ccode=IL tag=www.elvis.com cn1=200 in=54 xff=1.128.0.0, 81.2.69.144 cs1=NOT_SUPPORTED cs1Label=Cap Support cs4=c2e72124-0e8a-4dd8-b13b-3da246af3ab2 cs4Label=VID cs5=de3c633ac428e0678f3aac20cf7f239431e54cbb8a17e8302f53653923305e1835a9cd871db32aa4fc7b8a9463366cc4 cs5Label=clappsig dproc=Browser cs6=Firefox cs6Label=clapp ccode=IL cicode=Rehovot cs7=31.8969 cs7Label=latitude cs8=34.8186 cs8Label=longitude Customer=CEFcustomer123 siteTag=my-site-tag start=1453290121336 request=site123.abcd.info/ requestmethod=GET qstr=p\\=%2fetc%2fpasswd app=HTTP act=REQ_CHALLENGE_CAPTCHA deviceExternalID=33411452762204224 cpt=443 src=1.128.0.1 ver=TLSv1.2 ECDHE-RSA-AES128-GCM-SHA256 end=1566300670892 additionalReqHeaders=[{\"Accept\":\"*/*\"},{\"x-v\":\"1\"},{\"x-fapi-interaction-id\":\"10.10.10.10\"}] additionalResHeaders=[{\"Content-Type\":\"text/html; charset\\=UTF-8\"}] filetype=30037,1001, filepermission=2,1, cs9=Block Malicious User,High Risk Resources, cs9Label=Rule name cs11=[{\"api_specification_violation_type\":\"INVALID_PARAM_NAME\",\"parameter_name\":\"somename\"}] cs11Label=Rule Additional Info",
+                "code": "1",
+                "severity": 3,
+                "start": "2016-01-20T11:42:01.336Z",
+                "action": "REQ_CHALLENGE_CAPTCHA"
+            },
+            "cef": {
+                "name": "Normal",
+                "severity": "3",
+                "extensions": {
+                    "filePermission": "2,1,",
+                    "deviceCustomString3": "true",
+                    "startTime": "2016-01-20T11:42:01.336Z",
+                    "ver": "TLSv1.2 ECDHE-RSA-AES128-GCM-SHA256",
+                    "sip": "10.1.0.1",
+                    "tag": "www.elvis.com",
+                    "additionalReqHeaders": "[{\"Accept\":\"*/*\"},{\"x-v\":\"1\"},{\"x-fapi-interaction-id\":\"10.10.10.10\"}]",
+                    "siteTag": "my-site-tag",
+                    "additionalResHeaders": "[{\"Content-Type\":\"text/html; charset=UTF-8\"}]",
+                    "deviceCustomString6": "Firefox",
+                    "Customer": "CEFcustomer123",
+                    "cs11": "[{\"api_specification_violation_type\":\"INVALID_PARAM_NAME\",\"parameter_name\":\"somename\"}]",
+                    "deviceFacility": "mia",
+                    "xff": "1.128.0.0, 81.2.69.144",
+                    "sourceServiceName": "site123.abcd.info",
+                    "cs8Label": "longitude",
+                    "requestClientApplication": "Mozilla/6.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0",
+                    "deviceAction": "REQ_CHALLENGE_CAPTCHA",
+                    "deviceCustomString3Label": "CO Support",
+                    "endTime": "2019-08-20T11:31:10.892Z",
+                    "fileType": "30037,1001,",
+                    "cs7Label": "latitude",
+                    "applicationProtocol": "HTTP",
+                    "cicode": "Rehovot",
+                    "siteid": "1509732",
+                    "cs11Label": "Rule Additional Info",
+                    "deviceCustomString6Label": "clapp",
+                    "fileId": "3412341160002518171",
+                    "deviceCustomString2Label": "Javascript Support",
+                    "cs9": "Block Malicious User,High Risk Resources,",
+                    "deviceCustomString2": "true",
+                    "requestUrl": "site123.abcd.info/",
+                    "destinationProcessName": "Browser",
+                    "deviceCustomString1": "NOT_SUPPORTED",
+                    "sourcePort": 80,
+                    "qstr": "p=%2fetc%2fpasswd",
+                    "deviceCustomString4Label": "VID",
+                    "deviceCustomString4": "c2e72124-0e8a-4dd8-b13b-3da246af3ab2",
+                    "cs9Label": "Rule name",
+                    "deviceExternalId": "33411452762204224",
+                    "deviceCustomString1Label": "Cap Support",
+                    "requestMethod": "GET",
+                    "ccode": "IL",
+                    "cs7": "31.8969",
+                    "cs8": "34.8186",
+                    "bytesIn": 54,
+                    "cpt": "443",
+                    "deviceCustomNumber1": 200,
+                    "deviceCustomString5Label": "clappsig",
+                    "sourceAddress": "1.128.0.1",
+                    "sourceUserId": "50005477",
+                    "deviceCustomString5": "de3c633ac428e0678f3aac20cf7f239431e54cbb8a17e8302f53653923305e1835a9cd871db32aa4fc7b8a9463366cc4"
+                },
+                "version": "0",
+                "device": {
+                    "version": "1",
+                    "event_class_id": "1",
+                    "vendor": "Incapsula",
+                    "product": "SIEMintegration"
+                }
+            },
+            "file": {
+                "inode": "3412341160002518171",
+                "group": "2,1,",
+                "type": "30037,1001,"
+            },
+            "source": {
+                "port": 80,
+                "ip": "1.128.0.1",
+                "user": {
+                    "id": "50005477"
+                },
+                "service": {
+                    "name": "site123.abcd.info"
+                },
+                "bytes": 54
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "input": {
+                "type": "filestream"
+            },
+            "user_agent": {
+                "original": "Mozilla/6.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0"
+            },
+            "destination": {
+                "process": {
+                    "name": "Browser"
+                }
+            },
+            "network": {
+                "application": "HTTP"
+            },
+            "observer": {
+                "vendor": "Incapsula",
+                "product": "SIEMintegration",
+                "version": "1"
+            },
+            "message": "Illegal Resource Access",
+            "http": {
+                "request": {
+                    "method": "GET"
+                }
+            },
+            "url": {
+                "original": "site123.abcd.info/"
+            }
         }
     ]
 }

--- a/packages/imperva_cloud_waf/data_stream/event/_dev/test/pipeline/test-event.json-expected.json
+++ b/packages/imperva_cloud_waf/data_stream/event/_dev/test/pipeline/test-event.json-expected.json
@@ -131,7 +131,9 @@
                         "start_time": "2016-01-20T11:42:01.336Z",
                         "tag": "www.elvis.com",
                         "ver": "TLSv1.2 ECDHE-RSA-AES128-GCM-SHA256",
-                        "xff": "1.128.0.0"
+                        "xff": [
+                            "1.128.0.0"
+                        ]
                     },
                     "name": "Illegal Resource Access",
                     "severity": 3,
@@ -147,7 +149,9 @@
             "message": "Illegal Resource Access",
             "network": {
                 "application": "http",
-                "forwarded_ip": "1.128.0.0"
+                "forwarded_ip": [
+                    "1.128.0.0"
+                ]
             },
             "observer": {
                 "product": "SIEMintegration",
@@ -205,6 +209,226 @@
                 },
                 "name": "Firefox",
                 "original": "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0",
+                "os": {
+                    "full": "Windows 7",
+                    "name": "Windows",
+                    "version": "7"
+                },
+                "version": "40.0."
+            }
+        },
+        {
+            "@timestamp": "2023-12-15T05:38:35.570Z",
+            "destination": {
+                "ip": "10.1.0.1",
+                "port": 80,
+                "process": {
+                    "name": "Browser"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "req-challenge-captcha",
+                "category": [
+                    "web"
+                ],
+                "code": "1",
+                "end": "2019-08-20T11:31:10.892Z",
+                "kind": "event",
+                "original": "CEF:0|Incapsula|SIEMintegration|1|1|Normal|3| fileid=3412341160002518171 sourceServiceName=site123.abcd.info sip=10.1.0.1 spt=80 siteid=1509732 suid=50005477 requestClientApplication=Mozilla/6.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0 deviceFacility=mia cs2=true cs2Label=Javascript Support cs3=true cs3Label=CO Support ccode=IL tag=www.elvis.com cn1=200 in=54 xff=1.128.0.0, 81.2.69.144 cs1=NOT_SUPPORTED cs1Label=Cap Support cs4=c2e72124-0e8a-4dd8-b13b-3da246af3ab2 cs4Label=VID cs5=de3c633ac428e0678f3aac20cf7f239431e54cbb8a17e8302f53653923305e1835a9cd871db32aa4fc7b8a9463366cc4 cs5Label=clappsig dproc=Browser cs6=Firefox cs6Label=clapp ccode=IL cicode=Rehovot cs7=31.8969 cs7Label=latitude cs8=34.8186 cs8Label=longitude Customer=CEFcustomer123 siteTag=my-site-tag start=1453290121336 request=site123.abcd.info/ requestmethod=GET qstr=p\\=%2fetc%2fpasswd app=HTTP act=REQ_CHALLENGE_CAPTCHA deviceExternalID=33411452762204224 cpt=443 src=1.128.0.1 ver=TLSv1.2 ECDHE-RSA-AES128-GCM-SHA256 end=1566300670892 additionalReqHeaders=[{\"Accept\":\"*/*\"},{\"x-v\":\"1\"},{\"x-fapi-interaction-id\":\"10.10.10.10\"}] additionalResHeaders=[{\"Content-Type\":\"text/html; charset\\=UTF-8\"}] filetype=30037,1001, filepermission=2,1, cs9=Block Malicious User,High Risk Resources, cs9Label=Rule name cs11=[{\"api_specification_violation_type\":\"INVALID_PARAM_NAME\",\"parameter_name\":\"somename\"}] cs11Label=Rule Additional Info",
+                "severity": 3,
+                "start": "2016-01-20T11:42:01.336Z",
+                "type": [
+                    "info"
+                ]
+            },
+            "file": {
+                "group": "2,1,",
+                "inode": "3412341160002518171",
+                "type": "30037,1001,"
+            },
+            "http": {
+                "request": {
+                    "method": "GET"
+                },
+                "response": {
+                    "status_code": 200
+                }
+            },
+            "imperva_cloud_waf": {
+                "event": {
+                    "device": {
+                        "event_class_id": "1",
+                        "product": "SIEMintegration",
+                        "vendor": "Incapsula",
+                        "version": "1"
+                    },
+                    "extensions": {
+                        "action": "REQ_CHALLENGE_CAPTCHA",
+                        "additional": {
+                            "req_headers": [
+                                {
+                                    "Accept": "*/*"
+                                },
+                                {
+                                    "x-v": "1"
+                                },
+                                {
+                                    "x-fapi-interaction-id": "10.10.10.10"
+                                }
+                            ],
+                            "res_headers": [
+                                {
+                                    "Content-Type": "text/html; charset=UTF-8"
+                                }
+                            ]
+                        },
+                        "application_protocol": "HTTP",
+                        "bytes_in": 54,
+                        "ccode": "IL",
+                        "cicode": "Rehovot",
+                        "cpt": 443,
+                        "cs11": [
+                            {
+                                "api_specification_violation_type": "INVALID_PARAM_NAME",
+                                "parameter_name": "somename"
+                            }
+                        ],
+                        "cs11Label": "Rule Additional Info",
+                        "cs7": 31.8969,
+                        "cs7Label": "latitude",
+                        "cs8": 34.8186,
+                        "cs8Label": "longitude",
+                        "cs9": "Block Malicious User,High Risk Resources,",
+                        "cs9Label": "Rule name",
+                        "customer": "CEFcustomer123",
+                        "destination_process_name": "Browser",
+                        "device": {
+                            "custom_number1": 200,
+                            "custom_string1": "NOT_SUPPORTED",
+                            "custom_string1_label": "Cap Support",
+                            "custom_string2": true,
+                            "custom_string2_label": "Javascript Support",
+                            "custom_string3": true,
+                            "custom_string3_label": "CO Support",
+                            "custom_string4": "c2e72124-0e8a-4dd8-b13b-3da246af3ab2",
+                            "custom_string4_label": "VID",
+                            "custom_string5": "de3c633ac428e0678f3aac20cf7f239431e54cbb8a17e8302f53653923305e1835a9cd871db32aa4fc7b8a9463366cc4",
+                            "custom_string5_label": "clappsig",
+                            "custom_string6": "Firefox",
+                            "custom_string6_label": "clapp",
+                            "externalId": "33411452762204224",
+                            "facility": "mia"
+                        },
+                        "end_time": "2019-08-20T11:31:10.892Z",
+                        "file": {
+                            "permission": "2,1,",
+                            "type": "30037,1001,"
+                        },
+                        "file_id": "3412341160002518171",
+                        "qstr": "p=%2fetc%2fpasswd",
+                        "request": {
+                            "client_application": "Mozilla/6.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0",
+                            "method": "GET",
+                            "url": "site123.abcd.info/"
+                        },
+                        "sip": "10.1.0.1",
+                        "site": {
+                            "id": "1509732",
+                            "tag": "my-site-tag"
+                        },
+                        "source": {
+                            "address": "1.128.0.1",
+                            "port": 80,
+                            "service_name": "site123.abcd.info",
+                            "user_id": "50005477"
+                        },
+                        "start_time": "2016-01-20T11:42:01.336Z",
+                        "tag": "www.elvis.com",
+                        "ver": "TLSv1.2 ECDHE-RSA-AES128-GCM-SHA256",
+                        "xff": [
+                            "1.128.0.0",
+                            "81.2.69.144"
+                        ]
+                    },
+                    "name": "Normal",
+                    "severity": 3,
+                    "version": "0"
+                }
+            },
+            "input": {
+                "type": "filestream"
+            },
+            "log": {
+                "offset": 0
+            },
+            "message": "Illegal Resource Access",
+            "network": {
+                "application": "http",
+                "forwarded_ip": [
+                    "1.128.0.0",
+                    "81.2.69.144"
+                ]
+            },
+            "observer": {
+                "product": "SIEMintegration",
+                "vendor": "Incapsula",
+                "version": "1"
+            },
+            "related": {
+                "ip": [
+                    "10.1.0.1",
+                    "1.128.0.1",
+                    "1.128.0.0",
+                    "81.2.69.144"
+                ],
+                "user": [
+                    "50005477"
+                ]
+            },
+            "rule": {
+                "name": "Block Malicious User,High Risk Resources,"
+            },
+            "source": {
+                "bytes": 54,
+                "geo": {
+                    "country_iso_code": "IL",
+                    "location": {
+                        "lat": 31.8969,
+                        "lon": 34.8186
+                    }
+                },
+                "ip": "1.128.0.1",
+                "port": 443,
+                "service": {
+                    "name": "site123.abcd.info"
+                },
+                "user": {
+                    "id": "50005477"
+                }
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ],
+            "tls": {
+                "cipher": "ECDHE-RSA-AES128-GCM-SHA256",
+                "version": "1.2"
+            },
+            "url": {
+                "extension": "info/",
+                "original": "site123.abcd.info/",
+                "path": "site123.abcd.info/",
+                "query": "p=%2fetc%2fpasswd"
+            },
+            "user_agent": {
+                "device": {
+                    "name": "Other"
+                },
+                "name": "Firefox",
+                "original": "Mozilla/6.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0",
                 "os": {
                     "full": "Windows 7",
                     "name": "Windows",

--- a/packages/imperva_cloud_waf/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/imperva_cloud_waf/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -529,28 +529,65 @@ processors:
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - convert:
+  - split:
       field: cef.extensions.xff
-      tag: convert_extensions_xff_to_ip
-      target_field: imperva_cloud_waf.event.extensions.xff
-      type: ip
+      separator: ',\s?'
+      tag: split_extensions_xff
       ignore_missing: true
-      if: ctx.cef?.extensions?.xff != null && ctx.cef.extensions.xff != ''
+      if: ctx.cef?.extensions?.xff instanceof String
       on_failure:
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - foreach:
+      field: cef.extensions.xff
+      if: ctx.cef?.extensions?.xff instanceof List
+      tag: foreach_extensions_xff_convert_to_ip
+      processor:
+        convert:
+          field: _ingest._value
+          tag: convert_extensions_xff_to_ip
+          type: ip
+          ignore_missing: true
+          on_failure:
+            - remove:
+                field: _ingest._value
+                ignore_missing: true
+            - append:
+                field: error.message
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - rename:
+      field: cef.extensions.xff
+      tag: rename_extensions_xff
+      target_field: imperva_cloud_waf.event.extensions.xff
+      ignore_missing: true
+      if: ctx.cef?.extensions?.xff instanceof List
+  # - convert:
+  #     field: cef.extensions.xff
+  #     tag: convert_extensions_xff_to_ip
+  #     target_field: imperva_cloud_waf.event.extensions.xff
+  #     type: ip
+  #     ignore_missing: true
+  #     if: ctx.cef?.extensions?.xff != null && ctx.cef.extensions.xff != ''
+  #     on_failure:
+  #       - append:
+  #           field: error.message
+  #           value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: network.forwarded_ip
       tag: set_network_forwarded_ip_from_event_extensions_xff
       copy_from: imperva_cloud_waf.event.extensions.xff
       ignore_empty_value: true
-  - append:
-      field: related.ip
-      tag: append_network_forwarded_ip_into_related_ip
-      value: '{{{network.forwarded_ip}}}'
-      allow_duplicates: false
-      if: ctx.network?.forwarded_ip != null
+  - foreach:
+      field: network.forwarded_ip
+      if: ctx.network?.forwarded_ip instanceof List
+      tag: foreach_network_forwarded_ip_append_related_ip
+      processor:
+        append:
+          field: related.ip
+          tag: append_network_forwarded_ip_into_related_ip
+          value: '{{{_ingest._value}}}'
+          allow_duplicates: false
   - rename:
       field: cef.name
       tag: rename_name

--- a/packages/imperva_cloud_waf/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/imperva_cloud_waf/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -562,17 +562,6 @@ processors:
       target_field: imperva_cloud_waf.event.extensions.xff
       ignore_missing: true
       if: ctx.cef?.extensions?.xff instanceof List
-  # - convert:
-  #     field: cef.extensions.xff
-  #     tag: convert_extensions_xff_to_ip
-  #     target_field: imperva_cloud_waf.event.extensions.xff
-  #     type: ip
-  #     ignore_missing: true
-  #     if: ctx.cef?.extensions?.xff != null && ctx.cef.extensions.xff != ''
-  #     on_failure:
-  #       - append:
-  #           field: error.message
-  #           value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: network.forwarded_ip
       tag: set_network_forwarded_ip_from_event_extensions_xff

--- a/packages/imperva_cloud_waf/data_stream/event/sample_event.json
+++ b/packages/imperva_cloud_waf/data_stream/event/sample_event.json
@@ -1,17 +1,17 @@
 {
-    "@timestamp": "2024-01-31T09:22:42.456Z",
+    "@timestamp": "2025-03-21T16:26:32.183Z",
     "agent": {
-        "ephemeral_id": "7d22d234-404b-426a-be1c-8ca128c3357b",
-        "id": "1c0e504b-c5db-46af-aa55-bd7efb79ed8c",
-        "name": "docker-fleet-agent",
+        "ephemeral_id": "eb4bebd1-5ad1-4b86-8d31-d1db64d1488e",
+        "id": "cff3afe2-2775-4d3c-88f3-b1e55551f982",
+        "name": "elastic-agent-88200",
         "type": "filebeat",
-        "version": "8.10.1"
+        "version": "8.13.0"
     },
     "aws": {
         "s3": {
             "bucket": {
-                "arn": "arn:aws:s3:::elastic-package-imperva-cloud-waf-bucket-13510",
-                "name": "elastic-package-imperva-cloud-waf-bucket-13510"
+                "arn": "arn:aws:s3:::elastic-package-imperva-cloud-waf-bucket-18864",
+                "name": "elastic-package-imperva-cloud-waf-bucket-18864"
             },
             "object": {
                 "key": "events.log"
@@ -23,16 +23,16 @@
     },
     "data_stream": {
         "dataset": "imperva_cloud_waf.event",
-        "namespace": "ep",
+        "namespace": "56866",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "1c0e504b-c5db-46af-aa55-bd7efb79ed8c",
+        "id": "cff3afe2-2775-4d3c-88f3-b1e55551f982",
         "snapshot": false,
-        "version": "8.10.1"
+        "version": "8.13.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -42,7 +42,7 @@
         "code": "1",
         "dataset": "imperva_cloud_waf.event",
         "end": "2019-08-20T11:31:10.892Z",
-        "ingested": "2024-01-31T09:22:43Z",
+        "ingested": "2025-03-21T16:26:33Z",
         "kind": "event",
         "original": "CEF:0|Incapsula|SIEMintegration|1|1|Normal|0| sourceServiceName=site123.abcd.info siteid=1509732 suid=50005477 requestClientApplication=Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0 deviceFacility=mia ccode=IL tag=www.elvis.com cicode=Rehovot cs7=31.8969 cs7Label=latitude cs8=34.8186 cs8Label=longitude Customer=CEFcustomer123 siteTag=my-site-tag start=1453290121336 request=site123.abcd.info/main.css ref=www.incapsula.com/lama requestmethod=GET cn1=200 app=HTTP deviceExternalID=33411452762204224 in=54 xff=44.44.44.44 cpt=443 src=12.12.12.12 ver=TLSv1.2 ECDHE-RSA-AES128-GCM-SHA256 end=1566300670892 additionalReqHeaders=[{\"Accept\":\"*/*\"},{\"x-v\":\"1\"},{\"x-fapi-interaction-id\":\"10.10.10.10\"}] additionalResHeaders=[{\"Content-Type\":\"text/html; charset\\=UTF-8\"}]",
         "severity": 0,
@@ -108,14 +108,16 @@
     },
     "log": {
         "file": {
-            "path": "https://elastic-package-imperva-cloud-waf-bucket-13510.s3.us-east-1.amazonaws.com/events.log"
+            "path": "https://elastic-package-imperva-cloud-waf-bucket-18864.s3.us-east-1.amazonaws.com/events.log"
         },
         "offset": 134
     },
     "message": "Normal",
     "network": {
         "application": "http",
-        "forwarded_ip": "44.44.44.44"
+        "forwarded_ip": [
+            "44.44.44.44"
+        ]
     },
     "observer": {
         "product": "SIEMintegration",

--- a/packages/imperva_cloud_waf/docs/README.md
+++ b/packages/imperva_cloud_waf/docs/README.md
@@ -93,19 +93,19 @@ An example event for `event` looks as following:
 
 ```json
 {
-    "@timestamp": "2024-01-31T09:22:42.456Z",
+    "@timestamp": "2025-03-21T16:26:32.183Z",
     "agent": {
-        "ephemeral_id": "7d22d234-404b-426a-be1c-8ca128c3357b",
-        "id": "1c0e504b-c5db-46af-aa55-bd7efb79ed8c",
-        "name": "docker-fleet-agent",
+        "ephemeral_id": "eb4bebd1-5ad1-4b86-8d31-d1db64d1488e",
+        "id": "cff3afe2-2775-4d3c-88f3-b1e55551f982",
+        "name": "elastic-agent-88200",
         "type": "filebeat",
-        "version": "8.10.1"
+        "version": "8.13.0"
     },
     "aws": {
         "s3": {
             "bucket": {
-                "arn": "arn:aws:s3:::elastic-package-imperva-cloud-waf-bucket-13510",
-                "name": "elastic-package-imperva-cloud-waf-bucket-13510"
+                "arn": "arn:aws:s3:::elastic-package-imperva-cloud-waf-bucket-18864",
+                "name": "elastic-package-imperva-cloud-waf-bucket-18864"
             },
             "object": {
                 "key": "events.log"
@@ -117,16 +117,16 @@ An example event for `event` looks as following:
     },
     "data_stream": {
         "dataset": "imperva_cloud_waf.event",
-        "namespace": "ep",
+        "namespace": "56866",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "1c0e504b-c5db-46af-aa55-bd7efb79ed8c",
+        "id": "cff3afe2-2775-4d3c-88f3-b1e55551f982",
         "snapshot": false,
-        "version": "8.10.1"
+        "version": "8.13.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -136,7 +136,7 @@ An example event for `event` looks as following:
         "code": "1",
         "dataset": "imperva_cloud_waf.event",
         "end": "2019-08-20T11:31:10.892Z",
-        "ingested": "2024-01-31T09:22:43Z",
+        "ingested": "2025-03-21T16:26:33Z",
         "kind": "event",
         "original": "CEF:0|Incapsula|SIEMintegration|1|1|Normal|0| sourceServiceName=site123.abcd.info siteid=1509732 suid=50005477 requestClientApplication=Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0 deviceFacility=mia ccode=IL tag=www.elvis.com cicode=Rehovot cs7=31.8969 cs7Label=latitude cs8=34.8186 cs8Label=longitude Customer=CEFcustomer123 siteTag=my-site-tag start=1453290121336 request=site123.abcd.info/main.css ref=www.incapsula.com/lama requestmethod=GET cn1=200 app=HTTP deviceExternalID=33411452762204224 in=54 xff=44.44.44.44 cpt=443 src=12.12.12.12 ver=TLSv1.2 ECDHE-RSA-AES128-GCM-SHA256 end=1566300670892 additionalReqHeaders=[{\"Accept\":\"*/*\"},{\"x-v\":\"1\"},{\"x-fapi-interaction-id\":\"10.10.10.10\"}] additionalResHeaders=[{\"Content-Type\":\"text/html; charset\\=UTF-8\"}]",
         "severity": 0,
@@ -202,14 +202,16 @@ An example event for `event` looks as following:
     },
     "log": {
         "file": {
-            "path": "https://elastic-package-imperva-cloud-waf-bucket-13510.s3.us-east-1.amazonaws.com/events.log"
+            "path": "https://elastic-package-imperva-cloud-waf-bucket-18864.s3.us-east-1.amazonaws.com/events.log"
         },
         "offset": 134
     },
     "message": "Normal",
     "network": {
         "application": "http",
-        "forwarded_ip": "44.44.44.44"
+        "forwarded_ip": [
+            "44.44.44.44"
+        ]
     },
     "observer": {
         "product": "SIEMintegration",

--- a/packages/imperva_cloud_waf/manifest.yml
+++ b/packages/imperva_cloud_waf/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: imperva_cloud_waf
 title: Imperva Cloud WAF
-version: "1.11.1"
+version: "1.11.2"
 description: Collect logs from Imperva Cloud WAF with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
It is possible that cef.extensions.xff can contain ',' separated 
IPs. Handle such cases and convert the field as array by default.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Passes pipeline tests (with comma-separated `xff`)
```
--- Test results for package: imperva_cloud_waf - START ---
╭───────────────────┬─────────────┬───────────┬────────────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE           │ DATA STREAM │ TEST TYPE │ TEST NAME                                  │ RESULT │ TIME ELAPSED │
├───────────────────┼─────────────┼───────────┼────────────────────────────────────────────┼────────┼──────────────┤
│ imperva_cloud_waf │ event       │ pipeline  │ (ingest pipeline warnings test-event.json) │ PASS   │ 376.180458ms │
│ imperva_cloud_waf │ event       │ pipeline  │ test-event.json                            │ PASS   │ 111.661208ms │
╰───────────────────┴─────────────┴───────────┴────────────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: imperva_cloud_waf - END   ---
Done
```

