### PR TITLE
entityanalytics_entra_id: Add "event.original" field when "preserve_original_event" is set.

### DIFF
--- a/packages/entityanalytics_entra_id/changelog.yml
+++ b/packages/entityanalytics_entra_id/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.0"
+  changes:
+    - description: Add "event.original" field when "preserve_original_event" is set.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.6.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/entityanalytics_entra_id/changelog.yml
+++ b/packages/entityanalytics_entra_id/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add "event.original" field when "preserve_original_event" is set.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/13378
 - version: "1.6.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/entityanalytics_entra_id/data_stream/entity/_dev/test/pipeline/test-common-config.yml
+++ b/packages/entityanalytics_entra_id/data_stream/entity/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,4 @@
 fields:
   tags:
+    - preserve_original_event
     - preserve_duplicate_custom_fields

--- a/packages/entityanalytics_entra_id/data_stream/entity/_dev/test/pipeline/test-device.json-expected.json
+++ b/packages/entityanalytics_entra_id/data_stream/entity/_dev/test/pipeline/test-device.json-expected.json
@@ -58,6 +58,7 @@
                     "host"
                 ],
                 "kind": "asset",
+                "original": "{\"@timestamp\":\"2022-11-04T09:57:19.786056-05:00\",\"azure_ad\":{\"operatingSystemVersion\":\"10.0.19043.1337\",\"displayName\":\"DESKTOP-LETW452G\",\"alternativeSecurityIds\":[{\"type\":2,\"identityProvider\":null,\"key\":\"DGFSGHSGGTH345A...35DSFH0A\"}],\"operatingSystem\":\"Windows\",\"accountEnabled\":true},\"ecs\":{\"version\":\"8.11.0\"},\"event\":{\"action\":\"device-discovered\"},\"device\":{\"id\":\"2fbbb8f9-ff67-4a21-b867-a344d18a4198\",\"group\":[{\"name\":\"group1\",\"id\":\"331676df-b8fd-4492-82ed-02b927f8dd80\"}]},\"labels\":{\"identity_source\":\"azure-1\"},\"tags\":[\"preserve_original_event\",\"preserve_duplicate_custom_fields\"],\"_index\":\"logs-entityanalytics_entra_id.entity-default\",\"_id\":\"_id\",\"_version\":-3}",
                 "type": [
                     "info"
                 ]
@@ -80,6 +81,7 @@
                 ]
             },
             "tags": [
+                "preserve_original_event",
                 "preserve_duplicate_custom_fields"
             ]
         },
@@ -202,6 +204,7 @@
                     "host"
                 ],
                 "kind": "asset",
+                "original": "{\"@timestamp\":\"2022-11-04T09:57:19.786056-05:00\",\"azure_ad\":{\"operatingSystemVersion\":\"10.0.19043.1337\",\"displayName\":\"DESKTOP-LETW452G\",\"alternativeSecurityIds\":[{\"type\":2,\"identityProvider\":null,\"key\":\"DGFSGHSGGTH345A...35DSFH0A\"}],\"deviceId\":\"2fbbb8f9-ff67-4a21-b867-a344d18a4198\",\"operatingSystem\":\"Windows\",\"accountEnabled\":true},\"ecs\":{\"version\":\"8.11.0\"},\"event\":{\"action\":\"device-discovered\"},\"device\":{\"registered_users\":[{\"businessPhones\":[\"123-555-0122\"],\"mail\":\"example.user@example.com\",\"mobilePhone\":\"123-555-1000\",\"displayName\":\"Example User\",\"surname\":\"User\",\"givenName\":\"Example\",\"jobTitle\":\"Software Engineer\",\"id\":\"5ebc6a0f-05b7-4f42-9c8a-682bbc75d0fc\",\"userPrincipalName\":\"example.user@example.com\"}],\"registered_owners\":[{\"businessPhones\":[\"123-555-0122\"],\"mail\":\"example.user@example.com\",\"mobilePhone\":\"123-555-1000\",\"displayName\":\"Example User\",\"surname\":\"User\",\"givenName\":\"Example\",\"jobTitle\":\"Software Engineer\",\"id\":\"5ebc6a0f-05b7-4f42-9c8a-682bbc75d0fc\",\"userPrincipalName\":\"example.user@example.com\"}],\"id\":\"adbbe40a-0627-4328-89f1-88cac84dbc7f\",\"group\":[{\"name\":\"group1\",\"id\":\"331676df-b8fd-4492-82ed-02b927f8dd80\"}]},\"labels\":{\"identity_source\":\"azure-1\"},\"tags\":[\"preserve_original_event\",\"preserve_duplicate_custom_fields\"],\"_index\":\"logs-entityanalytics_entra_id.entity-default\",\"_id\":\"_id\",\"_version\":-3}",
                 "type": [
                     "info"
                 ]
