### PR TITLE
[docs] Remove reliance on temporary redirects

### DIFF
--- a/docs/extend/add-data-stream.md
+++ b/docs/extend/add-data-stream.md
@@ -22,7 +22,7 @@ A data stream defines multiple {{es}} assets, like index templates, ingest pipel
 
 A data stream also defines a policy template. Policy templates include variables that allow users to configure the data stream using the {{fleet}} UI in {{kib}}. Then, the {{agent}} interprets the resulting policy to collect relevant information from the product or service being observed. Policy templates can also define an integration’s supported [`deployment_modes`](/extend/define-deployment-modes.md#deployment_modes).
 
-See [data streams](docs-content://reference/ingestion-tools/fleet/data-streams.md) for more information.
+See [data streams](docs-content://reference/fleet/data-streams.md) for more information.
 
 ::::
 

--- a/docs/extend/developer-tsds-guidelines.md
+++ b/docs/extend/developer-tsds-guidelines.md
@@ -44,7 +44,7 @@ To set a field as a dimension simply add `dimension: true` to its mapping:
 ```
 
 ::::{note}
-A field having type [flattened](elasticsearch://reference/elasticsearch/mapping-reference/flattened.md) cannot be selected as a dimension field. If the field that you are choosing as a dimension is too long or is of type flattened, consider hashing the value of this field and using the result as a dimension. [Fingerprint processor](elasticsearch://reference/ingestion-tools/enrich-processor/fingerprint-processor.md) can be used for this purpose.
+A field having type [flattened](elasticsearch://reference/elasticsearch/mapping-reference/flattened.md) cannot be selected as a dimension field. If the field that you are choosing as a dimension is too long or is of type flattened, consider hashing the value of this field and using the result as a dimension. [Fingerprint processor](elasticsearch://reference/enrich-processor/fingerprint-processor.md) can be used for this purpose.
 
 You can find an example in [Oracle Integration TSDS Enablement Example](https://github.com/elastic/integrations/blob/8a57d6ba96d391afc33da20c80ec51280d22f009/packages/oracle/data_stream/performance/elasticsearch/ingest_pipeline/default.yml#LL127C4-L131C29)
 
@@ -163,7 +163,7 @@ elasticsearch:
 
 * Use [Lens](docs-content://explore-analyze/visualize/lens.md) as the preferred visualisation type.
 * Always assess the number of unique values the field that is selected to be a dimension would hold, especially if it is a numeric field. A field that holds millions of unique values may not be an ideal candidate for becoming a dimension field.
-* If the dimension field value length is very long (max limit is 1024B), consider transforming the value to hash value representation. [Fingerprint processor](elasticsearch://reference/ingestion-tools/enrich-processor/fingerprint-processor.md) can be used for this purpose.
+* If the dimension field value length is very long (max limit is 1024B), consider transforming the value to hash value representation. [Fingerprint processor](elasticsearch://reference/enrich-processor/fingerprint-processor.md) can be used for this purpose.
 * In the field mapping files above each dimension field, add in-line comments stating the reason for selecting the field as a dimension field.
 * As part of TSDS migration testing, you may discover other errors which may be unrelated to TSDS migration. Keep the pull request for TSDS migration free from such changes. This helps in obtaining quick PR approval.
 

--- a/docs/extend/edit-ingest-pipeline.md
+++ b/docs/extend/edit-ingest-pipeline.md
@@ -52,4 +52,4 @@ processors:
 
 Open each `elasticsearch/ingest_pipeline/default.yml` file created for each data stream. Edit each ingest pipeline to match your needs.
 
-The [processor reference](elasticsearch://reference/ingestion-tools/enrich-processor/index.md) provides a list of all available processors and their configurations.
+The [processor reference](elasticsearch://reference/enrich-processor/index.md) provides a list of all available processors and their configurations.

--- a/docs/extend/quick-start.md
+++ b/docs/extend/quick-start.md
@@ -371,7 +371,7 @@ To run these steps using {{fleet}}-managed {{agent}}, you just need to update th
 
 
 1. [Download the {{agent}} install package](https://www.elastic.co/downloads/elastic-agent) to your machine.
-2. Download the {{agent}} package, extract it, and change into the package directory. You can find the steps for each available platform in [Install standalone {{agents}}](docs-content://reference/ingestion-tools/fleet/install-standalone-elastic-agent.md).
+2. Download the {{agent}} package, extract it, and change into the package directory. You can find the steps for each available platform in [Install standalone {{agents}}](docs-content://reference/fleet/install-standalone-elastic-agent.md).
 
     You can also download a package directly from the [{{agent}} download site](https://www.elastic.co/downloads/elastic-agent).
 

--- a/docs/extend/what-is-an-integration.md
+++ b/docs/extend/what-is-an-integration.md
@@ -33,7 +33,7 @@ Integrations have a strict, well-defined structure, and offer a number of benefi
 
 2. Publish the integration to the package registry
 
-    Once an integration (package) has been created, it needs to be built. Built integrations are stored in the [Package Storage repository](https://github.com/elastic/package-storage) and served up via the [{{package-registry}}](https://github.com/elastic/package-registry). The {{fleet}} UI in {{kib}} connects to the {{package-registry}} and allows users to discover, install, and configure Elastic Packages. The {{package-registry}} can also be [deployed on-premise in air-gapped environments](docs-content://reference/ingestion-tools/fleet/air-gapped.md#air-gapped-diy-epr).
+    Once an integration (package) has been created, it needs to be built. Built integrations are stored in the [Package Storage repository](https://github.com/elastic/package-storage) and served up via the [{{package-registry}}](https://github.com/elastic/package-registry). The {{fleet}} UI in {{kib}} connects to the {{package-registry}} and allows users to discover, install, and configure Elastic Packages. The {{package-registry}} can also be [deployed on-premise in air-gapped environments](docs-content://reference/fleet/air-gapped.md#air-gapped-diy-epr).
 
 3. Install the integration
 


### PR DESCRIPTION
Related to https://github.com/elastic/docs-content/pull/914
Related to https://github.com/elastic/elasticsearch/pull/125663

Removes reliance on temporary redirects in the docs-content and elasticsearch repos.