### PR TITLE
[Cloud Security] bump posture package

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,6 +1,6 @@
 # newer versions go on top
 # version map:
-# 1.14.x - 8.19.x, 9.1.x
+# 2.0.x - 8.19.x, 9.1.x
 # 1.13.x - 8.18.x, 9.0.x
 # 1.12.x - 8.17.x
 # 1.11.x - 8.16.x
@@ -13,6 +13,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "2.0.0-preview01"
+  changes:
+    - description: Populate event.outcome field with value from result.evaluation
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/13582
 - version: "1.14.0-preview05"
   changes:
     - description: Remove unused azure credentials.

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.14.0-preview05"
+version: "2.0.0-preview01"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
## Proposed commit message

bump posture package major version to indicate a breaking change in Cloudbeat's next version which includes populating the event.outcome field with the same value from result.evaluation


## Related issues

- related https://github.com/elastic/cloudbeat/pull/3179
- closes https://github.com/elastic/security-team/issues/10639


