### PR TITLE
[Jamf_Pro] - Fix empty string issue for date query param in filter for Jamf Pro inventory data stream

### DIFF
--- a/packages/jamf_pro/changelog.yml
+++ b/packages/jamf_pro/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix empty string issue for date query param in filter for Jamf Pro inventory data stream.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1111
+      link: https://github.com/elastic/integrations/pull/13329
 - version: "0.5.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/jamf_pro/changelog.yml
+++ b/packages/jamf_pro/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.1"
+  changes:
+    - description: Fix empty string issue for date query param in filter for Jamf Pro inventory data stream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1111
 - version: "0.5.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/jamf_pro/data_stream/inventory/_dev/test/pipeline/test-inventory.json
+++ b/packages/jamf_pro/data_stream/inventory/_dev/test/pipeline/test-inventory.json
@@ -229,7 +229,9 @@
                     "supervised": false,
                     "mdmCapable": {
                         "capable": false,
-                        "capableUsers": ["user.mcuserface@company.com"]
+                        "capableUsers": [
+                            "user.mcuserface@company.com"
+                        ]
                     },
                     "reportDate": "2024-06-19T15:54:37.692Z",
                     "lastContactTime": "2024-04-18T14:26:51.514Z",

--- a/packages/jamf_pro/data_stream/inventory/agent/stream/cel.yml.hbs
+++ b/packages/jamf_pro/data_stream/inventory/agent/stream/cel.yml.hbs
@@ -29,6 +29,8 @@ publisher_pipeline.disable_host: true
 {{/contains}}
 
 keep_null: true
+redact:
+    fields: ~
 program: |-
   request(
   	"GET",
@@ -36,7 +38,10 @@ program: |-
   		"section": state.sections,
   		"page-size": [string(state.page_size)],
   		"sort": ["general.reportDate:asc"],
-  		?"filter": state.?cursor.last_report_date.optMap(d, ["general.reportDate>=\"" + d + "\""]),
+  		?"filter": (has(state.?cursor.last_report_date) && state.cursor.last_report_date.orValue("") != "") ?
+   			optional.of(["general.reportDate>=\"" + state.cursor.last_report_date + "\""])
+   		:
+   			optional.none(),
   	}.format_query()
   ).with(
   	{

--- a/packages/jamf_pro/data_stream/inventory/agent/stream/cel.yml.hbs
+++ b/packages/jamf_pro/data_stream/inventory/agent/stream/cel.yml.hbs
@@ -38,7 +38,7 @@ program: |-
   		"section": state.sections,
   		"page-size": [string(state.page_size)],
   		"sort": ["general.reportDate:asc"],
-  		?"filter": (has(state.?cursor.last_report_date) && state.cursor.last_report_date.orValue("") != "") ?
+  		?"filter": state.?cursor.last_report_date.orValue("") != "" ?
    			optional.of(["general.reportDate>=\"" + state.cursor.last_report_date + "\""])
    		:
    			optional.none(),

--- a/packages/jamf_pro/data_stream/inventory/manifest.yml
+++ b/packages/jamf_pro/data_stream/inventory/manifest.yml
@@ -4,11 +4,7 @@ streams:
   - input: cel
     template_path: cel.yml.hbs
     title: Inventory data
-    description: |
-      Settings for inventory requests.  
-      *NOTE* Enabling many sections may impact query processing.
-      It is recommended to only enable sections of interest.
-      The General section is always included.
+    description: "Settings for inventory requests.  \n*NOTE* Enabling many sections may impact query processing.\nIt is recommended to only enable sections of interest.\nThe General section is always included.\n"
     vars:
       - name: interval
         type: text

--- a/packages/jamf_pro/manifest.yml
+++ b/packages/jamf_pro/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.5
 name: jamf_pro
 title: "Jamf Pro"
-version: "0.5.0"
+version: "0.5.1"
 source:
   license: "Elastic-2.0"
 description: "Collect logs and inventory data from Jamf Pro with Elastic Agent"


### PR DESCRIPTION
## Type of change
- Bug

## Proposed commit message
**WHAT:** Fixed empty string issue for date query param in filter for Jamf Pro inventory data stream.

**WHY:** Recently there was a commit changing how the filter works detailed [here](https://github.com/harnish-elastic/integrations/commit/c730ea0f0ddbaa955e2a7189043617827fa880b5#diff-0ffc4d4d6aab9bfef1f294ac1e04c5560811b7c9ad54baba832b9d369b989476R40). The issue is that this change does not take into account the fact that due to the [previously existing cursor logic](https://github.com/harnish-elastic/integrations/commit/c730ea0f0ddbaa955e2a7189043617827fa880b5#diff-0ffc4d4d6aab9bfef1f294ac1e04c5560811b7c9ad54baba832b9d369b989476L73), there could be scenarios where the `cursor.last_report_date` is an **empty string**. 

Sending the date in the filter as an empty string causes the API to respond with a status_code: 400 leading to failures. The fix in this PR tries to address this specific issue along with some minor cleanup.

**Commit Message:**  `The current cursor handling assumes that state.cursor.last_report_date is
either absent or a valid cursor. However, previously stored cursor values may
include an empty string for this value to indicate an absence. The outcome of
this is that an invalid filter parameter was being sent in those cases. This
changes the logic to correctly handle cursors that have used an empty string
as an absence marker.`

## NOTE
Some minor cleanup and additions are included since they are all + changes. Some are just elastic-package format behaviour.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
- Relates https://github.com/elastic/integrations/pull/12231


## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
