### PR TITLE
Set a default owner for new packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,8 @@
 # Everything outside of packages is maintained by the ecosystem team.
 * @elastic/ecosystem
-/packages/
+
+# Default owner of packages, which will triage new packages and assignment to other teams.
+/packages/ @elastic/ecosystem
 
 # CODEOWNERS file is checked by CI.
 /.github/CODEOWNERS


### PR DESCRIPTION
New packages may not be assigned to any team, so they can pass unnoticed.

Assign a default owner for the `/packages` directory, who should triage new packages and assign to the team actually maintaining the package.