### PR TITLE
Logstash fix health report conditional cel logic

### DIFF
--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.7.1"
+  changes:
+    - description: Fixes the Logstash Health Report data stream to conditionally parse the pipeline state and flow fields.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/14000
 - version: "2.7.0"
   changes:
     - description: Add support for Kibana 9.0

--- a/packages/logstash/data_stream/health_report/agent/stream/stream.yml.hbs
+++ b/packages/logstash/data_stream/health_report/agent/stream/stream.yml.hbs
@@ -47,8 +47,8 @@ program: |
                             "id":pipeline_name,
                             "status":pipeline.status,
                             "symptom":pipeline.symptom,
-                            "state":pipeline.details.status.state,
-                            "flow": pipeline.details.flow,
+                            "state": has(pipeline.details.status.state) ? pipeline.details.status.state : {},
+                            "flow": has(pipeline.details.flow) ? pipeline.details.flow : {},
                             "diagnosis": has(pipeline.diagnosis) ? pipeline.diagnosis[0] : {},
                             "impacts": has(pipeline.impacts) ? pipeline.impacts[0] : {},
                         }

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -1,6 +1,6 @@
 name: logstash
 title: Logstash
-version: 2.7.0
+version: 2.7.1
 description: Collect logs and metrics from Logstash with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION

- Bug

## Proposed commit message

Check for pipeline.details for flow and state in cel for health report datastream to handle "unknown" status


## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [X] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## How to test this PR locally

Use of logstash integration no longer has cel parsing failures 

## Related issues

## Screenshots
