### PR TITLE
checkpoint_harmony_endpoint: fixes in CEL to control data flow

### DIFF
--- a/packages/checkpoint_harmony_endpoint/changelog.yml
+++ b/packages/checkpoint_harmony_endpoint/changelog.yml
@@ -1,4 +1,15 @@
 # newer versions go on top
+- version: "0.7.0"
+  changes:
+    - description: Base subsequent request ranges on the latest data received.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
+    - description: Adjust default request limits to avoid API timeouts.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
+    - description: Gratefully handle `Canceled` state responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "0.6.0"
   changes:
     - description: Improve cleaning of query parameters on errors.

--- a/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
@@ -180,6 +180,22 @@ program: |
   								),
   							}
   						)
+  					: (body.data.state == "Canceled") ?
+  						// 'Canceled' (Error or timeout) - Clear the task ID and reset the sequence for the same timeframe.
+  						state.with(
+  							{
+  								"events": [],
+  								"want_more": false,
+  								"cursor": state.cursor.with(
+  									{
+  										"auth_data": auth_data,
+  										"task_id": null,
+  										"next_startTime": state.cursor.current_startTime,
+  										"next_endTime": state.cursor.current_endTime,
+  									}
+  								),
+  							}
+  						)
   					:
   						// Not ready or done - Keep polling.
   						state.with(

--- a/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
@@ -308,6 +308,7 @@ program: |
   						)
   					:
   						// Last page - Clear the task ID and page token, and end the sequence.
+  						// Next sequence starts pulling data from the last timestamp received.
   						state.with(
   							{
   								"events": body.data.records.map(e, {"message": e.encode_json()}),
@@ -317,6 +318,11 @@ program: |
   										"auth_data": auth_data,
   										"task_id": null,
   										"page_token": null,
+  										"next_startTime": has(body.?data.results) && body.data.results.size() > 0 ?
+  											optional.of(body.data.results.map(t, timestamp(t.time)).max().format(time_layout.RFC3339))
+  										:
+  											state.cursor.current_endTime,
+  										"next_endTime": null,
   									}
   								),
   							}

--- a/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
@@ -180,6 +180,22 @@ program: |
   								),
   							}
   						)
+  					: (body.data.state == "Canceled") ?
+  						// 'Canceled' (Error or timeout) - Clear the task ID and reset the sequence for the same timeframe.
+  						state.with(
+  							{
+  								"events": [],
+  								"want_more": false,
+  								"cursor": state.cursor.with(
+  									{
+  										"auth_data": auth_data,
+  										"task_id": null,
+  										"next_startTime": state.cursor.current_startTime,
+  										"next_endTime": state.cursor.current_endTime,
+  									}
+  								),
+  							}
+  						)
   					:
   						// Not ready or done - Keep polling.
   						state.with(

--- a/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
@@ -308,6 +308,7 @@ program: |
   						)
   					:
   						// Last page - Clear the task ID and page token, and end the sequence.
+  						// Next sequence starts pulling data from the last timestamp received.
   						state.with(
   							{
   								"events": body.data.records.map(e, {"message": e.encode_json()}),
@@ -317,6 +318,11 @@ program: |
   										"auth_data": auth_data,
   										"task_id": null,
   										"page_token": null,
+  										"next_startTime": has(body.?data.results) && body.data.results.size() > 0 ?
+  											optional.of(body.data.results.map(t, timestamp(t.time)).max().format(time_layout.RFC3339))
+  										:
+  											state.cursor.current_endTime,
+  										"next_endTime": null,
   									}
   								),
   							}

--- a/packages/checkpoint_harmony_endpoint/data_stream/forensics/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/forensics/agent/stream/cel.yml.hbs
@@ -180,6 +180,22 @@ program: |
   								),
   							}
   						)
+  					: (body.data.state == "Canceled") ?
+  						// 'Canceled' (Error or timeout) - Clear the task ID and reset the sequence for the same timeframe.
+  						state.with(
+  							{
+  								"events": [],
+  								"want_more": false,
+  								"cursor": state.cursor.with(
+  									{
+  										"auth_data": auth_data,
+  										"task_id": null,
+  										"next_startTime": state.cursor.current_startTime,
+  										"next_endTime": state.cursor.current_endTime,
+  									}
+  								),
+  							}
+  						)
   					:
   						// Not ready or done - Keep polling.
   						state.with(

--- a/packages/checkpoint_harmony_endpoint/data_stream/forensics/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/forensics/agent/stream/cel.yml.hbs
@@ -308,6 +308,7 @@ program: |
   						)
   					:
   						// Last page - Clear the task ID and page token, and end the sequence.
