### PR TITLE
[ti_threatconnect] Add a compatibility pipeline to the transform

### DIFF
--- a/packages/ti_threatconnect/changelog.yml
+++ b/packages/ti_threatconnect/changelog.yml
@@ -1,4 +1,10 @@
 # newer versions go on top
+# WARNING: this version number needs to be kept up to date in the transform!
+- version: "1.9.2"
+  changes:
+    - description: Add a compatibility pipeline to the transform.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13303
 - version: "1.9.1"
   changes:
     - description: Update transform version numbers.

--- a/packages/ti_threatconnect/elasticsearch/ingest_pipeline/tactics_compatibility.yml
+++ b/packages/ti_threatconnect/elasticsearch/ingest_pipeline/tactics_compatibility.yml
@@ -1,0 +1,34 @@
+---
+processors:
+  - script:
+      # Before 1.9.0, `threat_connect.indicator.tags.data.tactics` was not
+      # processed. It came out of the ingest pipeline with values such as
+      # `{ "data": ["Tactic Name"], "count": 1 }` which would be retained in
+      # the `_source`, but not indexed in the source data stream. When the
+      # transform used the `_source` value to index the document in the
+      # destination data stream, the dynamic mappings there _would_ index
+      # `threat_connect.indicator.tags.data.tactics.data`, etc.
+      #
+      # Since 1.9.0, `threat_connect.indicator.tags.data.tactics` is processed
+      # to remove the `data` wrapper and it is mapped as `keyword`.
+      #
+      # When upgrading to 1.9.1, rebuilding the destination index fails because
+      # old `_source` values conflict with the new `keyword` mapping for
+      #`threat_connect.indicator.tags.data.tactics`.
+      #
+      # In 1.9.2, this processor is added to make old `_source` values
+      # compatible with the new mapping during the rebuild of the transform
+      # destination index.
+      #
+      # By defalt, old data is expired after 90 days, so this processing can
+      # likely be removed at some point in the future.
+      lang: painless
+      tag: ensure_tag_tactics_is_unwrapped
+      source: >
+        if (ctx.threat_connect?.indicator?.tags?.data instanceof List) {
+          for (tag_data in ctx.threat_connect.indicator.tags.data) {
+            if (tag_data.tactics instanceof Map && tag_data.tactics.data != null) {
+              tag_data.tactics = tag_data.tactics.data;
+            }
+          }
+        }

--- a/packages/ti_threatconnect/elasticsearch/ingest_pipeline/tactics_compatibility.yml
+++ b/packages/ti_threatconnect/elasticsearch/ingest_pipeline/tactics_compatibility.yml
@@ -20,7 +20,7 @@ processors:
       # compatible with the new mapping during the rebuild of the transform
       # destination index.
       #
-      # By defalt, old data is expired after 90 days, so this processing can
+      # By default, old data is expired after 90 days, so this processing can
       # likely be removed at some point in the future.
       lang: painless
       tag: ensure_tag_tactics_is_unwrapped

--- a/packages/ti_threatconnect/elasticsearch/transform/latest/transform.yml
+++ b/packages/ti_threatconnect/elasticsearch/transform/latest/transform.yml
@@ -9,7 +9,8 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_threatconnect_latest.dest_indicator-4"
+  index: "logs-ti_threatconnect_latest.dest_indicator-5"
+  pipeline: "1.9.2-tactics_compatibility"
   aliases:
     - alias: "logs-ti_threatconnect_latest.indicator"
       move_on_creation: true
@@ -32,4 +33,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.4.0
+  fleet_transform_version: 0.5.0

--- a/packages/ti_threatconnect/manifest.yml
+++ b/packages/ti_threatconnect/manifest.yml
@@ -2,7 +2,7 @@
 format_version: 3.0.3
 name: ti_threatconnect
 title: ThreatConnect
-version: "1.9.1"
+version: "1.9.2"
 description: Collects Indicators from ThreatConnect using the Elastic Agent and saves them as logs inside Elastic
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[ti_threatconnect] Add a compatibility pipeline to the transform

See `packages/ti_threatconnect/elasticsearch/ingest_pipeline/tactics_compatibility.yml`
for an explanation of this change.

This has been manually tested against a live server.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

<!-- Recommended
## Related issues

Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

## Manual testing

I tested by ingesting data that included tactics using package version 1.8.0, then updated to 1.9.2 and checked that the transform did not encounter any mapping conflicts and the rebuilt destination index had the correct data.

Here's an example from the old destination index (note the field `threat_connect.indicator.tags.data.tactics.data`):
![logs-ti_threatconnect_latest dest_indicator-3](https://github.com/user-attachments/assets/8396801a-4e78-40d9-8295-27e2a9f762f9)

And the same document in the rebuilt destination index (note the field `threat_connect.indicator.tags.data.tactics`):
![logs-ti_threatconnect_latest dest_indicator-5](https://github.com/user-attachments/assets/a3ea7d8b-a368-4a94-aa77-c961309ecbeb)