### PR TITLE
proofpoint_on_demand: set subobjects false to msg_parts.metadata field

### DIFF
--- a/packages/proofpoint_on_demand/changelog.yml
+++ b/packages/proofpoint_on_demand/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.1"
+  changes:
+    - description: Set subobjects false to `message.msg_parts.metadata` to avoid mapping conflicts.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "1.5.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/proofpoint_on_demand/changelog.yml
+++ b/packages/proofpoint_on_demand/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set subobjects false to `message.msg_parts.metadata` to avoid mapping conflicts.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/13421
 - version: "1.5.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/proofpoint_on_demand/data_stream/message/fields/fields.yml
+++ b/packages/proofpoint_on_demand/data_stream/message/fields/fields.yml
@@ -533,6 +533,8 @@
             - name: metadata
               type: object
               object_type: keyword
+              object_type_mapping_type: "*"
+              subobjects: false
               description: The metadata of the message part as reported by cvtd (interface to the document extraction engine).
             - name: sandbox_status
               type: keyword

--- a/packages/proofpoint_on_demand/manifest.yml
+++ b/packages/proofpoint_on_demand/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.4
 name: proofpoint_on_demand
 title: Proofpoint On Demand
-version: "1.5.0"
+version: "1.5.1"
 description: Collect logs from Proofpoint On Demand with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Applying `subobjects: false` to the `message.msg_parts.metadata` field in the messages data stream.

This object in source documents can look like:
```
"metadata": {
  "mxtype": "Documentation",
  "mxtype.localized": "Documentation",
  ...
}
```

Leading to the error when ingesting it:
```
(status=400): {"type":"illegal_argument_exception","reason":"can't merge a non object mapping [proofpoint_on_demand.message.msg_parts.metadata.mxtype] with an object mapping"}, dropping event!"
```

Setting `subobjects: false` so fields can be stored avoiding the nesting and the conflict.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
