### PR TITLE
[AmazonMQ] Add firehose routing rules for ActiveMQ and RabbitMQ metrics

### DIFF
--- a/packages/awsfirehose/changelog.yml
+++ b/packages/awsfirehose/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add support for AmazonMQ metrics for both managed RabbitMQ and ActiveMQ.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/13342
 - version: "1.5.2"
   changes:
     - description: Avoid using dynamic template for flattened fields

--- a/packages/awsfirehose/changelog.yml
+++ b/packages/awsfirehose/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.0"
+  changes:
+    - description: Add support for AmazonMQ metrics for both managed RabbitMQ and ActiveMQ.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.5.2"
   changes:
     - description: Avoid using dynamic template for flattened fields

--- a/packages/awsfirehose/data_stream/metrics/_dev/test/pipeline/test-mq-metrics.json
+++ b/packages/awsfirehose/data_stream/metrics/_dev/test/pipeline/test-mq-metrics.json
@@ -1,0 +1,142 @@
+{
+    "events": [
+        {
+            "@timestamp": "2025-03-28T09:13:00.000Z",
+            "start_timestamp": "2025-03-28T09:12:00.000Z",
+            "agent.type": "firehose",
+            "cloud.provider": "aws",
+            "cloud.account.id": "111111111111111111",
+            "cloud.region": "ap-south-1",
+            "aws.exporter.arn": "arn:aws:cloudwatch:ap-south-1:627286350134:metric-stream/AWSBedrockMetricStream",
+            "aws.cloudwatch.namespace": "AWS/AmazonMQ",
+            "aws.firehose.arn": "arn:aws:firehose:ap-south-1:627286350134:deliverystream/AWS-Bedrok-Firehose-Stream-AgiKThomas",
+            "aws.firehose.request_id": "bf51208a-d776-4161-b2ce-87ff64a6b095",
+            "aws.dimensions": {
+                "Broker": "ObsIntegrations-RabbitMQ",
+                "Queue": "rabbit-mq-message-queue",
+                "VirtualHost": "/"
+            },
+            "aws.amazonmq.metrics.MessageCount": {
+                "count": 1,
+                "sum": 0,
+                "avg": 0,
+                "min": 0,
+                "max": 0
+            },
+            "aws.amazonmq.metrics.ConsumerCount": {
+                "count": 1,
+                "sum": 0,
+                "avg": 0,
+                "min": 0,
+                "max": 0
+            },
+            "aws.amazonmq.metrics.MessageUnacknowledgedCount": {
+                "count": 1,
+                "sum": 0,
+                "avg": 0,
+                "min": 0,
+                "max": 0
+            },
+            "aws.amazonmq.metrics.MessageReadyCount": {
+                "count": 1,
+                "sum": 0,
+                "avg": 0,
+                "min": 0,
+                "max": 0
+            },
+            "data_stream.type": "metrics",
+            "data_stream.dataset": "aws.cloudwatch",
+            "data_stream.namespace": "default"
+        },
+        {
+            "@timestamp": "2025-03-28T09:13:00.000Z",
+            "start_timestamp": "2025-03-28T09:12:00.000Z",
+            "agent.type": "firehose",
+            "cloud.provider": "aws",
+            "cloud.account.id": "111111111111111111",
+            "cloud.region": "ap-south-1",
+            "aws.exporter.arn": "arn:aws:cloudwatch:ap-south-1:627286350134:metric-stream/AWSBedrockMetricStream",
+            "aws.cloudwatch.namespace": "AWS/AmazonMQ",
+            "aws.firehose.arn": "arn:aws:firehose:ap-south-1:627286350134:deliverystream/AWS-Bedrok-Firehose-Stream-AgiKThomas",
+            "aws.firehose.request_id": "bf51208a-d776-4161-b2ce-87ff64a6b095",
+            "aws.dimensions": {
+                "Broker": "ObsIntegrations-ActiveMQ-1",
+                "Queue": "testQueue"
+            },
+            "aws.amazonmq.metrics.ExpiredCount": {
+                "count": 1,
+                "sum": 0,
+                "avg": 0,
+                "min": 0,
+                "max": 0
+            },
+            "aws.amazonmq.metrics.ProducerCount": {
+                "count": 1,
+                "sum": 0,
+                "avg": 0,
+                "min": 0,
+                "max": 0
+            },
+            "aws.amazonmq.metrics.InFlightCount": {
+                "count": 1,
+                "sum": 0,
+                "avg": 0,
+                "min": 0,
+                "max": 0
+            },
+            "aws.amazonmq.metrics.DequeueCount": {
+                "count": 1,
+                "sum": 0,
+                "avg": 0,
+                "min": 0,
+                "max": 0
+            },
+            "aws.amazonmq.metrics.MemoryUsage": {
+                "count": 1,
+                "sum": 0,
+                "avg": 0,
+                "min": 0,
+                "max": 0
+            },
+            "aws.amazonmq.metrics.EnqueueCount": {
+                "count": 1,
+                "sum": 0,
+                "avg": 0,
+                "min": 0,
+                "max": 0
+            },
+            "aws.amazonmq.metrics.QueueSize": {
+                "count": 1,
+                "sum": 9,
+                "avg": 9,
+                "min": 9,
+                "max": 9
+            },
+            "aws.amazonmq.metrics.DispatchCount": {
+                "count": 1,
+                "sum": 0,
+                "avg": 0,
+                "min": 0,
+                "max": 0
+            },
+            "aws.amazonmq.metrics.ConsumerCount": {
+                "count": 1,
+                "sum": 0,
+                "avg": 0,
+                "min": 0,
+                "max": 0
+            },
+            "aws.amazonmq.metrics.EnqueueTime": {
+                "count": 2,
+                "sum": 0,
+                "avg": 0,
+                "min": 0,
+                "max": 0
+            },
+            "data_stream.type": "metrics",
+            "data_stream.dataset": "aws.cloudwatch",
+            "data_stream.namespace": "default"
+        }
+
+    ]
+}