@@ -228,6 +231,7 @@
                 ]
             },
             "tags": [
+                "preserve_original_event",
                 "preserve_duplicate_custom_fields"
             ]
         }

--- a/packages/entityanalytics_entra_id/data_stream/entity/_dev/test/pipeline/test-users.json-expected.json
+++ b/packages/entityanalytics_entra_id/data_stream/entity/_dev/test/pipeline/test-users.json-expected.json
@@ -58,6 +58,7 @@
                     "iam"
                 ],
                 "kind": "asset",
+                "original": "{\"@timestamp\":\"2023-03-06T10:07:13.883Z\",\"azure_ad\":{\"businessPhones\":[\"55-692-8856\",\"552-265-6614\"],\"mail\":\"First21480_Last11836@example.com\",\"mobilePhone\":\"231-482-2649\",\"officeLocation\":\"608 St N, Somewhere, ABC, XYZ\",\"displayName\":\"First21480 Last11836\",\"surname\":\"Last11836\",\"givenName\":\"First21480\",\"jobTitle\":\"Manager\",\"accountEnabled\":true,\"userPrincipalName\":\"First21480.Last11836@example.com\"},\"ecs\":{\"version\":\"8.11.0\"},\"event\":{\"action\":\"user-discovered\"},\"user\":{\"id\":\"aa534e49-edfd-4541-8256-8bbf34f122b4\",\"group\":[{\"name\":\"Group 5202\",\"id\":\"e7089e3a-2c83-4f08-8280-7530ed39b6ca\"},{\"name\":\"Group 16739\",\"id\":\"526588ce-2828-4cb1-9c9b-e57026e94b82\"}]},\"labels\":{\"identity_source\":\"entra_id-1\"},\"tags\":[\"preserve_original_event\",\"preserve_duplicate_custom_fields\"],\"_index\":\"logs-entityanalytics_entra_id.entity-default\",\"_id\":\"_id\",\"_version\":-3}",
                 "type": [
                     "user",
                     "info"
@@ -75,6 +76,7 @@
                 ]
             },
             "tags": [
+                "preserve_original_event",
                 "preserve_duplicate_custom_fields"
             ],
             "user": {
@@ -152,6 +154,7 @@
                     "iam"
                 ],
                 "kind": "asset",
