### PR TITLE
Add delete options for Custom Filestream integration

### DIFF
--- a/packages/filestream/changelog.yml
+++ b/packages/filestream/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Add support for removing files after ingestion
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/999999
 - version: "1.1.0"
   changes:
     - description: Add support for defining Conditions

--- a/packages/filestream/data_stream/generic/agent/stream/filestream.yml.hbs
+++ b/packages/filestream/data_stream/generic/agent/stream/filestream.yml.hbs
@@ -148,3 +148,15 @@ file_identity.fingerprint.length: {{ fingerprint_length  }}
 {{#if condition }}
 condition: {{ condition }}
 {{/if}}
+
+{{#if delete_on_eof }}
+delete.on_close.eof: true
+{{/if}}
+
+{{#if delete_on_inactive }}
+delete.on_close.inactive: true
+{{/if}}
+
+{{# if delete_grace_period }}
+delete.grace_period: {{delete_grace_period}}
+{{/if}}

--- a/packages/filestream/data_stream/generic/manifest.yml
+++ b/packages/filestream/data_stream/generic/manifest.yml
@@ -288,3 +288,35 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: delete_on_eof
+        type: bool
+        title: Delete file on EOF
+        default: false
+        show_user: false
+        description: |
+          When enabled, files will be removed after they have been
+          read until the End-Of-File (EOF) and all events have been
+          published to the output.
+      - name: delete_on_inactive
+        type: bool
+        title: Delete files when inactive
+        default: false
+        show_user: false
+        description: |
+          When enabled, files will be removed after they're considered
+          inactive. A file is considered inactive based on the time
+          when the last line was read. To configure the inactive
+          timeout set 'Close on State Changed Inactive'.
+
+          If this option is enabled, `close.on_state_change.inactive`
+          has its default changed to 30min, to overwrite the inactive
+          timeout, set 'Close on State Changed Inactive'.
+      - name: delete_grace_period
+        type: text
+        show_user: false
+        description: |
+          An interval to wait after the file is closed and all events
+          have been published before trying to remove it.
+
+          E.g: "30m", Valid time units are "ns", "us" (or "µs"), "ms",
+          "s", "m", "h".

--- a/packages/filestream/manifest.yml
+++ b/packages/filestream/manifest.yml
@@ -3,10 +3,10 @@ name: filestream
 title: Custom Filestream Logs
 description: Collect log data using filestream with Elastic Agent.
 type: integration
-version: 1.1.0
+version: 1.2.0
 conditions:
   kibana:
-    version: "^8.15.0 || ^9.0.0"
+    version: "^8.15.0 || >=9.1.0"
 categories:
   - custom
   - custom_logs


### PR DESCRIPTION
## Proposed commit message

See title

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

- [ ] Verify when the delete feature will be released
- [ ] Wait for the compatible Elastic-Agent/Filebeat to be released

## How to test this PR locally

1. Create a log file > 1kb
2. Add the Custom Filestream integration to read the file created in `#1` and add it to an Elastic-Agent policy
3. Deploy and start the Elastic-Agent
4. Wait the condition for the file removal to be reached
5. Assert the log file has been removed

## Related issues
- https://github.com/elastic/beats/pull/43368

## Screenshots

![2025-04-16_17-50](https://github.com/user-attachments/assets/323ed7b6-2968-4b20-b8ae-de44f29fb9ba)

