### PR TITLE
checkpoint_harmony_endpoint: improve handling of API errors

### DIFF
--- a/packages/checkpoint_harmony_endpoint/changelog.yml
+++ b/packages/checkpoint_harmony_endpoint/changelog.yml
@@ -3,10 +3,10 @@
   changes:
     - description: Improve cleaning of query parameters on errors.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/13333
     - description: Handle 404 error for the retrieve endpoint.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/13333
 - version: "0.5.1"
   changes:
     - description: Fix endTime query parameter assignment.

--- a/packages/checkpoint_harmony_endpoint/changelog.yml
+++ b/packages/checkpoint_harmony_endpoint/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "0.6.0"
+  changes:
+    - description: Improve cleaning of query parameters on errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
+    - description: Handle 404 error for the retrieve endpoint.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "0.5.1"
   changes:
     - description: Fix endTime query parameter assignment.

--- a/packages/checkpoint_harmony_endpoint/changelog.yml
+++ b/packages/checkpoint_harmony_endpoint/changelog.yml
@@ -4,9 +4,6 @@
     - description: Improve cleaning of query parameters on errors.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/13333
-    - description: Handle 404 error for the retrieve endpoint.
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/13333
 - version: "0.5.1"
   changes:
     - description: Fix endTime query parameter assignment.

--- a/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
@@ -150,23 +150,6 @@ program: |
   					}
   				)
   			:
-  			(resp.StatusCode == 404) ?
-  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
-  				state.with(
-  					{
-  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
-  						"want_more": true,
-  						"cursor": state.cursor.with(
-  							{
-  								"auth_data": auth_data,
-  								"task_id": null,
-  								"next_startTime": state.cursor.current_startTime,
-  								"next_endTime": state.cursor.current_endTime,
-  							}
-  						),
-  					}
-  				)
-  			:
   			(resp.StatusCode == 200) ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.state == "Ready") ?
@@ -212,6 +195,7 @@ program: |
   						)
   				)
   			:
+  				// Clear the task ID, and reset the sequence for the same timeframe.
   				state.with(
   					{
   						"events": {
@@ -231,6 +215,8 @@ program: |
   							{
   								"auth_data": auth_data,
   								"task_id": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
   							}
   						),
   					}
@@ -258,24 +244,6 @@ program: |
   						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
   						"want_more": true,
   						"cursor": state.cursor.with({"auth_data": null}),
-  					}
-  				)
-  			:
-  			(resp.StatusCode == 404) ?
-  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
-  				state.with(
-  					{
-  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
-  						"want_more": true,
-  						"cursor": state.cursor.with(
-  							{
-  								"auth_data": auth_data,
-  								"task_id": null,
-  								"page_token": null,
-  								"next_startTime": state.cursor.current_startTime,
-  								"next_endTime": state.cursor.current_endTime,
-  							}
-  						),
   					}
   				)
   			:
@@ -339,6 +307,7 @@ program: |
   						)
   				)
   			:
+  				// Clear the task ID and page token, and reset the sequence for the same timeframe.
   				state.with(
   					{
   						"events": {
@@ -359,6 +328,8 @@ program: |
   								"auth_data": auth_data,
   								"task_id": null,
   								"page_token": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
   							}
   						),
   					}

--- a/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
@@ -227,6 +227,12 @@ program: |
   							},
   						},
   						"want_more": false,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  							}
+  						),
   					}
   				)
   		)
@@ -252,6 +258,24 @@ program: |
   						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
   						"want_more": true,
   						"cursor": state.cursor.with({"auth_data": null}),
+  					}
+  				)
+  			:
+  			(resp.StatusCode == 404) ?
+  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
+  				state.with(
+  					{
+  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"want_more": true,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"page_token": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
+  							}
+  						),
   					}
   				)
   			:
@@ -330,6 +354,13 @@ program: |
   							},
   						},
   						"want_more": false,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"page_token": null,
+  							}
+  						),
   					}
   				)
   		)

--- a/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
@@ -150,23 +150,6 @@ program: |
   					}
   				)
   			:
