### PR TITLE
ti_anomali: Add `initial_interval` parameter to API ingestion.

### DIFF
--- a/packages/ti_anomali/_dev/deploy/docker/files/intelligence-api-config.yml
+++ b/packages/ti_anomali/_dev/deploy/docker/files/intelligence-api-config.yml
@@ -58,6 +58,7 @@ rules:
     query_params:
       order_by: update_id
       modified_ts__lt: "{modified_ts__lt:.*}"
+      modified_ts__gt: "{modified_ts__gt:.*}"
       limit: "3"
       # update_id__gt: null
     responses:

--- a/packages/ti_anomali/changelog.yml
+++ b/packages/ti_anomali/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.26.2"
+  changes:
+    - description: Add initial_interval parameter to API ingestion.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.26.1"
   changes:
     - description: Fix lower bound query parameter in Threatstream API.

--- a/packages/ti_anomali/changelog.yml
+++ b/packages/ti_anomali/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add initial_interval parameter to API ingestion.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/113426
 - version: "1.26.1"
   changes:
     - description: Fix lower bound query parameter in Threatstream API.

--- a/packages/ti_anomali/data_stream/intelligence/_dev/test/system/test-default-config.yml
+++ b/packages/ti_anomali/data_stream/intelligence/_dev/test/system/test-default-config.yml
@@ -7,6 +7,7 @@ data_stream:
     api_key: test_api_key
     url: http://{{Hostname}}:{{Port}}
     interval: 5m
+    initial_interval: 24h
     page_size: 3
     enable_request_tracer: true
     ioc_duration_before_deletion: 7d

