### PR TITLE
[Asset Discovery] Change entity.name from text to keyword

### DIFF
--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -1,6 +1,11 @@
 # newer versions go on top
 # version map:
 # 0.1.x - 8.15.x
+- version: "0.9.0"
+  changes:
+    - description: Map entity.name as keyword
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12363
 - version: "0.8.0"
   changes:
     - description: Default to agentless deployment

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/fields/entity.yml
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/fields/entity.yml
@@ -13,7 +13,7 @@
     type: keyword
 
   - name: name
-    type: text
+    type: keyword
 
   - name: category
     type: keyword

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_asset_inventory
 title: "Cloud Asset Inventory"
-version: "0.8.0"
+version: "0.9.0"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Inventory"


### PR DESCRIPTION
`entity.name` was mistakenly mapped as `text` and not `keyword` impacting entity store aggregations