--- a/packages/awsfirehose/data_stream/metrics/_dev/test/pipeline/test-mq-metrics.json-expected.json
+++ b/packages/awsfirehose/data_stream/metrics/_dev/test/pipeline/test-mq-metrics.json-expected.json
@@ -1,0 +1,189 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2025-03-28T09:13:00.000Z",
+            "agent": {
+                "type": "firehose"
+            },
+            "aws": {
+                "amazonmq": {
+                    "metrics": {
+                        "ConsumerCount": {
+                            "avg": 0,
+                            "count": 1,
+                            "max": 0,
+                            "min": 0,
+                            "sum": 0
+                        },
+                        "MessageCount": {
+                            "avg": 0,
+                            "count": 1,
+                            "max": 0,
+                            "min": 0,
+                            "sum": 0
+                        },
+                        "MessageReadyCount": {
+                            "avg": 0,
+                            "count": 1,
+                            "max": 0,
+                            "min": 0,
+                            "sum": 0
+                        },
+                        "MessageUnacknowledgedCount": {
+                            "avg": 0,
+                            "count": 1,
+                            "max": 0,
+                            "min": 0,
+                            "sum": 0
+                        }
+                    }
+                },
+                "cloudwatch": {
+                    "namespace": "AWS/AmazonMQ"
+                },
+                "dimensions": {
+                    "Broker": "ObsIntegrations-RabbitMQ",
+                    "Queue": "rabbit-mq-message-queue",
+                    "VirtualHost": "/"
+                },
+                "exporter": {
+                    "arn": "arn:aws:cloudwatch:ap-south-1:627286350134:metric-stream/AWSBedrockMetricStream"
+                },
+                "firehose": {
+                    "arn": "arn:aws:firehose:ap-south-1:627286350134:deliverystream/AWS-Bedrok-Firehose-Stream-AgiKThomas",
+                    "request_id": "bf51208a-d776-4161-b2ce-87ff64a6b095"
+                },
+                "metrics_names_fingerprint": "Oo6DWr7SrPalaNAWIjgrXXLyKIg="
+            },
+            "cloud": {
+                "account": {
+                    "id": "111111111111111111"
+                },
+                "provider": "aws",
+                "region": "ap-south-1"
+            },
+            "data_stream": {
+                "dataset": "aws_mq.rabbitmq_metrics",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "start_timestamp": "2025-03-28T09:12:00.000Z"
+        },
+        {
+            "@timestamp": "2025-03-28T09:13:00.000Z",
+            "agent": {
+                "type": "firehose"
+            },
+            "aws": {
+                "amazonmq": {
+                    "metrics": {
+                        "ConsumerCount": {
+                            "avg": 0,
+                            "count": 1,
+                            "max": 0,
+                            "min": 0,
+                            "sum": 0
+                        },
+                        "DequeueCount": {
+                            "avg": 0,
+                            "count": 1,
+                            "max": 0,
+                            "min": 0,
+                            "sum": 0
+                        },
+                        "DispatchCount": {
+                            "avg": 0,
+                            "count": 1,
+                            "max": 0,
+                            "min": 0,
+                            "sum": 0
+                        },
+                        "EnqueueCount": {
+                            "avg": 0,
+                            "count": 1,
+                            "max": 0,
+                            "min": 0,
+                            "sum": 0
+                        },
+                        "EnqueueTime": {
+                            "avg": 0,
+                            "count": 2,
+                            "max": 0,
+                            "min": 0,
+                            "sum": 0
+                        },
+                        "ExpiredCount": {
+                            "avg": 0,
+                            "count": 1,
+                            "max": 0,
+                            "min": 0,
+                            "sum": 0
+                        },
+                        "InFlightCount": {
+                            "avg": 0,
+                            "count": 1,
+                            "max": 0,
+                            "min": 0,
+                            "sum": 0
+                        },
+                        "MemoryUsage": {
+                            "avg": 0,
+                            "count": 1,
+                            "max": 0,
+                            "min": 0,
+                            "sum": 0
+                        },
+                        "ProducerCount": {
+                            "avg": 0,
+                            "count": 1,
+                            "max": 0,
+                            "min": 0,
+                            "sum": 0
+                        },
+                        "QueueSize": {
+                            "avg": 9,
+                            "count": 1,
+                            "max": 9,
+                            "min": 9,
+                            "sum": 9
+                        }
+                    }
+                },
+                "cloudwatch": {
+                    "namespace": "AWS/AmazonMQ"
+                },
+                "dimensions": {
+                    "Broker": "ObsIntegrations-ActiveMQ-1",
+                    "Queue": "testQueue"
+                },
+                "exporter": {
+                    "arn": "arn:aws:cloudwatch:ap-south-1:627286350134:metric-stream/AWSBedrockMetricStream"
+                },
+                "firehose": {
+                    "arn": "arn:aws:firehose:ap-south-1:627286350134:deliverystream/AWS-Bedrok-Firehose-Stream-AgiKThomas",
+                    "request_id": "bf51208a-d776-4161-b2ce-87ff64a6b095"
+                },
+                "metrics_names_fingerprint": "2rvRGJG912vF5iOdng4PjKe2+nc="
+            },
+            "cloud": {
+                "account": {
+                    "id": "111111111111111111"
+                },
+                "provider": "aws",
+                "region": "ap-south-1"
+            },
+            "data_stream": {
+                "dataset": "aws_mq.activemq_metrics",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "start_timestamp": "2025-03-28T09:12:00.000Z"
+        }
+    ]
+}