+  						// Next sequence starts pulling data from the last timestamp received.
   						state.with(
   							{
   								"events": body.data.records.map(e, {"message": e.encode_json()}),
@@ -317,6 +318,11 @@ program: |
   										"auth_data": auth_data,
   										"task_id": null,
   										"page_token": null,
+  										"next_startTime": has(body.?data.results) && body.data.results.size() > 0 ?
+  											optional.of(body.data.results.map(t, timestamp(t.time)).max().format(time_layout.RFC3339))
+  										:
+  											state.cursor.current_endTime,
+  										"next_endTime": null,
   									}
   								),
   							}

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
@@ -180,6 +180,22 @@ program: |
   								),
   							}
   						)
+  					: (body.data.state == "Canceled") ?
+  						// 'Canceled' (Error or timeout) - Clear the task ID and reset the sequence for the same timeframe.
+  						state.with(
+  							{
+  								"events": [],
+  								"want_more": false,
+  								"cursor": state.cursor.with(
+  									{
+  										"auth_data": auth_data,
+  										"task_id": null,
+  										"next_startTime": state.cursor.current_startTime,
+  										"next_endTime": state.cursor.current_endTime,
+  									}
+  								),
+  							}
+  						)
   					:
   						// Not ready or done - Keep polling.
   						state.with(

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
@@ -308,6 +308,7 @@ program: |
   						)
   					:
   						// Last page - Clear the task ID and page token, and end the sequence.
+  						// Next sequence starts pulling data from the last timestamp received.
   						state.with(
   							{
   								"events": body.data.records.map(e, {"message": e.encode_json()}),
@@ -317,6 +318,11 @@ program: |
   										"auth_data": auth_data,
   										"task_id": null,
   										"page_token": null,
+  										"next_startTime": has(body.?data.results) && body.data.results.size() > 0 ?
+  											optional.of(body.data.results.map(t, timestamp(t.time)).max().format(time_layout.RFC3339))
+  										:
+  											state.cursor.current_endTime,
+  										"next_endTime": null,
   									}
   								),
   							}

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
@@ -180,6 +180,22 @@ program: |
   								),
   							}
   						)
+  					: (body.data.state == "Canceled") ?
+  						// 'Canceled' (Error or timeout) - Clear the task ID and reset the sequence for the same timeframe.
+  						state.with(
+  							{
+  								"events": [],
+  								"want_more": false,
+  								"cursor": state.cursor.with(
+  									{
+  										"auth_data": auth_data,
+  										"task_id": null,
+  										"next_startTime": state.cursor.current_startTime,
+  										"next_endTime": state.cursor.current_endTime,
+  									}
+  								),
+  							}
+  						)
   					:
   						// Not ready or done - Keep polling.
   						state.with(

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
@@ -308,6 +308,7 @@ program: |
   						)
   					:
   						// Last page - Clear the task ID and page token, and end the sequence.
+  						// Next sequence starts pulling data from the last timestamp received.
   						state.with(
   							{
   								"events": body.data.records.map(e, {"message": e.encode_json()}),
@@ -317,6 +318,11 @@ program: |
   										"auth_data": auth_data,
   										"task_id": null,
   										"page_token": null,
+  										"next_startTime": has(body.?data.results) && body.data.results.size() > 0 ?
+  											optional.of(body.data.results.map(t, timestamp(t.time)).max().format(time_layout.RFC3339))
+  										:
+  											state.cursor.current_endTime,
+  										"next_endTime": null,
   									}
   								),
   							}

--- a/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
@@ -180,6 +180,22 @@ program: |
   								),
   							}
   						)
+  					: (body.data.state == "Canceled") ?
+  						// 'Canceled' (Error or timeout) - Clear the task ID and reset the sequence for the same timeframe.
+  						state.with(
+  							{
+  								"events": [],
+  								"want_more": false,
+  								"cursor": state.cursor.with(
+  									{
+  										"auth_data": auth_data,
+  										"task_id": null,
+  										"next_startTime": state.cursor.current_startTime,
+  										"next_endTime": state.cursor.current_endTime,
+  									}
+  								),
+  							}
+  						)
   					:
   						// Not ready or done - Keep polling.
   						state.with(

--- a/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
@@ -308,6 +308,7 @@ program: |
   						)
   					:
   						// Last page - Clear the task ID and page token, and end the sequence.
