### PR TITLE
[EDR Workflows] change the codeowner of osquery to security-defend-workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -317,7 +317,7 @@
 /packages/oracle @elastic/obs-infraobs-integrations
 /packages/oracle_weblogic @elastic/obs-infraobs-integrations
 /packages/osquery @elastic/sec-deployment-and-devices
-/packages/osquery_manager @elastic/security-asset-management
+/packages/osquery_manager @elastic/security-defend-workflows
 /packages/pad @elastic/ml-ui @elastic/sec-applied-ml
 /packages/panw @elastic/sec-deployment-and-devices
 /packages/panw_cortex_xdr @elastic/security-service-integrations

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -28,4 +28,4 @@ policy_templates:
         description: Send interactive or scheduled queries to the osquery instances executed by the elastic-agent.
 owner:
   type: elastic
-  github: elastic/security-asset-management
+  github: elastic/security-defend-workflows


### PR DESCRIPTION
## Proposed commit message

Change the code owner of the Osquery integration to `security-defend-workflows`

## Checklist

- [ ] ~~I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.~~
- [ ] ~~I have verified that all data streams collect metrics or logs.~~
- [ ] ~~I have added an entry to my package's `changelog.yml` file.~~
- [ ] ~~I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~~
- [ ] ~~I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

## Author's Checklist

Just verify the team name is right I guess?

## How to test this PR locally

No code changes.

## Related issues

None

## Screenshots

None