### PR TITLE
[Auth0] Fix `event.type` and `event.category` for failed authentication events

### DIFF
--- a/packages/auth0/changelog.yml
+++ b/packages/auth0/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.21.2"
+  changes:
+    - description: Fix `event.type` and `event.category` classification of failed authentication events.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.21.1"
   changes:
     - description: Fixed date parsing issue for `auth0.logs` data stream.

--- a/packages/auth0/changelog.yml
+++ b/packages/auth0/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix `event.type` and `event.category` classification of failed authentication events.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/13480
 - version: "1.21.1"
   changes:
     - description: Fixed date parsing issue for `auth0.logs` data stream.

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-login-failure.json
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-login-failure.json
@@ -176,6 +176,47 @@
                     "log_id": "90020211103082515482106767167326018758436529088273317970"
                 }
             }
-        }
+        },
+        {
+            "json": {
+              "log_id": "90020250408092515987654321012345678901234567890123456789",
+              "data": {
+                "date": "2025-04-08T09:25:15.000Z",
+                "type": "limit_wc",
+                "description": "An IP address is blocked with 10 failed login attempts into a single account from the same IP address",
+                "ip": "192.168.1.50",
+                "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36",
+                "details": {
+                  "attempts": 10,
+                  "user_id": "auth0|6431a2b7b4d29e0068d88abc",
+                  "email": "blockeduser@example.com",
+                  "connection": "Username-Password-Authentication"
+                },
+                "hostname": "dev-yourtenant.auth0.com"
+              }
+            }
+        },
+        {
+            "json": {
+              "log_id": "90020250408092616987654321098765432109876543210987654321",
+              "data": {
+                "date": "2025-04-08T09:26:16.000Z",
+                "type": "limit_mu",
+                "description": "An IP address is blocked with 100 failed login attempts using different usernames",
+                "ip": "192.168.1.51",
+                "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15",
+                "details": {
+                  "attempts": 100,
+                  "usernames_attempted": [
+                    "user1@example.com",
+                    "admin@example.com",
+                    "guest@example.com"
+                  ],
+                  "connection": "Username-Password-Authentication"
+                },
+                "hostname": "dev-yourtenant.auth0.com"
+              }
+            }
+        }           
     ]
 }

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-login-failure.json-expected.json
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-login-failure.json-expected.json
@@ -417,6 +417,127 @@
                 },
                 "version": "95.0.4638.69"
             }
+        },
+        {
+            "@timestamp": "2025-04-08T09:25:15.000Z",
+            "auth0": {
+                "logs": {
+                    "data": {
+                        "classification": "System - Notification",
+                        "date": "2025-04-08T09:25:15.000Z",
+                        "description": "An IP address is blocked with 10 failed login attempts into a single account from the same IP address",
+                        "details": {
+                            "attempts": 10,
+                            "connection": "Username-Password-Authentication",
+                            "email": "blockeduser@example.com",
+                            "user_id": "auth0|6431a2b7b4d29e0068d88abc"
+                        },
+                        "hostname": "dev-yourtenant.auth0.com",
+                        "type": "An IP address is blocked with 10 failed login attempts into a single account from the same IP address",
+                        "type_id": "limit_wc"
+                    }
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "ten-failed-logins-ip-address-blocked",
+                "category": [
+                    "authentication",
+                    "intrusion_detection"
+                ],
+                "kind": "event",
+                "outcome": "unknown",
+                "type": [
+                    "info",
+                    "denied"
+                ]
+            },
+            "log": {
+                "level": "info"
+            },
+            "network": {
+                "type": "ipv4"
+            },
+            "source": {
+                "ip": "192.168.1.50"
+            },
+            "user_agent": {
+                "device": {
+                    "name": "Other"
+                },
+                "name": "Chrome",
+                "original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36",
+                "os": {
+                    "full": "Windows 10",
+                    "name": "Windows",
+                    "version": "10"
+                },
+                "version": "112.0.0.0"
+            }
+        },
+        {
+            "@timestamp": "2025-04-08T09:26:16.000Z",
+            "auth0": {
+                "logs": {
+                    "data": {
+                        "classification": "System - Notification",
+                        "date": "2025-04-08T09:26:16.000Z",
+                        "description": "An IP address is blocked with 100 failed login attempts using different usernames",
+                        "details": {
+                            "attempts": 100,
+                            "connection": "Username-Password-Authentication",
+                            "usernames_attempted": [
+                                "user1@example.com",
+                                "admin@example.com",
+                                "guest@example.com"
+                            ]
+                        },
+                        "hostname": "dev-yourtenant.auth0.com",
+                        "type": "An IP address is blocked with 100 failed login attempts using different usernames",
+                        "type_id": "limit_mu"
+                    }
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "hundred-failed-logins-ip-address-blocked",
+                "category": [
+                    "authentication",
+                    "intrusion_detection"
+                ],
+                "kind": "event",
+                "outcome": "unknown",
+                "type": [
+                    "info",
+                    "denied"
+                ]
+            },
+            "log": {
+                "level": "info"
+            },
+            "network": {
+                "type": "ipv4"
+            },
+            "source": {
+                "ip": "192.168.1.51"
+            },
+            "user_agent": {
+                "device": {
+                    "name": "Mac"
+                },
+                "name": "Safari",
+                "original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15",
+                "os": {
+                    "full": "Mac OS X 10.15.7",
+                    "name": "Mac OS X",
+                    "version": "10.15.7"
+                },
+                "version": "15.1"
+            }
         }
     ]
 }

--- a/packages/auth0/data_stream/logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/auth0/data_stream/logs/elasticsearch/ingest_pipeline/default.yml
@@ -517,20 +517,18 @@ processors:
           classification: "System - Notification"
           value: "An IP address is blocked with 100 failed login attempts using different usernames"
           type:
-            - indicator
             - info
+            - denied
           category:
-            - threat
             - intrusion_detection
           action: hundred-failed-logins-ip-address-blocked
         limit_wc:
           classification: "System - Notification"
           value: "An IP address is blocked with 10 failed login attempts into a single account from the same IP address"
           type:
-            - indicator
             - info
+            - denied
           category:
-            - threat
             - intrusion_detection
           action: ten-failed-logins-ip-address-blocked
         sys_os_update_start:

--- a/packages/auth0/manifest.yml
+++ b/packages/auth0/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: auth0
 title: "Auth0"
-version: "1.21.1"
+version: "1.21.2"
 description: Collect logs from Auth0 with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

This PR fixes `event.type` and `event.category` for the following failed authentication event actions:
- hundred-failed-logins-ip-address-blocked
- ten-failed-logins-ip-address-blocked

we've removed the `indicator` event.type and `threat` event.category for the above mentioned event.

**Note:** The newly added test logs are not live data but generated from the existing logs as per the requirement.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/m365_defender directory.
- Run the following command to run tests.
> elastic-package test

## Related issues

- Closes #13262