--- a/packages/ti_anomali/data_stream/intelligence/agent/stream/cel.yml.hbs
+++ b/packages/ti_anomali/data_stream/intelligence/agent/stream/cel.yml.hbs
@@ -39,7 +39,7 @@ program: |-
   		state.url.trim_right("/") + "/api/v2/intelligence/?" + {
   			"order_by": ["update_id"],
   			"modified_ts__lt": [(now - duration(state.delay)).format(time_layout.RFC3339)],
-  			?"modified_ts__gt": !has(state.cursor) ? optional.of([(now - duration(state.initial_interval)).format(time_layout.RFC3339)]) : optional.none(),
+  			?"modified_ts__gt": state.?cursor.last_update_id.orValue(null) == null ? optional.of([(now - duration(state.initial_interval)).format(time_layout.RFC3339)]) : optional.none(),
   			"limit": [string(state.page_size)],
   			?"update_id__gt": state.?cursor.last_update_id.optMap(id, [string(int(id))]),
   			?"remote_api": state.remote_api_true ? optional.of(["true"]) : optional.none(), // never set remote_api=false, only true or absent

--- a/packages/ti_anomali/data_stream/intelligence/agent/stream/cel.yml.hbs
+++ b/packages/ti_anomali/data_stream/intelligence/agent/stream/cel.yml.hbs
@@ -26,6 +26,7 @@ state:
   page_size: {{page_size}}
   remote_api_true: {{remote_api_true}}
   delay: 1m
+  initial_interval: {{initial_interval}}
   want_more: false
   preserve_original_event: {{preserve_original_event}}
 redact:
@@ -38,6 +39,7 @@ program: |-
   		state.url.trim_right("/") + "/api/v2/intelligence/?" + {
   			"order_by": ["update_id"],
   			"modified_ts__lt": [(now - duration(state.delay)).format(time_layout.RFC3339)],
+  			?"modified_ts__gt": !has(state.cursor) ? optional.of([(now - duration(state.initial_interval)).format(time_layout.RFC3339)]) : optional.none(),
   			"limit": [string(state.page_size)],
   			?"update_id__gt": state.?cursor.last_update_id.optMap(id, [string(int(id))]),
   			?"remote_api": state.remote_api_true ? optional.of(["true"]) : optional.none(), // never set remote_api=false, only true or absent

--- a/packages/ti_anomali/data_stream/intelligence/manifest.yml
+++ b/packages/ti_anomali/data_stream/intelligence/manifest.yml
@@ -32,11 +32,19 @@ streams:
       - name: interval
         type: text
         title: Interval
-        description: Duration between requests to the CrowdStrike Falcon Intelligence API. Supported units for this parameter are h/m/s.
+        description: Duration between requests to the Anomali ThreatStream API. Supported units for this parameter are h/m/s.
         default: 5m
         multi: false
         required: true
         show_user: true
+      - name: initial_interval
+        type: text
+        title: Initial Interval
+        multi: false
+        required: true
+        show_user: true
+        default: 2160h
+        description: How far back to pull the indicators from Anomali ThreatStream API. Defaults to 2160h i.e., 90 days. Supported units for this parameter are h/m/s.
       - name: ioc_duration_before_deletion
         type: text
         title: IOC Duration Before Deletion
@@ -45,10 +53,7 @@ streams:
         show_user: true
         default: "90d"
         description: >-
-          All IOCs are deleted after this duration. This setting is required to avoid "orphaned" IOCs that never expire.
-          If an earlier expiration time is set upstream, that will be used.
-          Use [Elasticsearch time units](https://www.elastic.co/guide/en/elasticsearch/reference/current/api-conventions.html#time-units)
-          to specify a duration in minutes, hours or days (e.g 10d).
+          All IOCs are deleted after this duration. This setting is required to avoid "orphaned" IOCs that never expire. If an earlier expiration time is set upstream, that will be used. Use [Elasticsearch time units](https://www.elastic.co/guide/en/elasticsearch/reference/current/api-conventions.html#time-units) to specify a duration in minutes, hours or days (e.g 10d).
       - name: preserve_original_event
         required: true
         show_user: true
@@ -64,10 +69,7 @@ streams:
         required: false
         show_user: false
         description: >-
-          The request tracer logs requests and responses to the agent's local file-system for debugging configurations.
-          Enabling this request tracing compromises security and should only be used for debugging.
-          See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_filename)
-          for details.
+          The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_filename) for details.
       - name: remote_api_true
         type: bool
         title: Get remote observables
@@ -76,9 +78,7 @@ streams:
         show_user: false
         default: false
         description: >-
-          Get remote observables (for ThreatStream OnPrem only).
-          This attribute does not need to be set to retrieve local observables.
-          Only use this when retrieving remote observables from ThreatStream Cloud.
+          Get remote observables (for ThreatStream OnPrem only). This attribute does not need to be set to retrieve local observables. Only use this when retrieving remote observables from ThreatStream Cloud.
       - name: page_size
         type: integer
         title: Page Size
@@ -111,6 +111,4 @@ streams:
         required: false
         show_user: false
         description: >-
-          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata.
-          This executes in the agent before the logs are parsed.
-          See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.

--- a/packages/ti_anomali/data_stream/intelligence/sample_event.json
+++ b/packages/ti_anomali/data_stream/intelligence/sample_event.json
@@ -1,48 +1,48 @@
 {
-    "@timestamp": "2025-02-12T10:26:45.318654640Z",
+    "@timestamp": "2025-04-04T11:44:07.880474718Z",
     "agent": {
-        "ephemeral_id": "434f328f-443d-4cd9-aad8-717d835a2312",
-        "id": "c48e3b22-841c-4ed3-ba7f-a039638b8e1b",
-        "name": "elastic-agent-54553",
+        "ephemeral_id": "35ff0c62-c4fc-4cfb-9455-6964c2bbd56e",
+        "id": "bdebf2ec-527b-43f5-abb5-78f3826c5e53",
+        "name": "elastic-agent-96548",
         "type": "filebeat",
         "version": "8.13.0"
     },
     "anomali": {
         "threatstream": {
             "can_add_public_tags": true,
-            "confidence": 12,
-            "deletion_scheduled_at": "2025-02-19T10:26:45.31865464Z",
+            "confidence": 60,
+            "deletion_scheduled_at": "2025-04-11T11:44:07.880474718Z",
             "expiration_ts": "9999-12-31T00:00:00.000Z",
             "feed_id": 0,
-            "id": "235548914",
+            "id": "232020126",
             "is_anonymous": false,
             "is_editable": false,
             "is_public": true,
-            "itype": "apt_email",
+            "itype": "apt_domain",
             "meta": {
-                "severity": "medium"
+                "severity": "very-high"
             },
-            "owner_organization_id": 70,
+            "owner_organization_id": 67,
             "retina_confidence": -1,
-            "source_reported_confidence": 12,
+            "source_reported_confidence": 60,
             "status": "active",
             "threat_type": "apt",
-            "type": "email",
-            "update_id": 100000002,
-            "uuid": "bc5a223e-f7a1-4acb-b50b-c81395e34218",
-            "value": "edc2@wsx.com"
+            "type": "domain",
+            "update_id": 100000001,
+            "uuid": "0921be47-9cc2-4265-b896-c62a7cb91042",
+            "value": "gen1xyz.com"
         }
     },
     "data_stream": {
         "dataset": "ti_anomali.intelligence",
-        "namespace": "29572",
+        "namespace": "62702",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "c48e3b22-841c-4ed3-ba7f-a039638b8e1b",
+        "id": "bdebf2ec-527b-43f5-abb5-78f3826c5e53",
         "snapshot": false,
         "version": "8.13.0"
     },
@@ -51,12 +51,12 @@
         "category": [
             "threat"
         ],
-        "created": "2021-04-29T16:00:35.529Z",
+        "created": "2021-04-06T09:56:22.915Z",
         "dataset": "ti_anomali.intelligence",
-        "ingested": "2025-02-12T10:26:45Z",
+        "ingested": "2025-04-04T11:44:07Z",
         "kind": "enrichment",
-        "original": "{\"asn\":\"\",\"can_add_public_tags\":true,\"confidence\":12,\"created_by\":null,\"created_ts\":\"2021-04-29T16:00:35.529Z\",\"description\":null,\"expiration_ts\":\"9999-12-31T00:00:00.000Z\",\"feed_id\":0,\"id\":235548914,\"is_anonymous\":false,\"is_editable\":false,\"is_public\":true,\"itype\":\"apt_email\",\"locations\":[],\"meta\":{\"detail2\":\"imported by user 142\",\"severity\":\"medium\"},\"modified_ts\":\"2021-04-29T16:00:35.529Z\",\"org\":\"\",\"owner_organization_id\":70,\"rdns\":null,\"resource_uri\":\"/api/v2/intelligence/235548914/\",\"retina_confidence\":-1,\"sort\":[467407026],\"source\":\"Analyst\",\"source_locations\":[],\"source_reported_confidence\":12,\"status\":\"active\",\"subtype\":null,\"tags\":null,\"target_industry\":[],\"threat_type\":\"apt\",\"threatscore\":9,\"tlp\":null,\"trusted_circle_ids\":null,\"type\":\"email\",\"update_id\":100000002,\"uuid\":\"bc5a223e-f7a1-4acb-b50b-c81395e34218\",\"value\":\"edc2@wsx.com\",\"workgroups\":[]}",
-        "severity": 5,
+        "original": "{\"asn\":\"\",\"can_add_public_tags\":true,\"confidence\":60,\"created_by\":null,\"created_ts\":\"2021-04-06T09:56:22.915Z\",\"description\":null,\"expiration_ts\":\"9999-12-31T00:00:00.000Z\",\"feed_id\":0,\"id\":232020126,\"is_anonymous\":false,\"is_editable\":false,\"is_public\":true,\"itype\":\"apt_domain\",\"locations\":[],\"meta\":{\"detail2\":\"imported by user 136\",\"severity\":\"very-high\"},\"modified_ts\":\"2021-04-06T09:56:22.915Z\",\"org\":\"\",\"owner_organization_id\":67,\"rdns\":null,\"resource_uri\":\"/api/v2/intelligence/232020126/\",\"retina_confidence\":-1,\"sort\":[455403032],\"source\":\"Analyst\",\"source_locations\":[],\"source_reported_confidence\":60,\"status\":\"active\",\"subtype\":null,\"tags\":null,\"target_industry\":[],\"threat_type\":\"apt\",\"threatscore\":54,\"tlp\":null,\"trusted_circle_ids\":null,\"type\":\"domain\",\"update_id\":100000001,\"uuid\":\"0921be47-9cc2-4265-b896-c62a7cb91042\",\"value\":\"gen1xyz.com\",\"workgroups\":[]}",
+        "severity": 9,
         "type": [
             "indicator"
         ]
@@ -71,16 +71,16 @@
     ],
     "threat": {
         "indicator": {
-            "confidence": "Low",
-            "email": {
-                "address": "edc2@wsx.com"
-            },
+            "confidence": "Medium",
             "marking": {
                 "tlp": "WHITE"
             },
-            "modified_at": "2021-04-29T16:00:35.529Z",
+            "modified_at": "2021-04-06T09:56:22.915Z",
             "provider": "Analyst",
-            "type": "email-addr"
+            "type": "domain-name",
+            "url": {
+                "domain": "gen1xyz.com"
+            }
         }
     }
 }

--- a/packages/ti_anomali/docs/README.md
+++ b/packages/ti_anomali/docs/README.md
@@ -41,50 +41,50 @@ An example event for `intelligence` looks as following:
 
 ```json
 {
-    "@timestamp": "2025-02-12T10:26:45.318654640Z",
+    "@timestamp": "2025-04-04T11:44:07.880474718Z",
     "agent": {
-        "ephemeral_id": "434f328f-443d-4cd9-aad8-717d835a2312",
-        "id": "c48e3b22-841c-4ed3-ba7f-a039638b8e1b",
-        "name": "elastic-agent-54553",
+        "ephemeral_id": "35ff0c62-c4fc-4cfb-9455-6964c2bbd56e",
+        "id": "bdebf2ec-527b-43f5-abb5-78f3826c5e53",
+        "name": "elastic-agent-96548",
         "type": "filebeat",
         "version": "8.13.0"
     },
     "anomali": {
         "threatstream": {
             "can_add_public_tags": true,
-            "confidence": 12,
-            "deletion_scheduled_at": "2025-02-19T10:26:45.31865464Z",
+            "confidence": 60,
+            "deletion_scheduled_at": "2025-04-11T11:44:07.880474718Z",
             "expiration_ts": "9999-12-31T00:00:00.000Z",
             "feed_id": 0,
-            "id": "235548914",
+            "id": "232020126",
             "is_anonymous": false,
             "is_editable": false,
             "is_public": true,
-            "itype": "apt_email",
+            "itype": "apt_domain",
             "meta": {
-                "severity": "medium"
+                "severity": "very-high"
             },
-            "owner_organization_id": 70,
+            "owner_organization_id": 67,
             "retina_confidence": -1,
-            "source_reported_confidence": 12,
+            "source_reported_confidence": 60,
             "status": "active",
             "threat_type": "apt",
-            "type": "email",
-            "update_id": 100000002,
-            "uuid": "bc5a223e-f7a1-4acb-b50b-c81395e34218",
-            "value": "edc2@wsx.com"
+            "type": "domain",
+            "update_id": 100000001,
+            "uuid": "0921be47-9cc2-4265-b896-c62a7cb91042",
+            "value": "gen1xyz.com"
         }
     },
     "data_stream": {
         "dataset": "ti_anomali.intelligence",
-        "namespace": "29572",
+        "namespace": "62702",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "c48e3b22-841c-4ed3-ba7f-a039638b8e1b",
+        "id": "bdebf2ec-527b-43f5-abb5-78f3826c5e53",
         "snapshot": false,
         "version": "8.13.0"
     },
@@ -93,12 +93,12 @@ An example event for `intelligence` looks as following:
         "category": [
             "threat"
         ],
-        "created": "2021-04-29T16:00:35.529Z",
+        "created": "2021-04-06T09:56:22.915Z",
         "dataset": "ti_anomali.intelligence",
-        "ingested": "2025-02-12T10:26:45Z",
+        "ingested": "2025-04-04T11:44:07Z",
         "kind": "enrichment",
-        "original": "{\"asn\":\"\",\"can_add_public_tags\":true,\"confidence\":12,\"created_by\":null,\"created_ts\":\"2021-04-29T16:00:35.529Z\",\"description\":null,\"expiration_ts\":\"9999-12-31T00:00:00.000Z\",\"feed_id\":0,\"id\":235548914,\"is_anonymous\":false,\"is_editable\":false,\"is_public\":true,\"itype\":\"apt_email\",\"locations\":[],\"meta\":{\"detail2\":\"imported by user 142\",\"severity\":\"medium\"},\"modified_ts\":\"2021-04-29T16:00:35.529Z\",\"org\":\"\",\"owner_organization_id\":70,\"rdns\":null,\"resource_uri\":\"/api/v2/intelligence/235548914/\",\"retina_confidence\":-1,\"sort\":[467407026],\"source\":\"Analyst\",\"source_locations\":[],\"source_reported_confidence\":12,\"status\":\"active\",\"subtype\":null,\"tags\":null,\"target_industry\":[],\"threat_type\":\"apt\",\"threatscore\":9,\"tlp\":null,\"trusted_circle_ids\":null,\"type\":\"email\",\"update_id\":100000002,\"uuid\":\"bc5a223e-f7a1-4acb-b50b-c81395e34218\",\"value\":\"edc2@wsx.com\",\"workgroups\":[]}",
-        "severity": 5,
+        "original": "{\"asn\":\"\",\"can_add_public_tags\":true,\"confidence\":60,\"created_by\":null,\"created_ts\":\"2021-04-06T09:56:22.915Z\",\"description\":null,\"expiration_ts\":\"9999-12-31T00:00:00.000Z\",\"feed_id\":0,\"id\":232020126,\"is_anonymous\":false,\"is_editable\":false,\"is_public\":true,\"itype\":\"apt_domain\",\"locations\":[],\"meta\":{\"detail2\":\"imported by user 136\",\"severity\":\"very-high\"},\"modified_ts\":\"2021-04-06T09:56:22.915Z\",\"org\":\"\",\"owner_organization_id\":67,\"rdns\":null,\"resource_uri\":\"/api/v2/intelligence/232020126/\",\"retina_confidence\":-1,\"sort\":[455403032],\"source\":\"Analyst\",\"source_locations\":[],\"source_reported_confidence\":60,\"status\":\"active\",\"subtype\":null,\"tags\":null,\"target_industry\":[],\"threat_type\":\"apt\",\"threatscore\":54,\"tlp\":null,\"trusted_circle_ids\":null,\"type\":\"domain\",\"update_id\":100000001,\"uuid\":\"0921be47-9cc2-4265-b896-c62a7cb91042\",\"value\":\"gen1xyz.com\",\"workgroups\":[]}",
+        "severity": 9,
         "type": [
             "indicator"
         ]
@@ -113,16 +113,16 @@ An example event for `intelligence` looks as following:
     ],
     "threat": {
         "indicator": {
-            "confidence": "Low",
-            "email": {
-                "address": "edc2@wsx.com"
-            },
+            "confidence": "Medium",
             "marking": {
                 "tlp": "WHITE"
             },
-            "modified_at": "2021-04-29T16:00:35.529Z",
+            "modified_at": "2021-04-06T09:56:22.915Z",
             "provider": "Analyst",
-            "type": "email-addr"
+            "type": "domain-name",
+            "url": {
+                "domain": "gen1xyz.com"
+            }
         }
     }
 }

--- a/packages/ti_anomali/manifest.yml
+++ b/packages/ti_anomali/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_anomali
 title: Anomali
-version: "1.26.1"
+version: "1.26.2"
 description: Ingest threat intelligence indicators from Anomali with Elastic Agent.
 type: integration
 format_version: 3.0.2


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
Without initial polling interval, users fetch indicators from years ago
as seen in their Anomali Threatstream.

Adding configurable `initial_interval` option (with default 90 days) 
will help users adjust how far back to fetch indicators from.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Added `initial_interval` option to system tests config. System tests should pass.

```
--- Test results for package: ti_anomali - START ---
╭────────────┬──────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE    │ DATA STREAM  │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├────────────┼──────────────┼───────────┼───────────┼────────┼───────────────┤
│ ti_anomali │ intelligence │ system    │ default   │ PASS   │ 37.072411042s │
╰────────────┴──────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: ti_anomali - END   ---
Done
```