--- a/packages/awsfirehose/data_stream/metrics/routing_rules.yml
+++ b/packages/awsfirehose/data_stream/metrics/routing_rules.yml
@@ -115,3 +115,54 @@
       namespace:
         - "{{data_stream.namespace}}"
         - default
+    - target_dataset: aws_mq.activemq_metrics
+      if: ctx.aws?.cloudwatch?.namespace == "AWS/AmazonMQ" && (
+        ctx.aws?.amazonmq?.metrics?.AmqpMaximumConnections != null || 
+        ctx.aws?.amazonmq?.metrics?.MqttMaximumConnections != null || 
+        ctx.aws?.amazonmq?.metrics?.OpenwireMaximumConnections != null || 
+        ctx.aws?.amazonmq?.metrics?.StompMaximumConnections != null || 
+        ctx.aws?.amazonmq?.metrics?.WsMaximumConnections != null || 
+        ctx.aws?.amazonmq?.metrics?.CurrentConnectionsCount != null || 
+        ctx.aws?.amazonmq?.metrics?.EstablishedConnectionsCount != null || 
+        ctx.aws?.amazonmq?.metrics?.InactiveDurableTopicSubscribersCount != null || 
+        ctx.aws?.amazonmq?.metrics?.JournalFilesForFastRecovery != null || 
+        ctx.aws?.amazonmq?.metrics?.JournalFilesForFullRecovery != null || 
+        ctx.aws?.amazonmq?.metrics?.NetworkConnectorConnectionCount != null || 
+        ctx.aws?.amazonmq?.metrics?.NetworkIn != null || 
+        ctx.aws?.amazonmq?.metrics?.NetworkOut != null || 
+        ctx.aws?.amazonmq?.metrics?.OpenTransactionCount != null || 
+        ctx.aws?.amazonmq?.metrics?.TotalConsumerCount != null || 
+        ctx.aws?.amazonmq?.metrics?.TotalMessageCount != null || 
+        ctx.aws?.amazonmq?.metrics?.TotalProducerCount != null || 
+        ctx.aws?.amazonmq?.metrics?.VolumeReadOps != null || 
+        ctx.aws?.amazonmq?.metrics?.VolumeWriteOps != null || 
+        ctx.aws?.amazonmq?.metrics?.ReceiveCount != null || 
+        ctx.aws?.amazonmq?.metrics?.ProducerCount != null || 
+        ctx.aws?.amazonmq?.metrics?.QueueSize != null || 
+        ctx.aws?.amazonmq?.metrics?.TotalEnqueueCount != null || 
+        ctx.aws?.amazonmq?.metrics?.TotalDequeueCount != null)
+      namespace:
+        - "{{data_stream.namespace}}"
+        - default
+    - target_dataset: aws_mq.rabbitmq_metrics
+      if: ctx.aws?.cloudwatch?.namespace == "AWS/AmazonMQ" && (
+        ctx.aws?.amazonmq?.metrics?.ExchangeCount != null || 
+        ctx.aws?.amazonmq?.metrics?.QueueCount != null || 
+        ctx.aws?.amazonmq?.metrics?.ConnectionCount != null || 
+        ctx.aws?.amazonmq?.metrics?.ChannelCount != null || 
+        ctx.aws?.amazonmq?.metrics?.MessageCount != null || 
+        ctx.aws?.amazonmq?.metrics?.MessageReadyCount != null || 
+        ctx.aws?.amazonmq?.metrics?.MessageUnacknowledgedCount != null || 
+        ctx.aws?.amazonmq?.metrics?.PublishRate != null || 
+        ctx.aws?.amazonmq?.metrics?.ConfirmRate != null || 
+        ctx.aws?.amazonmq?.metrics?.AckRate != null || 
+        ctx.aws?.amazonmq?.metrics?.SystemCpuUtilization != null || 
+        ctx.aws?.amazonmq?.metrics?.RabbitMQMemLimit != null || 
+        ctx.aws?.amazonmq?.metrics?.RabbitMQMemUsed != null || 
+        ctx.aws?.amazonmq?.metrics?.RabbitMQDiskFreeLimit != null || 
+        ctx.aws?.amazonmq?.metrics?.RabbitMQFdUsed != null || 
+        ctx.aws?.amazonmq?.metrics?.RabbitMQIOReadAverageTime != null || 
+        ctx.aws?.amazonmq?.metrics?.RabbitMQIOWriteAverageTime != null)
+      namespace:
+        - "{{data_stream.namespace}}"
+        - default

--- a/packages/awsfirehose/manifest.yml
+++ b/packages/awsfirehose/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.0"
 name: awsfirehose
 title: Amazon Data Firehose
-version: 1.5.2
+version: 1.6.0
 description: Stream logs and metrics from Amazon Data Firehose into Elastic Cloud.
 type: integration
 categories:


### PR DESCRIPTION
- Enhancement

## Proposed commit message

Add firehose routing rules for metrics from AWS/AmazonMQ namespaces. Select aws_mq.activemq_metrics and  aws_mq.rabbitmq_metrics datasets respectively for ActiveMQ and RabbitMQ metrics


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

- [x] Pipeline test update
- [x] Configuring ActiveMQ metricstream for testing
- [x] Package upgrade test 

## How to test this PR locally

- elastic-package build && elastic-package stack up -v -d --services package-registry


## Screenshots

Not applicable
