### PR TITLE
updating disclaimer for aws_cloudwatch logs

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.45.0"
+  changes:
+  - description: Update default data_stream.dataset to cloudwatch_logs for cloudwatch_logs data stream.
+    type: breaking-change
+    link: https://github.com/elastic/integrations/pull/12685
 - version: "2.44.0"
   changes:
   - description: Add `actor.entity.id` and `target.entity.id`

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
   - description: Update default data_stream.dataset to cloudwatch_logs for cloudwatch_logs data stream.
     type: breaking-change
-    link: https://github.com/elastic/integrations/pull/12685
+    link: https://github.com/elastic/integrations/pull/13370
 - version: "2.44.0"
   changes:
   - description: Add `actor.entity.id` and `target.entity.id`

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.45.0"
   changes:
-  - description: Update default data_stream.dataset to cloudwatch_logs for cloudwatch_logs data stream.
+  - description: Update default data_stream.dataset to aws.cloudwatch_logs for cloudwatch_logs data stream.
     type: breaking-change
     link: https://github.com/elastic/integrations/pull/13370
 - version: "2.44.0"

--- a/packages/aws/data_stream/cloudwatch_logs/manifest.yml
+++ b/packages/aws/data_stream/cloudwatch_logs/manifest.yml
@@ -130,12 +130,13 @@ streams:
       - name: data_stream.dataset
         type: text
         required: true
-        default: cloudwatch_logs
+        default: aws.cloudwatch_logs
         show_user: false
         title: Dataset name
         description: |
           Set the name for your dataset. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-          Note: In case you change the dataset name, the default mappings and ingest templates will not be applied to the new dataset. Advise [Datastreams Pipelines](https://www.elastic.co/guide/en/fleet/current/data-streams-pipeline-tutorial.html) for new pipeline creation or [Index Template](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-template.html)
+
+          Note: In case you change the dataset name, the default mappings and ingest templates will not be applied to the new dataset. Advise [Datastreams Pipelines](https://www.elastic.co/guide/en/fleet/current/data-streams-pipeline-tutorial.html) for new pipeline creation or [Index Template creation](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-template.html)
           
 # Ensures agents have permissions to write data to `logs-*-*`
 elasticsearch:

--- a/packages/aws/data_stream/cloudwatch_logs/manifest.yml
+++ b/packages/aws/data_stream/cloudwatch_logs/manifest.yml
@@ -136,6 +136,7 @@ streams:
         description: |
           Set the name for your dataset. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
           Note: In case you change the dataset name, the default mappings and ingest templates will not be applied to the new dataset. Advise [Datastreams Pipelines](https://www.elastic.co/guide/en/fleet/current/data-streams-pipeline-tutorial.html) for new pipeline creation or [Index Template](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-template.html)
+          
 # Ensures agents have permissions to write data to `logs-*-*`
 elasticsearch:
   dynamic_dataset: true

--- a/packages/aws/data_stream/cloudwatch_logs/manifest.yml
+++ b/packages/aws/data_stream/cloudwatch_logs/manifest.yml
@@ -130,12 +130,12 @@ streams:
       - name: data_stream.dataset
         type: text
         required: true
-        default: generic
+        default: cloudwatch_logs
         show_user: false
         title: Dataset name
-        description: >
+        description: |
           Set the name for your dataset. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-
+          Note: In case you change the dataset name, the default mappings and ingest templates will not be applied to the new dataset. Advise [Datastreams Pipelines](https://www.elastic.co/guide/en/fleet/current/data-streams-pipeline-tutorial.html) for new pipeline creation or [Index Template](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-template.html)
 # Ensures agents have permissions to write data to `logs-*-*`
 elasticsearch:
   dynamic_dataset: true

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.1
 name: aws
 title: AWS
-version: 2.44.0
+version: 2.45.0
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Breaking change

## Proposed commit message


Please explain:

- WHAT: We change the default value of the cloudwatch_lods data_stream.dataset to aws.cloudwatch_logs
- WHY:  This needs to match the package name cloudwatch_logs in order the preinstalled ingest mappings/templates for the given datastream to apply


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## How to test this PR locally

- Clone dir
- cd packages/integrations/kubernetes
- elastic-package build
- elastic-package stack up -d -vvv --version=9.0.0-SNAPSHOT
- Create an elastic-agent policy
- Add kubernetes integration. The version 2.45.0 should be available 

## Related issues

- Closes #https://github.com/elastic/integrations/issues/12640

## Screenshots

This is how the discalimer is displayed:

![Screenshot 2025-04-02 at 4 26 19 PM](https://github.com/user-attachments/assets/30f9a6a4-3a43-4a5e-9de1-ef6403462a66)

The default ingest template is displayed below:

![Screenshot 2025-04-02 at 4 33 04 PM](https://github.com/user-attachments/assets/9269f13b-686c-4426-bda8-0652c1472b10)

So we changed the datastream.dataset to `aws.cloudwatch_logs`

Successful processing of cloudwatch events:
![Screenshot 2025-04-02 at 5 48 48 PM](https://github.com/user-attachments/assets/a0a3b1ac-802f-4690-83be-e206142a9a39)

Important: We enable the preserve_original event that is defined in [ingest pipeline](https://github.com/elastic/integrations/blob/main/packages/aws/data_stream/cloudwatch_logs/elasticsearch/ingest_pipeline/default.yml)

This one works fine as you can see in previous image

But we test again with version 2.44.0:

![Screenshot 2025-04-02 at 6 02 54 PM](https://github.com/user-attachments/assets/5a8330e5-b563-4ace-8363-649c13c1843a)

See that event.original is not present and that that preserve_original.event is present that indicates that the option was enabled.

