### PR TITLE
fix(issue template): sort packages by title

### DIFF
--- a/.github/workflows/updatecli/updatecli.d/sync-packages-to-bug-issue-template.yml
+++ b/.github/workflows/updatecli/updatecli.d/sync-packages-to-bug-issue-template.yml
@@ -35,7 +35,7 @@ targets:
           title=$(yq .title packages/$i/manifest.yml)
           pkg=$i
           echo "- $title [$pkg]"
-        done | yq -o json .)
+        done | sort -s -f | yq -o json .)
         
         yq eval ".body[1].attributes.options = $pkgs" -i '.github/ISSUE_TEMPLATE/integration_bug.yml'
         yq eval ".body[1].attributes.options = $pkgs" -i '.github/ISSUE_TEMPLATE/integration_feature_request.yml'


### PR DESCRIPTION
## Proposed commit message

Sort the list of integrations in the issue template by title (ignoring case). Previously they were ordered by directory name which was confusing.

## Related

- https://github.com/elastic/integrations/issues/13580#issuecomment-2812766382