### PR TITLE
[Auth0] - Fixed an existing date parsing issue for `auth0.logs` data stream

### DIFF
--- a/packages/auth0/_dev/deploy/docker/files/config-logs.yml
+++ b/packages/auth0/_dev/deploy/docker/files/config-logs.yml
@@ -83,7 +83,84 @@ rules:
                   "tenant_name": "dev-fulaoenaspapatoulp",
                   "_id": "90020240308035905601176000000000000001223372052035100532",
                   "isMobile": false
-              }
+              },
+              {
+                "$event_schema": {
+                    "version": "1.0.0"
+                },
+                "_id": "90020250315180807266045000000000000001223372126167226037",
+                "client_id": "A123v04ZMgorp521yX4lIyeI9nYIuwGP",
+                "client_name": "XYZ",
+                "connection": "example-users",
+                "connection_id": "con_Abc4hRDDmVrZWomi",
+                "date": "2025-03-15T18:08:04.365Z",
+                "details": {
+                    "actions": {
+                        "executions": [
+                            "ABCnLEtG3EJGfIJMP2UZms1pMjAyNTAzMja25rxa3ZNFXYDkKlwulvVB"
+                        ]
+                    },
+                    "completedAt": 1743012484363,
+                    "elapsedTime": 63604,
+                    "initiatedAt": 1743012420759,
+                    "prompts": [
+                        {
+                            "completedAt": 1743012449133,
+                            "connection": "example-users",
+                            "connection_id": "con_Abc4hRDDmVrZWomi",
+                            "elapsedTime": 649,
+                            "identity": 12345,
+                            "initiatedAt": 1743012448484,
+                            "name": "lock-password-authenticate",
+                            "stats": {
+                                "loginsCount": 5
+                            },
+                            "strategy": "auth0"
+                        },
+                        {
+                            "completedAt": 1743012449137,
+                            "elapsedTime": 28376,
+                            "flow": "login",
+                            "initiatedAt": 1743012420761,
+                            "name": "login",
+                            "timers": {
+                                "rules": 626
+                            },
+                            "user_id": "auth0|12345",
+                            "user_name": "jdoe@example.com"
+                        },
+                        {
+                            "completedAt": 1743012484145,
+                            "elapsedTime": 34160,
+                            "flow": "mfa",
+                            "initiatedAt": 1743012449985,
+                            "name": "mfa",
+                            "performed_acr": [
+                                "http://schemas.openid.net/pape/policies/2007/06/multi-factor"
+                            ],
+                            "performed_amr": [
+                                "mfa"
+                            ],
+                            "provider": "guardian"
+                        }
+                    ],
+                    "session_id": "abcKFtsdFoVQqpf-a4gjQIXe1pMdM5kAH",
+                    "stats": {
+                        "loginsCount": 5
+                    }
+                },
+                "hostname": "auth.example.com",
+                "ip": "192.168.1.1",
+                "isMobile": false,
+                "log_id": "90020250315180807266045000000000000001223372126167226037",
+                "strategy": "auth0",
+                "strategy_type": "database",
+                "tenant_name": "example-apps",
+                "type": "s",
+                "user_agent": "Chrome 134.0.0 / Windows 10.0.0",
+                "user_id": "auth0|12345",
+                "user_name": "jdoe@example.com"
+            }
           ]
           ` }}
   - path: /api/v2/logs
@@ -150,7 +227,84 @@ rules:
                   "tenant_name": "dev-fulaoenaspapatoulp",
                   "_id": "90020240308035906742643000000000000001223372052035101088",
                   "isMobile": false
-              }
+              },
+              {
+                "$event_schema": {
+                    "version": "1.0.0"
+                },
+                "_id": "90020250315180807266045000000000000001223372126167226037",
+                "client_id": "A123v04ZMgorp521yX4lIyeI9nYIuwGP",
+                "client_name": "XYZ",
+                "connection": "example-users",
+                "connection_id": "con_Abc4hRDDmVrZWomi",
+                "date": "2025-03-15T18:08:04.365Z",
+                "details": {
+                    "actions": {
+                        "executions": [
+                            "ABCnLEtG3EJGfIJMP2UZms1pMjAyNTAzMja25rxa3ZNFXYDkKlwulvVB"
+                        ]
+                    },
+                    "completedAt": 1743012484363,
+                    "elapsedTime": 63604,
+                    "initiatedAt": 1743012420759,
+                    "prompts": [
+                        {
+                            "completedAt": 1743012449133,
+                            "connection": "example-users",
+                            "connection_id": "con_Abc4hRDDmVrZWomi",
+                            "elapsedTime": 649,
+                            "identity": 12345,
+                            "initiatedAt": 1743012448484,
+                            "name": "lock-password-authenticate",
+                            "stats": {
+                                "loginsCount": 5
+                            },
+                            "strategy": "auth0"
+                        },
+                        {
+                            "completedAt": 1743012449137,
+                            "elapsedTime": 28376,
+                            "flow": "login",
+                            "initiatedAt": 1743012420761,
+                            "name": "login",
+                            "timers": {
+                                "rules": 626
+                            },
+                            "user_id": "auth0|12345",
+                            "user_name": "jdoe@example.com"
+                        },
+                        {
+                            "completedAt": 1743012484145,
+                            "elapsedTime": 34160,
+                            "flow": "mfa",
+                            "initiatedAt": 1743012449985,
+                            "name": "mfa",
+                            "performed_acr": [
+                                "http://schemas.openid.net/pape/policies/2007/06/multi-factor"
+                            ],
+                            "performed_amr": [
+                                "mfa"
+                            ],
+                            "provider": "guardian"
+                        }
+                    ],
+                    "session_id": "abcKFtsdFoVQqpf-a4gjQIXe1pMdM5kAH",
+                    "stats": {
+                        "loginsCount": 5
+                    }
+                },
+                "hostname": "auth.example.com",
+                "ip": "192.168.1.1",
+                "isMobile": false,
+                "log_id": "90020250315180807266045000000000000001223372126167226037",
+                "strategy": "auth0",
+                "strategy_type": "database",
+                "tenant_name": "example-apps",
+                "type": "s",
+                "user_agent": "Chrome 134.0.0 / Windows 10.0.0",
+                "user_id": "auth0|12345",
+                "user_name": "jdoe@example.com"
+            }
           ]
           ` }}
   - path: /api/v2/logs

