### PR TITLE
[Cloud Security][Wiz] add vulnerability event.id to use ecs mapping

### DIFF
--- a/packages/wiz/changelog.yml
+++ b/packages/wiz/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.10.0"
+  changes:
+    - description: Rely on external ecs for ESC fields. event.id changed from text to keyword
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/13312
 - version: "2.9.3"
   changes:
     - description: Set `event.id` inside vulnerability data required for CDR workflow.

--- a/packages/wiz/elasticsearch/transform/latest_cdr_vulnerabilities/fields/fields.yml
+++ b/packages/wiz/elasticsearch/transform/latest_cdr_vulnerabilities/fields/fields.yml
@@ -40,6 +40,8 @@
   external: ecs
 - name: ecs.version
   external: ecs
+- name: event.id
+  external: ecs
 - name: tags
   external: ecs
 - name: related.ip

--- a/packages/wiz/manifest.yml
+++ b/packages/wiz/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.3
 name: wiz
 title: Wiz
-version: "2.9.3"
+version: "2.10.0"
 description: Collect logs from Wiz with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## add vulnerability event.id to use ecs mapping

Update event.id field in latest cdr vulnerabilities to use ECS mapping


