### PR TITLE
Cloudflare Logpush - fix SQS worker setting

### DIFF
--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fixed S3/SQS worker settings to not be dependent on S3 bucket
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/12699
+      link: https://github.com/elastic/integrations/pull/13346
 - version: "1.35.1"
   changes:
     - description: Fix handling of http_request events missing `ClientRequestProtocol`.

--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.35.2"
   changes:
-    - description: Fixed S3/SQS worker settings to not be dependent on S3 bucket
+    - description: Fix handling of SQS worker count configuration.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/13346
 - version: "1.35.1"

--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.35.2"
+  changes:
+    - description: Fixed S3/SQS worker settings to not be dependent on S3 bucket
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12699
 - version: "1.35.1"
   changes:
     - description: Fix handling of http_request events missing `ClientRequestProtocol`.

--- a/packages/cloudflare_logpush/data_stream/access_request/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/access_request/agent/stream/aws-s3.yml.hbs
@@ -9,9 +9,6 @@ When using an S3 bucket, you can specify only one of the following options:
 
 {{#if collect_s3_logs}}
 {{! shared S3 bucket polling options }}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
 
 {{#if bucket_list_prefix }}
 bucket_list_prefix: {{ bucket_list_prefix }}
@@ -70,6 +67,10 @@ queue_url: {{queue_url_access_request}}
 queue_url: {{queue_url}}
 {{/if}}
 
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
+{{/if}}
+
 {{#if visibility_timeout}}
 visibility_timeout: {{visibility_timeout}}
 {{/if}}
@@ -88,6 +89,11 @@ file_selectors:
 {{/if}}
 {{! end SQS queue }}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/cloudflare_logpush/data_stream/access_request/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/access_request/agent/stream/aws-s3.yml.hbs
@@ -67,10 +67,6 @@ queue_url: {{queue_url_access_request}}
 queue_url: {{queue_url}}
 {{/if}}
 
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
-
 {{#if visibility_timeout}}
 visibility_timeout: {{visibility_timeout}}
 {{/if}}

--- a/packages/cloudflare_logpush/data_stream/access_request/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/access_request/manifest.yml
@@ -115,12 +115,12 @@ streams:
         description: Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: '[S3] Number of Workers'
+        title: '[S3/SQS] Number of Workers'
         multi: false
         required: false
         show_user: true
         default: 5
-        description: Number of workers that will process the S3 objects listed.
+        description: Number of workers that will process the S3/SQS objects listed.
       - name: start_timestamp
         type: text
         title: "[S3] Start Timestamp"
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/access_request/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/access_request/manifest.yml
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/audit/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/audit/agent/stream/aws-s3.yml.hbs
@@ -9,9 +9,6 @@ When using an S3 bucket, you can specify only one of the following options:
 
 {{#if collect_s3_logs}}
 {{! shared S3 bucket polling options }}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
 
 {{#if bucket_list_prefix }}
 bucket_list_prefix: {{ bucket_list_prefix }}
@@ -88,6 +85,11 @@ file_selectors:
 {{/if}}
 {{! end SQS queue }}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/cloudflare_logpush/data_stream/audit/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/audit/manifest.yml
@@ -115,12 +115,12 @@ streams:
         description: Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: '[S3] Number of Workers'
+        title: '[S3/SQS] Number of Workers'
         multi: false
         required: false
         show_user: true
         default: 5
-        description: Number of workers that will process the S3 objects listed.
+        description: Number of workers that will process the S3/SQS objects listed.
       - name: start_timestamp
         type: text
         title: "[S3] Start Timestamp"
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/audit/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/audit/manifest.yml
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/casb/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/casb/agent/stream/aws-s3.yml.hbs
@@ -9,9 +9,6 @@ When using an S3 bucket, you can specify only one of the following options:
 
 {{#if collect_s3_logs}}
 {{! shared S3 bucket polling options }}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
 
 {{#if bucket_list_prefix }}
 bucket_list_prefix: {{ bucket_list_prefix }}
@@ -88,6 +85,11 @@ file_selectors:
 {{/if}}
 {{! end SQS queue }}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/cloudflare_logpush/data_stream/casb/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/casb/manifest.yml
@@ -115,12 +115,12 @@ streams:
         description: Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: '[S3] Number of Workers'
+        title: '[S3/SQS] Number of Workers'
         multi: false
         required: false
         show_user: true
         default: 5
-        description: Number of workers that will process the S3 objects listed.
+        description: Number of workers that will process the S3/SQS objects listed.
       - name: start_timestamp
         type: text
         title: "[S3] Start Timestamp"
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/casb/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/casb/manifest.yml
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/device_posture/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/device_posture/agent/stream/aws-s3.yml.hbs
@@ -9,9 +9,6 @@ When using an S3 bucket, you can specify only one of the following options:
 
 {{#if collect_s3_logs}}
 {{! shared S3 bucket polling options }}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
 
 {{#if bucket_list_prefix }}
 bucket_list_prefix: {{ bucket_list_prefix }}
@@ -89,6 +86,11 @@ file_selectors:
 {{/if}}
 {{! end SQS queue }}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/cloudflare_logpush/data_stream/device_posture/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/device_posture/manifest.yml
@@ -115,12 +115,12 @@ streams:
         description: Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: '[S3] Number of Workers'
+        title: '[S3/SQS] Number of Workers'
         multi: false
         required: false
         show_user: true
         default: 5
-        description: Number of workers that will process the S3 objects listed.
+        description: Number of workers that will process the S3/SQS objects listed.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'
@@ -143,7 +143,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/device_posture/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/device_posture/manifest.yml
@@ -143,7 +143,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/dns/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/dns/agent/stream/aws-s3.yml.hbs
@@ -9,9 +9,6 @@ When using an S3 bucket, you can specify only one of the following options:
 
 {{#if collect_s3_logs}}
 {{! shared S3 bucket polling options }}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
 
 {{#if bucket_list_prefix }}
 bucket_list_prefix: {{ bucket_list_prefix }}
@@ -88,6 +85,11 @@ file_selectors:
 {{/if}}
 {{! end SQS queue }}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/cloudflare_logpush/data_stream/dns/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/dns/manifest.yml
@@ -115,12 +115,12 @@ streams:
         description: Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: '[S3] Number of Workers'
+        title: '[S3/SQS] Number of Workers'
         multi: false
         required: false
         show_user: true
         default: 5
-        description: Number of workers that will process the S3 objects listed.
+        description: Number of workers that will process the S3/SQS objects listed.
       - name: start_timestamp
         type: text
         title: "[S3] Start Timestamp"
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/dns/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/dns/manifest.yml
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/dns_firewall/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/dns_firewall/agent/stream/aws-s3.yml.hbs
@@ -9,9 +9,6 @@ When using an S3 bucket, you can specify only one of the following options:
 
 {{#if collect_s3_logs}}
 {{! shared S3 bucket polling options }}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
 
 {{#if bucket_list_prefix }}
 bucket_list_prefix: {{ bucket_list_prefix }}
@@ -88,6 +85,11 @@ file_selectors:
 {{/if}}
 {{! end SQS queue }}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/cloudflare_logpush/data_stream/dns_firewall/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/dns_firewall/manifest.yml
@@ -115,12 +115,12 @@ streams:
         description: Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: '[S3] Number of Workers'
+        title: '[S3/SQS] Number of Workers'
         multi: false
         required: false
         show_user: true
         default: 5
-        description: Number of workers that will process the S3 objects listed.
+        description: Number of workers that will process the S3/SQS objects listed.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'
@@ -143,7 +143,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/dns_firewall/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/dns_firewall/manifest.yml
@@ -143,7 +143,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/firewall_event/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/agent/stream/aws-s3.yml.hbs
@@ -9,9 +9,6 @@ When using an S3 bucket, you can specify only one of the following options:
 
 {{#if collect_s3_logs}}
 {{! shared S3 bucket polling options }}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
 
 {{#if bucket_list_prefix }}
 bucket_list_prefix: {{ bucket_list_prefix }}
@@ -88,6 +85,11 @@ file_selectors:
 {{/if}}
 {{! end SQS queue }}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/cloudflare_logpush/data_stream/firewall_event/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/manifest.yml
@@ -115,12 +115,12 @@ streams:
         description: Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: '[S3] Number of Workers'
+        title: '[S3/SQS] Number of Workers'
         multi: false
         required: false
         show_user: true
         default: 5
-        description: Number of workers that will process the S3 objects listed.
+        description: Number of workers that will process the S3/SQS objects listed.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'
@@ -143,7 +143,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/firewall_event/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/manifest.yml
@@ -143,7 +143,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/gateway_dns/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/gateway_dns/agent/stream/aws-s3.yml.hbs
@@ -9,9 +9,6 @@ When using an S3 bucket, you can specify only one of the following options:
 
 {{#if collect_s3_logs}}
 {{! shared S3 bucket polling options }}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
 
 {{#if bucket_list_prefix }}
 bucket_list_prefix: {{ bucket_list_prefix }}
@@ -88,6 +85,11 @@ file_selectors:
 {{/if}}
 {{! end SQS queue }}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/cloudflare_logpush/data_stream/gateway_dns/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_dns/manifest.yml
@@ -115,12 +115,12 @@ streams:
         description: Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: '[S3] Number of Workers'
+        title: '[S3/SQS] Number of Workers'
         multi: false
         required: false
         show_user: true
         default: 5
-        description: Number of workers that will process the S3 objects listed.
+        description: Number of workers that will process the S3/SQS objects listed.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'
@@ -143,7 +143,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/gateway_dns/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_dns/manifest.yml
@@ -143,7 +143,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/gateway_http/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/gateway_http/agent/stream/aws-s3.yml.hbs
@@ -90,6 +90,11 @@ file_selectors:
 
 {{/if}}
 
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
+{{/if}}
+
 {{#if access_key_id}}
 access_key_id: {{access_key_id}}
 {{/if}}

--- a/packages/cloudflare_logpush/data_stream/gateway_http/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_http/manifest.yml
@@ -115,12 +115,12 @@ streams:
         description: Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: '[S3] Number of Workers'
+        title: '[S3/SQS] Number of Workers'
         multi: false
         required: false
         show_user: true
         default: 5
-        description: Number of workers that will process the S3 objects listed.
+        description: Number of workers that will process the S3/SQS objects listed.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'

--- a/packages/cloudflare_logpush/data_stream/gateway_network/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/gateway_network/agent/stream/aws-s3.yml.hbs
@@ -9,9 +9,6 @@ When using an S3 bucket, you can specify only one of the following options:
 
 {{#if collect_s3_logs}}
 {{! shared S3 bucket polling options }}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
 
 {{#if bucket_list_prefix }}
 bucket_list_prefix: {{ bucket_list_prefix }}
@@ -88,6 +85,11 @@ file_selectors:
 {{/if}}
 {{! end SQS queue }}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/cloudflare_logpush/data_stream/gateway_network/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_network/manifest.yml
@@ -115,12 +115,12 @@ streams:
         description: Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: '[S3] Number of Workers'
+        title: '[S3/SQS] Number of Workers'
         multi: false
         required: false
         show_user: true
         default: 5
-        description: Number of workers that will process the S3 objects listed.
+        description: Number of workers that will process the S3/SQS objects listed.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'
@@ -143,7 +143,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/gateway_network/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_network/manifest.yml
@@ -143,7 +143,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/http_request/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/http_request/agent/stream/aws-s3.yml.hbs
@@ -9,9 +9,6 @@ When using an S3 bucket, you can specify only one of the following options:
 
 {{#if collect_s3_logs}}
 {{! shared S3 bucket polling options }}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
 
 {{#if bucket_list_prefix }}
 bucket_list_prefix: {{ bucket_list_prefix }}
@@ -89,6 +86,11 @@ file_selectors:
 {{/if}}
 {{! end SQS queue }}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/cloudflare_logpush/data_stream/http_request/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/http_request/manifest.yml
@@ -115,12 +115,12 @@ streams:
         description: Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: '[S3] Number of Workers'
+        title: '[S3/SQS] Number of Workers'
         multi: false
         required: false
         show_user: true
         default: 5
-        description: Number of workers that will process the S3 objects listed.
+        description: Number of workers that will process the S3/SQS objects listed.
       - name: visibility_timeout
         type: text
         title: '[SQS] Visibility Timeout'
@@ -143,7 +143,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/http_request/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/http_request/manifest.yml
@@ -143,7 +143,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/magic_ids/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/agent/stream/aws-s3.yml.hbs
@@ -9,9 +9,6 @@ When using an S3 bucket, you can specify only one of the following options:
 
 {{#if collect_s3_logs}}
 {{! shared S3 bucket polling options }}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
 
 {{#if bucket_list_prefix }}
 bucket_list_prefix: {{ bucket_list_prefix }}
@@ -88,6 +85,11 @@ file_selectors:
 {{/if}}
 {{! end SQS queue }}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/cloudflare_logpush/data_stream/magic_ids/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/manifest.yml
@@ -115,12 +115,12 @@ streams:
         description: Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: '[S3] Number of Workers'
+        title: '[S3/SQS] Number of Workers'
         multi: false
         required: false
         show_user: true
         default: 5
-        description: Number of workers that will process the S3 objects listed.
+        description: Number of workers that will process the S3/SQS objects listed.
       - name: start_timestamp
         type: text
         title: "[S3] Start Timestamp"
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/magic_ids/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/manifest.yml
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/nel_report/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/nel_report/agent/stream/aws-s3.yml.hbs
@@ -9,9 +9,6 @@ When using an S3 bucket, you can specify only one of the following options:
 
 {{#if collect_s3_logs}}
 {{! shared S3 bucket polling options }}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
 
 {{#if bucket_list_prefix }}
 bucket_list_prefix: {{ bucket_list_prefix }}
@@ -88,6 +85,11 @@ file_selectors:
 {{/if}}
 {{! end SQS queue }}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/cloudflare_logpush/data_stream/nel_report/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/nel_report/manifest.yml
@@ -115,12 +115,12 @@ streams:
         description: Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: '[S3] Number of Workers'
+        title: '[S3/SQS] Number of Workers'
         multi: false
         required: false
         show_user: true
         default: 5
-        description: Number of workers that will process the S3 objects listed.
+        description: Number of workers that will process the S3/SQS objects listed.
       - name: start_timestamp
         type: text
         title: "[S3] Start Timestamp"
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/nel_report/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/nel_report/manifest.yml
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/network_analytics/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/network_analytics/agent/stream/aws-s3.yml.hbs
@@ -9,9 +9,6 @@ When using an S3 bucket, you can specify only one of the following options:
 
 {{#if collect_s3_logs}}
 {{! shared S3 bucket polling options }}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
 
 {{#if bucket_list_prefix }}
 bucket_list_prefix: {{ bucket_list_prefix }}
@@ -88,6 +85,11 @@ file_selectors:
 {{/if}}
 {{! end SQS queue }}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/cloudflare_logpush/data_stream/network_analytics/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/network_analytics/manifest.yml
@@ -115,12 +115,12 @@ streams:
         description: Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: '[S3] Number of Workers'
+        title: '[S3/SQS] Number of Workers'
         multi: false
         required: false
         show_user: true
         default: 5
-        description: Number of workers that will process the S3 objects listed.
+        description: Number of workers that will process the S3/SQS objects listed.
       - name: start_timestamp
         type: text
         title: "[S3] Start Timestamp"
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/network_analytics/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/network_analytics/manifest.yml
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/network_session/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/network_session/agent/stream/aws-s3.yml.hbs
@@ -9,9 +9,6 @@ When using an S3 bucket, you can specify only one of the following options:
 
 {{#if collect_s3_logs}}
 {{! shared S3 bucket polling options }}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
 
 {{#if bucket_list_prefix }}
 bucket_list_prefix: {{ bucket_list_prefix }}
@@ -88,6 +85,11 @@ file_selectors:
 {{/if}}
 {{! end SQS queue }}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/cloudflare_logpush/data_stream/network_session/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/network_session/manifest.yml
@@ -115,12 +115,12 @@ streams:
         description: Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: '[S3] Number of Workers'
+        title: '[S3/SQS] Number of Workers'
         multi: false
         required: false
         show_user: true
         default: 5
-        description: Number of workers that will process the S3 objects listed.
+        description: Number of workers that will process the S3/SQS objects listed.
       - name: start_timestamp
         type: text
         title: "[S3] Start Timestamp"
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/network_session/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/network_session/manifest.yml
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/sinkhole_http/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/sinkhole_http/manifest.yml
@@ -115,12 +115,12 @@ streams:
         description: Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: '[S3] Number of Workers'
+        title: '[S3/SQS] Number of Workers'
         multi: false
         required: false
         show_user: true
         default: 5
-        description: Number of workers that will process the S3 objects listed.
+        description: Number of workers that will process the S3/SQS objects listed.
       - name: start_timestamp
         type: text
         title: "[S3] Start Timestamp"
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/sinkhole_http/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/sinkhole_http/manifest.yml
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/agent/stream/aws-s3.yml.hbs
@@ -9,10 +9,6 @@ When using an S3 bucket, you can specify only one of the following options:
 
 {{#if collect_s3_logs}}
 {{! shared S3 bucket polling options }}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
-
 {{#if bucket_list_prefix }}
 bucket_list_prefix: {{ bucket_list_prefix }}
 {{/if}}
@@ -88,6 +84,11 @@ file_selectors:
 {{/if}}
 {{! end SQS queue }}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/manifest.yml
@@ -115,12 +115,12 @@ streams:
         description: Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: '[S3] Number of Workers'
+        title: '[S3/SQS] Number of Workers'
         multi: false
         required: false
         show_user: true
         default: 5
-        description: Number of workers that will process the S3 objects listed.
+        description: Number of workers that will process the S3/SQS objects listed.
       - name: start_timestamp
         type: text
         title: "[S3] Start Timestamp"
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/manifest.yml
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/workers_trace/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/workers_trace/agent/stream/aws-s3.yml.hbs
@@ -9,9 +9,6 @@ When using an S3 bucket, you can specify only one of the following options:
 
 {{#if collect_s3_logs}}
 {{! shared S3 bucket polling options }}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
 
 {{#if bucket_list_prefix }}
 bucket_list_prefix: {{ bucket_list_prefix }}
@@ -88,6 +85,11 @@ file_selectors:
 {{/if}}
 {{! end SQS queue }}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/cloudflare_logpush/data_stream/workers_trace/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/workers_trace/manifest.yml
@@ -115,12 +115,12 @@ streams:
         description: Time interval for polling listing of the S3 bucket. NOTE:- Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: '[S3] Number of Workers'
+        title: '[S3/SQS] Number of Workers'
         multi: false
         required: false
         show_user: true
         default: 5
-        description: Number of workers that will process the S3 objects listed.
+        description: Number of workers that will process the S3/SQS objects listed.
       - name: start_timestamp
         type: text
         title: "[S3] Start Timestamp"
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/data_stream/workers_trace/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/workers_trace/manifest.yml
@@ -157,7 +157,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time. 
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/cloudflare_logpush/manifest.yml
+++ b/packages/cloudflare_logpush/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cloudflare_logpush
 title: Cloudflare Logpush
-version: "1.35.1"
+version: "1.35.2"
 description: Collect and parse logs from Cloudflare API with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Bug


## Proposed commit message

Fixes number_of_workers setting so it is not dependent on S3 bucket collection being enabled

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [N/A] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally
Modify number of worker settings on previous version of the integration without enabling S3 bucket selection. 
Download policy
Observe that default number of workers is still present or not present at all, relying on aws-s3 input defaults

Modify number of worker settings on this version of the integration without enabling S3 bucket selection. 
Download policy
Observe that default number of workers is the value of user input

## Related issues

- Closes #13179

 

## Screenshots