-  			(resp.StatusCode == 404) ?
-  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
-  				state.with(
-  					{
-  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
-  						"want_more": true,
-  						"cursor": state.cursor.with(
-  							{
-  								"auth_data": auth_data,
-  								"task_id": null,
-  								"next_startTime": state.cursor.current_startTime,
-  								"next_endTime": state.cursor.current_endTime,
-  							}
-  						),
-  					}
-  				)
-  			:
   			(resp.StatusCode == 200) ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.state == "Ready") ?
@@ -212,6 +195,7 @@ program: |
   						)
   				)
   			:
+  				// Clear the task ID, and reset the sequence for the same timeframe.
   				state.with(
   					{
   						"events": {
@@ -231,6 +215,8 @@ program: |
   							{
   								"auth_data": auth_data,
   								"task_id": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
   							}
   						),
   					}
@@ -258,24 +244,6 @@ program: |
   						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
   						"want_more": true,
   						"cursor": state.cursor.with({"auth_data": null}),
-  					}
-  				)
-  			:
-  			(resp.StatusCode == 404) ?
-  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
-  				state.with(
-  					{
-  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
-  						"want_more": true,
-  						"cursor": state.cursor.with(
-  							{
-  								"auth_data": auth_data,
-  								"task_id": null,
-  								"page_token": null,
-  								"next_startTime": state.cursor.current_startTime,
-  								"next_endTime": state.cursor.current_endTime,
-  							}
-  						),
   					}
   				)
   			:
@@ -339,6 +307,7 @@ program: |
   						)
   				)
   			:
+  				// Clear the task ID and page token, and reset the sequence for the same timeframe.
   				state.with(
   					{
   						"events": {
@@ -359,6 +328,8 @@ program: |
   								"auth_data": auth_data,
   								"task_id": null,
   								"page_token": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
   							}
   						),
   					}

--- a/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
@@ -227,6 +227,12 @@ program: |
   							},
   						},
   						"want_more": false,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  							}
+  						),
   					}
   				)
   		)
@@ -252,6 +258,24 @@ program: |
   						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
   						"want_more": true,
   						"cursor": state.cursor.with({"auth_data": null}),
+  					}
+  				)
+  			:
+  			(resp.StatusCode == 404) ?
+  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
+  				state.with(
+  					{
+  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"want_more": true,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"page_token": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
+  							}
+  						),
   					}
   				)
   			:
@@ -330,6 +354,13 @@ program: |
   							},
   						},
   						"want_more": false,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"page_token": null,
+  							}
+  						),
   					}
   				)
   		)

--- a/packages/checkpoint_harmony_endpoint/data_stream/forensics/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/forensics/agent/stream/cel.yml.hbs
@@ -150,23 +150,6 @@ program: |
   					}
   				)
   			:
-  			(resp.StatusCode == 404) ?
-  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
-  				state.with(
-  					{
-  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
-  						"want_more": true,
-  						"cursor": state.cursor.with(
-  							{
-  								"auth_data": auth_data,
-  								"task_id": null,
-  								"next_startTime": state.cursor.current_startTime,
-  								"next_endTime": state.cursor.current_endTime,
-  							}
-  						),
-  					}
-  				)
-  			:
   			(resp.StatusCode == 200) ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.state == "Ready") ?
@@ -212,6 +195,7 @@ program: |
   						)
   				)
   			:
+  				// Clear the task ID, and reset the sequence for the same timeframe.
   				state.with(
   					{
   						"events": {
@@ -231,6 +215,8 @@ program: |
   							{
   								"auth_data": auth_data,
   								"task_id": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
   							}
   						),
   					}
@@ -258,24 +244,6 @@ program: |
   						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
   						"want_more": true,
   						"cursor": state.cursor.with({"auth_data": null}),
-  					}
-  				)
-  			:
-  			(resp.StatusCode == 404) ?
-  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
-  				state.with(
-  					{
-  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
-  						"want_more": true,
-  						"cursor": state.cursor.with(
-  							{
-  								"auth_data": auth_data,
-  								"task_id": null,
-  								"page_token": null,
-  								"next_startTime": state.cursor.current_startTime,
-  								"next_endTime": state.cursor.current_endTime,
-  							}
-  						),
   					}
   				)
   			:
@@ -339,6 +307,7 @@ program: |
   						)
   				)
   			:
+  				// Clear the task ID and page token, and reset the sequence for the same timeframe.
   				state.with(
   					{
   						"events": {
@@ -359,6 +328,8 @@ program: |
   								"auth_data": auth_data,
   								"task_id": null,
   								"page_token": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
   							}
   						),
   					}

