### PR TITLE
AWS S3 input bulk fix for number_of_workers

### DIFF
--- a/packages/amazon_security_lake/changelog.yml
+++ b/packages/amazon_security_lake/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.1"
+  changes:
+    - description: Fix handling of SQS worker count configuration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13350
 - version: "2.5.0"
   changes:
     - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.

--- a/packages/amazon_security_lake/data_stream/event/agent/stream/aws-s3.yml.hbs
+++ b/packages/amazon_security_lake/data_stream/event/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -44,6 +41,11 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/amazon_security_lake/data_stream/event/manifest.yml
+++ b/packages/amazon_security_lake/data_stream/event/manifest.yml
@@ -86,7 +86,7 @@ streams:
         description: Time interval for polling listing of the S3 bucket. It should be greater than 5m. Supported units are h/m/s.
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: true
@@ -135,7 +135,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: "[SQS] File Selectors"

--- a/packages/amazon_security_lake/manifest.yml
+++ b/packages/amazon_security_lake/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: amazon_security_lake
 title: Amazon Security Lake
-version: "2.5.0"
+version: "2.5.1"
 description: Collect logs from Amazon Security Lake with Elastic Agent.
 type: integration
 categories: ["aws", "security"]

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.45.1"
+  changes:
+    - description: Fix handling of SQS worker count configuration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13350
 - version: "2.45.0"
   changes:
   - description: Update default data_stream.dataset to aws.cloudwatch_logs for cloudwatch_logs data stream.