+                "original": "{\"@timestamp\":\"2023-03-06T10:07:13.883Z\",\"azure_ad\":{\"businessPhones\":null,\"mail\":\"First45375_Last58638@example.com\",\"mobilePhone\":\"385-169-3671\",\"officeLocation\":\"682 St N, Somewhere, ABC, XYZ\",\"displayName\":\"First45375 Last58638\",\"surname\":\"Last58638\",\"givenName\":\"First45375\",\"jobTitle\":\"Tech Writer\",\"accountEnabled\":false,\"userPrincipalName\":\"First45375.Last58638@example.com\"},\"ecs\":{\"version\":\"8.11.0\"},\"event\":{\"action\":\"user-discovered\"},\"user\":{\"id\":\"feb6a386-612a-4ed1-9b13-2adc73074a19\",\"group\":[{\"name\":\"Group 5202\",\"id\":\"e7089e3a-2c83-4f08-8280-7530ed39b6ca\"}]},\"labels\":{\"identity_source\":\"entra_id-1\"},\"tags\":[\"preserve_original_event\",\"preserve_duplicate_custom_fields\"],\"_index\":\"logs-entityanalytics_entra_id.entity-default\",\"_id\":\"_id\",\"_version\":-3}",
                 "type": [
                     "user",
                     "info"
@@ -169,6 +172,7 @@
                 ]
             },
             "tags": [
+                "preserve_original_event",
                 "preserve_duplicate_custom_fields"
             ],
             "user": {

--- a/packages/entityanalytics_entra_id/data_stream/entity/_dev/test/system/test-default-config.yml
+++ b/packages/entityanalytics_entra_id/data_stream/entity/_dev/test/system/test-default-config.yml
@@ -9,3 +9,4 @@ data_stream:
     api_endpoint: http://{{Hostname}}:{{Port}}/v1.0
     dataset: all
     enable_request_tracer: true
+    preserve_original_event: true

--- a/packages/entityanalytics_entra_id/data_stream/entity/agent/stream/entity-analytics.yml.hbs
+++ b/packages/entityanalytics_entra_id/data_stream/entity/agent/stream/entity-analytics.yml.hbs
@@ -30,6 +30,9 @@ timeout: {{http_client_timeout}}
 {{/if}}
 tags:
   - {{dataset}}-entities
+{{#if preserve_original_event}}
+  - preserve_original_event
+{{/if}}
 {{#if preserve_duplicate_custom_fields}}
   - preserve_duplicate_custom_fields
 {{/if}}

--- a/packages/entityanalytics_entra_id/data_stream/entity/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/entityanalytics_entra_id/data_stream/entity/elasticsearch/ingest_pipeline/default.yml
@@ -6,6 +6,19 @@ processors:
       tag: set_ecs_version
       value: 8.11.0
 
+  - script:
+      tag: script_add_event_original
+      lang: painless
+      description: Add "event.original"
+      if: ctx.tags != null && ctx.tags.contains('preserve_original_event')
+      source: |
+        def stringified_orig = Json.dump(ctx);
+        if (stringified_orig != null) {
+          if (ctx.event == null) {
+            ctx.event = new HashMap();
+          }
+          ctx.event.original = stringified_orig;
+        }
   - remove:
       field: event.action
       if: ctx.event?.action != "started" && ctx.event?.action != "completed"

--- a/packages/entityanalytics_entra_id/data_stream/entity/manifest.yml
+++ b/packages/entityanalytics_entra_id/data_stream/entity/manifest.yml
@@ -148,6 +148,14 @@ streams:
         default:
           - forwarded
           - entityanalytics_entra_id-entity
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`.
+        type: bool
+        multi: false
+        default: false
       - name: preserve_duplicate_custom_fields
         required: true
         show_user: false

--- a/packages/entityanalytics_entra_id/data_stream/entity/sample_event.json
+++ b/packages/entityanalytics_entra_id/data_stream/entity/sample_event.json
@@ -1,41 +1,43 @@
 {
-    "@timestamp": "2023-10-10T18:07:24.682Z",
+    "@timestamp": "2025-04-01T18:07:36.482Z",
     "agent": {
-        "ephemeral_id": "f3f1bfb7-14d6-4f81-abf2-96c6d4a03158",
-        "id": "15e5a007-7f90-47f5-be2c-f8f167a4d8ba",
-        "name": "docker-fleet-agent",
+        "ephemeral_id": "91db5bd7-4c69-428c-83d2-01c1bf05ba7c",
+        "id": "c8d80307-c3e5-45ae-bb30-a0025259b7ae",
+        "name": "elastic-agent-65963",
         "type": "filebeat",
-        "version": "8.11.0"
+        "version": "8.15.1"
     },
     "data_stream": {
         "dataset": "entityanalytics_entra_id.entity",
-        "namespace": "ep",
+        "namespace": "55663",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "15e5a007-7f90-47f5-be2c-f8f167a4d8ba",
-        "snapshot": true,
-        "version": "8.11.0"
+        "id": "c8d80307-c3e5-45ae-bb30-a0025259b7ae",
+        "snapshot": false,
+        "version": "8.15.1"
     },
     "event": {
         "action": "started",
         "agent_id_status": "verified",
         "dataset": "entityanalytics_entra_id.entity",
-        "ingested": "2023-10-10T18:07:27Z",
+        "ingested": "2025-04-01T18:07:39Z",
         "kind": "asset",
-        "start": "2023-10-10T18:07:24.682Z"
+        "original": "{\"input\":{\"type\":\"entity-analytics\"},\"agent\":{\"name\":\"elastic-agent-65963\",\"id\":\"c8d80307-c3e5-45ae-bb30-a0025259b7ae\",\"type\":\"filebeat\",\"ephemeral_id\":\"91db5bd7-4c69-428c-83d2-01c1bf05ba7c\",\"version\":\"8.15.1\"},\"@timestamp\":\"2025-04-01T18:07:36.482Z\",\"ecs\":{\"version\":\"8.11.0\"},\"data_stream\":{\"namespace\":\"55663\",\"type\":\"logs\",\"dataset\":\"entityanalytics_entra_id.entity\"},\"elastic_agent\":{\"id\":\"c8d80307-c3e5-45ae-bb30-a0025259b7ae\",\"version\":\"8.15.1\",\"snapshot\":false},\"event\":{\"start\":\"2025-04-01T18:07:36.482Z\",\"action\":\"started\",\"dataset\":\"entityanalytics_entra_id.entity\"},\"labels\":{\"identity_source\":\"entity-analytics-entityanalytics_entra_id.entity-b4dd8d01-dde7-48c9-8b0f-9c1f991c2117\"},\"tags\":[\"all-entities\",\"preserve_original_event\",\"forwarded\",\"entityanalytics_entra_id-entity\"],\"_version_type\":\"internal\",\"_index\":\"logs-entityanalytics_entra_id.entity-55663\",\"_id\":null,\"_version\":-4}",
+        "start": "2025-04-01T18:07:36.482Z"
     },
     "input": {
         "type": "entity-analytics"
     },
     "labels": {
-        "identity_source": "entity-analytics-entityanalytics_entra_id.entity-790e3b22-3c7a-48ed-a5e8-9188d8ef1e1f"
+        "identity_source": "entity-analytics-entityanalytics_entra_id.entity-b4dd8d01-dde7-48c9-8b0f-9c1f991c2117"
     },
     "tags": [
         "all-entities",
+        "preserve_original_event",
         "forwarded",
         "entityanalytics_entra_id-entity"
     ]

--- a/packages/entityanalytics_entra_id/docs/README.md
+++ b/packages/entityanalytics_entra_id/docs/README.md
@@ -176,43 +176,45 @@ An example event for `entity` looks as following:
 
 ```json
 {
-    "@timestamp": "2023-10-10T18:07:24.682Z",
+    "@timestamp": "2025-04-01T18:07:36.482Z",
     "agent": {
-        "ephemeral_id": "f3f1bfb7-14d6-4f81-abf2-96c6d4a03158",
-        "id": "15e5a007-7f90-47f5-be2c-f8f167a4d8ba",
-        "name": "docker-fleet-agent",
+        "ephemeral_id": "91db5bd7-4c69-428c-83d2-01c1bf05ba7c",
+        "id": "c8d80307-c3e5-45ae-bb30-a0025259b7ae",
+        "name": "elastic-agent-65963",
         "type": "filebeat",
-        "version": "8.11.0"
+        "version": "8.15.1"
     },
     "data_stream": {
         "dataset": "entityanalytics_entra_id.entity",
-        "namespace": "ep",
+        "namespace": "55663",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "15e5a007-7f90-47f5-be2c-f8f167a4d8ba",
-        "snapshot": true,
-        "version": "8.11.0"
+        "id": "c8d80307-c3e5-45ae-bb30-a0025259b7ae",
+        "snapshot": false,
+        "version": "8.15.1"
     },
     "event": {
         "action": "started",
         "agent_id_status": "verified",
         "dataset": "entityanalytics_entra_id.entity",
-        "ingested": "2023-10-10T18:07:27Z",
+        "ingested": "2025-04-01T18:07:39Z",
         "kind": "asset",
-        "start": "2023-10-10T18:07:24.682Z"
+        "original": "{\"input\":{\"type\":\"entity-analytics\"},\"agent\":{\"name\":\"elastic-agent-65963\",\"id\":\"c8d80307-c3e5-45ae-bb30-a0025259b7ae\",\"type\":\"filebeat\",\"ephemeral_id\":\"91db5bd7-4c69-428c-83d2-01c1bf05ba7c\",\"version\":\"8.15.1\"},\"@timestamp\":\"2025-04-01T18:07:36.482Z\",\"ecs\":{\"version\":\"8.11.0\"},\"data_stream\":{\"namespace\":\"55663\",\"type\":\"logs\",\"dataset\":\"entityanalytics_entra_id.entity\"},\"elastic_agent\":{\"id\":\"c8d80307-c3e5-45ae-bb30-a0025259b7ae\",\"version\":\"8.15.1\",\"snapshot\":false},\"event\":{\"start\":\"2025-04-01T18:07:36.482Z\",\"action\":\"started\",\"dataset\":\"entityanalytics_entra_id.entity\"},\"labels\":{\"identity_source\":\"entity-analytics-entityanalytics_entra_id.entity-b4dd8d01-dde7-48c9-8b0f-9c1f991c2117\"},\"tags\":[\"all-entities\",\"preserve_original_event\",\"forwarded\",\"entityanalytics_entra_id-entity\"],\"_version_type\":\"internal\",\"_index\":\"logs-entityanalytics_entra_id.entity-55663\",\"_id\":null,\"_version\":-4}",
+        "start": "2025-04-01T18:07:36.482Z"
     },
     "input": {
         "type": "entity-analytics"
     },
     "labels": {
-        "identity_source": "entity-analytics-entityanalytics_entra_id.entity-790e3b22-3c7a-48ed-a5e8-9188d8ef1e1f"
+        "identity_source": "entity-analytics-entityanalytics_entra_id.entity-b4dd8d01-dde7-48c9-8b0f-9c1f991c2117"
     },
     "tags": [
         "all-entities",
+        "preserve_original_event",
         "forwarded",
         "entityanalytics_entra_id-entity"
     ]

--- a/packages/entityanalytics_entra_id/manifest.yml
+++ b/packages/entityanalytics_entra_id/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: entityanalytics_entra_id
 title: "Microsoft Entra ID Entity Analytics"
-version: "1.6.0"
+version: "1.7.0"
 description: "Collect identities from Microsoft Entra ID (formerly Azure Active Directory) with Elastic Agent."
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
Currently the integration doesn't have a way to preserve event.original.
Following a similar approach to #12206, this PR adds an option to 
preserve event.original.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Pipeline and system tests pass and populates `event.original` field.
```
--- Test results for package: entityanalytics_entra_id - START ---
╭──────────────────────────┬─────────────┬───────────┬─────────────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE                  │ DATA STREAM │ TEST TYPE │ TEST NAME                                   │ RESULT │ TIME ELAPSED │
├──────────────────────────┼─────────────┼───────────┼─────────────────────────────────────────────┼────────┼──────────────┤
│ entityanalytics_entra_id │ entity      │ pipeline  │ (ingest pipeline warnings test-device.json) │ PASS   │ 324.246667ms │
│ entityanalytics_entra_id │ entity      │ pipeline  │ (ingest pipeline warnings test-users.json)  │ PASS   │ 324.847875ms │
│ entityanalytics_entra_id │ entity      │ pipeline  │ test-device.json                            │ PASS   │  99.675125ms │
│ entityanalytics_entra_id │ entity      │ pipeline  │ test-users.json                             │ PASS   │       56.2ms │
╰──────────────────────────┴─────────────┴───────────┴─────────────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: entityanalytics_entra_id - END   ---
Done
```

```
--- Test results for package: entityanalytics_entra_id - START ---
╭──────────────────────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE                  │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├──────────────────────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ entityanalytics_entra_id │ entity      │ system    │ default   │ PASS   │ 34.761849666s │
╰──────────────────────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: entityanalytics_entra_id - END   ---
Done
```
