### PR TITLE
crowdstrike: improve ingest pipeline performance

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.61.0"
+  changes:
+    - description: Improve performance of script processors in fdr data stream ingest pipeline.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/13325
 - version: "1.60.0"
   changes:
     - description: Add option to delete long fields thus avoiding _ignored fields.

--- a/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
@@ -2840,24 +2840,24 @@ processors:
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |
         void handleMap(Map map) {
-          for (def x : map.values()) {
-            if (x instanceof Map) {
-                handleMap(x);
-            } else if (x instanceof List) {
-                handleList(x);
+          map.values().removeIf(v -> {
+            if (v instanceof Map) {
+                handleMap(v);
+            } else if (v instanceof List) {
+                handleList(v);
             }
-          }
-          map.values().removeIf(v -> v == null || v == '' || v == '-' || v == 'none' || (v instanceof Map && v.size() == 0) || (v instanceof List && v.size() == 0));
+            return v == null || v == '' || v == '-' || v == 'none' || (v instanceof Map && v.size() == 0) || (v instanceof List && v.size() == 0)
+          });
         }
         void handleList(List list) {
-          for (def x : list) {
-              if (x instanceof Map) {
-                  handleMap(x);
-              } else if (x instanceof List) {
-                  handleList(x);
-              }
-          }
-          list.removeIf(v -> v == null || v == '' || v == '-' || v == 'none' || (v instanceof Map && v.size() == 0) || (v instanceof List && v.size() == 0));
+          list.removeIf(v -> {
+            if (v instanceof Map) {
+                handleMap(v);
+            } else if (v instanceof List) {
+                handleList(v);
+            }
+            return v == null || v == '' || v == '-' || v == 'none' || (v instanceof Map && v.size() == 0) || (v instanceof List && v.size() == 0)
+          });
         }
         handleMap(ctx);
 on_failure:

--- a/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
@@ -1735,19 +1735,19 @@ processors:
             return b;
         }
 
-        // readNextArg splits command line string cmd into next
-        // argument and command line remainder.
-        def readNextArg(String cmd) {
+        // readNextArg splits command line string into next
+        // argument and command line remainder offset.
+        def readNextArg(String line, int offset) {
             def b = new StringBuilder();
             boolean inquote;
             int nslash;
-            for (; cmd.length() > 0; cmd = cmd.substring(1)) {
-                def c = cmd.charAt(0);
+            for (; offset < line.length(); offset++) {
+                def c = line.charAt(offset);
                 if (c == (char)' ' || c == (char)0x09) {
                     if (!inquote) {
                         return [
                             "arg":  appendBSBytes(b, nslash).toString(),
-                            "rest": cmd.substring(1)
+                            "offset": offset+1
                         ];
                     }
                 } else if (c == (char)'"') {
@@ -1756,9 +1756,9 @@ processors:
                         // use "Prior to 2008" rule from
                         // http://daviddeley.com/autohotkey/parameters/parameters.htm
                         // section 5.2 to deal with double double quotes
-                        if (inquote && cmd.length() > 1 && cmd.charAt(1) == (char)'"') {
+                        if (inquote && offset+1 < line.length() && line.charAt(offset+1) == (char)'"') {
                             b.append(c);
-                            cmd = cmd.substring(1);
+                            offset++;
                         }
                         inquote = !inquote;
                     } else {
@@ -1776,7 +1776,7 @@ processors:
             }
             return [
                 "arg":  appendBSBytes(b, nslash).toString(), 
-                "rest": ''
+                "offset": line.length()
             ];
         }
 
@@ -1784,15 +1784,19 @@ processors:
         // strings, following the Windows conventions documented
         // at http://daviddeley.com/autohotkey/parameters/parameters.htm#WINARGV
         // Original implementation found at: https://github.com/golang/go/commit/39c8d2b7faed06b0e91a1ad7906231f53aab45d1
-        def commandLineToArgv(String cmd) {
+        def commandLineToArgv(String line) {
             def args = new ArrayList();
-            while (cmd.length() > 0) {
-                if (cmd.charAt(0) == (char)' ' || cmd.charAt(0) == (char)0x09) {
-                    cmd = cmd.substring(1);
+            for (int i = 0; i < line.length();) {
+                if (line.charAt(i) == (char)' ' || line.charAt(i) == (char)0x09) {
+                    i++;
                     continue;
                 }
-                def next = readNextArg(cmd);
-                cmd = next.rest;
+                def next = readNextArg(line, i);
+                i = next.offset;
+                if (next.arg == '') {
+                    // Empty strings will be removed later so don't bother adding them.
+                    continue;
+                }
                 args.add(next.arg);
             }
             return args;

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "1.60.0"
+version: "1.61.0"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: "3.3.1"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

```
crowdstrike: improve ingest pipeline performance

This improves the performance of the null cleaning script in the pipeline's
postamble, and the command line arg splitter in the body of the pipeline.

The empty field change reduces the number of allocations for iterators by
half and improves the readability of the code.

             │  old.bench  │           new.bench           │
             │   sec/op    │    sec/op     vs base         │
remove-nulls   4.000µ ± 0%   2.000µ ± 50%  -50.00% (n=100)

The command line splitting script was consuming a significant proportion
of the pipeline's total CPU use. The original code was based on Go code
used in libbeat, on the assumption that the allocation and GC behaviour
would be similar between the two languages; this is not the case. While
slicing strings in Go is extremely cheap (likely not involving an
allocation at all in most cases since the string header can be retained
on the stack), this is not the case in Java where the substring method
does allocate. So to address this, instead of consuming the string and
biting off chunks, only take fragments when they are known to be a
complete argument.

Before the change, using the elastic-package benchmarking tool with
munging to allow benchstat to consume the data, the performance was

                   │ cmd_old.bench │
                   │    sec/op     │
split-command-line     10.31µ ± 0%

After the change, the time taken is not great enough to be emitted by
the benchmark tool. This would place it in the approximately
sub-microsecond range.
```

> [!NOTE]
> Great appreciation to @joegallo for looking through this with me.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
