### PR TITLE
[doc] ti_crowdstrike doc update to setup on IOC scope to add ioc-management:read

### DIFF
--- a/packages/ti_crowdstrike/_dev/build/docs/README.md
+++ b/packages/ti_crowdstrike/_dev/build/docs/README.md
@@ -50,10 +50,11 @@ This module has been tested against the **CrowdStrike Falcon Intelligence API Ve
 4. API Endpoint url
 5. Required scopes for each data stream :
 
-    | Data Stream   | Scope         |
-    | ------------- | ------------- |
-    | Intel         | read:intel    |
-    | IOC           | read:iocs     |
+    | Data Stream   | Scope                 |
+    | ------------- | --------------------- |
+    | Intel         | read:intel            |
+    | IOC           | read:iocs             |
+    |               | read:ioc-management   |
 
 Follow the [documentation](https://www.crowdstrike.com/blog/tech-center/consume-ioc-and-threat-feeds/) for enabling the scopes from the CrowdStrike console.
 

--- a/packages/ti_crowdstrike/changelog.yml
+++ b/packages/ti_crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.1"
+  changes:
+    - description: Update the required scope for IOC data stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/13331
 - version: "2.4.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/ti_crowdstrike/docs/README.md
+++ b/packages/ti_crowdstrike/docs/README.md
@@ -50,10 +50,11 @@ This module has been tested against the **CrowdStrike Falcon Intelligence API Ve
 4. API Endpoint url
 5. Required scopes for each data stream :
 
-    | Data Stream   | Scope         |
-    | ------------- | ------------- |
-    | Intel         | read:intel    |
-    | IOC           | read:iocs     |
+    | Data Stream   | Scope                 |
+    | ------------- | --------------------- |
+    | Intel         | read:intel            |
+    | IOC           | read:iocs             |
+    |               | read:ioc-management   |
 
 Follow the [documentation](https://www.crowdstrike.com/blog/tech-center/consume-ioc-and-threat-feeds/) for enabling the scopes from the CrowdStrike console.
 
@@ -455,3 +456,4 @@ An example event for `ioc` looks as following:
 | ti_crowdstrike.ioc.tags | Tags associated with the IOC. | keyword |
 | ti_crowdstrike.ioc.type | The type of indicator. | keyword |
 | ti_crowdstrike.ioc.value | The specific value of the indicator. | keyword |
+

--- a/packages/ti_crowdstrike/manifest.yml
+++ b/packages/ti_crowdstrike/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_crowdstrike
 title: CrowdStrike Falcon Intelligence
-version: "2.4.0"
+version: "2.4.1"
 description: Collect logs from CrowdStrike Falcon Intelligence with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message
The Scope for ti_crowdstrike IOC needs also have 'ioc-management:read' otherwise it results in 403  (access denied, authorization failed)

cel-ti_crowdstrike.ioc component state degraded, with 
```
error: 'single event error object returned by evaluation: {"error":{"code":"403","id":"403 Forbidden","message":"GET:{\n \"meta\": {\n  \"query_time\": 2.08e-7,\n  \"powered_by\": \"crowdstrike-api-gateway\",\n  \"trace_id\": \"8ad80abe-39e3-4b77-abb2-aefe3fc4037c\"\n },\n \"errors\": [\n  {\n   \"code\": 403,\n   \"message\": \"access denied, authorization failed\"\n  }\n ]\n}"}}'
```

For example from agent (debug) logs
```
{"log.level":"debug","@timestamp":"2025-03-21T13:10:57.138Z","message":"response state","component":{"binary":"filebeat","dataset":"elastic_agent.filebeat","id":"cel-default","type":"cel"},"log":{"source":"cel-default"},"id":"cel-ti_crowdstrike.ioc-54d15ceb-4cde-44d0-8ef3-a24a6877cda0","input_url":"https://api.us-2.crowdstrike.com","log.origin":{"file.line":254,"file.name":"cel/input.go","function":"github.com/elastic/beats/v7/x-pack/filebeat/input/cel.input.run.func1"},"log.logger":"input.cel","service.name":"filebeat","input_source":"https://api.us-2.crowdstrike.com","cel":{"ecs.version":"1.6.0","state":"{\"batch_size\":2000,\"events\":{\"error\":{\"code\":\"403\",\"id\":\"403 Forbidden\",\"message\":\"GET:{\\n \\\"meta\\\": {\\n  \\\"query_time\\\": 2.23e-7,\\n  \\\"powered_by\\\": \\\"crowdstrike-api-gateway\\\",\\n  \\\"trace_id\\\": \\\"eebad11e-fba0-460b-abd7-e7b6a4613a75\\\"\\n },\\n \\\"errors\\\": [\\n  {\\n   \\\"code\\\": 403,\\n   \\\"message\\\": \\\"access denied, authorization failed\\\"\\n  }\\n ]\\n}\"}},\"initial_interval\":\"24h\",\"offset\":0,\"url\":\"https://api.us-2.crowdstrike.com\",\"want_more\":false}"},"ecs.version":"1.6.0"}
```

Related KB  https://support.elastic.co/knowledge/8703a71e

Can the integration package be rebuilt to push out this change to the documentation for ti_crowdstrike setup permission scope(s) listed?