--- a/packages/checkpoint_harmony_endpoint/data_stream/forensics/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/forensics/agent/stream/cel.yml.hbs
@@ -227,6 +227,12 @@ program: |
   							},
   						},
   						"want_more": false,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  							}
+  						),
   					}
   				)
   		)
@@ -252,6 +258,24 @@ program: |
   						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
   						"want_more": true,
   						"cursor": state.cursor.with({"auth_data": null}),
+  					}
+  				)
+  			:
+  			(resp.StatusCode == 404) ?
+  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
+  				state.with(
+  					{
+  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"want_more": true,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"page_token": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
+  							}
+  						),
   					}
   				)
   			:
@@ -330,6 +354,13 @@ program: |
   							},
   						},
   						"want_more": false,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"page_token": null,
+  							}
+  						),
   					}
   				)
   		)

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
@@ -150,23 +150,6 @@ program: |
   					}
   				)
   			:
-  			(resp.StatusCode == 404) ?
-  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
-  				state.with(
-  					{
-  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
-  						"want_more": true,
-  						"cursor": state.cursor.with(
-  							{
-  								"auth_data": auth_data,
-  								"task_id": null,
-  								"next_startTime": state.cursor.current_startTime,
-  								"next_endTime": state.cursor.current_endTime,
-  							}
-  						),
-  					}
-  				)
-  			:
   			(resp.StatusCode == 200) ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.state == "Ready") ?
@@ -212,6 +195,7 @@ program: |
   						)
   				)
   			:
+  				// Clear the task ID, and reset the sequence for the same timeframe.
   				state.with(
   					{
   						"events": {
@@ -231,6 +215,8 @@ program: |
   							{
   								"auth_data": auth_data,
   								"task_id": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
   							}
   						),
   					}
@@ -258,24 +244,6 @@ program: |
   						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
   						"want_more": true,
   						"cursor": state.cursor.with({"auth_data": null}),
-  					}
-  				)
-  			:
-  			(resp.StatusCode == 404) ?
-  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
-  				state.with(
-  					{
-  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
-  						"want_more": true,
-  						"cursor": state.cursor.with(
-  							{
-  								"auth_data": auth_data,
-  								"task_id": null,
-  								"page_token": null,
-  								"next_startTime": state.cursor.current_startTime,
-  								"next_endTime": state.cursor.current_endTime,
-  							}
-  						),
   					}
   				)
   			:
@@ -339,6 +307,7 @@ program: |
   						)
   				)
   			:
+  				// Clear the task ID and page token, and reset the sequence for the same timeframe.
   				state.with(
   					{
   						"events": {
@@ -359,6 +328,8 @@ program: |
   								"auth_data": auth_data,
   								"task_id": null,
   								"page_token": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
   							}
   						),
   					}

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
@@ -227,6 +227,12 @@ program: |
   							},
   						},
   						"want_more": false,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  							}
+  						),
   					}
   				)
   		)
@@ -252,6 +258,24 @@ program: |
   						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
   						"want_more": true,
   						"cursor": state.cursor.with({"auth_data": null}),
+  					}
+  				)
+  			:
+  			(resp.StatusCode == 404) ?
+  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
+  				state.with(
+  					{
+  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"want_more": true,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"page_token": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
+  							}
+  						),
   					}
   				)
   			:
@@ -330,6 +354,13 @@ program: |
   							},
   						},
   						"want_more": false,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"page_token": null,
+  							}
+  						),
   					}
   				)
   		)

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
@@ -150,23 +150,6 @@ program: |
   					}
   				)
   			:
-  			(resp.StatusCode == 404) ?
-  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
-  				state.with(
-  					{
-  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
-  						"want_more": true,
-  						"cursor": state.cursor.with(
-  							{
-  								"auth_data": auth_data,
-  								"task_id": null,
-  								"next_startTime": state.cursor.current_startTime,
-  								"next_endTime": state.cursor.current_endTime,
-  							}
-  						),
-  					}
-  				)
-  			:
   			(resp.StatusCode == 200) ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.state == "Ready") ?
@@ -212,6 +195,7 @@ program: |
   						)
   				)
   			:
