### PR TITLE
Update link for tips building integrations documentation

### DIFF
--- a/docs/tips_for_building_integrations.md
+++ b/docs/tips_for_building_integrations.md
@@ -1,1 +1,1 @@
-**This content has moved. Please see the [Integrations Developer Guide](https://www.elastic.co/guide/en/integrations-developer/current/developer-workflow-import-beat.html) instead.**
+**This content has moved. Please see the [Integrations Developer Guide](https://www.elastic.co/guide/en/integrations-developer/current/tips-for-building.html) instead.**


### PR DESCRIPTION
## Proposed commit message

Update link to tips building integrations documentation.

This link is also used as part of the GitHub Pull Request template:
https://github.com/elastic/integrations/blob/b0dbc03952c9c55dae129b2eb7bf8401f8ad6c7a/.github/PULL_REQUEST_TEMPLATE.md?plain=1#L32

