### PR TITLE
[cisco_asa] Allow masked usernames for 315011 messages

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.43.3"
+  changes:
+    - description: Allow masked usernames for 315011 messages.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.43.2"
   changes:
     - description: Handle another variation of message type 315011

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
@@ -127,6 +127,7 @@ May  5 19:02:25 dev01: %ASA-6-716039: Group <malcorp group> User <malory> IP <17
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-302010: 12 in use, 10 most used
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-315011: SSH session from 10.1.2.1 on interface inside for user USER_1 disconnected by SSH server, reason: Out of memory
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-315011: SSH session from 10.1.2.3 on interface inside for user "user-test" terminated normally.
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-315011: SSH session from 10.1.2.3 on interface inside for user "*****" disconnected by SSH server, reason: "Time-out activated" (0x91)
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-721016: (DEVICE_1) WebVPN session for client user USER_1, IP 10.20.0.1 has been created.
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-721018: (DEVICE_1) WebVPN session for client user USER_1, IP 10.20.0.1 has been deleted.
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-5-722028: Group <GROUP 1> User <USER 1> IP <10.20.0.1> Stale SVC connection closed.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -9096,6 +9096,73 @@
             "@timestamp": "2023-10-03T16:40:40.000Z",
             "cisco": {
                 "asa": {
+                    "source_interface": "inside"
+                }
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "ssh-session-ended",
+                "category": [
+                    "network"
+                ],
+                "code": "315011",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-315011: SSH session from 10.1.2.3 on interface inside for user \"*****\" disconnected by SSH server, reason: \"Time-out activated\" (0x91)",
+                "reason": "\"Time-out activated\" (0x91)",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "end"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "10.1.2.3"
+                ]
+            },
+            "source": {
+                "ip": "10.1.2.3"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
                     "device_type": "DEVICE_1"
                 }
             },

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -652,8 +652,10 @@ processors:
       field: "message"
       description: "315011"
       patterns:
-        - 'SSH session from %{IP:source.ip} on interface %{WORD:_temp_.cisco.source_interface} for user "?%{USERNAME:source.user.name}"? disconnected by SSH server, reason: %{GREEDYDATA:event.reason}'
-        - 'SSH session from %{IP:source.ip} on interface %{WORD:_temp_.cisco.source_interface} for user "?%{USERNAME:source.user.name}"? terminated normally'
+        - 'SSH session from %{IP:source.ip} on interface %{WORD:_temp_.cisco.source_interface} for user %{CISCO_USER} disconnected by SSH server, reason: %{GREEDYDATA:event.reason}'
+        - 'SSH session from %{IP:source.ip} on interface %{WORD:_temp_.cisco.source_interface} for user %{CISCO_USER} terminated normally'
+      pattern_definitions:
+        CISCO_USER: '\"?(?:\*{5}|%{USERNAME:source.user.name})\"?'
   - dissect:
       if: "ctx._temp_.cisco.message_id == '322001'"
       tag: parse_322001

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_asa
 title: Cisco ASA
-version: "2.43.2"
+version: "2.43.3"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- Expand grok patterns for 315011 to support masked ('*****') usernames

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~


## How to test this PR locally

```
cd packages/cisco_asa
elastic-package test
```