--- a/packages/auth0/changelog.yml
+++ b/packages/auth0/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fixed date parsing issue for `auth0.logs` data stream.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1111
+      link: https://github.com/elastic/integrations/pull/13371
 - version: "1.21.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/auth0/changelog.yml
+++ b/packages/auth0/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.21.1"
+  changes:
+    - description: Fixed date parsing issue for `auth0.logs` data stream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1111
 - version: "1.21.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/auth0/data_stream/logs/_dev/test/system/test-auth0-cel-config.yml
+++ b/packages/auth0/data_stream/logs/_dev/test/system/test-auth0-cel-config.yml
@@ -10,4 +10,4 @@ data_stream:
     preserve_original_event: true
     enable_request_tracer: true
 assert:
-  hit_count: 2
+  hit_count: 4

--- a/packages/auth0/data_stream/logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/auth0/data_stream/logs/elasticsearch/ingest_pipeline/default.yml
@@ -1038,6 +1038,26 @@ processors:
          } else {
            ctx.event.outcome = "unknown";
          }
+- script:
+    if: ctx?.auth0?.logs?.data?.details?.initiatedAt != null
+    tag: convert_timestamp_initiated_at to string removing any scientific notation if present
+    lang: painless
+    source: >
+      ctx.auth0.logs.data.details.initiatedAt = Math.round(Double.parseDouble(ctx.auth0.logs.data.details.initiatedAt.toString()));
+    on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+- script:
+    if: ctx?.auth0?.logs?.data?.details?.completedAt != null
+    tag: convert_timestamp_completed_at to string removing any scientific notation if present
+    lang: painless
+    source: >
+      ctx.auth0.logs.data.details.completedAt = Math.round(Double.parseDouble(ctx.auth0.logs.data.details.completedAt.toString()));
+    on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 - date:
     if: ctx?.auth0?.logs?.data?.details?.initiatedAt != null
     field: auth0.logs.data.details.initiatedAt
@@ -1066,7 +1086,7 @@ processors:
 # Clean up
 ##
 - remove:
-    field: 
+    field:
       - json
       - auth0.logs.data.$event_schema.version
       - auth0.logs.data._id

