### PR TITLE
[DOCS] Remove duplicated content on installation instructions

### DIFF
--- a/packages/abnormal_security/_dev/build/docs/README.md
+++ b/packages/abnormal_security/_dev/build/docs/README.md
@@ -20,25 +20,7 @@ The Abnormal Security integration collects four types of logs:
 
 ## Requirements
 
-You need to have Elastic Agent installed. For detailed guidance, refer to the Elastic Agent [installation instructions](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
-
-### Installing and managing an Elastic Agent
-
-There are several options for installing and managing Elastic Agent:
-
-#### Install a Fleet-managed Elastic Agent (recommended)
-
-With this approach, you install Elastic Agent and use Fleet in Kibana to define, configure, and manage your agents in a central location. We recommend using Fleet management because it makes the management and upgrade of your agents considerably easier.
-
-#### Install Elastic Agent in standalone mode (advanced users)
-
-With this approach, you install Elastic Agent and manually configure the agent locally on the system where it’s installed. You are responsible for managing and upgrading the agents. This approach is reserved for advanced users only.
-
-#### Install Elastic Agent in a containerized environment
-
-You can run Elastic Agent inside a container, either with Fleet Server or standalone. Docker images for all versions of Elastic Agent are available from the Elastic Docker registry, and we provide deployment manifests for running on Kubernetes.
-
-Before installing the Elastic Agent, check the [minimum requirements](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
+Elastic Agent must be installed. For more details, check the Elastic Agent [installation instructions](docs-content://reference/fleet/install-elastic-agents.md).
 
 ## Setup
 

--- a/packages/abnormal_security/docs/README.md
+++ b/packages/abnormal_security/docs/README.md
@@ -20,25 +20,7 @@ The Abnormal Security integration collects four types of logs:
 
 ## Requirements
 
-You need to have Elastic Agent installed. For detailed guidance, refer to the Elastic Agent [installation instructions](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
-
-### Installing and managing an Elastic Agent
-
-There are several options for installing and managing Elastic Agent:
-
-#### Install a Fleet-managed Elastic Agent (recommended)
-
-With this approach, you install Elastic Agent and use Fleet in Kibana to define, configure, and manage your agents in a central location. We recommend using Fleet management because it makes the management and upgrade of your agents considerably easier.
-
-#### Install Elastic Agent in standalone mode (advanced users)
-
-With this approach, you install Elastic Agent and manually configure the agent locally on the system where it’s installed. You are responsible for managing and upgrading the agents. This approach is reserved for advanced users only.
-
-#### Install Elastic Agent in a containerized environment
-
-You can run Elastic Agent inside a container, either with Fleet Server or standalone. Docker images for all versions of Elastic Agent are available from the Elastic Docker registry, and we provide deployment manifests for running on Kubernetes.
-
-Before installing the Elastic Agent, check the [minimum requirements](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
+Elastic Agent must be installed. For more details, check the Elastic Agent [installation instructions](docs-content://reference/fleet/install-elastic-agents.md).
 
 ## Setup
 


### PR DESCRIPTION
**WIP DO NOT MERGE**


This PR:
- removes the Install sections as these are the same **[installation instructions]** linked from the Requirements section.
- updates the link format, compatible with the new doc system rules
- adjusts the text in the Requirements section

Relates https://github.com/elastic/integration-docs/issues/653

_________________


<img width="909" alt="image" src="https://github.com/user-attachments/assets/e31a9bbb-780f-47f7-95d8-0e7d7f8788cb" />

