### PR TITLE
Fix Sign-in logs location.state field to region field

### DIFF
--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,8 +1,8 @@
 - version: "1.23.1"
   changes:
-    - description: Fix Geo Country name for backward compatibility field.
+    - description: Fix location.state field mapping from country_name to region_name.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/13439
 - version: "1.23.0"
   changes:
     - description: Enable Event Hub processor v2.

--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,7 +1,7 @@
 - version: "1.23.1"
   changes:
     - description: Fix Geo Country name for backward compatibility field.
-      type: enhancement
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/1
 - version: "1.23.0"
   changes:

--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.23.1"
+  changes:
+    - description: Fix Geo Country name for backward compatibility field.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.23.0"
   changes:
     - description: Enable Event Hub processor v2.

--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,6 +1,6 @@
 - version: "1.23.1"
   changes:
-    - description: Fix location.state field mapping from country_name to region_name.
+    - description: Map `azure.signinlogs.properties.location.state` field to `geo.region_name` instead of `geo.country_name`.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/13439
 - version: "1.23.0"

--- a/packages/azure/data_stream/signinlogs/_dev/test/pipeline/test-managed-identity-sample.log-expected.json
+++ b/packages/azure/data_stream/signinlogs/_dev/test/pipeline/test-managed-identity-sample.log-expected.json
@@ -14,7 +14,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "b3b975ac-995b-426e-8b5d-363a165df41c",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "ad8c289f-a81d-4959-bacc-c5774ab9baaa",
@@ -66,8 +65,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -101,7 +98,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "b3b975ac-995b-426e-8b5d-363a165df41c",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "4a7c5bd2-f1df-4c67-afe4-15b2e1dce594",
@@ -153,8 +149,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -188,7 +182,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "8e1e40fc-5ec1-4077-b595-08d5cf42fef4",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "a215db46-9d3b-4d28-8e0e-ae2363072d43",
@@ -240,8 +233,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -275,7 +266,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "8e1e40fc-5ec1-4077-b595-08d5cf42fef4",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "1a601004-5425-4eae-a060-50a6bcb22832",
@@ -327,8 +317,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -362,7 +350,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "6528e359-af96-4214-ba42-18723813e564",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "2e34efa6-8429-4f39-83d4-4fa0d71c959d",
@@ -414,8 +401,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -449,7 +434,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "8e1e40fc-5ec1-4077-b595-08d5cf42fef4",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "dbfd6e7f-a888-4daa-8336-fd56d2925be6",
@@ -501,8 +485,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -536,7 +518,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "6528e359-af96-4214-ba42-18723813e564",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "65962907-d329-422b-bc3b-2e818ec8ba47",
@@ -588,8 +569,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -623,7 +602,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "b3b975ac-995b-426e-8b5d-363a165df41c",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "7eb04a82-b947-4d95-84fe-7a3eb45ce17b",
@@ -675,8 +653,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -710,7 +686,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "8e1e40fc-5ec1-4077-b595-08d5cf42fef4",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "e56c00f9-d250-45a9-bf85-612935e34177",
@@ -762,8 +737,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -797,7 +770,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "b6e10128-f4bf-4134-99c2-ea60b8057ac4",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "dc0890dc-ef32-490a-9947-7b9ed208d0d6",
@@ -849,8 +821,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -884,7 +854,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "b3b975ac-995b-426e-8b5d-363a165df41c",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "ea2309d1-a5a2-44b7-9b10-9b13a3eb29fd",
@@ -936,8 +905,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -971,7 +938,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "b6e10128-f4bf-4134-99c2-ea60b8057ac4",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "fab28c63-b52c-49a4-a105-dced17d31a47",
@@ -1023,8 +989,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -1058,7 +1022,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "6528e359-af96-4214-ba42-18723813e564",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "5c404523-c0ac-42ca-a716-44f34f977bbd",
@@ -1110,8 +1073,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -1145,7 +1106,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "6528e359-af96-4214-ba42-18723813e564",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "7061179b-2b80-4f0f-9bce-576cfaf9f5fc",
@@ -1197,8 +1157,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -1232,7 +1190,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "b3b975ac-995b-426e-8b5d-363a165df41c",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "617617ff-809a-418f-9e18-ef7e530c8f0d",
@@ -1284,8 +1241,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -1319,7 +1274,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "b3b975ac-995b-426e-8b5d-363a165df41c",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "6a424ab7-225c-47d9-8170-62d6c7ec27cf",
@@ -1371,8 +1325,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -1406,7 +1358,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "8e1e40fc-5ec1-4077-b595-08d5cf42fef4",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "56119e99-4c69-4060-ac06-c2bfa3e0af6b",
@@ -1458,8 +1409,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -1493,7 +1442,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "8e1e40fc-5ec1-4077-b595-08d5cf42fef4",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "2eab3ec7-d2f5-48ed-aaf0-5933206c7ce7",
@@ -1545,8 +1493,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -1580,7 +1526,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "e3d9a3ac-f3d2-40e9-9aa6-ab336823a166",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "fe4134a2-5551-4cb2-885c-5e9fd71614e3",
@@ -1632,8 +1577,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -1667,7 +1610,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "b6e10128-f4bf-4134-99c2-ea60b8057ac4",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "de232683-6186-4044-a68a-e98e0691850b",
@@ -1719,8 +1661,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -1754,7 +1694,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "b3b975ac-995b-426e-8b5d-363a165df41c",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "04415740-f441-4dcf-9702-ad4c3e3731ef",
@@ -1806,8 +1745,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -1841,7 +1778,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "b6e10128-f4bf-4134-99c2-ea60b8057ac4",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "3de4fa62-8bcb-4e9b-a1f3-34ac53567dca",
@@ -1893,8 +1829,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -1928,7 +1862,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "8e1e40fc-5ec1-4077-b595-08d5cf42fef4",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "830bd6f6-e864-4b77-8e79-38ec89c8d6ea",
@@ -1980,8 +1913,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -2015,7 +1946,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "6528e359-af96-4214-ba42-18723813e564",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "4a4b9d81-c58f-4b34-a046-d60910fe92af",
@@ -2067,8 +1997,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -2102,7 +2030,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "6528e359-af96-4214-ba42-18723813e564",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "4b8f5933-c3d3-4ce4-8542-ff97ec365867",
@@ -2154,8 +2081,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -2189,7 +2114,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "8e1e40fc-5ec1-4077-b595-08d5cf42fef4",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "bd056bcc-80c9-407b-8147-67e31cdca3c1",
@@ -2241,8 +2165,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -2276,7 +2198,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "92edba11-5082-45f0-bd5e-7021c9a7e3a7",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "83734d98-3345-4b14-bf19-e43728173898",
@@ -2328,8 +2249,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -2363,7 +2282,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "6464370b-b04c-4f06-8687-f0a23a3c52b3",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "a6f00f15-d01e-4422-9ae7-9023937ea336",
@@ -2415,8 +2333,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -2450,7 +2366,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "8e1e40fc-5ec1-4077-b595-08d5cf42fef4",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "8bad92c9-71b5-4e38-b351-e2754d973d58",
@@ -2502,8 +2417,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -2537,7 +2450,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "8e1e40fc-5ec1-4077-b595-08d5cf42fef4",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "1f00055b-d510-4902-8b47-ae2a02f55075",
@@ -2589,8 +2501,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -2624,7 +2534,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "8e1e40fc-5ec1-4077-b595-08d5cf42fef4",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "fda9f9cd-72ac-449d-a53a-7014bcaabeac",
@@ -2676,8 +2585,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -2711,7 +2618,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "8e1e40fc-5ec1-4077-b595-08d5cf42fef4",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "7acd8ff5-9256-4aae-be0e-935e4cdcb03e",
@@ -2763,8 +2669,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0
@@ -2798,7 +2702,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "8e1e40fc-5ec1-4077-b595-08d5cf42fef4",
-                        "applied_conditional_access_policies": [],
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "99f61710-8f61-4eb2-829e-7bc9f438a9d4",
@@ -2850,8 +2753,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0.0,
                     "lon": 0.0