--- a/packages/auth0/data_stream/logs/sample_event.json
+++ b/packages/auth0/data_stream/logs/sample_event.json
@@ -1,115 +1,155 @@
 {
-    "@timestamp": "2021-11-03T03:06:05.696Z",
+    "@timestamp": "2025-03-15T18:08:04.365Z",
     "agent": {
-        "ephemeral_id": "43a5c1c4-07f0-45c2-b500-d13f835a029b",
-        "id": "69cd4013-cce1-4df6-b3fb-6f59a9969e32",
-        "name": "elastic-agent-38349",
+        "ephemeral_id": "e052c974-795f-41ed-802f-69f92e97d682",
+        "id": "fb7f48ab-5817-4c31-8e7b-0d943895ca0d",
+        "name": "elastic-agent-79075",
         "type": "filebeat",
-        "version": "8.13.0"
+        "version": "8.17.3"
     },
     "auth0": {
         "logs": {
             "data": {
-                "classification": "Login - Failure",
-                "date": "2021-11-03T03:06:05.696Z",
-                "description": "Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs",
+                "classification": "Login - Success",
+                "client_id": "A123v04ZMgorp521yX4lIyeI9nYIuwGP",
+                "client_name": "XYZ",
+                "connection": "example-users",
+                "connection_id": "con_Abc4hRDDmVrZWomi",
+                "date": "2025-03-15T18:08:04.365Z",
                 "details": {
-                    "error": {
-                        "message": "Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs",
-                        "oauthError": "Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs. Please go to 'https://manage.auth0.com/#/applications/aI61p8I8aFjmYRliLWgvM9ev97kCCNDB/settings' and make sure you are sending the same callback url from your application.",
-                        "payload": {
-                            "attempt": "http://localhost:3000/callback",
-                            "client": {
-                                "clientID": "aI61p8I8aFjmYRliLWgvM9ev97kCCNDB"
-                            },
-                            "code": "unauthorized_client",
-                            "message": "Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs",
-                            "name": "CallbackMismatchError",
-                            "status": 403
-                        },
-                        "type": "callback-url-mismatch"
+                    "actions": {
+                        "executions": [
+                            "ABCnLEtG3EJGfIJMP2UZms1pMjAyNTAzMja25rxa3ZNFXYDkKlwulvVB"
+                        ]
                     },
-                    "qs": {
-                        "client_id": "aI61p8I8aFjmYRliLWgvM9ev97kCCNDB",
-                        "redirect_uri": "http://localhost:3000/callback",
-                        "response_type": "code",
-                        "scope": "openid profile",
-                        "state": "Vz6G2zZf95/FCOQALrpvd4bS6jx5xvRos2pVldFAiw4="
+                    "completedAt": 1743012484363,
+                    "elapsedTime": 63604,
+                    "initiatedAt": 1743012420759,
+                    "prompts": [
+                        {
+                            "completedAt": 1743012449133,
+                            "connection": "example-users",
+                            "connection_id": "con_Abc4hRDDmVrZWomi",
+                            "elapsedTime": 649,
+                            "identity": 12345,
+                            "initiatedAt": 1743012448484,
+                            "name": "lock-password-authenticate",
+                            "stats": {
+                                "loginsCount": 5
+                            },
+                            "strategy": "auth0"
+                        },
+                        {
+                            "completedAt": 1743012449137,
+                            "elapsedTime": 28376,
+                            "flow": "login",
+                            "initiatedAt": 1743012420761,
+                            "name": "login",
+                            "timers": {
+                                "rules": 626
+                            },
+                            "user_id": "auth0|12345",
+                            "user_name": "jdoe@example.com"
+                        },
+                        {
+                            "completedAt": 1743012484145,
+                            "elapsedTime": 34160,
+                            "flow": "mfa",
+                            "initiatedAt": 1743012449985,
+                            "name": "mfa",
+                            "performed_acr": [
+                                "http://schemas.openid.net/pape/policies/2007/06/multi-factor"
+                            ],
+                            "performed_amr": [
+                                "mfa"
+                            ],
+                            "provider": "guardian"
+                        }
+                    ],
+                    "session_id": "abcKFtsdFoVQqpf-a4gjQIXe1pMdM5kAH",
+                    "stats": {
+                        "loginsCount": 5
                     }
                 },
-                "hostname": "dev-yoj8axza.au.auth0.com",
-                "type": "Failed login",
-                "type_id": "f"
+                "hostname": "auth.example.com",
+                "is_mobile": false,
+                "login": {
+                    "completedAt": "2025-03-26T18:08:04.363Z",
+                    "elapsedTime": 63604,
+                    "initiatedAt": "2025-03-26T18:07:00.759Z",
+                    "stats": {
+                        "loginsCount": 5
+                    }
+                },
+                "strategy": "auth0",
+                "strategy_type": "database",
+                "tenant_name": "example-apps",
+                "type": "Successful login",
+                "type_id": "s"
             }
         }
     },
     "data_stream": {
         "dataset": "auth0.logs",
-        "namespace": "26539",
+        "namespace": "61704",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "69cd4013-cce1-4df6-b3fb-6f59a9969e32",
+        "id": "fb7f48ab-5817-4c31-8e7b-0d943895ca0d",
         "snapshot": false,
-        "version": "8.13.0"
+        "version": "8.17.3"
     },
     "event": {
-        "action": "failed-login",
+        "action": "successful-login",
         "agent_id_status": "verified",
         "category": [
-            "authentication"
+            "authentication",
+            "session"
         ],
         "dataset": "auth0.logs",
-        "id": "90020211103030609732115389415260839021644201259064885298",
-        "ingested": "2025-02-18T00:59:52Z",
+        "id": "90020250315180807266045000000000000001223372126167226037",
+        "ingested": "2025-04-01T10:59:14Z",
         "kind": "event",
-        "original": "{\"data\":{\"connection_id\":\"\",\"date\":\"2021-11-03T03:06:05.696Z\",\"description\":\"Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs\",\"details\":{\"body\":{},\"error\":{\"message\":\"Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs\",\"oauthError\":\"Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs. Please go to 'https://manage.auth0.com/#/applications/aI61p8I8aFjmYRliLWgvM9ev97kCCNDB/settings' and make sure you are sending the same callback url from your application.\",\"payload\":{\"attempt\":\"http://localhost:3000/callback\",\"authorized\":[],\"client\":{\"clientID\":\"aI61p8I8aFjmYRliLWgvM9ev97kCCNDB\"},\"code\":\"unauthorized_client\",\"message\":\"Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs\",\"name\":\"CallbackMismatchError\",\"status\":403},\"type\":\"callback-url-mismatch\"},\"qs\":{\"client_id\":\"aI61p8I8aFjmYRliLWgvM9ev97kCCNDB\",\"redirect_uri\":\"http://localhost:3000/callback\",\"response_type\":\"code\",\"scope\":\"openid profile\",\"state\":\"Vz6G2zZf95/FCOQALrpvd4bS6jx5xvRos2pVldFAiw4=\"}},\"hostname\":\"dev-yoj8axza.au.auth0.com\",\"ip\":\"81.2.69.143\",\"log_id\":\"90020211103030609732115389415260839021644201259064885298\",\"type\":\"f\",\"user_agent\":\"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0\"},\"log_id\":\"90020211103030609732115389415260839021644201259064885298\"}",
-        "outcome": "failure",
+        "outcome": "success",
         "type": [
-            "info"
+            "info",
+            "start"
         ]
     },
     "input": {
-        "type": "http_endpoint"
+        "type": "cel"
     },
     "log": {
-        "level": "error"
+        "level": "info"
     },
     "network": {
         "type": "ipv4"
     },
     "source": {
-        "geo": {
-            "city_name": "London",
-            "continent_name": "Europe",
-            "country_iso_code": "GB",
-            "country_name": "United Kingdom",
-            "location": {
-                "lat": 51.5142,
-                "lon": -0.0931
-            },
-            "region_iso_code": "GB-ENG",
-            "region_name": "England"
-        },
-        "ip": "81.2.69.143"
+        "ip": "192.168.1.1"
     },
     "tags": [
         "preserve_original_event",
         "forwarded",
         "auth0-logstream"
     ],
+    "user": {
+        "id": "auth0|12345",
+        "name": "jdoe@example.com"
+    },
     "user_agent": {
         "device": {
             "name": "Other"
         },
-        "name": "Firefox",
-        "original": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0",
+        "name": "Other",
+        "original": "Chrome 134.0.0 / Windows 10.0.0",
         "os": {
-            "name": "Ubuntu"
-        },
-        "version": "93.0."
+            "full": "Windows 10",
+            "name": "Windows",
+            "version": "10"
+        }
     }
 }

--- a/packages/auth0/docs/README.md
+++ b/packages/auth0/docs/README.md
@@ -118,118 +118,158 @@ An example event for `logs` looks as following:
 
 ```json
 {
-    "@timestamp": "2021-11-03T03:06:05.696Z",
+    "@timestamp": "2025-03-15T18:08:04.365Z",
     "agent": {
-        "ephemeral_id": "43a5c1c4-07f0-45c2-b500-d13f835a029b",
-        "id": "69cd4013-cce1-4df6-b3fb-6f59a9969e32",
-        "name": "elastic-agent-38349",
+        "ephemeral_id": "e052c974-795f-41ed-802f-69f92e97d682",
+        "id": "fb7f48ab-5817-4c31-8e7b-0d943895ca0d",
+        "name": "elastic-agent-79075",
         "type": "filebeat",
-        "version": "8.13.0"
+        "version": "8.17.3"
     },
     "auth0": {
         "logs": {
             "data": {
-                "classification": "Login - Failure",
-                "date": "2021-11-03T03:06:05.696Z",
-                "description": "Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs",
+                "classification": "Login - Success",
+                "client_id": "A123v04ZMgorp521yX4lIyeI9nYIuwGP",
+                "client_name": "XYZ",
+                "connection": "example-users",
+                "connection_id": "con_Abc4hRDDmVrZWomi",
+                "date": "2025-03-15T18:08:04.365Z",
                 "details": {
-                    "error": {
-                        "message": "Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs",
-                        "oauthError": "Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs. Please go to 'https://manage.auth0.com/#/applications/aI61p8I8aFjmYRliLWgvM9ev97kCCNDB/settings' and make sure you are sending the same callback url from your application.",
-                        "payload": {
-                            "attempt": "http://localhost:3000/callback",
-                            "client": {
-                                "clientID": "aI61p8I8aFjmYRliLWgvM9ev97kCCNDB"
-                            },
-                            "code": "unauthorized_client",
-                            "message": "Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs",
-                            "name": "CallbackMismatchError",
-                            "status": 403
-                        },
-                        "type": "callback-url-mismatch"
+                    "actions": {
+                        "executions": [
+                            "ABCnLEtG3EJGfIJMP2UZms1pMjAyNTAzMja25rxa3ZNFXYDkKlwulvVB"
+                        ]
                     },
-                    "qs": {
-                        "client_id": "aI61p8I8aFjmYRliLWgvM9ev97kCCNDB",
-                        "redirect_uri": "http://localhost:3000/callback",
-                        "response_type": "code",
-                        "scope": "openid profile",
-                        "state": "Vz6G2zZf95/FCOQALrpvd4bS6jx5xvRos2pVldFAiw4="
+                    "completedAt": 1743012484363,
+                    "elapsedTime": 63604,
+                    "initiatedAt": 1743012420759,
+                    "prompts": [
+                        {
+                            "completedAt": 1743012449133,
+                            "connection": "example-users",
+                            "connection_id": "con_Abc4hRDDmVrZWomi",
+                            "elapsedTime": 649,
+                            "identity": 12345,
+                            "initiatedAt": 1743012448484,
+                            "name": "lock-password-authenticate",
+                            "stats": {
+                                "loginsCount": 5
+                            },
+                            "strategy": "auth0"
+                        },
+                        {
+                            "completedAt": 1743012449137,
+                            "elapsedTime": 28376,
+                            "flow": "login",
+                            "initiatedAt": 1743012420761,
+                            "name": "login",
+                            "timers": {
+                                "rules": 626
+                            },
+                            "user_id": "auth0|12345",
+                            "user_name": "jdoe@example.com"
+                        },
+                        {
+                            "completedAt": 1743012484145,
+                            "elapsedTime": 34160,
+                            "flow": "mfa",
+                            "initiatedAt": 1743012449985,
+                            "name": "mfa",
+                            "performed_acr": [
+                                "http://schemas.openid.net/pape/policies/2007/06/multi-factor"
+                            ],
+                            "performed_amr": [
+                                "mfa"
+                            ],
+                            "provider": "guardian"
+                        }
+                    ],
+                    "session_id": "abcKFtsdFoVQqpf-a4gjQIXe1pMdM5kAH",
+                    "stats": {
+                        "loginsCount": 5
                     }
                 },
-                "hostname": "dev-yoj8axza.au.auth0.com",
-                "type": "Failed login",
-                "type_id": "f"
+                "hostname": "auth.example.com",
+                "is_mobile": false,
+                "login": {
+                    "completedAt": "2025-03-26T18:08:04.363Z",
+                    "elapsedTime": 63604,
+                    "initiatedAt": "2025-03-26T18:07:00.759Z",
+                    "stats": {
+                        "loginsCount": 5
+                    }
+                },
+                "strategy": "auth0",
+                "strategy_type": "database",
+                "tenant_name": "example-apps",
+                "type": "Successful login",
+                "type_id": "s"
             }
         }
     },
     "data_stream": {
         "dataset": "auth0.logs",
-        "namespace": "26539",
+        "namespace": "61704",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "69cd4013-cce1-4df6-b3fb-6f59a9969e32",
+        "id": "fb7f48ab-5817-4c31-8e7b-0d943895ca0d",
         "snapshot": false,
-        "version": "8.13.0"
+        "version": "8.17.3"
     },
     "event": {
-        "action": "failed-login",
+        "action": "successful-login",
         "agent_id_status": "verified",
         "category": [
-            "authentication"
+            "authentication",
+            "session"
         ],
         "dataset": "auth0.logs",
-        "id": "90020211103030609732115389415260839021644201259064885298",
-        "ingested": "2025-02-18T00:59:52Z",
+        "id": "90020250315180807266045000000000000001223372126167226037",
+        "ingested": "2025-04-01T10:59:14Z",
         "kind": "event",
-        "original": "{\"data\":{\"connection_id\":\"\",\"date\":\"2021-11-03T03:06:05.696Z\",\"description\":\"Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs\",\"details\":{\"body\":{},\"error\":{\"message\":\"Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs\",\"oauthError\":\"Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs. Please go to 'https://manage.auth0.com/#/applications/aI61p8I8aFjmYRliLWgvM9ev97kCCNDB/settings' and make sure you are sending the same callback url from your application.\",\"payload\":{\"attempt\":\"http://localhost:3000/callback\",\"authorized\":[],\"client\":{\"clientID\":\"aI61p8I8aFjmYRliLWgvM9ev97kCCNDB\"},\"code\":\"unauthorized_client\",\"message\":\"Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs\",\"name\":\"CallbackMismatchError\",\"status\":403},\"type\":\"callback-url-mismatch\"},\"qs\":{\"client_id\":\"aI61p8I8aFjmYRliLWgvM9ev97kCCNDB\",\"redirect_uri\":\"http://localhost:3000/callback\",\"response_type\":\"code\",\"scope\":\"openid profile\",\"state\":\"Vz6G2zZf95/FCOQALrpvd4bS6jx5xvRos2pVldFAiw4=\"}},\"hostname\":\"dev-yoj8axza.au.auth0.com\",\"ip\":\"81.2.69.143\",\"log_id\":\"90020211103030609732115389415260839021644201259064885298\",\"type\":\"f\",\"user_agent\":\"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0\"},\"log_id\":\"90020211103030609732115389415260839021644201259064885298\"}",
-        "outcome": "failure",
+        "outcome": "success",
         "type": [
-            "info"
+            "info",
+            "start"
         ]
     },
     "input": {
-        "type": "http_endpoint"
+        "type": "cel"
     },
     "log": {
-        "level": "error"
+        "level": "info"
     },
     "network": {
         "type": "ipv4"
     },
     "source": {
-        "geo": {
-            "city_name": "London",
-            "continent_name": "Europe",
-            "country_iso_code": "GB",
-            "country_name": "United Kingdom",
-            "location": {
-                "lat": 51.5142,
-                "lon": -0.0931
-            },
-            "region_iso_code": "GB-ENG",
-            "region_name": "England"
-        },
-        "ip": "81.2.69.143"
+        "ip": "192.168.1.1"
     },
     "tags": [
         "preserve_original_event",
         "forwarded",
         "auth0-logstream"
     ],
+    "user": {
+        "id": "auth0|12345",
+        "name": "jdoe@example.com"
+    },
     "user_agent": {
         "device": {
             "name": "Other"
         },
-        "name": "Firefox",
-        "original": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0",
+        "name": "Other",
+        "original": "Chrome 134.0.0 / Windows 10.0.0",
         "os": {
-            "name": "Ubuntu"
-        },
-        "version": "93.0."
+            "full": "Windows 10",
+            "name": "Windows",
+            "version": "10"
+        }
     }
 }
 ```

--- a/packages/auth0/manifest.yml
+++ b/packages/auth0/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: auth0
 title: "Auth0"
-version: "1.21.0"
+version: "1.21.1"
 description: Collect logs from Auth0 with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Type of change
- Bug

## Proposed commit message
```
Under some circumstances when using the CEL input, the response can
be sent un-encoded,  since the CEL input sends it as a raw json to the
ingest pipeline to maintain compatibility, this can cause the date
processor to break when parsing the  fields
"auth0.logs.data.details.initiatedAt" and "auth0.logs.data.details.completedAt" as dates are interpreted
in  scientific notation, eg: "1.743012420759E12". This PR adds two
conversion scripts that fixes it by converting this  string notation to a
proper numeric value understood by the date processor.
```
## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
