### PR TITLE
Recover support for 9.0 in apache package

### DIFF
--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.30.0"
+  changes:
+    - description: Recover support stack 9.0
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13315
 - version: "1.29.1"
   changes:
     - description: Added description to ssl nodes including links to documentation.

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.5
 name: apache
 title: Apache HTTP Server
-version: "1.29.1"
+version: "1.30.0"
 source:
   license: Elastic-2.0
 description: Collect logs and metrics from Apache servers with Elastic Agent.
@@ -11,7 +11,7 @@ categories:
   - observability
 conditions:
   kibana:
-    version: "^8.13.0"
+    version: "^8.13.0 || ^9.0.0"
   elastic:
     subscription: basic
 screenshots:


### PR DESCRIPTION
## Proposed commit message

9.x support in the apache package was unexpectedly removed in 1.28.0, after https://github.com/elastic/integrations/pull/12503/files#diff-c1bfeefb3a7a71c324e3d6ee4ea6ed2b3cb6fd640e040b146c03582c3216cf37R14.

Recover support for 9.0 in this package.

## Related issues

- Reverts part of https://github.com/elastic/integrations/pull/12503.
- Recovers https://github.com/elastic/integrations/pull/12504.