--- a/packages/azure/data_stream/signinlogs/_dev/test/pipeline/test-managed-identity.log-expected.json
+++ b/packages/azure/data_stream/signinlogs/_dev/test/pipeline/test-managed-identity.log-expected.json
@@ -59,8 +59,6 @@
                 ]
             },
             "geo": {
-                "city_name": "",
-                "country_name": "",
                 "location": {
                     "lat": 0,
                     "lon": 0

--- a/packages/azure/data_stream/signinlogs/_dev/test/pipeline/test-non-interactive-user-sample.log-expected.json
+++ b/packages/azure/data_stream/signinlogs/_dev/test/pipeline/test-non-interactive-user-sample.log-expected.json
@@ -17,8 +17,6 @@
                     "properties": {
                         "app_display_name": "Azure Portal",
                         "app_id": "c44b4083-3bb0-49c1-b47d-974e53cbdf3c",
-                        "applied_conditional_access_policies": [],
-                        "authentication_details": [],
                         "authentication_processing_details": {
                             "Is CAE Token": "False",
                             "Legacy TLS (TLS 1.0, 1.1, 3DES)": "False",
@@ -26,7 +24,6 @@
                         },
                         "authentication_protocol": "none",
                         "authentication_requirement": "singleFactorAuthentication",
-                        "authentication_requirement_policies": [],
                         "autonomous_system_number": 55836,
                         "client_app_used": "Browser",
                         "conditional_access_status": "notApplied",
@@ -35,7 +32,6 @@
                         "cross_tenant_access_type": "none",
                         "device_detail": {
                             "browser": "Rich Client 4.40.0.0",
-                            "device_id": "",
                             "operating_system": "Windows10"
                         },
                         "flagged_for_review": false,
@@ -44,26 +40,18 @@
                         "incoming_token_type": "none",
                         "is_interactive": false,
                         "is_tenant_restricted": false,
-                        "mfa_detail": {},
-                        "network_location_details": [],
                         "original_request_id": "290faffa-477b-4b28-ae92-579daae7b000",
-                        "private_link_details": {},
                         "processing_time_ms": 722,
                         "resource_display_name": "Windows Azure Service Management API",
                         "resource_id": "797f4846-ba00-4fd7-ba43-dac1f8f63013",
                         "resource_tenant_id": "4bbb79f7-5724-4c9e-95f3-de075f6ec090",
                         "risk_detail": "none",
-                        "risk_event_types": [],
-                        "risk_event_types_v2": [],
                         "risk_level_aggregated": "none",
                         "risk_level_during_signin": "none",
                         "risk_state": "none",
-                        "service_principal_id": "",
-                        "sso_extension_version": "",
                         "status": {
                             "error_code": 0
                         },
-                        "token_issuer_name": "",
                         "token_issuer_type": "AzureAD",
                         "unique_token_identifier": "MjkwZmFmZmEtNDc3Yi00YjI4LWFlOTItNTc5ZGFhZTdiMDAw",
                         "user_display_name": "elastic testing",
@@ -102,11 +90,11 @@
             "geo": {
                 "city_name": "Nizampet",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.5164794921875,
                     "lon": 78.37663269042969
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"
@@ -158,8 +146,6 @@
                     "properties": {
                         "app_display_name": "ADIbizaUX",
                         "app_id": "74658136-14ec-4630-ad9b-26e160ff0fc6",
-                        "applied_conditional_access_policies": [],
-                        "authentication_details": [],
                         "authentication_processing_details": {
                             "Is CAE Token": "False",
                             "Legacy TLS (TLS 1.0, 1.1, 3DES)": "False",
@@ -167,7 +153,6 @@
                         },
                         "authentication_protocol": "none",
                         "authentication_requirement": "singleFactorAuthentication",
-                        "authentication_requirement_policies": [],
                         "autonomous_system_number": 55836,
                         "client_app_used": "Browser",
                         "conditional_access_status": "notApplied",
@@ -176,7 +161,6 @@
                         "cross_tenant_access_type": "none",
                         "device_detail": {
                             "browser": "Rich Client 4.38.0.0",
-                            "device_id": "",
                             "operating_system": "Windows10"
                         },
                         "flagged_for_review": false,
@@ -185,25 +169,18 @@
                         "incoming_token_type": "none",
                         "is_interactive": false,
                         "is_tenant_restricted": false,
-                        "network_location_details": [],
                         "original_request_id": "93aac097-ffcb-472c-974a-2cd454066b00",
-                        "private_link_details": {},
                         "processing_time_ms": 130,
                         "resource_display_name": "IAM Supportability",
                         "resource_id": "a57aca87-cbc0-4f3c-8b9e-dc095fdc8978",
                         "resource_tenant_id": "4bbb79f7-5724-4c9e-95f3-de075f6ec090",
                         "risk_detail": "none",
-                        "risk_event_types": [],
-                        "risk_event_types_v2": [],
                         "risk_level_aggregated": "none",
                         "risk_level_during_signin": "none",
                         "risk_state": "none",
-                        "service_principal_id": "",
-                        "sso_extension_version": "",
                         "status": {
                             "error_code": 0
                         },
-                        "token_issuer_name": "",
                         "token_issuer_type": "AzureAD",
                         "unique_token_identifier": "OTNhYWMwOTctZmZjYi00NzJjLTk3NGEtMmNkNDU0MDY2YjAw",
                         "user_display_name": "elastic testing",
@@ -242,11 +219,11 @@
             "geo": {
                 "city_name": "Nizampet",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.5164794921875,
                     "lon": 78.37663269042969
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"
@@ -298,8 +275,6 @@
                     "properties": {
                         "app_display_name": "ADIbizaUX",
                         "app_id": "74658136-14ec-4630-ad9b-26e160ff0fc6",
-                        "applied_conditional_access_policies": [],
-                        "authentication_details": [],
                         "authentication_processing_details": {
                             "Is CAE Token": "False",
                             "Legacy TLS (TLS 1.0, 1.1, 3DES)": "False",
@@ -307,7 +282,6 @@
                         },
                         "authentication_protocol": "none",
                         "authentication_requirement": "singleFactorAuthentication",
-                        "authentication_requirement_policies": [],
                         "autonomous_system_number": 55836,
                         "client_app_used": "Browser",
                         "conditional_access_status": "notApplied",
@@ -316,7 +290,6 @@
                         "cross_tenant_access_type": "none",
                         "device_detail": {
                             "browser": "Rich Client 4.38.0.0",
-                            "device_id": "",
                             "operating_system": "Windows10"
                         },
                         "flagged_for_review": false,
@@ -325,25 +298,18 @@
                         "incoming_token_type": "none",
                         "is_interactive": false,
                         "is_tenant_restricted": false,
-                        "network_location_details": [],
                         "original_request_id": "93aac097-ffcb-472c-974a-2cd45b066b00",
-                        "private_link_details": {},
                         "processing_time_ms": 101,
                         "resource_display_name": "Microsoft Graph",
                         "resource_id": "00000003-0000-0000-c000-000000000000",
                         "resource_tenant_id": "4bbb79f7-5724-4c9e-95f3-de075f6ec090",
                         "risk_detail": "none",
-                        "risk_event_types": [],
-                        "risk_event_types_v2": [],
                         "risk_level_aggregated": "none",
                         "risk_level_during_signin": "none",
                         "risk_state": "none",
-                        "service_principal_id": "",
-                        "sso_extension_version": "",
                         "status": {
                             "error_code": 0
                         },
-                        "token_issuer_name": "",
                         "token_issuer_type": "AzureAD",
                         "unique_token_identifier": "OTNhYWMwOTctZmZjYi00NzJjLTk3NGEtMmNkNDViMDY2YjAw",
                         "user_display_name": "elastic testing",
@@ -382,11 +348,11 @@
             "geo": {
                 "city_name": "Nizampet",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.5164794921875,
                     "lon": 78.37663269042969
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"
@@ -438,8 +404,6 @@
                     "properties": {
                         "app_display_name": "Azure Portal",
                         "app_id": "c44b4083-3bb0-49c1-b47d-974e53cbdf3c",
-                        "applied_conditional_access_policies": [],
-                        "authentication_details": [],
                         "authentication_processing_details": {
                             "Is CAE Token": "False",
                             "Legacy TLS (TLS 1.0, 1.1, 3DES)": "False",
@@ -447,7 +411,6 @@
                         },
                         "authentication_protocol": "none",
                         "authentication_requirement": "singleFactorAuthentication",
-                        "authentication_requirement_policies": [],
                         "autonomous_system_number": 55836,
                         "client_app_used": "Browser",
                         "conditional_access_status": "notApplied",
@@ -456,7 +419,6 @@
                         "cross_tenant_access_type": "none",
                         "device_detail": {
                             "browser": "Rich Client 4.40.0.0",
-                            "device_id": "",
                             "operating_system": "Windows10"
                         },
                         "flagged_for_review": false,
@@ -465,26 +427,18 @@
                         "incoming_token_type": "none",
                         "is_interactive": false,
                         "is_tenant_restricted": false,
-                        "mfa_detail": {},
-                        "network_location_details": [],
                         "original_request_id": "b90d97fb-eb91-4bf2-91ff-95288b4e3900",
-                        "private_link_details": {},
                         "processing_time_ms": 420,
                         "resource_display_name": "ADIbizaUX",
                         "resource_id": "74658136-14ec-4630-ad9b-26e160ff0fc6",
                         "resource_tenant_id": "4bbb79f7-5724-4c9e-95f3-de075f6ec090",
                         "risk_detail": "none",
-                        "risk_event_types": [],
-                        "risk_event_types_v2": [],
                         "risk_level_aggregated": "none",
                         "risk_level_during_signin": "none",
                         "risk_state": "none",
-                        "service_principal_id": "",
-                        "sso_extension_version": "",
                         "status": {
                             "error_code": 0
                         },
-                        "token_issuer_name": "",
                         "token_issuer_type": "AzureAD",
                         "unique_token_identifier": "YjkwZDk3ZmItZWI5MS00YmYyLTkxZmYtOTUyODhiNGUzOTAw",
                         "user_display_name": "elastic testing",
@@ -523,11 +477,11 @@
             "geo": {
                 "city_name": "Nizampet",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.5164794921875,
                     "lon": 78.37663269042969
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"
@@ -579,8 +533,6 @@
                     "properties": {
                         "app_display_name": "ADIbizaUX",
                         "app_id": "74658136-14ec-4630-ad9b-26e160ff0fc6",
-                        "applied_conditional_access_policies": [],
-                        "authentication_details": [],
                         "authentication_processing_details": {
                             "Is CAE Token": "False",
                             "Legacy TLS (TLS 1.0, 1.1, 3DES)": "False",
@@ -588,7 +540,6 @@
                         },
                         "authentication_protocol": "none",
                         "authentication_requirement": "singleFactorAuthentication",
-                        "authentication_requirement_policies": [],
                         "autonomous_system_number": 55836,
                         "client_app_used": "Browser",
                         "conditional_access_status": "notApplied",
@@ -597,7 +548,6 @@
                         "cross_tenant_access_type": "none",
                         "device_detail": {
                             "browser": "Rich Client 4.40.0.0",
-                            "device_id": "",
                             "operating_system": "Windows10"
                         },
                         "flagged_for_review": false,
@@ -606,25 +556,18 @@
                         "incoming_token_type": "none",
                         "is_interactive": false,
                         "is_tenant_restricted": false,
-                        "network_location_details": [],
                         "original_request_id": "5402a26a-6671-476a-8e13-fa8f2d935e00",
-                        "private_link_details": {},
                         "processing_time_ms": 354,
                         "resource_display_name": "IAM Supportability",
                         "resource_id": "a57aca87-cbc0-4f3c-8b9e-dc095fdc8978",
                         "resource_tenant_id": "4bbb79f7-5724-4c9e-95f3-de075f6ec090",
                         "risk_detail": "none",
-                        "risk_event_types": [],
-                        "risk_event_types_v2": [],
                         "risk_level_aggregated": "none",
                         "risk_level_during_signin": "none",
                         "risk_state": "none",
-                        "service_principal_id": "",
-                        "sso_extension_version": "",
                         "status": {
                             "error_code": 0
                         },
-                        "token_issuer_name": "",
                         "token_issuer_type": "AzureAD",
                         "unique_token_identifier": "NTQwMmEyNmEtNjY3MS00NzZhLThlMTMtZmE4ZjJkOTM1ZTAw",
                         "user_display_name": "elastic testing",
@@ -663,11 +606,11 @@
             "geo": {
                 "city_name": "Nizampet",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.5164794921875,
                     "lon": 78.37663269042969
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"
@@ -719,8 +662,6 @@
                     "properties": {
                         "app_display_name": "ADIbizaUX",
                         "app_id": "74658136-14ec-4630-ad9b-26e160ff0fc6",
-                        "applied_conditional_access_policies": [],
-                        "authentication_details": [],
                         "authentication_processing_details": {
                             "Is CAE Token": "False",
                             "Legacy TLS (TLS 1.0, 1.1, 3DES)": "False",
@@ -728,7 +669,6 @@
                         },
                         "authentication_protocol": "none",
                         "authentication_requirement": "singleFactorAuthentication",
-                        "authentication_requirement_policies": [],
                         "autonomous_system_number": 55836,
                         "client_app_used": "Browser",
                         "conditional_access_status": "notApplied",
@@ -737,7 +677,6 @@
                         "cross_tenant_access_type": "none",
                         "device_detail": {
                             "browser": "Rich Client 4.38.0.0",
-                            "device_id": "",
                             "operating_system": "Windows10"
                         },
                         "flagged_for_review": false,
@@ -746,25 +685,18 @@
                         "incoming_token_type": "none",
                         "is_interactive": false,
                         "is_tenant_restricted": false,
-                        "network_location_details": [],
                         "original_request_id": "120bcb31-ef0a-4d84-b2ad-f73dd5e52000",
-                        "private_link_details": {},
                         "processing_time_ms": 124,
                         "resource_display_name": "Windows Azure Active Directory",
                         "resource_id": "00000002-0000-0000-c000-000000000000",
                         "resource_tenant_id": "4bbb79f7-5724-4c9e-95f3-de075f6ec090",
                         "risk_detail": "none",
-                        "risk_event_types": [],
-                        "risk_event_types_v2": [],
                         "risk_level_aggregated": "none",
                         "risk_level_during_signin": "none",
                         "risk_state": "none",
-                        "service_principal_id": "",
-                        "sso_extension_version": "",
                         "status": {
                             "error_code": 0
                         },
-                        "token_issuer_name": "",
                         "token_issuer_type": "AzureAD",
                         "unique_token_identifier": "MTIwYmNiMzEtZWYwYS00ZDg0LWIyYWQtZjczZGQ1ZTUyMDAw",
                         "user_display_name": "elastic testing",
@@ -803,11 +735,11 @@
             "geo": {
                 "city_name": "Nizampet",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.5164794921875,
                     "lon": 78.37663269042969
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"
@@ -859,8 +791,6 @@
                     "properties": {
                         "app_display_name": "Microsoft_Azure_Monitoring",
                         "app_id": "46ff7383-ea2d-47fe-92a0-e27d7dc2fee9",
-                        "applied_conditional_access_policies": [],
-                        "authentication_details": [],
                         "authentication_processing_details": {
                             "Is CAE Token": "False",
                             "Legacy TLS (TLS 1.0, 1.1, 3DES)": "False",
@@ -868,7 +798,6 @@
                         },
                         "authentication_protocol": "none",
                         "authentication_requirement": "singleFactorAuthentication",
-                        "authentication_requirement_policies": [],
                         "autonomous_system_number": 55836,
                         "client_app_used": "Browser",
                         "conditional_access_status": "notApplied",
@@ -877,7 +806,6 @@
                         "cross_tenant_access_type": "none",
                         "device_detail": {
                             "browser": "Rich Client 4.40.0.0",
-                            "device_id": "",
                             "operating_system": "Windows10"
                         },
                         "flagged_for_review": false,
@@ -886,25 +814,18 @@
                         "incoming_token_type": "none",
                         "is_interactive": false,
                         "is_tenant_restricted": false,
-                        "network_location_details": [],
                         "original_request_id": "2c829c77-35f5-4d61-a854-faab5e356000",
-                        "private_link_details": {},
                         "processing_time_ms": 348,
                         "resource_display_name": "Windows Azure Active Directory",
                         "resource_id": "00000002-0000-0000-c000-000000000000",
                         "resource_tenant_id": "4bbb79f7-5724-4c9e-95f3-de075f6ec090",
                         "risk_detail": "none",
-                        "risk_event_types": [],
-                        "risk_event_types_v2": [],
                         "risk_level_aggregated": "none",
                         "risk_level_during_signin": "none",
                         "risk_state": "none",
-                        "service_principal_id": "",
-                        "sso_extension_version": "",
                         "status": {
                             "error_code": 0
                         },
-                        "token_issuer_name": "",
                         "token_issuer_type": "AzureAD",
                         "unique_token_identifier": "MmM4MjljNzctMzVmNS00ZDYxLWE4NTQtZmFhYjVlMzU2MDAw",
                         "user_display_name": "elastic testing",
@@ -943,11 +864,11 @@
             "geo": {
                 "city_name": "Nizampet",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.5164794921875,
                     "lon": 78.37663269042969
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"
@@ -999,8 +920,6 @@
                     "properties": {
                         "app_display_name": "Azure Portal",
                         "app_id": "c44b4083-3bb0-49c1-b47d-974e53cbdf3c",
-                        "applied_conditional_access_policies": [],
-                        "authentication_details": [],
                         "authentication_processing_details": {
                             "Is CAE Token": "False",
                             "Legacy TLS (TLS 1.0, 1.1, 3DES)": "False",
@@ -1008,7 +927,6 @@
                         },
                         "authentication_protocol": "none",
                         "authentication_requirement": "singleFactorAuthentication",
-                        "authentication_requirement_policies": [],
                         "autonomous_system_number": 55836,
                         "client_app_used": "Browser",
                         "conditional_access_status": "notApplied",
@@ -1017,7 +935,6 @@
                         "cross_tenant_access_type": "none",
                         "device_detail": {
                             "browser": "Rich Client 4.40.0.0",
-                            "device_id": "",
                             "operating_system": "Windows10"
                         },
                         "flagged_for_review": false,
@@ -1026,26 +943,18 @@
                         "incoming_token_type": "none",
                         "is_interactive": false,
                         "is_tenant_restricted": false,
-                        "mfa_detail": {},
-                        "network_location_details": [],
                         "original_request_id": "bccbe35c-7246-4d14-908d-a1eb70db7400",
-                        "private_link_details": {},
                         "processing_time_ms": 488,
                         "resource_display_name": "ADIbizaUX",
                         "resource_id": "74658136-14ec-4630-ad9b-26e160ff0fc6",
                         "resource_tenant_id": "4bbb79f7-5724-4c9e-95f3-de075f6ec090",
                         "risk_detail": "none",
-                        "risk_event_types": [],
-                        "risk_event_types_v2": [],
                         "risk_level_aggregated": "none",
                         "risk_level_during_signin": "none",
                         "risk_state": "none",
-                        "service_principal_id": "",
-                        "sso_extension_version": "",
                         "status": {
                             "error_code": 0
                         },
-                        "token_issuer_name": "",
                         "token_issuer_type": "AzureAD",
                         "unique_token_identifier": "YmNjYmUzNWMtNzI0Ni00ZDE0LTkwOGQtYTFlYjcwZGI3NDAw",
                         "user_display_name": "elastic testing",
@@ -1084,11 +993,11 @@
             "geo": {
                 "city_name": "Nizampet",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.5164794921875,
                     "lon": 78.37663269042969
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"
@@ -1140,8 +1049,6 @@
                     "properties": {
                         "app_display_name": "ADIbizaUX",
                         "app_id": "74658136-14ec-4630-ad9b-26e160ff0fc6",
-                        "applied_conditional_access_policies": [],
-                        "authentication_details": [],
                         "authentication_processing_details": {
                             "Is CAE Token": "False",
                             "Legacy TLS (TLS 1.0, 1.1, 3DES)": "False",
@@ -1149,7 +1056,6 @@
                         },
                         "authentication_protocol": "none",
                         "authentication_requirement": "singleFactorAuthentication",
-                        "authentication_requirement_policies": [],
                         "autonomous_system_number": 55836,
                         "client_app_used": "Browser",
                         "conditional_access_status": "notApplied",
@@ -1158,7 +1064,6 @@
                         "cross_tenant_access_type": "none",
                         "device_detail": {
                             "browser": "Rich Client 4.40.0.0",
-                            "device_id": "",
                             "operating_system": "Windows10"
                         },
                         "flagged_for_review": false,
@@ -1167,25 +1072,18 @@
                         "incoming_token_type": "none",
                         "is_interactive": false,
                         "is_tenant_restricted": false,
-                        "network_location_details": [],
                         "original_request_id": "28f679a5-38f7-4c82-8cf0-e61a0bb6b100",
-                        "private_link_details": {},
                         "processing_time_ms": 349,
                         "resource_display_name": "Microsoft Graph",
                         "resource_id": "00000003-0000-0000-c000-000000000000",
                         "resource_tenant_id": "4bbb79f7-5724-4c9e-95f3-de075f6ec090",
                         "risk_detail": "none",
-                        "risk_event_types": [],
-                        "risk_event_types_v2": [],
                         "risk_level_aggregated": "none",
                         "risk_level_during_signin": "none",
                         "risk_state": "none",
-                        "service_principal_id": "",
-                        "sso_extension_version": "",
                         "status": {
                             "error_code": 0
                         },
-                        "token_issuer_name": "",
                         "token_issuer_type": "AzureAD",
                         "unique_token_identifier": "MjhmNjc5YTUtMzhmNy00YzgyLThjZjAtZTYxYTBiYjZiMTAw",
                         "user_display_name": "elastic testing",
@@ -1224,11 +1122,11 @@
             "geo": {
                 "city_name": "Nizampet",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.5164794921875,
                     "lon": 78.37663269042969
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"
@@ -1280,8 +1178,6 @@
                     "properties": {
                         "app_display_name": "ADIbizaUX",
                         "app_id": "74658136-14ec-4630-ad9b-26e160ff0fc6",
-                        "applied_conditional_access_policies": [],
-                        "authentication_details": [],
                         "authentication_processing_details": {
                             "Is CAE Token": "False",
                             "Legacy TLS (TLS 1.0, 1.1, 3DES)": "False",
@@ -1289,7 +1185,6 @@
                         },
                         "authentication_protocol": "none",
                         "authentication_requirement": "singleFactorAuthentication",
-                        "authentication_requirement_policies": [],
                         "autonomous_system_number": 55836,
                         "client_app_used": "Browser",
                         "conditional_access_status": "notApplied",
@@ -1298,7 +1193,6 @@
                         "cross_tenant_access_type": "none",
                         "device_detail": {
                             "browser": "Rich Client 4.36.0.0",
-                            "device_id": "",
                             "operating_system": "Windows10"
                         },
                         "flagged_for_review": false,
@@ -1307,25 +1201,18 @@
                         "incoming_token_type": "none",
                         "is_interactive": false,
                         "is_tenant_restricted": false,
-                        "network_location_details": [],
                         "original_request_id": "01c1cf17-1a9e-4426-8375-9cb62e8cb100",
-                        "private_link_details": {},
                         "processing_time_ms": 112,
                         "resource_display_name": "Windows Azure Active Directory",
                         "resource_id": "00000002-0000-0000-c000-000000000000",
                         "resource_tenant_id": "4bbb79f7-5724-4c9e-95f3-de075f6ec090",
                         "risk_detail": "none",
-                        "risk_event_types": [],
-                        "risk_event_types_v2": [],
                         "risk_level_aggregated": "none",
                         "risk_level_during_signin": "none",
                         "risk_state": "none",
-                        "service_principal_id": "",
-                        "sso_extension_version": "",
                         "status": {
                             "error_code": 0
                         },
-                        "token_issuer_name": "",
                         "token_issuer_type": "AzureAD",
                         "unique_token_identifier": "MDFjMWNmMTctMWE5ZS00NDI2LTgzNzUtOWNiNjJlOGNiMTAw",
                         "user_display_name": "elastic testing",
@@ -1364,11 +1251,11 @@
             "geo": {
                 "city_name": "Nizampet",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.5164794921875,
                     "lon": 78.37663269042969
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"
@@ -1420,8 +1307,6 @@
                     "properties": {
                         "app_display_name": "ADIbizaUX",
                         "app_id": "74658136-14ec-4630-ad9b-26e160ff0fc6",
-                        "applied_conditional_access_policies": [],
-                        "authentication_details": [],
                         "authentication_processing_details": {
                             "Is CAE Token": "False",
                             "Legacy TLS (TLS 1.0, 1.1, 3DES)": "False",
@@ -1429,7 +1314,6 @@
                         },
                         "authentication_protocol": "none",
                         "authentication_requirement": "singleFactorAuthentication",
-                        "authentication_requirement_policies": [],
                         "autonomous_system_number": 55836,
                         "client_app_used": "Browser",
                         "conditional_access_status": "notApplied",
@@ -1438,7 +1322,6 @@
                         "cross_tenant_access_type": "none",
                         "device_detail": {
                             "browser": "Rich Client 4.36.0.0",
-                            "device_id": "",
                             "operating_system": "Windows10"
                         },
                         "flagged_for_review": false,
@@ -1447,25 +1330,18 @@
                         "incoming_token_type": "none",
                         "is_interactive": false,
                         "is_tenant_restricted": false,
-                        "network_location_details": [],
                         "original_request_id": "f9feccc8-e022-4b4a-8f52-7c2c8a0c8300",
-                        "private_link_details": {},
                         "processing_time_ms": 136,
                         "resource_display_name": "Windows Azure Active Directory",
                         "resource_id": "00000002-0000-0000-c000-000000000000",
                         "resource_tenant_id": "4bbb79f7-5724-4c9e-95f3-de075f6ec090",
                         "risk_detail": "none",
-                        "risk_event_types": [],
-                        "risk_event_types_v2": [],
                         "risk_level_aggregated": "none",
                         "risk_level_during_signin": "none",
                         "risk_state": "none",
-                        "service_principal_id": "",
-                        "sso_extension_version": "",
                         "status": {
                             "error_code": 0
                         },
-                        "token_issuer_name": "",
                         "token_issuer_type": "AzureAD",
                         "unique_token_identifier": "ZjlmZWNjYzgtZTAyMi00YjRhLThmNTItN2MyYzhhMGM4MzAw",
                         "user_display_name": "elastic testing",
@@ -1504,11 +1380,11 @@
             "geo": {
                 "city_name": "Nizampet",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.5164794921875,
                     "lon": 78.37663269042969
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"
@@ -1560,8 +1436,6 @@
                     "properties": {
                         "app_display_name": "ADIbizaUX",
                         "app_id": "74658136-14ec-4630-ad9b-26e160ff0fc6",
-                        "applied_conditional_access_policies": [],
-                        "authentication_details": [],
                         "authentication_processing_details": {
                             "Is CAE Token": "False",
                             "Legacy TLS (TLS 1.0, 1.1, 3DES)": "False",
@@ -1569,7 +1443,6 @@
                         },
                         "authentication_protocol": "none",
                         "authentication_requirement": "singleFactorAuthentication",
-                        "authentication_requirement_policies": [],
                         "autonomous_system_number": 55836,
                         "client_app_used": "Browser",
                         "conditional_access_status": "notApplied",
@@ -1578,7 +1451,6 @@
                         "cross_tenant_access_type": "none",
                         "device_detail": {
                             "browser": "Rich Client 4.36.0.0",
-                            "device_id": "",
                             "operating_system": "Windows10"
                         },
                         "flagged_for_review": false,
@@ -1587,25 +1459,18 @@
                         "incoming_token_type": "none",
                         "is_interactive": false,
                         "is_tenant_restricted": false,
-                        "network_location_details": [],
                         "original_request_id": "a456912b-61bb-42cd-9b67-ea82f8ac8300",
-                        "private_link_details": {},
                         "processing_time_ms": 158,
                         "resource_display_name": "Windows Azure Active Directory",
                         "resource_id": "00000002-0000-0000-c000-000000000000",
                         "resource_tenant_id": "4bbb79f7-5724-4c9e-95f3-de075f6ec090",
                         "risk_detail": "none",
-                        "risk_event_types": [],
-                        "risk_event_types_v2": [],
                         "risk_level_aggregated": "none",
                         "risk_level_during_signin": "none",
                         "risk_state": "none",
-                        "service_principal_id": "",
-                        "sso_extension_version": "",
                         "status": {
                             "error_code": 0
                         },
-                        "token_issuer_name": "",
                         "token_issuer_type": "AzureAD",
                         "unique_token_identifier": "YTQ1NjkxMmItNjFiYi00MmNkLTliNjctZWE4MmY4YWM4MzAw",
                         "user_display_name": "elastic testing",
@@ -1644,11 +1509,11 @@
             "geo": {
                 "city_name": "Nizampet",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.5164794921875,
                     "lon": 78.37663269042969
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"
@@ -1700,8 +1565,6 @@
                     "properties": {
                         "app_display_name": "Azure Portal",
                         "app_id": "c44b4083-3bb0-49c1-b47d-974e53cbdf3c",
-                        "applied_conditional_access_policies": [],
-                        "authentication_details": [],
                         "authentication_processing_details": {
                             "Is CAE Token": "False",
                             "Legacy TLS (TLS 1.0, 1.1, 3DES)": "False",
@@ -1709,7 +1572,6 @@
                         },
                         "authentication_protocol": "none",
                         "authentication_requirement": "singleFactorAuthentication",
-                        "authentication_requirement_policies": [],
                         "autonomous_system_number": 55836,
                         "client_app_used": "Browser",
                         "conditional_access_status": "notApplied",
@@ -1718,7 +1580,6 @@
                         "cross_tenant_access_type": "none",
                         "device_detail": {
                             "browser": "Rich Client 4.38.0.0",
-                            "device_id": "",
                             "operating_system": "Windows10"
                         },
                         "flagged_for_review": false,
@@ -1727,26 +1588,18 @@
                         "incoming_token_type": "none",
                         "is_interactive": false,
                         "is_tenant_restricted": false,
-                        "mfa_detail": {},
-                        "network_location_details": [],
                         "original_request_id": "97839f13-989d-4d09-b553-eb1919f31f00",
-                        "private_link_details": {},
                         "processing_time_ms": 267,
                         "resource_display_name": "Windows Azure Service Management API",
                         "resource_id": "797f4846-ba00-4fd7-ba43-dac1f8f63013",
                         "resource_tenant_id": "4bbb79f7-5724-4c9e-95f3-de075f6ec090",
                         "risk_detail": "none",
-                        "risk_event_types": [],
-                        "risk_event_types_v2": [],
                         "risk_level_aggregated": "none",
                         "risk_level_during_signin": "none",
                         "risk_state": "none",
-                        "service_principal_id": "",
-                        "sso_extension_version": "",
                         "status": {
                             "error_code": 0
                         },
-                        "token_issuer_name": "",
                         "token_issuer_type": "AzureAD",
                         "unique_token_identifier": "OTc4MzlmMTMtOTg5ZC00ZDA5LWI1NTMtZWIxOTE5ZjMxZjAw",
                         "user_display_name": "elastic testing",
@@ -1785,11 +1638,11 @@
             "geo": {
                 "city_name": "Nizampet",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.5164794921875,
                     "lon": 78.37663269042969
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"
@@ -1841,8 +1694,6 @@
                     "properties": {
                         "app_display_name": "Azure Portal",
                         "app_id": "c44b4083-3bb0-49c1-b47d-974e53cbdf3c",
-                        "applied_conditional_access_policies": [],
-                        "authentication_details": [],
                         "authentication_processing_details": {
                             "Is CAE Token": "False",
                             "Legacy TLS (TLS 1.0, 1.1, 3DES)": "False",
@@ -1850,7 +1701,6 @@
                         },
                         "authentication_protocol": "none",
                         "authentication_requirement": "singleFactorAuthentication",
-                        "authentication_requirement_policies": [],
                         "autonomous_system_number": 55836,
                         "client_app_used": "Browser",
                         "conditional_access_status": "notApplied",
@@ -1859,7 +1709,6 @@
                         "cross_tenant_access_type": "none",
                         "device_detail": {
                             "browser": "Rich Client 4.38.0.0",
-                            "device_id": "",
                             "operating_system": "Windows10"
                         },
                         "flagged_for_review": false,
@@ -1868,26 +1717,18 @@
                         "incoming_token_type": "none",
                         "is_interactive": false,
                         "is_tenant_restricted": false,
-                        "mfa_detail": {},
-                        "network_location_details": [],
                         "original_request_id": "97839f13-989d-4d09-b553-eb192cf31f00",
-                        "private_link_details": {},
                         "processing_time_ms": 177,
                         "resource_display_name": "ADIbizaUX",
                         "resource_id": "74658136-14ec-4630-ad9b-26e160ff0fc6",
                         "resource_tenant_id": "4bbb79f7-5724-4c9e-95f3-de075f6ec090",
                         "risk_detail": "none",
-                        "risk_event_types": [],
-                        "risk_event_types_v2": [],
                         "risk_level_aggregated": "none",
                         "risk_level_during_signin": "none",
                         "risk_state": "none",
-                        "service_principal_id": "",
-                        "sso_extension_version": "",
                         "status": {
                             "error_code": 0
                         },
-                        "token_issuer_name": "",
                         "token_issuer_type": "AzureAD",
                         "unique_token_identifier": "OTc4MzlmMTMtOTg5ZC00ZDA5LWI1NTMtZWIxOTJjZjMxZjAw",
                         "user_display_name": "elastic testing",
@@ -1926,11 +1767,11 @@
             "geo": {
                 "city_name": "Nizampet",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.5164794921875,
                     "lon": 78.37663269042969
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"
@@ -1982,8 +1823,6 @@
                     "properties": {
                         "app_display_name": "Azure Portal",
                         "app_id": "c44b4083-3bb0-49c1-b47d-974e53cbdf3c",
-                        "applied_conditional_access_policies": [],
-                        "authentication_details": [],
                         "authentication_processing_details": {
                             "Is CAE Token": "False",
                             "Legacy TLS (TLS 1.0, 1.1, 3DES)": "False",
@@ -1991,7 +1830,6 @@
                         },
                         "authentication_protocol": "none",
                         "authentication_requirement": "singleFactorAuthentication",
-                        "authentication_requirement_policies": [],
                         "autonomous_system_number": 55836,
                         "client_app_used": "Browser",
                         "conditional_access_status": "notApplied",
@@ -2000,7 +1838,6 @@
                         "cross_tenant_access_type": "none",
                         "device_detail": {
                             "browser": "Rich Client 4.38.0.0",
-                            "device_id": "",
                             "operating_system": "Windows10"
                         },
                         "flagged_for_review": false,
@@ -2009,26 +1846,18 @@
                         "incoming_token_type": "none",
                         "is_interactive": false,
                         "is_tenant_restricted": false,
-                        "mfa_detail": {},
-                        "network_location_details": [],
                         "original_request_id": "97839f13-989d-4d09-b553-eb1954f31f00",
-                        "private_link_details": {},
                         "processing_time_ms": 195,
                         "resource_display_name": "Windows Azure Active Directory",
                         "resource_id": "00000002-0000-0000-c000-000000000000",
                         "resource_tenant_id": "4bbb79f7-5724-4c9e-95f3-de075f6ec090",
                         "risk_detail": "none",
-                        "risk_event_types": [],
-                        "risk_event_types_v2": [],
                         "risk_level_aggregated": "none",
                         "risk_level_during_signin": "none",
                         "risk_state": "none",
-                        "service_principal_id": "",
-                        "sso_extension_version": "",
                         "status": {
                             "error_code": 0
                         },
-                        "token_issuer_name": "",
                         "token_issuer_type": "AzureAD",
                         "unique_token_identifier": "OTc4MzlmMTMtOTg5ZC00ZDA5LWI1NTMtZWIxOTU0ZjMxZjAw",
                         "user_display_name": "elastic testing",
@@ -2067,11 +1896,11 @@
             "geo": {
                 "city_name": "Nizampet",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.5164794921875,
                     "lon": 78.37663269042969
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"

--- a/packages/azure/data_stream/signinlogs/_dev/test/pipeline/test-non-interactive-user-signin.log-expected.json
+++ b/packages/azure/data_stream/signinlogs/_dev/test/pipeline/test-non-interactive-user-signin.log-expected.json
@@ -25,7 +25,6 @@
                                 "enforced_grant_controls": [
                                     "Mfa"
                                 ],
-                                "enforced_session_controls": [],
                                 "id": "9bc14439-0b78-4d1e-bb27-8fab658d0e83",
                                 "result": "success"
                             },
@@ -36,7 +35,6 @@
                                 "enforced_grant_controls": [
                                     "Block"
                                 ],
-                                "enforced_session_controls": [],
                                 "id": "f1938df8-77ab-445a-8cba-4e7be5d55dca",
                                 "result": "notApplied"
                             },
@@ -47,7 +45,6 @@
                                 "enforced_grant_controls": [
                                     "Block"
                                 ],
-                                "enforced_session_controls": [],
                                 "id": "97dd0e67-9953-49fc-ae42-70e4ead3ffc0",
                                 "result": "notApplied"
                             },
@@ -58,7 +55,6 @@
                                 "enforced_grant_controls": [
                                     "Block"
                                 ],
-                                "enforced_session_controls": [],
                                 "id": "c28b1740-4158-4b71-9269-9a4a41fd0204",
                                 "result": "notApplied"
                             },
@@ -69,7 +65,6 @@
                                 "enforced_grant_controls": [
                                     "Guest terms of use"
                                 ],
-                                "enforced_session_controls": [],
                                 "id": "b00a4704-5613-49d6-bd4e-283d23d29f0a",
                                 "result": "notApplied"
                             },
@@ -77,7 +72,6 @@
                                 "conditions_not_satisfied": 2,
                                 "conditions_satisfied": 1,
                                 "display_name": "Guest session timeout",
-                                "enforced_grant_controls": [],
                                 "enforced_session_controls": [
                                     "SignInFrequency"
                                 ],
@@ -91,7 +85,6 @@
                                 "enforced_grant_controls": [
                                     "Block"
                                 ],
-                                "enforced_session_controls": [],
                                 "id": "051d2ce9-6d47-4c12-a113-c25223217bcb",
                                 "result": "notApplied"
                             },
@@ -102,7 +95,6 @@
                                 "enforced_grant_controls": [
                                     "Mfa"
                                 ],
-                                "enforced_session_controls": [],
                                 "id": "8ddf1a42-cb27-44a7-aa12-a65343e41be4",
                                 "result": "reportOnlyNotApplied"
                             },
@@ -114,7 +106,6 @@
                                     "Mfa",
                                     "RequireCompliantDevice"
                                 ],
-                                "enforced_session_controls": [],
                                 "id": "ee64eba5-e4bd-40ca-aee7-d98ad45ab33a",
                                 "result": "reportOnlyNotApplied"
                             },
@@ -126,7 +117,6 @@
                                     "Mfa",
                                     "RequireApprovedApp"
                                 ],
-                                "enforced_session_controls": [],
                                 "id": "cb26a614-e2c4-4644-b226-4dcb0c79ad61",
                                 "result": "reportOnlyNotApplied"
                             },
@@ -137,7 +127,6 @@
                                 "enforced_grant_controls": [
                                     "RequireCompliantDevice"
                                 ],
-                                "enforced_session_controls": [],
                                 "id": "39300713-85f0-41f5-ae90-823cc0be3b4a",
                                 "result": "reportOnlyNotApplied"
                             },
@@ -148,7 +137,6 @@
                                 "enforced_grant_controls": [
                                     "Block"
                                 ],
-                                "enforced_session_controls": [],
                                 "id": "f6623a16-4455-48f9-893f-70f1c564a534",
                                 "result": "reportOnlyNotApplied"
                             }
@@ -196,26 +184,18 @@
                         "incoming_token_type": "none",
                         "is_interactive": false,
                         "is_tenant_restricted": false,
-                        "mfa_detail": {},
-                        "network_location_details": [],
                         "original_request_id": "088b4409-9e63-425d-b777-2c8c6c380b00",
-                        "private_link_details": {},
                         "processing_time_ms": 90,
                         "resource_display_name": "Microsoft News Feed",
                         "resource_id": "f920ab6b-8a48-4438-9255-1650179a3a0f",
                         "resource_tenant_id": "226f45e7-e2e2-4228-9e9d-612687e8c133",
                         "risk_detail": "none",
-                        "risk_event_types": [],
-                        "risk_event_types_v2": [],
                         "risk_level_aggregated": "none",
                         "risk_level_during_signin": "none",
                         "risk_state": "none",
-                        "service_principal_id": "",
-                        "sso_extension_version": "",
                         "status": {
                             "error_code": 0
                         },
-                        "token_issuer_name": "",
                         "token_issuer_type": "AzureAD",
                         "unique_token_identifier": "MDg4YjQ0MDktOWU2My00MjVkLWI3NzctMmM4YzZjMzgwYjAw",
                         "user_display_name": "Nikhita Sethi",
@@ -254,11 +234,11 @@
             "geo": {
                 "city_name": "Strood",
                 "country_iso_code": "GB",
-                "country_name": "Medway",
                 "location": {
                     "lat": 51.394798278808594,
                     "lon": 0.4803900122642517
-                }
+                },
+                "region_name": "Medway"
             },
             "log": {
                 "level": "4"

--- a/packages/azure/data_stream/signinlogs/_dev/test/pipeline/test-non-interactive-user.log-expected.json
+++ b/packages/azure/data_stream/signinlogs/_dev/test/pipeline/test-non-interactive-user.log-expected.json
@@ -25,7 +25,6 @@
                                 "enforced_grant_controls": [
                                     "RequireDomainJoinedDevice"
                                 ],
-                                "enforced_session_controls": [],
                                 "id": "22222222-b7da-4d9e-ae41-779c5c256ac8",
                                 "result": "success"
                             },
@@ -36,7 +35,6 @@
                                 "enforced_grant_controls": [
                                     "Mfa"
                                 ],
-                                "enforced_session_controls": [],
                                 "id": "22222222-e960-42e6-ae3a-355df7e475d5",
                                 "result": "notApplied"
                             },
@@ -47,7 +45,6 @@
                                 "enforced_grant_controls": [
                                     "Block"
                                 ],
-                                "enforced_session_controls": [],
                                 "id": "22222222-877a-4100-a0cf-5a589f2da3ad",
                                 "result": "notApplied"
                             },
@@ -58,7 +55,6 @@
                                 "enforced_grant_controls": [
                                     "Block"
                                 ],
-                                "enforced_session_controls": [],
                                 "id": "22222222-8e59-4055-87b1-b54a055a7ca5",
                                 "result": "notApplied"
                             },
@@ -69,7 +65,6 @@
                                 "enforced_grant_controls": [
                                     "Block"
                                 ],
-                                "enforced_session_controls": [],
                                 "id": "22222222-39cb-4ec4-8ed2-ac1352d260ba",
                                 "result": "notApplied"
                             },
@@ -80,7 +75,6 @@
                                 "enforced_grant_controls": [
                                     "Mfa"
                                 ],
-                                "enforced_session_controls": [],
                                 "id": "22222222-ea2f-4502-abb7-3689a1b0da41",
                                 "result": "notApplied"
                             },
@@ -91,7 +85,6 @@
                                 "enforced_grant_controls": [
                                     "Block"
                                 ],
-                                "enforced_session_controls": [],
                                 "id": "22222222-8b95-43cb-8e7d-69e34704ab56",
                                 "result": "notApplied"
                             },
@@ -102,7 +95,6 @@
                                 "enforced_grant_controls": [
                                     "RequireCompliantDevice"
                                 ],
-                                "enforced_session_controls": [],
                                 "id": "22222222-ff75-460a-800c-7fe88bd9c877",
                                 "result": "notApplied"
                             },
@@ -113,18 +105,15 @@
                                 "enforced_grant_controls": [
                                     "Block"
                                 ],
-                                "enforced_session_controls": [],
                                 "id": "22222222-9886-4897-b2e2-a096cd37bac3",
                                 "result": "notApplied"
                             }
                         ],
-                        "authentication_details": [],
                         "authentication_processing_details": {
                             "Is Client Capable": "True",
                             "IsCAEToken": "False"
                         },
                         "authentication_requirement": "singleFactorAuthentication",
-                        "authentication_requirement_policies": [],
                         "autonomous_system_number": 3320,
                         "client_app_used": "Mobile Apps and Desktop clients",
                         "conditional_access_status": "success",
@@ -152,23 +141,17 @@
                             }
                         ],
                         "original_request_id": "22222222-fb7b-4f83-bf74-3876f9ef3900",
-                        "private_link_details": {},
                         "processing_time_ms": 65,
                         "resource_display_name": "Office 365 Exchange Online",
                         "resource_id": "22222222-0000-0ff1-ce00-000000000000",
                         "resource_tenant_id": "22222222-902d-4dea-8026-5a790862fede",
                         "risk_detail": "none",
-                        "risk_event_types": [],
-                        "risk_event_types_v2": [],
                         "risk_level_aggregated": "none",
                         "risk_level_during_signin": "none",
                         "risk_state": "none",
-                        "service_principal_id": "",
-                        "sso_extension_version": "",
                         "status": {
                             "error_code": 0
                         },
-                        "token_issuer_name": "",
                         "token_issuer_type": "AzureAD",
                         "user_display_name": "Hello World",
                         "user_id": "22222222-473d-4f4e-a526-ff54e71afe84",
@@ -206,11 +189,11 @@
             "geo": {
                 "city_name": "Hannover",
                 "country_iso_code": "DE",
-                "country_name": "Niedersachsen",
                 "location": {
                     "lat": 50.12345678912345,
                     "lon": 9.123456789123455
-                }
+                },
+                "region_name": "Niedersachsen"
             },
             "log": {
                 "level": "4"

--- a/packages/azure/data_stream/signinlogs/_dev/test/pipeline/test-service-principal-signinlogs-sample.log-expected.json
+++ b/packages/azure/data_stream/signinlogs/_dev/test/pipeline/test-service-principal-signinlogs-sample.log-expected.json
@@ -15,10 +15,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "6131d760-7fda-4db5-8bb1-b771898e9f15",
-                        "applied_conditional_access_policies": [],
-                        "authentication_processing_details": {
-                            "Azure AD App Authentication Library": ""
-                        },
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "59fe2cc8-d7b0-4f88-a541-3399f4eff9b2",
@@ -76,11 +72,11 @@
             "geo": {
                 "city_name": "Hyderabad",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.385000228881836,
                     "lon": 78.48670196533203
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"
@@ -125,10 +121,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "6131d760-7fda-4db5-8bb1-b771898e9f15",
-                        "applied_conditional_access_policies": [],
-                        "authentication_processing_details": {
-                            "Azure AD App Authentication Library": ""
-                        },
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "5cc5d0c1-8573-43b4-8d1d-1c079033b548",
@@ -186,11 +178,11 @@
             "geo": {
                 "city_name": "Hyderabad",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.385000228881836,
                     "lon": 78.48670196533203
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"
@@ -235,10 +227,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "6131d760-7fda-4db5-8bb1-b771898e9f15",
-                        "applied_conditional_access_policies": [],
-                        "authentication_processing_details": {
-                            "Azure AD App Authentication Library": ""
-                        },
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "cfb5ff5b-1886-497c-86a5-443fb26aefa5",
@@ -296,11 +284,11 @@
             "geo": {
                 "city_name": "Hyderabad",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.385000228881836,
                     "lon": 78.48670196533203
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"
@@ -345,10 +333,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "6131d760-7fda-4db5-8bb1-b771898e9f15",
-                        "applied_conditional_access_policies": [],
-                        "authentication_processing_details": {
-                            "Azure AD App Authentication Library": ""
-                        },
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "c67a1c8a-2ab8-4db7-9123-d1e6793b384a",
@@ -406,11 +390,11 @@
             "geo": {
                 "city_name": "Hyderabad",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.385000228881836,
                     "lon": 78.48670196533203
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"
@@ -455,10 +439,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "6131d760-7fda-4db5-8bb1-b771898e9f15",
-                        "applied_conditional_access_policies": [],
-                        "authentication_processing_details": {
-                            "Azure AD App Authentication Library": ""
-                        },
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "15c6910a-b3cf-439f-acd9-0c6dbdaf7fd7",
@@ -516,11 +496,11 @@
             "geo": {
                 "city_name": "Hyderabad",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.385000228881836,
                     "lon": 78.48670196533203
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"
@@ -565,10 +545,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "6131d760-7fda-4db5-8bb1-b771898e9f15",
-                        "applied_conditional_access_policies": [],
-                        "authentication_processing_details": {
-                            "Azure AD App Authentication Library": ""
-                        },
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "07705b18-c395-4fd5-806b-df4ac0c80b8a",
@@ -626,11 +602,11 @@
             "geo": {
                 "city_name": "Hyderabad",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.385000228881836,
                     "lon": 78.48670196533203
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"
@@ -675,10 +651,6 @@
                     "operation_version": "1.0",
                     "properties": {
                         "app_id": "6131d760-7fda-4db5-8bb1-b771898e9f15",
-                        "applied_conditional_access_policies": [],
-                        "authentication_processing_details": {
-                            "Azure AD App Authentication Library": ""
-                        },
                         "authentication_protocol": "none",
                         "conditional_access_status": "notApplied",
                         "correlation_id": "64d9ae8b-68e7-4160-9d09-c8bff913d0e3",
@@ -736,11 +708,11 @@
             "geo": {
                 "city_name": "Hyderabad",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.385000228881836,
                     "lon": 78.48670196533203
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"

--- a/packages/azure/data_stream/signinlogs/_dev/test/pipeline/test-service-principal.log-expected.json
+++ b/packages/azure/data_stream/signinlogs/_dev/test/pipeline/test-service-principal.log-expected.json
@@ -67,11 +67,11 @@
             "geo": {
                 "city_name": "Hannover",
                 "country_iso_code": "DE",
-                "country_name": "Niedersachsen",
                 "location": {
                     "lat": 50.12345678912345,
                     "lon": 9.123456789012344
-                }
+                },
+                "region_name": "Niedersachsen"
             },
             "log": {
                 "level": "4"

--- a/packages/azure/data_stream/signinlogs/_dev/test/pipeline/test-signinlogs-raw.log-expected.json
+++ b/packages/azure/data_stream/signinlogs/_dev/test/pipeline/test-signinlogs-raw.log-expected.json
@@ -23,7 +23,6 @@
                         "created_at": "2019-10-18T04:45:48.0729893-05:00",
                         "device_detail": {
                             "browser": "Chrome 77.0.3865",
-                            "device_id": "",
                             "operating_system": "MacOs"
                         },
                         "id": "8a4de8b5-095c-47d0-a96f-a75130c61d53",
@@ -34,11 +33,9 @@
                         "risk_level_aggregated": "none",
                         "risk_level_during_signin": "none",
                         "risk_state": "none",
-                        "service_principal_id": "",
                         "status": {
                             "error_code": 50140
                         },
-                        "token_issuer_name": "",
                         "token_issuer_type": "AzureAD",
                         "user_display_name": "Test LTest",
                         "user_id": "8a4de8b5-095c-47d0-a96f-a75130c61d53",
@@ -76,11 +73,11 @@
             "geo": {
                 "city_name": "Champs-Sur-Marne",
                 "country_iso_code": "FR",
-                "country_name": "Seine-Et-Marne",
                 "location": {
                     "lat": 48.12341234,
                     "lon": 2.12341234
-                }
+                },
+                "region_name": "Seine-Et-Marne"
             },
             "log": {
                 "level": "4"
@@ -143,7 +140,6 @@
                         "created_at": "2019-10-18T04:45:48.0729893-05:00",
                         "device_detail": {
                             "browser": "Chrome 77.0.3865",
-                            "device_id": "",
                             "operating_system": "MacOs"
                         },
                         "id": "8a4de8b5-095c-47d0-a96f-a75130c61d53",
@@ -154,11 +150,9 @@
                         "risk_level_aggregated": "none",
                         "risk_level_during_signin": "none",
                         "risk_state": "none",
-                        "service_principal_id": "",
                         "status": {
                             "error_code": 50140
                         },
-                        "token_issuer_name": "",
                         "token_issuer_type": "AzureAD",
                         "user_display_name": "Test LTest",
                         "user_id": "8a4de8b5-095c-47d0-a96f-a75130c61d53",
@@ -196,11 +190,11 @@
             "geo": {
                 "city_name": "Champs-Sur-Marne",
                 "country_iso_code": "FR",
-                "country_name": "Seine-Et-Marne",
                 "location": {
                     "lat": 48.12341234,
                     "lon": 2.12341234
-                }
+                },
+                "region_name": "Seine-Et-Marne"
             },
             "log": {
                 "level": "4"

--- a/packages/azure/data_stream/signinlogs/_dev/test/pipeline/test-signinlogs-sample.log-expected.json
+++ b/packages/azure/data_stream/signinlogs/_dev/test/pipeline/test-signinlogs-sample.log-expected.json
@@ -17,7 +17,6 @@
                     "properties": {
                         "app_display_name": "Azure Portal",
                         "app_id": "c44b4083-3bb0-49c1-b47d-974e53cbdf3c",
-                        "applied_conditional_access_policies": [],
                         "authentication_details": [
                             {
                                 "authentication_method": "Previously satisfied",
@@ -32,12 +31,10 @@
                         "authentication_processing_details": {
                             "Is CAE Token": "False",
                             "Legacy TLS (TLS 1.0, 1.1, 3DES)": "False",
-                            "Login Hint Present": "True",
-                            "Oauth Scope Info": ""
+                            "Login Hint Present": "True"
                         },
                         "authentication_protocol": "none",
                         "authentication_requirement": "singleFactorAuthentication",
-                        "authentication_requirement_policies": [],
                         "autonomous_system_number": 55836,
                         "client_app_used": "Browser",
                         "conditional_access_status": "notApplied",
@@ -46,7 +43,6 @@
                         "cross_tenant_access_type": "none",
                         "device_detail": {
                             "browser": "Edge 97.0.1072",
-                            "device_id": "",
                             "operating_system": "Windows 10"
                         },
                         "flagged_for_review": false,
@@ -55,26 +51,18 @@
                         "incoming_token_type": "none",
                         "is_interactive": true,
                         "is_tenant_restricted": false,
-                        "mfa_detail": {},
-                        "network_location_details": [],
                         "original_request_id": "933f20c0-efdf-477f-9586-e5cc566d2e00",
-                        "private_link_details": {},
                         "processing_time_ms": 5662,
                         "resource_display_name": "Windows Azure Service Management API",
                         "resource_id": "797f4846-ba00-4fd7-ba43-dac1f8f63013",
                         "resource_tenant_id": "4bbb79f7-5724-4c9e-95f3-de075f6ec090",
                         "risk_detail": "none",
-                        "risk_event_types": [],
-                        "risk_event_types_v2": [],
                         "risk_level_aggregated": "none",
                         "risk_level_during_signin": "none",
                         "risk_state": "none",
-                        "service_principal_id": "",
-                        "sso_extension_version": "",
                         "status": {
                             "error_code": 0
                         },
-                        "token_issuer_name": "",
                         "token_issuer_type": "AzureAD",
                         "unique_token_identifier": "OTMzZjIwYzAtZWZkZi00NzdmLTk1ODYtZTVjYzU2NmQyZTAw",
                         "user_display_name": "elastic testing",
@@ -113,11 +101,11 @@
             "geo": {
                 "city_name": "Nizampet",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.5164794921875,
                     "lon": 78.37663269042969
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"
@@ -182,7 +170,6 @@
                     "properties": {
                         "app_display_name": "Azure Portal",
                         "app_id": "c44b4083-3bb0-49c1-b47d-974e53cbdf3c",
-                        "applied_conditional_access_policies": [],
                         "authentication_details": [
                             {
                                 "authentication_method": "Previously satisfied",
@@ -197,12 +184,10 @@
                         "authentication_processing_details": {
                             "Is CAE Token": "False",
                             "Legacy TLS (TLS 1.0, 1.1, 3DES)": "False",
-                            "Login Hint Present": "True",
-                            "Oauth Scope Info": ""
+                            "Login Hint Present": "True"
                         },
                         "authentication_protocol": "none",
                         "authentication_requirement": "singleFactorAuthentication",
-                        "authentication_requirement_policies": [],
                         "autonomous_system_number": 55836,
                         "client_app_used": "Browser",
                         "conditional_access_status": "notApplied",
@@ -211,7 +196,6 @@
                         "cross_tenant_access_type": "none",
                         "device_detail": {
                             "browser": "Edge 97.0.1072",
-                            "device_id": "",
                             "operating_system": "Windows 10"
                         },
                         "flagged_for_review": false,
@@ -220,26 +204,18 @@
                         "incoming_token_type": "none",
                         "is_interactive": true,
                         "is_tenant_restricted": false,
-                        "mfa_detail": {},
-                        "network_location_details": [],
                         "original_request_id": "933f20c0-efdf-477f-9586-e5cc676f2e00",
-                        "private_link_details": {},
                         "processing_time_ms": 1598,
                         "resource_display_name": "Windows Azure Service Management API",
                         "resource_id": "797f4846-ba00-4fd7-ba43-dac1f8f63013",
                         "resource_tenant_id": "4bbb79f7-5724-4c9e-95f3-de075f6ec090",
                         "risk_detail": "none",
-                        "risk_event_types": [],
-                        "risk_event_types_v2": [],
                         "risk_level_aggregated": "none",
                         "risk_level_during_signin": "none",
                         "risk_state": "none",
-                        "service_principal_id": "",
-                        "sso_extension_version": "",
                         "status": {
                             "error_code": 0
                         },
-                        "token_issuer_name": "",
                         "token_issuer_type": "AzureAD",
                         "unique_token_identifier": "OTMzZjIwYzAtZWZkZi00NzdmLTk1ODYtZTVjYzY3NmYyZTAw",
                         "user_display_name": "elastic testing",
@@ -278,11 +254,11 @@
             "geo": {
                 "city_name": "Nizampet",
                 "country_iso_code": "IN",
-                "country_name": "Telangana",
                 "location": {
                     "lat": 17.5164794921875,
                     "lon": 78.37663269042969
-                }
+                },
+                "region_name": "Telangana"
             },
             "log": {
                 "level": "4"

--- a/packages/azure/data_stream/signinlogs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure/data_stream/signinlogs/elasticsearch/ingest_pipeline/default.yml
@@ -176,7 +176,7 @@ processors:
       ignore_missing: true
   - rename:
       field: azure.signinlogs.properties.location.state
-      target_field: geo.country_name
+      target_field: geo.region_name
       ignore_missing: true
   - rename:
       field: azure.signinlogs.properties.location.geo_coordinates.latitude
@@ -316,7 +316,27 @@ processors:
       if: ctx.azure?.signinlogs?.properties?.device_detail?.device_id != null && ctx.azure.signinlogs.properties.device_detail.device_id != ''
   - pipeline:
       name: '{{ IngestPipeline "azure-shared-pipeline" }}'
+  - script:
+      description: Drops null/empty values recursively.
+      lang: painless
+      source: |
+        boolean dropEmptyFields(Object object) {
+          if (object == null || object == "") {
+            return true;
+          } else if (object instanceof Map) {
+            ((Map) object).values().removeIf(value -> dropEmptyFields(value));
+            return (((Map) object).size() == 0);
+          } else if (object instanceof List) {
+            ((List) object).removeIf(value -> dropEmptyFields(value));
+            return (((List) object).length == 0);
+          }
+          return false;
+        }
+        dropEmptyFields(ctx);
 on_failure:
-  - set:
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - set:
+      field: event.kind
+      value: pipeline_error

--- a/packages/azure/data_stream/signinlogs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure/data_stream/signinlogs/elasticsearch/ingest_pipeline/default.yml
@@ -334,7 +334,7 @@ processors:
         }
         dropEmptyFields(ctx);
 on_failure:
-  - append:
+  - set:
       field: error.message
       value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:

--- a/packages/azure/data_stream/signinlogs/fields/fields.yml
+++ b/packages/azure/data_stream/signinlogs/fields/fields.yml
@@ -252,6 +252,9 @@
     - name: city_name
       type: keyword
       description: City name.
+    - name: region_name
+      type: keyword
+      description: Region name.
 - name: related.entity
   description: >-
     All the entity identifiers related to the document. If the document contains

--- a/packages/azure/docs/adlogs.md
+++ b/packages/azure/docs/adlogs.md
@@ -298,6 +298,7 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | geo.country_iso_code | Country ISO code. | keyword |
 | geo.country_name | Country name. | keyword |
 | geo.location | Longitude and latitude. | geo_point |
+| geo.region_name | Region name. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |

--- a/packages/azure/manifest.yml
+++ b/packages/azure/manifest.yml
@@ -1,6 +1,6 @@
 name: azure
 title: Azure Logs
-version: "1.23.0"
+version: "1.23.1"
 description: This Elastic integration collects logs from Azure
 type: integration
 icons:


### PR DESCRIPTION
- Bug

## Proposed commit message

Add a new field `region_name` to map the location.state data to this field. Initially this was mapped to `country_name` which is not appropriate.

Added script to drop the null/empty values in the document and updated with more descriptive on_failure error message.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

Install the integration and verify the signin logs captures the state in region_name field instead of country_name.