--- a/packages/aws/data_stream/apigateway_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/apigateway_logs/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -37,6 +34,12 @@ max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
 
 {{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
+{{/if}}
+
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}
 {{/if}}

--- a/packages/aws/data_stream/apigateway_logs/manifest.yml
+++ b/packages/aws/data_stream/apigateway_logs/manifest.yml
@@ -69,7 +69,7 @@ streams:
         description: "Time interval for polling listing of the S3 bucket. NOTE: Supported units for this parameter are h/m/s."
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: false

--- a/packages/aws/data_stream/cloudfront_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/cloudfront_logs/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -37,6 +34,12 @@ max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
 
 {{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
+{{/if}}
+
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}
 {{/if}}

--- a/packages/aws/data_stream/cloudfront_logs/manifest.yml
+++ b/packages/aws/data_stream/cloudfront_logs/manifest.yml
@@ -45,7 +45,7 @@ streams:
         description: "Time interval for polling listing of the S3 bucket. NOTE: Supported units for this parameter are h/m/s."
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: false

--- a/packages/aws/data_stream/cloudtrail/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/cloudtrail/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -36,6 +33,11 @@ api_timeout: {{api_timeout}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 file_selectors:

--- a/packages/aws/data_stream/cloudtrail/manifest.yml
+++ b/packages/aws/data_stream/cloudtrail/manifest.yml
@@ -82,7 +82,7 @@ streams:
         description: "Time interval for polling listing of the S3 bucket. NOTE: Supported units for this parameter are h/m/s."
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: false

--- a/packages/aws/data_stream/ec2_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/ec2_logs/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -37,6 +34,12 @@ max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
 
 {{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
+{{/if}}
+
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}
 {{/if}}

--- a/packages/aws/data_stream/ec2_logs/manifest.yml
+++ b/packages/aws/data_stream/ec2_logs/manifest.yml
@@ -46,7 +46,7 @@ streams:
         description: "Time interval for polling listing of the S3 bucket. NOTE: Supported units for this parameter are h/m/s."
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: false

--- a/packages/aws/data_stream/elb_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/elb_logs/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -37,6 +34,12 @@ max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
 
 {{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
+{{/if}}
+
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}
 {{/if}}

--- a/packages/aws/data_stream/elb_logs/manifest.yml
+++ b/packages/aws/data_stream/elb_logs/manifest.yml
@@ -45,7 +45,7 @@ streams:
         description: "Time interval for polling listing of the S3 bucket. NOTE: Supported units for this parameter are h/m/s."
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: false

--- a/packages/aws/data_stream/emr_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/emr_logs/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -40,6 +37,11 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 {{#if endpoint}}

--- a/packages/aws/data_stream/emr_logs/manifest.yml
+++ b/packages/aws/data_stream/emr_logs/manifest.yml
@@ -84,7 +84,7 @@ streams:
         description: "Time interval for polling listing of the S3 bucket. NOTE: Supported units for this parameter are h/m/s."
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: false

--- a/packages/aws/data_stream/firewall_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/firewall_logs/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -46,6 +43,11 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 {{#if endpoint}}

--- a/packages/aws/data_stream/firewall_logs/manifest.yml
+++ b/packages/aws/data_stream/firewall_logs/manifest.yml
@@ -45,7 +45,7 @@ streams:
         description: "Time interval for polling listing of the S3 bucket. NOTE: Supported units for this parameter are h/m/s."
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: false

--- a/packages/aws/data_stream/guardduty/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/guardduty/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -40,6 +37,11 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 {{#if endpoint}}

--- a/packages/aws/data_stream/guardduty/manifest.yml
+++ b/packages/aws/data_stream/guardduty/manifest.yml
@@ -161,7 +161,7 @@ streams:
         description: "Time interval for polling listing of the S3 bucket. NOTE: Supported units for this parameter are h/m/s."
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: true

--- a/packages/aws/data_stream/route53_resolver_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/route53_resolver_logs/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -37,6 +34,12 @@ max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
 
 {{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
+{{/if}}
+
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}
 {{/if}}

--- a/packages/aws/data_stream/route53_resolver_logs/manifest.yml
+++ b/packages/aws/data_stream/route53_resolver_logs/manifest.yml
@@ -168,7 +168,7 @@ streams:
         description: "Time interval for polling listing of the S3 bucket. NOTE: Supported units for this parameter are h/m/s."
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: false

--- a/packages/aws/data_stream/s3access/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/s3access/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -37,6 +34,12 @@ max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
 
 {{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
+{{/if}}
+
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}
 {{/if}}

--- a/packages/aws/data_stream/s3access/manifest.yml
+++ b/packages/aws/data_stream/s3access/manifest.yml
@@ -45,7 +45,7 @@ streams:
         description: "Time interval for polling listing of the S3 bucket. NOTE: Supported units for this parameter are h/m/s."
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: false

--- a/packages/aws/data_stream/vpcflow/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/vpcflow/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -36,6 +33,11 @@ api_timeout: {{api_timeout}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 {{#if credential_profile_name}}

--- a/packages/aws/data_stream/vpcflow/manifest.yml
+++ b/packages/aws/data_stream/vpcflow/manifest.yml
@@ -53,7 +53,7 @@ streams:
         description: "Time interval for polling listing of the S3 bucket. NOTE: Supported units for this parameter are h/m/s."
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: false

--- a/packages/aws/data_stream/waf/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/waf/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -37,6 +34,12 @@ max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
 
 {{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
+{{/if}}
+
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}
 {{/if}}

--- a/packages/aws/data_stream/waf/manifest.yml
+++ b/packages/aws/data_stream/waf/manifest.yml
@@ -45,7 +45,7 @@ streams:
         description: "Time interval for polling listing of the S3 bucket. NOTE: Supported units for this parameter are h/m/s."
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: false

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.1
 name: aws
 title: AWS
-version: 2.45.0
+version: 2.45.1
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:

--- a/packages/aws_bedrock/changelog.yml
+++ b/packages/aws_bedrock/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.2.1"
+  changes:
+    - description: Fix handling of S3/SQS worker count configuration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13350
 - version: "1.2.0"
   changes:
     - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.

--- a/packages/aws_bedrock/data_stream/invocation/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws_bedrock/data_stream/invocation/agent/stream/aws-s3.yml.hbs
@@ -21,10 +21,6 @@ When using an S3 bucket, you can specify only one of the following options:
 }}
 
 {{! shared S3 bucket polling options }}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
-
 {{#if bucket_list_prefix }}
 bucket_list_prefix: {{ bucket_list_prefix }}
 {{/if}}
@@ -69,6 +65,11 @@ access_point_arn: {{ access_point_arn }}
 {{/unless}}
 
 {{/unless}}{{! end S3 bucket polling }}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
+{{/if}}
 
 {{#if buffer_size }}
 buffer_size: {{ buffer_size }}

--- a/packages/aws_bedrock/data_stream/invocation/manifest.yml
+++ b/packages/aws_bedrock/data_stream/invocation/manifest.yml
@@ -165,12 +165,12 @@ streams:
         description: ARN of the AWS S3 Access Point that will be polled for list operation. (This is an alternative to the Bucket ARN, and required when `queue_url`, `bucket_arn` or `non_aws_bucket_name` are not set).
       - name: number_of_workers
         type: integer
-        title: Number of Workers
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
-        default: 1
         show_user: true
-        description: Number of workers that will process the S3 objects listed. (Required when `bucket_arn` or `access_point_arn` are set).
+        default: 1
+        description: Number of workers that will process the S3 objects listed.
       - name: start_timestamp
         type: text
         title: "Start Timestamp"
@@ -269,7 +269,7 @@ streams:
       - name: max_number_of_messages
         type: integer
         title: Maximum Concurrent SQS Messages
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
         default: 5
         required: false
         show_user: false

--- a/packages/aws_bedrock/manifest.yml
+++ b/packages/aws_bedrock/manifest.yml
@@ -3,7 +3,7 @@ name: aws_bedrock
 title: Amazon Bedrock
 description: Collect Amazon Bedrock model invocation logs and runtime metrics with Elastic Agent.
 type: integration
-version: "1.2.0"
+version: "1.2.1"
 categories:
   - aws
   - cloud

--- a/packages/canva/changelog.yml
+++ b/packages/canva/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.1"
+  changes:
+    - description: Fix handling of SQS worker count configuration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13350
 - version: "0.6.0"
   changes:
     - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.

--- a/packages/canva/data_stream/audit/agent/stream/aws-s3.yml.hbs
+++ b/packages/canva/data_stream/audit/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -43,6 +40,11 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/canva/data_stream/audit/manifest.yml
+++ b/packages/canva/data_stream/audit/manifest.yml
@@ -112,7 +112,7 @@ streams:
         description: Time interval for polling listing of the S3 bucket. It should be greater than 1m. Supported units are h/m/s.
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: true
@@ -161,7 +161,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: preserve_original_event
         required: false
         show_user: true

--- a/packages/canva/manifest.yml
+++ b/packages/canva/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: canva
 title: Canva
-version: "0.6.0"
+version: "0.6.1"
 description: Collect logs from Canva with Elastic Agent.
 type: integration
 categories:

--- a/packages/carbon_black_cloud/changelog.yml
+++ b/packages/carbon_black_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.0.1"
+  changes:
+    - description: Fix handling of SQS worker count configuration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13350
 - version: "3.0.0"
   changes:
     - description: Removed legacy alert data stream.

--- a/packages/carbon_black_cloud/data_stream/alert_v7/agent/stream/aws-s3.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/alert_v7/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -41,6 +38,11 @@ max_number_of_messages: {{max_number_of_messages}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 expand_event_list_from_field: Records

--- a/packages/carbon_black_cloud/data_stream/alert_v7/manifest.yml
+++ b/packages/carbon_black_cloud/data_stream/alert_v7/manifest.yml
@@ -87,7 +87,7 @@ streams:
         description: Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: true
@@ -129,7 +129,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: "[SQS] File Selectors"

--- a/packages/carbon_black_cloud/data_stream/endpoint_event/agent/stream/aws-s3.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/endpoint_event/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -41,6 +38,11 @@ max_number_of_messages: {{max_number_of_messages}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 expand_event_list_from_field: Records

--- a/packages/carbon_black_cloud/data_stream/endpoint_event/manifest.yml
+++ b/packages/carbon_black_cloud/data_stream/endpoint_event/manifest.yml
@@ -33,7 +33,7 @@ streams:
         description: Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: true
@@ -75,7 +75,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: "[SQS] File Selectors"

--- a/packages/carbon_black_cloud/data_stream/watchlist_hit/agent/stream/aws-s3.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/watchlist_hit/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -41,6 +38,11 @@ max_number_of_messages: {{max_number_of_messages}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 expand_event_list_from_field: Records

--- a/packages/carbon_black_cloud/data_stream/watchlist_hit/manifest.yml
+++ b/packages/carbon_black_cloud/data_stream/watchlist_hit/manifest.yml
@@ -33,7 +33,7 @@ streams:
         description: Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: true
@@ -75,7 +75,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: "[SQS] File Selectors"

--- a/packages/carbon_black_cloud/manifest.yml
+++ b/packages/carbon_black_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: carbon_black_cloud
 title: VMware Carbon Black Cloud
-version: "3.0.0"
+version: "3.0.1"
 description: Collect logs from VMWare Carbon Black Cloud with Elastic Agent.
 type: integration
 categories:

--- a/packages/f5_bigip/changelog.yml
+++ b/packages/f5_bigip/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.27.1"
+  changes:
+    - description: Fix handling of SQS worker count configuration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13350
 - version: "1.27.0"
   changes:
     - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.

--- a/packages/f5_bigip/data_stream/log/agent/stream/aws-s3.yml.hbs
+++ b/packages/f5_bigip/data_stream/log/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -40,6 +37,11 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/f5_bigip/data_stream/log/manifest.yml
+++ b/packages/f5_bigip/data_stream/log/manifest.yml
@@ -121,7 +121,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/f5_bigip/manifest.yml
+++ b/packages/f5_bigip/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: f5_bigip
 title: F5 BIG-IP
-version: "1.27.0"
+version: "1.27.1"
 description: Collect logs from F5 BIG-IP with Elastic Agent.
 type: integration
 categories:

--- a/packages/imperva_cloud_waf/changelog.yml
+++ b/packages/imperva_cloud_waf/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.3"
+  changes:
+    - description: Fix handling of SQS worker count configuration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13350
 - version: "1.11.2"
   changes:
     - description: Handle multiple IPs in `extensions.xff`.

--- a/packages/imperva_cloud_waf/data_stream/event/agent/stream/aws-s3.yml.hbs
+++ b/packages/imperva_cloud_waf/data_stream/event/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -43,6 +40,11 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/imperva_cloud_waf/data_stream/event/manifest.yml
+++ b/packages/imperva_cloud_waf/data_stream/event/manifest.yml
@@ -194,7 +194,7 @@ streams:
         description: Time interval for polling listing of the S3 bucket. It should be greater than 5m. Supported units are h/m/s.
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: true
@@ -243,7 +243,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: "[SQS] File Selectors"

--- a/packages/imperva_cloud_waf/manifest.yml
+++ b/packages/imperva_cloud_waf/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: imperva_cloud_waf
 title: Imperva Cloud WAF
-version: "1.11.2"
+version: "1.11.3"
 description: Collect logs from Imperva Cloud WAF with Elastic Agent.
 type: integration
 categories:

--- a/packages/jamf_protect/changelog.yml
+++ b/packages/jamf_protect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.0.1"
+  changes:
+    - description: Fix handling of SQS worker count configuration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13350
 - version: "3.0.0"
   changes:
     - description: Adding new Gatekeeper Override event for telemetry data streams.

--- a/packages/jamf_protect/data_stream/alerts/agent/stream/aws-s3.yml.hbs
+++ b/packages/jamf_protect/data_stream/alerts/agent/stream/aws-s3.yml.hbs
@@ -9,9 +9,6 @@ When using an S3 bucket, you can specify only one of the following options:
 
 {{#if collect_s3_logs}}
 {{! shared S3 bucket polling options }}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
 
 {{#if bucket_list_prefix }}
 bucket_list_prefix: {{ bucket_list_prefix }}
@@ -88,6 +85,11 @@ file_selectors:
 {{/if}}
 {{! end SQS queue }}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/jamf_protect/data_stream/alerts/manifest.yml
+++ b/packages/jamf_protect/data_stream/alerts/manifest.yml
@@ -92,7 +92,7 @@ streams:
         description: Time interval for polling listing of the S3 bucket. Supported units for this parameter are h/m/s.
       - name: number_of_workers
         type: integer
-        title: '[S3] Number of Workers'
+        title: '[S3/SQS] Number of Workers'
         multi: false
         required: false
         show_user: true
@@ -134,7 +134,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/jamf_protect/data_stream/telemetry/manifest.yml
+++ b/packages/jamf_protect/data_stream/telemetry/manifest.yml
@@ -134,7 +134,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/jamf_protect/data_stream/telemetry_legacy/manifest.yml
+++ b/packages/jamf_protect/data_stream/telemetry_legacy/manifest.yml
@@ -134,7 +134,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/jamf_protect/data_stream/web_threat_events/manifest.yml
+++ b/packages/jamf_protect/data_stream/web_threat_events/manifest.yml
@@ -143,7 +143,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/jamf_protect/data_stream/web_traffic_events/manifest.yml
+++ b/packages/jamf_protect/data_stream/web_traffic_events/manifest.yml
@@ -143,7 +143,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/jamf_protect/manifest.yml
+++ b/packages/jamf_protect/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: jamf_protect
 title: Jamf Protect
-version: "3.0.0"
+version: "3.0.1"
 description: Receives events from Jamf Protect with Elastic Agent.
 type: integration
 categories:

--- a/packages/sentinel_one_cloud_funnel/changelog.yml
+++ b/packages/sentinel_one_cloud_funnel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.1"
+  changes:
+    - description: Fix handling of SQS worker count configuration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13350
 - version: "1.11.0"
   changes:
     - description: Improve performance of event ingest pipeline.

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/agent/stream/aws-s3.yml.hbs
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -40,6 +37,11 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/manifest.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/manifest.yml
@@ -33,7 +33,7 @@ streams:
         description: "Time interval for polling listing of the S3 bucket. It should be greater than 5m. Supported units are h/m/s."
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: true
@@ -75,7 +75,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: "[SQS] File Selectors"

--- a/packages/sentinel_one_cloud_funnel/manifest.yml
+++ b/packages/sentinel_one_cloud_funnel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: sentinel_one_cloud_funnel
 title: SentinelOne Cloud Funnel
-version: "1.11.0"
+version: "1.11.1"
 description: Collect logs from SentinelOne Cloud Funnel with Elastic Agent.
 type: integration
 categories: ["security", "edr_xdr"]

--- a/packages/servicenow/changelog.yml
+++ b/packages/servicenow/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.12.1"
+  changes:
+    - description: Fix handling of SQS worker count configuration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13350
 - version: "0.12.0"
   changes:
     - description: Enable request trace log removal.

--- a/packages/servicenow/data_stream/event/agent/stream/aws-s3.yml.hbs
+++ b/packages/servicenow/data_stream/event/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -43,6 +40,11 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 {{#if decode_parquet_enabled}}

--- a/packages/servicenow/data_stream/event/manifest.yml
+++ b/packages/servicenow/data_stream/event/manifest.yml
@@ -298,7 +298,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: decode_parquet_enabled
         type: bool
         title: Parquet Codec

--- a/packages/servicenow/manifest.yml
+++ b/packages/servicenow/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: servicenow
 title: "ServiceNow"
-version: "0.12.0"
+version: "0.12.1"
 description: "Collect logs from ServiceNow with Elastic Agent."
 type: integration
 categories:

--- a/packages/sublime_security/changelog.yml
+++ b/packages/sublime_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: Fix handling of SQS worker count configuration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13350
 - version: "1.8.0"
   changes:
     - description: Enable request trace log removal.

--- a/packages/sublime_security/data_stream/audit/agent/stream/aws-s3.yml.hbs
+++ b/packages/sublime_security/data_stream/audit/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -43,6 +40,11 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 expand_event_list_from_field: events

--- a/packages/sublime_security/data_stream/audit/manifest.yml
+++ b/packages/sublime_security/data_stream/audit/manifest.yml
@@ -148,7 +148,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/sublime_security/data_stream/email_message/agent/stream/aws-s3.yml.hbs
+++ b/packages/sublime_security/data_stream/email_message/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -43,6 +40,11 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/sublime_security/data_stream/email_message/manifest.yml
+++ b/packages/sublime_security/data_stream/email_message/manifest.yml
@@ -87,7 +87,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/sublime_security/data_stream/message_event/agent/stream/aws-s3.yml.hbs
+++ b/packages/sublime_security/data_stream/message_event/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -43,6 +40,11 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 expand_event_list_from_field: events

--- a/packages/sublime_security/data_stream/message_event/manifest.yml
+++ b/packages/sublime_security/data_stream/message_event/manifest.yml
@@ -170,7 +170,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: '[SQS] File Selectors'

--- a/packages/sublime_security/manifest.yml
+++ b/packages/sublime_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: sublime_security
 title: Sublime Security
-version: "1.8.0"
+version: "1.8.1"
 description: Collect logs from Sublime Security with Elastic Agent.
 type: integration
 categories:

--- a/packages/symantec_endpoint_security/changelog.yml
+++ b/packages/symantec_endpoint_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.1"
+  changes:
+    - description: Fix handling of SQS worker count configuration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13350
 - version: "1.10.0"
   changes:
     - description: Enable request trace log removal.

--- a/packages/symantec_endpoint_security/data_stream/event/agent/stream/aws-s3.yml.hbs
+++ b/packages/symantec_endpoint_security/data_stream/event/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -43,6 +40,11 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/symantec_endpoint_security/data_stream/event/manifest.yml
+++ b/packages/symantec_endpoint_security/data_stream/event/manifest.yml
@@ -120,7 +120,7 @@ streams:
         description: "Time interval for polling listing of the S3 bucket. NOTE: Supported units are h/m/s."
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: true
@@ -162,7 +162,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: "[SQS] File Selectors"

--- a/packages/symantec_endpoint_security/manifest.yml
+++ b/packages/symantec_endpoint_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: symantec_endpoint_security
 title: Symantec Endpoint Security
-version: "1.10.0"
+version: "1.10.1"
 description: Collect logs from Symantec Endpoint Security with Elastic Agent.
 type: integration
 categories:

--- a/packages/tanium/changelog.yml
+++ b/packages/tanium/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.2"
+  changes:
+    - description: Fix handling of SQS worker count configuration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13350
 - version: "1.16.1"
   changes:
     - description: Use `host.name` instead of `host.hostname`.

--- a/packages/tanium/data_stream/action_history/agent/stream/aws-s3.yml.hbs
+++ b/packages/tanium/data_stream/action_history/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -40,6 +37,11 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/tanium/data_stream/action_history/manifest.yml
+++ b/packages/tanium/data_stream/action_history/manifest.yml
@@ -24,7 +24,7 @@ streams:
         description: "Time interval for polling listing of the S3 bucket. Interval should be greater than the Tanium scheduler time and supported units are h/m/s."
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: true
@@ -66,7 +66,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: "[SQS] File Selectors"

--- a/packages/tanium/data_stream/client_status/agent/stream/aws-s3.yml.hbs
+++ b/packages/tanium/data_stream/client_status/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -40,6 +37,11 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/tanium/data_stream/client_status/manifest.yml
+++ b/packages/tanium/data_stream/client_status/manifest.yml
@@ -79,7 +79,7 @@ streams:
         description: "Time interval for polling listing of the S3 bucket. Interval should be greater than the Tanium scheduler time and supported units are h/m/s."
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: true
@@ -121,7 +121,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: "[SQS] File Selectors"

--- a/packages/tanium/data_stream/discover/agent/stream/aws-s3.yml.hbs
+++ b/packages/tanium/data_stream/discover/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -40,6 +37,11 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/tanium/data_stream/discover/manifest.yml
+++ b/packages/tanium/data_stream/discover/manifest.yml
@@ -24,7 +24,7 @@ streams:
         description: "Time interval for polling listing of the S3 bucket. Interval should be greater than the Tanium scheduler time and supported units are h/m/s."
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: true
@@ -66,7 +66,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: "[SQS] File Selectors"

--- a/packages/tanium/data_stream/endpoint_config/agent/stream/aws-s3.yml.hbs
+++ b/packages/tanium/data_stream/endpoint_config/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -40,6 +37,11 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/tanium/data_stream/endpoint_config/manifest.yml
+++ b/packages/tanium/data_stream/endpoint_config/manifest.yml
@@ -24,7 +24,7 @@ streams:
         description: "Time interval for polling listing of the S3 bucket. Interval should be greater than the Tanium scheduler time and supported units are h/m/s."
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: true
@@ -66,7 +66,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: "[SQS] File Selectors"

--- a/packages/tanium/data_stream/reporting/agent/stream/aws-s3.yml.hbs
+++ b/packages/tanium/data_stream/reporting/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -40,6 +37,11 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/tanium/data_stream/reporting/manifest.yml
+++ b/packages/tanium/data_stream/reporting/manifest.yml
@@ -79,7 +79,7 @@ streams:
         description: "Time interval for polling listing of the S3 bucket. Interval should be greater than the Tanium scheduler time and supported units are h/m/s."
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: true
@@ -121,7 +121,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: "[SQS] File Selectors"

--- a/packages/tanium/data_stream/threat_response/agent/stream/aws-s3.yml.hbs
+++ b/packages/tanium/data_stream/threat_response/agent/stream/aws-s3.yml.hbs
@@ -5,9 +5,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -40,6 +37,11 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 {{#if access_key_id}}

--- a/packages/tanium/data_stream/threat_response/manifest.yml
+++ b/packages/tanium/data_stream/threat_response/manifest.yml
@@ -24,7 +24,7 @@ streams:
         description: "Time interval for polling listing of the S3 bucket. Interval should be greater than the Tanium scheduler time and supported units are h/m/s."
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: true
@@ -66,7 +66,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: "[SQS] File Selectors"

--- a/packages/tanium/manifest.yml
+++ b/packages/tanium/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: tanium
 title: Tanium
-version: "1.16.1"
+version: "1.16.2"
 description: This Elastic integration collects logs from Tanium with Elastic Agent.
 type: integration
 categories:

--- a/packages/trellix_edr_cloud/changelog.yml
+++ b/packages/trellix_edr_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: Fix handling of SQS worker count configuration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13350
 - version: "1.8.0"
   changes:
     - description: Add support to configure start_timestamp and ignore_older configurations for AWS S3 backed inputs.

--- a/packages/trellix_edr_cloud/data_stream/event/agent/stream/aws-s3.yml.hbs
+++ b/packages/trellix_edr_cloud/data_stream/event/agent/stream/aws-s3.yml.hbs
@@ -4,9 +4,6 @@ bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
-{{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
 {{/if}}
@@ -42,6 +39,11 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+{{/if}}
+
+{{! allows number of workers to be configured for SQS queue and S3 buckets}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 
 expand_event_list_from_field: '.[]'

--- a/packages/trellix_edr_cloud/data_stream/event/manifest.yml
+++ b/packages/trellix_edr_cloud/data_stream/event/manifest.yml
@@ -24,7 +24,7 @@ streams:
         description: "Time interval for polling listing of the S3 bucket. NOTE: Supported units are h/m/s."
       - name: number_of_workers
         type: integer
-        title: "[S3] Number of Workers"
+        title: "[S3/SQS] Number of Workers"
         multi: false
         required: false
         show_user: true
@@ -66,7 +66,7 @@ streams:
         required: false
         show_user: true
         default: 5
-        description: The maximum number of SQS messages that can be inflight at any time.
+        description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
         title: "[SQS] File Selectors"

--- a/packages/trellix_edr_cloud/manifest.yml
+++ b/packages/trellix_edr_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: trellix_edr_cloud
 title: Trellix EDR Cloud
-version: "1.8.0"
+version: "1.8.1"
 description: Collect logs from Trellix EDR Cloud with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Bug


## Proposed commit message

Fixes number_of_workers setting so it is not dependent on S3 bucket collection being enabled

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [N/A] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally
Modify number of worker settings on previous version of the integration without enabling S3 bucket selection. 
Download policy
Observe that default number of workers is still present or not present at all, relying on aws-s3 input defaults

Modify number of worker settings on this version of the integration without enabling S3 bucket selection. 
Download policy
Observe that default number of workers is the value of user input

## Related issues

- Closes #13179

 

## Screenshots