+  						// Next sequence starts pulling data from the last timestamp received.
   						state.with(
   							{
   								"events": body.data.records.map(e, {"message": e.encode_json()}),
@@ -317,6 +318,11 @@ program: |
   										"auth_data": auth_data,
   										"task_id": null,
   										"page_token": null,
+  										"next_startTime": has(body.?data.results) && body.data.results.size() > 0 ?
+  											optional.of(body.data.results.map(t, timestamp(t.time)).max().format(time_layout.RFC3339))
+  										:
+  											state.cursor.current_endTime,
+  										"next_endTime": null,
   									}
   								),
   							}

--- a/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
@@ -180,6 +180,22 @@ program: |
   								),
   							}
   						)
+  					: (body.data.state == "Canceled") ?
+  						// 'Canceled' (Error or timeout) - Clear the task ID and reset the sequence for the same timeframe.
+  						state.with(
+  							{
+  								"events": [],
+  								"want_more": false,
+  								"cursor": state.cursor.with(
+  									{
+  										"auth_data": auth_data,
+  										"task_id": null,
+  										"next_startTime": state.cursor.current_startTime,
+  										"next_endTime": state.cursor.current_endTime,
+  									}
+  								),
+  							}
+  						)
   					:
   						// Not ready or done - Keep polling.
   						state.with(

--- a/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
@@ -308,6 +308,7 @@ program: |
   						)
   					:
   						// Last page - Clear the task ID and page token, and end the sequence.
+  						// Next sequence starts pulling data from the last timestamp received.
   						state.with(
   							{
   								"events": body.data.records.map(e, {"message": e.encode_json()}),
@@ -317,6 +318,11 @@ program: |
   										"auth_data": auth_data,
   										"task_id": null,
   										"page_token": null,
+  										"next_startTime": has(body.?data.results) && body.data.results.size() > 0 ?
+  											optional.of(body.data.results.map(t, timestamp(t.time)).max().format(time_layout.RFC3339))
+  										:
+  											state.cursor.current_endTime,
+  										"next_endTime": null,
   									}
   								),
   							}

--- a/packages/checkpoint_harmony_endpoint/manifest.yml
+++ b/packages/checkpoint_harmony_endpoint/manifest.yml
@@ -78,7 +78,7 @@ policy_templates:
             type: integer
             title: Number of results per search
             description: Sets the number of results to return per search. Limit should not be less than 'Page Limit'. Maximum allowed value 10000.
-            default: 10000
+            default: 1000
             multi: false
             required: true
             show_user: true
@@ -86,7 +86,7 @@ policy_templates:
             type: integer
             title: Number of results per page
             description: Sets the number of results to return per page. Maximum allowed value 1000. Minimum allowed value 10.
-            default: 1000
+            default: 100
             multi: false
             required: true
             show_user: true

--- a/packages/checkpoint_harmony_endpoint/manifest.yml
+++ b/packages/checkpoint_harmony_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: checkpoint_harmony_endpoint
 title: "Check Point Harmony Endpoint"
-version: "0.6.0"
+version: "0.7.0"
 source:
   license: "Elastic-2.0"
 description: "Collect logs from Check Point Harmony Endpoint"


### PR DESCRIPTION
## Proposed commit message

```
Three changes have been made to improve handling of pulled data:
- Base subsequent request timeranges on the timestamp of the latest data received instead of the last requested range, to avoid losing events that could not be pulled in the previous iteration.
- Adjusted default request limits (results per search, and results per page) to avoid an overload on the API server that could lead to a timeout.
- When receiving a Canceled state[1] for the TaskStatusResponse, gratefully ending, clearing task ID and restarting the sequence for the same timeframe.

Ref:
- [1] https://app.swaggerhub.com/apis-docs/Check-Point/infinity-events-api/1.0.0#/Search%20Event%20Logs/getTaskStatus
```

> [!NOTE]
> Each change is delivered in a different commit for better reviewing.

> [!NOTE]
> All data streams have identical `cel.yml.hbs` files.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

