### PR TITLE
Change ecosystem to integrations-triaging as default owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 * @elastic/ecosystem
 
 # Default owner of packages, which will triage new packages and assignment to other teams.
-/packages/ @elastic/ecosystem
+/packages/ @elastic/integrations-triaging
 
 # CODEOWNERS file is checked by CI.
 /.github/CODEOWNERS


### PR DESCRIPTION
In https://github.com/elastic/integrations/pull/13391 we set a default owner for new packages, so a review is automatically requested and new packages don't pass unnoticed.

During the weeks we have had this system in place, we have noticed that most of the time someone from an integrations team has to do the review, and then the ecosystem still needs to approve.

To make this process more agile, we have created a new @elastic/integrations-triaging team where we could add representatives of the different integration teams.

This team is composed by now by some members of the ecosystem area plus @kcreddy from the security integrations team.