+  				// Clear the task ID, and reset the sequence for the same timeframe.
   				state.with(
   					{
   						"events": {
@@ -231,6 +215,8 @@ program: |
   							{
   								"auth_data": auth_data,
   								"task_id": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
   							}
   						),
   					}
@@ -258,24 +244,6 @@ program: |
   						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
   						"want_more": true,
   						"cursor": state.cursor.with({"auth_data": null}),
-  					}
-  				)
-  			:
-  			(resp.StatusCode == 404) ?
-  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
-  				state.with(
-  					{
-  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
-  						"want_more": true,
-  						"cursor": state.cursor.with(
-  							{
-  								"auth_data": auth_data,
-  								"task_id": null,
-  								"page_token": null,
-  								"next_startTime": state.cursor.current_startTime,
-  								"next_endTime": state.cursor.current_endTime,
-  							}
-  						),
   					}
   				)
   			:
@@ -339,6 +307,7 @@ program: |
   						)
   				)
   			:
+  				// Clear the task ID and page token, and reset the sequence for the same timeframe.
   				state.with(
   					{
   						"events": {
@@ -359,6 +328,8 @@ program: |
   								"auth_data": auth_data,
   								"task_id": null,
   								"page_token": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
   							}
   						),
   					}

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
@@ -227,6 +227,12 @@ program: |
   							},
   						},
   						"want_more": false,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  							}
+  						),
   					}
   				)
   		)
@@ -252,6 +258,24 @@ program: |
   						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
   						"want_more": true,
   						"cursor": state.cursor.with({"auth_data": null}),
+  					}
+  				)
+  			:
+  			(resp.StatusCode == 404) ?
+  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
+  				state.with(
+  					{
+  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"want_more": true,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"page_token": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
+  							}
+  						),
   					}
   				)
   			:
@@ -330,6 +354,13 @@ program: |
   							},
   						},
   						"want_more": false,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"page_token": null,
+  							}
+  						),
   					}
   				)
   		)

--- a/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
@@ -150,23 +150,6 @@ program: |
   					}
   				)
   			:
-  			(resp.StatusCode == 404) ?
-  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
-  				state.with(
-  					{
-  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
-  						"want_more": true,
-  						"cursor": state.cursor.with(
-  							{
-  								"auth_data": auth_data,
-  								"task_id": null,
-  								"next_startTime": state.cursor.current_startTime,
-  								"next_endTime": state.cursor.current_endTime,
-  							}
-  						),
-  					}
-  				)
-  			:
   			(resp.StatusCode == 200) ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.state == "Ready") ?
@@ -212,6 +195,7 @@ program: |
   						)
   				)
   			:
+  				// Clear the task ID, and reset the sequence for the same timeframe.
   				state.with(
   					{
   						"events": {
@@ -231,6 +215,8 @@ program: |
   							{
   								"auth_data": auth_data,
   								"task_id": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
   							}
   						),
   					}
@@ -258,24 +244,6 @@ program: |
   						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
   						"want_more": true,
   						"cursor": state.cursor.with({"auth_data": null}),
-  					}
-  				)
-  			:
-  			(resp.StatusCode == 404) ?
-  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
-  				state.with(
-  					{
-  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
-  						"want_more": true,
-  						"cursor": state.cursor.with(
-  							{
-  								"auth_data": auth_data,
-  								"task_id": null,
-  								"page_token": null,
-  								"next_startTime": state.cursor.current_startTime,
-  								"next_endTime": state.cursor.current_endTime,
-  							}
-  						),
   					}
   				)
   			:
@@ -339,6 +307,7 @@ program: |
   						)
   				)
   			:
+  				// Clear the task ID and page token, and reset the sequence for the same timeframe.
   				state.with(
   					{
   						"events": {
@@ -359,6 +328,8 @@ program: |
   								"auth_data": auth_data,
   								"task_id": null,
   								"page_token": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
   							}
   						),
   					}

--- a/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
@@ -227,6 +227,12 @@ program: |
   							},
   						},
   						"want_more": false,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  							}
+  						),
   					}
   				)
   		)
@@ -252,6 +258,24 @@ program: |
   						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
   						"want_more": true,
   						"cursor": state.cursor.with({"auth_data": null}),
