### PR TITLE
Removed deprecated _source.mode in transform index

### DIFF
--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Removed deprecated _source.mode in transform index
       type: enhancement
-      link: TODO
+      link: "https://github.com/elastic/integrations/pull/13295"
 - version: "1.18.1"
   changes:
     - description: Fixed transform job definition that was inflating ingest volume

--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.0"
+  changes:
+    - description: Removed deprecated _source.mode in transform index
+      type: enhancement
+      link: TODO
 - version: "1.18.1"
   changes:
     - description: Fixed transform job definition that was inflating ingest volume

--- a/packages/elasticsearch/elasticsearch/transform/index_pivot/manifest.yml
+++ b/packages/elasticsearch/elasticsearch/transform/index_pivot/manifest.yml
@@ -1,12 +1,6 @@
 start: false
 destination_index_template:
-  # All these settings aim to optimize the index for storage space, as we can't use rollovers or monthly indices.
-  # In most cases, this should be enough for 1+ year of usage insights.
   settings:
     index:
       codec: best_compression
       number_of_shards: 3
-      mode: logsdb
-      sort:
-        field: ["elasticsearch.cluster.name", "elasticsearch.index.name", "@timestamp"]
-        order: ["asc", "asc", "desc"]

--- a/packages/elasticsearch/elasticsearch/transform/index_pivot/manifest.yml
+++ b/packages/elasticsearch/elasticsearch/transform/index_pivot/manifest.yml
@@ -6,6 +6,7 @@ destination_index_template:
     index:
       codec: best_compression
       number_of_shards: 3
-  mappings:
-    _source:
-      mode: synthetic
+      mode: logsdb
+      sort:
+        field: ["elasticsearch.cluster.name", "elasticsearch.index.name", "@timestamp"]
+        order: ["asc", "asc", "desc"]

--- a/packages/elasticsearch/elasticsearch/transform/index_pivot/transform.yml
+++ b/packages/elasticsearch/elasticsearch/transform/index_pivot/transform.yml
@@ -119,7 +119,7 @@ pivot:
         script: "Math.max(0, params.end-params.start)"
 dest:
   index: "monitoring-indices"
-  pipeline: "1.18.1-monitoring_indices"
+  pipeline: "1.19.0-monitoring_indices"
 description: This transform runs every 10 minutes to compute extra metrics for the Elasticsearch indices.
 frequency: 10m
 settings:

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 1.18.1
+version: 1.19.0
 description: Elasticsearch Integration
 type: integration
 icons:


### PR DESCRIPTION
## Proposed commit message

Direct `_source` mode control is deprecated  - removed the setting for the transform destination index in the Elasticsearch integration

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

Closes https://github.com/elastic/integrations/issues/12847