+  					}
+  				)
+  			:
+  			(resp.StatusCode == 404) ?
+  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
+  				state.with(
+  					{
+  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"want_more": true,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"page_token": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
+  							}
+  						),
   					}
   				)
   			:
@@ -330,6 +354,13 @@ program: |
   							},
   						},
   						"want_more": false,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"page_token": null,
+  							}
+  						),
   					}
   				)
   		)

--- a/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
@@ -150,23 +150,6 @@ program: |
   					}
   				)
   			:
-  			(resp.StatusCode == 404) ?
-  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
-  				state.with(
-  					{
-  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
-  						"want_more": true,
-  						"cursor": state.cursor.with(
-  							{
-  								"auth_data": auth_data,
-  								"task_id": null,
-  								"next_startTime": state.cursor.current_startTime,
-  								"next_endTime": state.cursor.current_endTime,
-  							}
-  						),
-  					}
-  				)
-  			:
   			(resp.StatusCode == 200) ?
   				bytes(resp.Body).decode_json().as(body,
   					(body.data.state == "Ready") ?
@@ -212,6 +195,7 @@ program: |
   						)
   				)
   			:
+  				// Clear the task ID, and reset the sequence for the same timeframe.
   				state.with(
   					{
   						"events": {
@@ -231,6 +215,8 @@ program: |
   							{
   								"auth_data": auth_data,
   								"task_id": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
   							}
   						),
   					}
@@ -258,24 +244,6 @@ program: |
   						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
   						"want_more": true,
   						"cursor": state.cursor.with({"auth_data": null}),
-  					}
-  				)
-  			:
-  			(resp.StatusCode == 404) ?
-  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
-  				state.with(
-  					{
-  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
-  						"want_more": true,
-  						"cursor": state.cursor.with(
-  							{
-  								"auth_data": auth_data,
-  								"task_id": null,
-  								"page_token": null,
-  								"next_startTime": state.cursor.current_startTime,
-  								"next_endTime": state.cursor.current_endTime,
-  							}
-  						),
   					}
   				)
   			:
@@ -339,6 +307,7 @@ program: |
   						)
   				)
   			:
+  				// Clear the task ID and page token, and reset the sequence for the same timeframe.
   				state.with(
   					{
   						"events": {
@@ -359,6 +328,8 @@ program: |
   								"auth_data": auth_data,
   								"task_id": null,
   								"page_token": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
   							}
   						),
   					}

--- a/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
@@ -227,6 +227,12 @@ program: |
   							},
   						},
   						"want_more": false,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  							}
+  						),
   					}
   				)
   		)
@@ -252,6 +258,24 @@ program: |
   						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
   						"want_more": true,
   						"cursor": state.cursor.with({"auth_data": null}),
+  					}
+  				)
+  			:
+  			(resp.StatusCode == 404) ?
+  				// 404 Not Found - Resubmit the task ID query for the same timeframe.
+  				state.with(
+  					{
+  						"events": [{"message": {"event": {"reason": "polling"}}.encode_json()}],
+  						"want_more": true,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"page_token": null,
+  								"next_startTime": state.cursor.current_startTime,
+  								"next_endTime": state.cursor.current_endTime,
+  							}
+  						),
   					}
   				)
   			:
@@ -330,6 +354,13 @@ program: |
   							},
   						},
   						"want_more": false,
+  						"cursor": state.cursor.with(
+  							{
+  								"auth_data": auth_data,
+  								"task_id": null,
+  								"page_token": null,
+  							}
+  						),
   					}
   				)
   		)

--- a/packages/checkpoint_harmony_endpoint/manifest.yml
+++ b/packages/checkpoint_harmony_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: checkpoint_harmony_endpoint
 title: "Check Point Harmony Endpoint"
-version: "0.5.1"
+version: "0.6.0"
 source:
   license: "Elastic-2.0"
 description: "Collect logs from Check Point Harmony Endpoint"


### PR DESCRIPTION
## Proposed commit message

```
The two changes included are:
- The handling of the 404 error when hitting the retrieve endpoint (that happens when the integration already received a valid task ID and page token, in this case, both parameters are cleaned and a new task ID is requested again for the same timeframe.
- In the generic error handling, also clean task ID and page token to avoid entering in a loop making requests with stale parameters.
```

> [!NOTE]
> All data streams have identical `cel.yml.hbs` files.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

