### PR TITLE
[sentinel_one] Populate ECS field message for threat, alert and activity datastreams

### DIFF
--- a/packages/sentinel_one/changelog.yml
+++ b/packages/sentinel_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.34.0"
+  changes:
+    - description: Populate ECS field `message` for threat, alert and activity datastreams.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.33.0"
   changes:
     - description: Update `host.*` ECS mappings.

--- a/packages/sentinel_one/data_stream/activity/_dev/test/pipeline/test-pipeline-activity.log-expected.json
+++ b/packages/sentinel_one/data_stream/activity/_dev/test/pipeline/test-pipeline-activity.log-expected.json
@@ -15,7 +15,7 @@
                     "info"
                 ]
             },
-            "message": "API",
+            "message": "The management user API enabled Two factor authentication on the user API.",
             "related": {
                 "user": [
                     "API"
@@ -52,6 +52,7 @@
                     "description": {
                         "primary": "The management user API enabled Two factor authentication on the user API."
                     },
+                    "description_value": "API",
                     "id": "1234567890123456789",
                     "type": 1234,
                     "updated_at": "2022-04-18T05:14:08.922Z"
@@ -98,6 +99,7 @@
                     "81.2.69.144"
                 ]
             },
+            "message": "The management user API logged in to the management console with IP Address 81.2.69.144",
             "related": {
                 "ip": [
                     "81.2.69.144"
@@ -161,6 +163,7 @@
                     "creation"
                 ]
             },
+            "message": "User test User added a recovery email user@example.com",
             "related": {
                 "user": [
                     "test User"
@@ -237,6 +240,7 @@
                 ],
                 "name": "user-computer-name"
             },
+            "message": "System initiated a full disk scan to the agent: user-computer-name (81.2.69.144).",
             "related": {
                 "hosts": [
                     "user-computer-name"
@@ -311,6 +315,7 @@
                 "id": "1234567890123456789",
                 "name": "user-computer-name"
             },
+            "message": "user-computer-name subscribed and joined the group Default Group of site Default site.",
             "related": {
                 "hosts": [
                     "user-computer-name"
@@ -377,6 +382,7 @@
                 "id": "1234567890123456789",
                 "name": "user-computer-name"
             },
+            "message": "Agent user-computer-name started full disk scan at Wed, 06 Apr 2022, 08:26:52 UTC.",
             "related": {
                 "hosts": [
                     "user-computer-name"
@@ -461,6 +467,7 @@
                     "family": "osname"
                 }
             },
+            "message": "Cloud added or modified osname blacklist hash.",
             "observer": {
                 "os": {
                     "family": "osname"
@@ -547,6 +554,7 @@
                 "id": "1234567890123456789",
                 "name": "user-computer-name"
             },
+            "message": "Threat with confidence level malicious detected: default.exe",
             "related": {
                 "hash": [
                     "aaf4c61ddcc5e8a2dabede0f3b482cxxxxxxxxxx"
@@ -638,6 +646,7 @@
                 "id": "1234567890123456789",
                 "name": "user-test"
             },
+            "message": "The agent user-computer-name successfully killed the threat: default.exe.",
             "related": {
                 "hash": [
                     "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"
@@ -733,6 +742,7 @@
                 "id": "1234567890123456789",
                 "name": "user-test"
             },
+            "message": "Status of threat default.exe on agent user-computer-name changed from Not mitigated to Mitigated.",
             "related": {
                 "hash": [
                     "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"
@@ -827,6 +837,7 @@
                 "id": "1234567890123456789",
                 "name": "user-test"
             },
+            "message": "The agent user-computer-name successfully quarantined the threat: default.exe.",
             "related": {
                 "hash": [
                     "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"
@@ -923,6 +934,7 @@
                     "type": "linux"
                 }
             },
+            "message": "Cloud added or modified linux blacklist hash.",
             "observer": {
                 "os": {
                     "family": "linux"
@@ -995,6 +1007,7 @@
                     "info"
                 ]
             },
+            "message": "The management user test User turned off policy inheritance for account Default.",
             "related": {
                 "user": [
                     "test User"
@@ -1054,6 +1067,7 @@
                     "info"
                 ]
             },
+            "message": "Agent UI setting was changed for  all Sites .",
             "related": {
                 "user": [
                     "test User"
@@ -1135,6 +1149,7 @@
                 "id": "1234567890123456789",
                 "name": "user-test"
             },
+            "message": "Agent user-computer-name changed the Confidence Level of the threat from suspicious to malicious",
             "related": {
                 "hash": [
                     "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"
@@ -1224,6 +1239,7 @@
                     "info"
                 ]
             },
+            "message": "The management user test user turned on Deep Visibility configuration \"BEHAVIORAL_INDICATORS\" for account Default.",
             "related": {
                 "user": [
                     "test user"
@@ -1303,6 +1319,7 @@
                 ],
                 "name": "user-test"
             },
+            "message": "System initiated a full disk scan to the agent: user-computer-name (81.2.69.144).",
             "related": {
                 "hosts": [
                     "user-test"
@@ -1376,6 +1393,7 @@
                     "creation"
                 ]
             },
+            "message": "created Default account.",
             "related": {
                 "user": [
                     "test user"
@@ -1444,6 +1462,7 @@
                     "type": "linux"
                 }
             },
+            "message": "Cloud added or modified linux blacklist hash.",
             "observer": {
                 "os": {
                     "family": "linux"
@@ -1537,6 +1556,7 @@
                     "81.2.69.143"
                 ]
             },
+            "message": "The management user test User logged in to the management console with IP Address 81.2.69.144",
             "related": {
                 "ip": [
                     "81.2.69.143"
@@ -1600,7 +1620,7 @@
                     "creation"
                 ]
             },
-            "message": "<ManagementUser at 0x7f6e6xxc34 with id=1234567890123456789, email='user@example.com', user_scope='account'>",
+            "message": "The management user test User added user test user as Level.",
             "related": {
                 "user": [
                     "test user"
@@ -1633,6 +1653,7 @@
                     "description": {
                         "primary": "The management user test User added user test user as Level."
                     },
+                    "description_value": "<ManagementUser at 0x7f6e6xxc34 with id=1234567890123456789, email='user@example.com', user_scope='account'>",
                     "id": "1234567890123456789",
                     "type": 1234,
                     "updated_at": "2022-04-18T05:09:27.520Z"
@@ -1661,6 +1682,7 @@
                     "creation"
                 ]
             },
+            "message": "The management user test User added user test user to role Level in scope Default",
             "related": {
                 "user": [
                     "test user"
@@ -1725,6 +1747,7 @@
                     "info"
                 ]
             },
+            "message": "The management user test sent a Verification Email to the user test.",
             "related": {
                 "user": [
                     "test User"
@@ -1786,6 +1809,7 @@
                     "info"
                 ]
             },
+            "message": "The management user Test failed to log in to the management console with IP Address x.x.x.x.",
             "related": {
                 "user": [
                     "test User"
@@ -1959,6 +1983,7 @@
                 "id": "1234567890123456789",
                 "name": "user-computer-name"
             },
+            "message": "Threat with confidence level malicious detected: default.exe",
             "related": {
                 "hash": [
                     "aaf4c61ddcc5e8a2dabede0f3b482cxxxxxxxxxx"

--- a/packages/sentinel_one/data_stream/activity/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sentinel_one/data_stream/activity/elasticsearch/ingest_pipeline/default.yml
@@ -105,7 +105,7 @@ processors:
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
       field: json.description
-      target_field: message
+      target_field: sentinel_one.activity.description_value
       ignore_missing: true
   - rename:
       field: json.hash
@@ -170,6 +170,10 @@ processors:
       field: json.primaryDescription
       target_field: sentinel_one.activity.description.primary
       ignore_missing: true
+  - set:
+      field: message
+      copy_from: sentinel_one.activity.description.primary
+      if: ctx.sentinel_one?.activity?.description?.primary != null
   - rename:
       field: json.secondaryDescription
       target_field: sentinel_one.activity.description.secondary

--- a/packages/sentinel_one/data_stream/activity/fields/fields.yml
+++ b/packages/sentinel_one/data_stream/activity/fields/fields.yml
@@ -193,6 +193,8 @@
         - name: secondary
           type: keyword
           description: Secondary description.
+    - name: description_value
+      type: keyword
     - name: id
       type: keyword
       description: Activity ID.

--- a/packages/sentinel_one/data_stream/activity/sample_event.json
+++ b/packages/sentinel_one/data_stream/activity/sample_event.json
@@ -1,23 +1,23 @@
 {
     "@timestamp": "2022-04-05T16:01:56.995Z",
     "agent": {
-        "ephemeral_id": "9319bd57-cf05-46e2-b333-1bed7686b36a",
-        "id": "8a970448-3422-428e-b4dd-650eb0e9c205",
-        "name": "elastic-agent-39532",
+        "ephemeral_id": "9708976f-46ea-47f7-9fe8-5a9e412560cd",
+        "id": "2a5e3cb8-63c3-416a-b22d-cd062f0ac61d",
+        "name": "elastic-agent-33921",
         "type": "filebeat",
         "version": "8.18.0"
     },
     "data_stream": {
         "dataset": "sentinel_one.activity",
-        "namespace": "94834",
+        "namespace": "32847",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "8a970448-3422-428e-b4dd-650eb0e9c205",
-        "snapshot": true,
+        "id": "2a5e3cb8-63c3-416a-b22d-cd062f0ac61d",
+        "snapshot": false,
         "version": "8.18.0"
     },
     "event": {
@@ -25,9 +25,9 @@
         "category": [
             "configuration"
         ],
-        "created": "2025-04-01T09:27:03.091Z",
+        "created": "2025-04-21T14:22:01.561Z",
         "dataset": "sentinel_one.activity",
-        "ingested": "2025-04-01T09:27:04Z",
+        "ingested": "2025-04-21T14:22:02Z",
         "kind": "event",
         "original": "{\"accountId\":\"1234567890123456789\",\"accountName\":\"Default\",\"activityType\":1234,\"agentId\":null,\"agentUpdatedVersion\":null,\"comments\":null,\"createdAt\":\"2022-04-05T16:01:56.995120Z\",\"data\":{\"accountId\":1234567890123456800,\"accountName\":\"Default\",\"fullScopeDetails\":\"Account Default\",\"fullScopeDetailsPath\":\"test/path\",\"groupName\":null,\"scopeLevel\":\"Account\",\"scopeName\":\"Default\",\"siteName\":null,\"username\":\"test user\"},\"description\":null,\"groupId\":null,\"groupName\":null,\"hash\":null,\"id\":\"1234567890123456789\",\"osFamily\":null,\"primaryDescription\":\"created Default account.\",\"secondaryDescription\":null,\"siteId\":null,\"siteName\":null,\"threatId\":null,\"updatedAt\":\"2022-04-05T16:01:56.992136Z\",\"userId\":\"1234567890123456789\"}",
         "type": [
@@ -37,6 +37,7 @@
     "input": {
         "type": "httpjson"
     },
+    "message": "created Default account.",
     "related": {
         "user": [
             "test user"

--- a/packages/sentinel_one/data_stream/alert/_dev/test/pipeline/test-pipeline-alert.log-expected.json
+++ b/packages/sentinel_one/data_stream/alert/_dev/test/pipeline/test-pipeline-alert.log-expected.json
@@ -54,6 +54,7 @@
                 },
                 "type": "string"
             },
+            "message": "string",
             "observer": {
                 "serial_number": "string",
                 "version": "3.x.x.x"
@@ -280,6 +281,7 @@
                 },
                 "type": "server"
             },
+            "message": "test5",
             "observer": {
                 "serial_number": "0efd7bcfd285450885e05bd8d5bf2ba7",
                 "version": "23.4.4.223"
@@ -437,6 +439,7 @@
                 },
                 "type": "server"
             },
+            "message": "test5",
             "observer": {
                 "serial_number": "0efd7bcfd285450885e05bd8d5bf2ba7",
                 "version": "23.4.4.223"

--- a/packages/sentinel_one/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sentinel_one/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
@@ -477,6 +477,10 @@ processors:
       field: json.ruleInfo.name
       target_field: rule.name
       ignore_missing: true
+  - set:
+      field: message
+      copy_from: rule.name
+      if: ctx.rule?.name != null
   - rename:
       field: json.ruleInfo.scopeLevel
       target_field: sentinel_one.alert.rule.scope_level

--- a/packages/sentinel_one/data_stream/alert/sample_event.json
+++ b/packages/sentinel_one/data_stream/alert/sample_event.json
@@ -1,9 +1,9 @@
 {
     "@timestamp": "2018-02-27T04:49:26.257Z",
     "agent": {
-        "ephemeral_id": "383eb2ea-2541-4fc5-b484-1120abc815e2",
-        "id": "34d91faa-14cf-412c-9de8-d739c7b078b1",
-        "name": "elastic-agent-80600",
+        "ephemeral_id": "f7263a43-43f1-494d-b833-7fdb8bb2335d",
+        "id": "1a5b477b-17d5-4254-8418-2e57e88f7806",
+        "name": "elastic-agent-26994",
         "type": "filebeat",
         "version": "8.18.0"
     },
@@ -16,7 +16,7 @@
     },
     "data_stream": {
         "dataset": "sentinel_one.alert",
-        "namespace": "53336",
+        "namespace": "59397",
         "type": "logs"
     },
     "destination": {
@@ -38,8 +38,8 @@
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "34d91faa-14cf-412c-9de8-d739c7b078b1",
-        "snapshot": true,
+        "id": "1a5b477b-17d5-4254-8418-2e57e88f7806",
+        "snapshot": false,
         "version": "8.18.0"
     },
     "event": {
@@ -47,10 +47,10 @@
         "category": [
             "malware"
         ],
-        "created": "2025-04-01T09:30:31.193Z",
+        "created": "2025-04-21T14:20:33.126Z",
         "dataset": "sentinel_one.alert",
         "id": "123456789123456789",
-        "ingested": "2025-04-01T09:30:34Z",
+        "ingested": "2025-04-21T14:20:36Z",
         "kind": "event",
         "original": "{\"agentDetectionInfo\":{\"machineType\":\"string\",\"name\":\"string\",\"osFamily\":\"string\",\"osName\":\"string\",\"osRevision\":\"string\",\"siteId\":\"123456789123456789\",\"uuid\":\"string\",\"version\":\"3.x.x.x\"},\"alertInfo\":{\"alertId\":\"123456789123456789\",\"analystVerdict\":\"string\",\"createdAt\":\"2018-02-27T04:49:26.257525Z\",\"dnsRequest\":\"string\",\"dnsResponse\":\"string\",\"dstIp\":\"81.2.69.144\",\"dstPort\":\"1234\",\"dvEventId\":\"string\",\"eventType\":\"info\",\"hitType\":\"Events\",\"incidentStatus\":\"string\",\"indicatorCategory\":\"string\",\"indicatorDescription\":\"string\",\"indicatorName\":\"string\",\"loginAccountDomain\":\"string\",\"loginAccountSid\":\"string\",\"loginIsAdministratorEquivalent\":\"string\",\"loginIsSuccessful\":\"string\",\"loginType\":\"string\",\"loginsUserName\":\"string\",\"modulePath\":\"string\",\"moduleSha1\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"netEventDirection\":\"string\",\"registryKeyPath\":\"string\",\"registryOldValue\":\"string\",\"registryOldValueType\":\"string\",\"registryPath\":\"string\",\"registryValue\":\"string\",\"reportedAt\":\"2018-02-27T04:49:26.257525Z\",\"source\":\"string\",\"srcIp\":\"81.2.69.142\",\"srcMachineIp\":\"81.2.69.142\",\"srcPort\":\"1234\",\"tiIndicatorComparisonMethod\":\"string\",\"tiIndicatorSource\":\"string\",\"tiIndicatorType\":\"string\",\"tiIndicatorValue\":\"string\",\"updatedAt\":\"2018-02-27T04:49:26.257525Z\"},\"containerInfo\":{\"id\":\"string\",\"image\":\"string\",\"labels\":\"string\",\"name\":\"string\"},\"kubernetesInfo\":{\"cluster\":\"string\",\"controllerKind\":\"string\",\"controllerLabels\":\"string\",\"controllerName\":\"string\",\"namespace\":\"string\",\"namespaceLabels\":\"string\",\"node\":\"string\",\"pod\":\"string\",\"podLabels\":\"string\"},\"ruleInfo\":{\"description\":\"string\",\"id\":\"string\",\"name\":\"string\",\"scopeLevel\":\"string\",\"severity\":\"Low\",\"treatAsThreat\":\"UNDEFINED\"},\"sourceParentProcessInfo\":{\"commandline\":\"string\",\"fileHashMd5\":\"5d41402abc4b2a76b9719d911017c592\",\"fileHashSha1\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"fileHashSha256\":\"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824\",\"filePath\":\"string\",\"fileSignerIdentity\":\"string\",\"integrityLevel\":\"unknown\",\"name\":\"string\",\"pid\":\"12345\",\"pidStarttime\":\"2018-02-27T04:49:26.257525Z\",\"storyline\":\"string\",\"subsystem\":\"unknown\",\"uniqueId\":\"string\",\"user\":\"string\"},\"sourceProcessInfo\":{\"commandline\":\"string\",\"fileHashMd5\":\"5d41402abc4b2a76b9719d911017c592\",\"fileHashSha1\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"fileHashSha256\":\"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824\",\"filePath\":\"string\",\"fileSignerIdentity\":\"string\",\"integrityLevel\":\"unknown\",\"name\":\"string\",\"pid\":\"12345\",\"pidStarttime\":\"2018-02-27T04:49:26.257525Z\",\"storyline\":\"string\",\"subsystem\":\"unknown\",\"uniqueId\":\"string\",\"user\":\"string\"},\"targetProcessInfo\":{\"tgtFileCreatedAt\":\"2018-02-27T04:49:26.257525Z\",\"tgtFileHashSha1\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"tgtFileHashSha256\":\"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824\",\"tgtFileId\":\"string\",\"tgtFileIsSigned\":\"string\",\"tgtFileModifiedAt\":\"2018-02-27T04:49:26.257525Z\",\"tgtFileOldPath\":\"string\",\"tgtFilePath\":\"string\",\"tgtProcCmdLine\":\"string\",\"tgtProcImagePath\":\"string\",\"tgtProcIntegrityLevel\":\"unknown\",\"tgtProcName\":\"string\",\"tgtProcPid\":\"12345\",\"tgtProcSignedStatus\":\"string\",\"tgtProcStorylineId\":\"string\",\"tgtProcUid\":\"string\",\"tgtProcessStartTime\":\"2018-02-27T04:49:26.257525Z\"}}",
         "type": [
@@ -76,6 +76,7 @@
     "input": {
         "type": "httpjson"
     },
+    "message": "string",
     "observer": {
         "serial_number": "string",
         "version": "3.x.x.x"

--- a/packages/sentinel_one/data_stream/threat/_dev/test/pipeline/test-pipeline-threat.log-expected.json
+++ b/packages/sentinel_one/data_stream/threat/_dev/test/pipeline/test-pipeline-threat.log-expected.json
@@ -44,6 +44,7 @@
                     "type": "linux"
                 }
             },
+            "message": "Threat Detected: default.exe (malicious)",
             "observer": {
                 "version": "21.x.x.1234"
             },
@@ -298,6 +299,7 @@
                     "type": "linux"
                 }
             },
+            "message": "Threat Detected: Threats (malicious)",
             "observer": {
                 "version": "21.x.x.1234"
             },
@@ -597,6 +599,7 @@
                     "type": "linux"
                 }
             },
+            "message": "Threat Detected: Threats (malicious)",
             "observer": {
                 "version": "21.x.x.1234"
             },
@@ -896,6 +899,7 @@
                     "type": "linux"
                 }
             },
+            "message": "Threat Detected: Threats (malicious)",
             "observer": {
                 "version": "21.x.x.1234"
             },
@@ -1195,6 +1199,7 @@
                     "type": "linux"
                 }
             },
+            "message": "Threat Detected: Threats (malicious)",
             "observer": {
                 "version": "21.x.x.1234"
             },
@@ -1494,6 +1499,7 @@
                     "type": "macos"
                 }
             },
+            "message": "Threat Detected: UC232A_Windows_Setup.exe (malicious)",
             "observer": {
                 "version": "24.3.2.7753"
             },
@@ -1929,6 +1935,7 @@
                     "type": "windows"
                 }
             },
+            "message": "Threat Detected: 44371a.rbf (malicious)",
             "observer": {
                 "version": "24.1.5.277"
             },

--- a/packages/sentinel_one/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sentinel_one/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
@@ -596,7 +596,7 @@ processors:
       ignore_missing: true
   - rename:
       field: json.description
-      target_field: message
+      target_field: sentinel_one.threat.description
       ignore_missing: true
   - set:
       field: event.id
@@ -1215,6 +1215,10 @@ processors:
       field: json.threatInfo.threatName
       target_field: sentinel_one.threat.name
       ignore_missing: true
+  - set:
+      field: message
+      value: 'Threat Detected: {{{sentinel_one.threat.name}}} ({{{sentinel_one.threat.confidence_level}}})'
+      if: ctx.sentinel_one?.threat.name != null && ctx.sentinel_one?.threat?.confidence_level != null
   - rename:
       field: json.whiteningOptions
       target_field: sentinel_one.threat.whitening_option

--- a/packages/sentinel_one/data_stream/threat/sample_event.json
+++ b/packages/sentinel_one/data_stream/threat/sample_event.json
@@ -1,23 +1,23 @@
 {
     "@timestamp": "2022-04-06T08:54:17.194Z",
     "agent": {
-        "ephemeral_id": "c6b202e4-98c4-4349-a65c-e65b908e071a",
-        "id": "f12f6421-3fe5-4b8b-85dc-edc7a78bb4ff",
-        "name": "elastic-agent-52847",
+        "ephemeral_id": "4ad502cd-94d6-4be0-bbd3-4a726c111c52",
+        "id": "d58c2916-6feb-495e-af59-368df9d32f82",
+        "name": "elastic-agent-80138",
         "type": "filebeat",
         "version": "8.18.0"
     },
     "data_stream": {
         "dataset": "sentinel_one.threat",
-        "namespace": "85660",
+        "namespace": "51415",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "f12f6421-3fe5-4b8b-85dc-edc7a78bb4ff",
-        "snapshot": true,
+        "id": "d58c2916-6feb-495e-af59-368df9d32f82",
+        "snapshot": false,
         "version": "8.18.0"
     },
     "event": {
@@ -26,10 +26,10 @@
         "category": [
             "malware"
         ],
-        "created": "2025-04-01T09:32:31.271Z",
+        "created": "2025-04-21T14:24:22.083Z",
         "dataset": "sentinel_one.threat",
         "id": "1234567890123456789",
-        "ingested": "2025-04-01T09:32:34Z",
+        "ingested": "2025-04-21T14:24:25Z",
         "kind": "alert",
         "original": "{\"agentDetectionInfo\":{\"accountId\":\"1234567890123456789\",\"accountName\":\"Default\",\"agentDetectionState\":null,\"agentDomain\":\"WORKGROUP\",\"agentIpV4\":\"10.0.0.1\",\"agentIpV6\":\"2a02:cf40::\",\"agentLastLoggedInUpn\":null,\"agentLastLoggedInUserMail\":null,\"agentLastLoggedInUserName\":\"\",\"agentMitigationMode\":\"protect\",\"agentOsName\":\"linux\",\"agentOsRevision\":\"1234\",\"agentRegisteredAt\":\"2022-04-06T08:26:45.515278Z\",\"agentUuid\":\"fwfbxxxxxxxxxxqcfjfnxxxxxxxxx\",\"agentVersion\":\"21.x.x\",\"cloudProviders\":{},\"externalIp\":\"81.2.69.143\",\"groupId\":\"1234567890123456789\",\"groupName\":\"Default Group\",\"siteId\":\"1234567890123456789\",\"siteName\":\"Default site\"},\"agentRealtimeInfo\":{\"accountId\":\"1234567890123456789\",\"accountName\":\"Default\",\"activeThreats\":7,\"agentComputerName\":\"test-LINUX\",\"agentDecommissionedAt\":null,\"agentDomain\":\"WORKGROUP\",\"agentId\":\"1234567890123456789\",\"agentInfected\":true,\"agentIsActive\":true,\"agentIsDecommissioned\":false,\"agentMachineType\":\"server\",\"agentMitigationMode\":\"detect\",\"agentNetworkStatus\":\"connected\",\"agentOsName\":\"linux\",\"agentOsRevision\":\"1234\",\"agentOsType\":\"linux\",\"agentUuid\":\"fwfbxxxxxxxxxxqcfjfnxxxxxxxxx\",\"agentVersion\":\"21.x.x.1234\",\"groupId\":\"1234567890123456789\",\"groupName\":\"Default Group\",\"networkInterfaces\":[{\"id\":\"1234567890123456789\",\"inet\":[\"10.0.0.1\"],\"inet6\":[\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\"],\"name\":\"Ethernet\",\"physical\":\"DE:AD:00:00:BE:EF\"}],\"operationalState\":\"na\",\"rebootRequired\":false,\"scanAbortedAt\":null,\"scanFinishedAt\":\"2022-04-06T09:18:21.090855Z\",\"scanStartedAt\":\"2022-04-06T08:26:52.838047Z\",\"scanStatus\":\"finished\",\"siteId\":\"1234567890123456789\",\"siteName\":\"Default site\",\"storageName\":null,\"storageType\":null,\"userActionsNeeded\":[]},\"containerInfo\":{\"id\":null,\"image\":null,\"labels\":null,\"name\":null},\"id\":\"1234567890123456789\",\"indicators\":[],\"kubernetesInfo\":{\"cluster\":null,\"controllerKind\":null,\"controllerLabels\":null,\"controllerName\":null,\"namespace\":null,\"namespaceLabels\":null,\"node\":null,\"pod\":null,\"podLabels\":null},\"mitigationStatus\":[{\"action\":\"unquarantine\",\"actionsCounters\":{\"failed\":0,\"notFound\":0,\"pendingReboot\":0,\"success\":1,\"total\":1},\"agentSupportsReport\":true,\"groupNotFound\":false,\"lastUpdate\":\"2022-04-06T08:54:17.198002Z\",\"latestReport\":\"/threats/mitigation-report\",\"mitigationEndedAt\":\"2022-04-06T08:54:17.101000Z\",\"mitigationStartedAt\":\"2022-04-06T08:54:17.101000Z\",\"status\":\"success\"},{\"action\":\"kill\",\"actionsCounters\":null,\"agentSupportsReport\":true,\"groupNotFound\":false,\"lastUpdate\":\"2022-04-06T08:45:55.303355Z\",\"latestReport\":null,\"mitigationEndedAt\":\"2022-04-06T08:45:55.297364Z\",\"mitigationStartedAt\":\"2022-04-06T08:45:55.297363Z\",\"status\":\"success\"}],\"threatInfo\":{\"analystVerdict\":\"undefined\",\"analystVerdictDescription\":\"Undefined\",\"automaticallyResolved\":false,\"browserType\":null,\"certificateId\":\"\",\"classification\":\"Trojan\",\"classificationSource\":\"Cloud\",\"cloudFilesHashVerdict\":\"black\",\"collectionId\":\"1234567890123456789\",\"confidenceLevel\":\"malicious\",\"createdAt\":\"2022-04-06T08:45:54.519988Z\",\"detectionEngines\":[{\"key\":\"sentinelone_cloud\",\"title\":\"SentinelOne Cloud\"}],\"detectionType\":\"static\",\"engines\":[\"SentinelOne Cloud\"],\"externalTicketExists\":false,\"externalTicketId\":null,\"failedActions\":false,\"fileExtension\":\"EXE\",\"fileExtensionType\":\"Executable\",\"filePath\":\"default.exe\",\"fileSize\":1234,\"fileVerificationType\":\"NotSigned\",\"identifiedAt\":\"2022-04-06T08:45:53.968000Z\",\"incidentStatus\":\"unresolved\",\"incidentStatusDescription\":\"Unresolved\",\"initiatedBy\":\"agent_policy\",\"initiatedByDescription\":\"Agent Policy\",\"initiatingUserId\":null,\"initiatingUsername\":null,\"isFileless\":false,\"isValidCertificate\":false,\"maliciousProcessArguments\":null,\"md5\":null,\"mitigatedPreemptively\":false,\"mitigationStatus\":\"not_mitigated\",\"mitigationStatusDescription\":\"Not mitigated\",\"originatorProcess\":\"default.exe\",\"pendingActions\":false,\"processUser\":\"test user\",\"publisherName\":\"\",\"reachedEventsLimit\":false,\"rebootRequired\":false,\"sha1\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"sha256\":null,\"storyline\":\"D0XXXXXXXXXXAF4D\",\"threatId\":\"1234567890123456789\",\"threatName\":\"default.exe\",\"updatedAt\":\"2022-04-06T08:54:17.194122Z\"},\"whiteningOptions\":[\"hash\"]}",
         "type": [
@@ -66,6 +66,7 @@
     "input": {
         "type": "httpjson"
     },
+    "message": "Threat Detected: default.exe (malicious)",
     "observer": {
         "version": "21.x.x.1234"
     },
@@ -274,5 +275,8 @@
                 "size": 1234
             }
         }
+    },
+    "user": {
+        "name": "test user"
     }
 }

--- a/packages/sentinel_one/docs/README.md
+++ b/packages/sentinel_one/docs/README.md
@@ -40,23 +40,23 @@ An example event for `activity` looks as following:
 {
     "@timestamp": "2022-04-05T16:01:56.995Z",
     "agent": {
-        "ephemeral_id": "9319bd57-cf05-46e2-b333-1bed7686b36a",
-        "id": "8a970448-3422-428e-b4dd-650eb0e9c205",
-        "name": "elastic-agent-39532",
+        "ephemeral_id": "9708976f-46ea-47f7-9fe8-5a9e412560cd",
+        "id": "2a5e3cb8-63c3-416a-b22d-cd062f0ac61d",
+        "name": "elastic-agent-33921",
         "type": "filebeat",
         "version": "8.18.0"
     },
     "data_stream": {
         "dataset": "sentinel_one.activity",
-        "namespace": "94834",
+        "namespace": "32847",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "8a970448-3422-428e-b4dd-650eb0e9c205",
-        "snapshot": true,
+        "id": "2a5e3cb8-63c3-416a-b22d-cd062f0ac61d",
+        "snapshot": false,
         "version": "8.18.0"
     },
     "event": {
@@ -64,9 +64,9 @@ An example event for `activity` looks as following:
         "category": [
             "configuration"
         ],
-        "created": "2025-04-01T09:27:03.091Z",
+        "created": "2025-04-21T14:22:01.561Z",
         "dataset": "sentinel_one.activity",
-        "ingested": "2025-04-01T09:27:04Z",
+        "ingested": "2025-04-21T14:22:02Z",
         "kind": "event",
         "original": "{\"accountId\":\"1234567890123456789\",\"accountName\":\"Default\",\"activityType\":1234,\"agentId\":null,\"agentUpdatedVersion\":null,\"comments\":null,\"createdAt\":\"2022-04-05T16:01:56.995120Z\",\"data\":{\"accountId\":1234567890123456800,\"accountName\":\"Default\",\"fullScopeDetails\":\"Account Default\",\"fullScopeDetailsPath\":\"test/path\",\"groupName\":null,\"scopeLevel\":\"Account\",\"scopeName\":\"Default\",\"siteName\":null,\"username\":\"test user\"},\"description\":null,\"groupId\":null,\"groupName\":null,\"hash\":null,\"id\":\"1234567890123456789\",\"osFamily\":null,\"primaryDescription\":\"created Default account.\",\"secondaryDescription\":null,\"siteId\":null,\"siteName\":null,\"threatId\":null,\"updatedAt\":\"2022-04-05T16:01:56.992136Z\",\"userId\":\"1234567890123456789\"}",
         "type": [
@@ -76,6 +76,7 @@ An example event for `activity` looks as following:
     "input": {
         "type": "httpjson"
     },
+    "message": "created Default account.",
     "related": {
         "user": [
             "test user"
@@ -182,6 +183,7 @@ An example event for `activity` looks as following:
 | sentinel_one.activity.data.uuid | UUID. | keyword |
 | sentinel_one.activity.description.primary | Primary description. | keyword |
 | sentinel_one.activity.description.secondary | Secondary description. | keyword |
+| sentinel_one.activity.description_value |  | keyword |
 | sentinel_one.activity.id | Activity ID. | keyword |
 | sentinel_one.activity.site.id | Related site ID (if applicable). | keyword |
 | sentinel_one.activity.site.name | Related site name (if applicable). | keyword |
@@ -508,9 +510,9 @@ An example event for `alert` looks as following:
 {
     "@timestamp": "2018-02-27T04:49:26.257Z",
     "agent": {
-        "ephemeral_id": "383eb2ea-2541-4fc5-b484-1120abc815e2",
-        "id": "34d91faa-14cf-412c-9de8-d739c7b078b1",
-        "name": "elastic-agent-80600",
+        "ephemeral_id": "f7263a43-43f1-494d-b833-7fdb8bb2335d",
+        "id": "1a5b477b-17d5-4254-8418-2e57e88f7806",
+        "name": "elastic-agent-26994",
         "type": "filebeat",
         "version": "8.18.0"
     },
@@ -523,7 +525,7 @@ An example event for `alert` looks as following:
     },
     "data_stream": {
         "dataset": "sentinel_one.alert",
-        "namespace": "53336",
+        "namespace": "59397",
         "type": "logs"
     },
     "destination": {
@@ -545,8 +547,8 @@ An example event for `alert` looks as following:
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "34d91faa-14cf-412c-9de8-d739c7b078b1",
-        "snapshot": true,
+        "id": "1a5b477b-17d5-4254-8418-2e57e88f7806",
+        "snapshot": false,
         "version": "8.18.0"
     },
     "event": {
@@ -554,10 +556,10 @@ An example event for `alert` looks as following:
         "category": [
             "malware"
         ],
-        "created": "2025-04-01T09:30:31.193Z",
+        "created": "2025-04-21T14:20:33.126Z",
         "dataset": "sentinel_one.alert",
         "id": "123456789123456789",
-        "ingested": "2025-04-01T09:30:34Z",
+        "ingested": "2025-04-21T14:20:36Z",
         "kind": "event",
         "original": "{\"agentDetectionInfo\":{\"machineType\":\"string\",\"name\":\"string\",\"osFamily\":\"string\",\"osName\":\"string\",\"osRevision\":\"string\",\"siteId\":\"123456789123456789\",\"uuid\":\"string\",\"version\":\"3.x.x.x\"},\"alertInfo\":{\"alertId\":\"123456789123456789\",\"analystVerdict\":\"string\",\"createdAt\":\"2018-02-27T04:49:26.257525Z\",\"dnsRequest\":\"string\",\"dnsResponse\":\"string\",\"dstIp\":\"81.2.69.144\",\"dstPort\":\"1234\",\"dvEventId\":\"string\",\"eventType\":\"info\",\"hitType\":\"Events\",\"incidentStatus\":\"string\",\"indicatorCategory\":\"string\",\"indicatorDescription\":\"string\",\"indicatorName\":\"string\",\"loginAccountDomain\":\"string\",\"loginAccountSid\":\"string\",\"loginIsAdministratorEquivalent\":\"string\",\"loginIsSuccessful\":\"string\",\"loginType\":\"string\",\"loginsUserName\":\"string\",\"modulePath\":\"string\",\"moduleSha1\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"netEventDirection\":\"string\",\"registryKeyPath\":\"string\",\"registryOldValue\":\"string\",\"registryOldValueType\":\"string\",\"registryPath\":\"string\",\"registryValue\":\"string\",\"reportedAt\":\"2018-02-27T04:49:26.257525Z\",\"source\":\"string\",\"srcIp\":\"81.2.69.142\",\"srcMachineIp\":\"81.2.69.142\",\"srcPort\":\"1234\",\"tiIndicatorComparisonMethod\":\"string\",\"tiIndicatorSource\":\"string\",\"tiIndicatorType\":\"string\",\"tiIndicatorValue\":\"string\",\"updatedAt\":\"2018-02-27T04:49:26.257525Z\"},\"containerInfo\":{\"id\":\"string\",\"image\":\"string\",\"labels\":\"string\",\"name\":\"string\"},\"kubernetesInfo\":{\"cluster\":\"string\",\"controllerKind\":\"string\",\"controllerLabels\":\"string\",\"controllerName\":\"string\",\"namespace\":\"string\",\"namespaceLabels\":\"string\",\"node\":\"string\",\"pod\":\"string\",\"podLabels\":\"string\"},\"ruleInfo\":{\"description\":\"string\",\"id\":\"string\",\"name\":\"string\",\"scopeLevel\":\"string\",\"severity\":\"Low\",\"treatAsThreat\":\"UNDEFINED\"},\"sourceParentProcessInfo\":{\"commandline\":\"string\",\"fileHashMd5\":\"5d41402abc4b2a76b9719d911017c592\",\"fileHashSha1\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"fileHashSha256\":\"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824\",\"filePath\":\"string\",\"fileSignerIdentity\":\"string\",\"integrityLevel\":\"unknown\",\"name\":\"string\",\"pid\":\"12345\",\"pidStarttime\":\"2018-02-27T04:49:26.257525Z\",\"storyline\":\"string\",\"subsystem\":\"unknown\",\"uniqueId\":\"string\",\"user\":\"string\"},\"sourceProcessInfo\":{\"commandline\":\"string\",\"fileHashMd5\":\"5d41402abc4b2a76b9719d911017c592\",\"fileHashSha1\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"fileHashSha256\":\"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824\",\"filePath\":\"string\",\"fileSignerIdentity\":\"string\",\"integrityLevel\":\"unknown\",\"name\":\"string\",\"pid\":\"12345\",\"pidStarttime\":\"2018-02-27T04:49:26.257525Z\",\"storyline\":\"string\",\"subsystem\":\"unknown\",\"uniqueId\":\"string\",\"user\":\"string\"},\"targetProcessInfo\":{\"tgtFileCreatedAt\":\"2018-02-27T04:49:26.257525Z\",\"tgtFileHashSha1\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"tgtFileHashSha256\":\"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824\",\"tgtFileId\":\"string\",\"tgtFileIsSigned\":\"string\",\"tgtFileModifiedAt\":\"2018-02-27T04:49:26.257525Z\",\"tgtFileOldPath\":\"string\",\"tgtFilePath\":\"string\",\"tgtProcCmdLine\":\"string\",\"tgtProcImagePath\":\"string\",\"tgtProcIntegrityLevel\":\"unknown\",\"tgtProcName\":\"string\",\"tgtProcPid\":\"12345\",\"tgtProcSignedStatus\":\"string\",\"tgtProcStorylineId\":\"string\",\"tgtProcUid\":\"string\",\"tgtProcessStartTime\":\"2018-02-27T04:49:26.257525Z\"}}",
         "type": [
@@ -583,6 +585,7 @@ An example event for `alert` looks as following:
     "input": {
         "type": "httpjson"
     },
+    "message": "string",
     "observer": {
         "serial_number": "string",
         "version": "3.x.x.x"
@@ -986,23 +989,23 @@ An example event for `threat` looks as following:
 {
     "@timestamp": "2022-04-06T08:54:17.194Z",
     "agent": {
-        "ephemeral_id": "c6b202e4-98c4-4349-a65c-e65b908e071a",
-        "id": "f12f6421-3fe5-4b8b-85dc-edc7a78bb4ff",
-        "name": "elastic-agent-52847",
+        "ephemeral_id": "4ad502cd-94d6-4be0-bbd3-4a726c111c52",
+        "id": "d58c2916-6feb-495e-af59-368df9d32f82",
+        "name": "elastic-agent-80138",
         "type": "filebeat",
         "version": "8.18.0"
     },
     "data_stream": {
         "dataset": "sentinel_one.threat",
-        "namespace": "85660",
+        "namespace": "51415",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "f12f6421-3fe5-4b8b-85dc-edc7a78bb4ff",
-        "snapshot": true,
+        "id": "d58c2916-6feb-495e-af59-368df9d32f82",
+        "snapshot": false,
         "version": "8.18.0"
     },
     "event": {
@@ -1011,10 +1014,10 @@ An example event for `threat` looks as following:
         "category": [
             "malware"
         ],
-        "created": "2025-04-01T09:32:31.271Z",
+        "created": "2025-04-21T14:24:22.083Z",
         "dataset": "sentinel_one.threat",
         "id": "1234567890123456789",
-        "ingested": "2025-04-01T09:32:34Z",
+        "ingested": "2025-04-21T14:24:25Z",
         "kind": "alert",
         "original": "{\"agentDetectionInfo\":{\"accountId\":\"1234567890123456789\",\"accountName\":\"Default\",\"agentDetectionState\":null,\"agentDomain\":\"WORKGROUP\",\"agentIpV4\":\"10.0.0.1\",\"agentIpV6\":\"2a02:cf40::\",\"agentLastLoggedInUpn\":null,\"agentLastLoggedInUserMail\":null,\"agentLastLoggedInUserName\":\"\",\"agentMitigationMode\":\"protect\",\"agentOsName\":\"linux\",\"agentOsRevision\":\"1234\",\"agentRegisteredAt\":\"2022-04-06T08:26:45.515278Z\",\"agentUuid\":\"fwfbxxxxxxxxxxqcfjfnxxxxxxxxx\",\"agentVersion\":\"21.x.x\",\"cloudProviders\":{},\"externalIp\":\"81.2.69.143\",\"groupId\":\"1234567890123456789\",\"groupName\":\"Default Group\",\"siteId\":\"1234567890123456789\",\"siteName\":\"Default site\"},\"agentRealtimeInfo\":{\"accountId\":\"1234567890123456789\",\"accountName\":\"Default\",\"activeThreats\":7,\"agentComputerName\":\"test-LINUX\",\"agentDecommissionedAt\":null,\"agentDomain\":\"WORKGROUP\",\"agentId\":\"1234567890123456789\",\"agentInfected\":true,\"agentIsActive\":true,\"agentIsDecommissioned\":false,\"agentMachineType\":\"server\",\"agentMitigationMode\":\"detect\",\"agentNetworkStatus\":\"connected\",\"agentOsName\":\"linux\",\"agentOsRevision\":\"1234\",\"agentOsType\":\"linux\",\"agentUuid\":\"fwfbxxxxxxxxxxqcfjfnxxxxxxxxx\",\"agentVersion\":\"21.x.x.1234\",\"groupId\":\"1234567890123456789\",\"groupName\":\"Default Group\",\"networkInterfaces\":[{\"id\":\"1234567890123456789\",\"inet\":[\"10.0.0.1\"],\"inet6\":[\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\"],\"name\":\"Ethernet\",\"physical\":\"DE:AD:00:00:BE:EF\"}],\"operationalState\":\"na\",\"rebootRequired\":false,\"scanAbortedAt\":null,\"scanFinishedAt\":\"2022-04-06T09:18:21.090855Z\",\"scanStartedAt\":\"2022-04-06T08:26:52.838047Z\",\"scanStatus\":\"finished\",\"siteId\":\"1234567890123456789\",\"siteName\":\"Default site\",\"storageName\":null,\"storageType\":null,\"userActionsNeeded\":[]},\"containerInfo\":{\"id\":null,\"image\":null,\"labels\":null,\"name\":null},\"id\":\"1234567890123456789\",\"indicators\":[],\"kubernetesInfo\":{\"cluster\":null,\"controllerKind\":null,\"controllerLabels\":null,\"controllerName\":null,\"namespace\":null,\"namespaceLabels\":null,\"node\":null,\"pod\":null,\"podLabels\":null},\"mitigationStatus\":[{\"action\":\"unquarantine\",\"actionsCounters\":{\"failed\":0,\"notFound\":0,\"pendingReboot\":0,\"success\":1,\"total\":1},\"agentSupportsReport\":true,\"groupNotFound\":false,\"lastUpdate\":\"2022-04-06T08:54:17.198002Z\",\"latestReport\":\"/threats/mitigation-report\",\"mitigationEndedAt\":\"2022-04-06T08:54:17.101000Z\",\"mitigationStartedAt\":\"2022-04-06T08:54:17.101000Z\",\"status\":\"success\"},{\"action\":\"kill\",\"actionsCounters\":null,\"agentSupportsReport\":true,\"groupNotFound\":false,\"lastUpdate\":\"2022-04-06T08:45:55.303355Z\",\"latestReport\":null,\"mitigationEndedAt\":\"2022-04-06T08:45:55.297364Z\",\"mitigationStartedAt\":\"2022-04-06T08:45:55.297363Z\",\"status\":\"success\"}],\"threatInfo\":{\"analystVerdict\":\"undefined\",\"analystVerdictDescription\":\"Undefined\",\"automaticallyResolved\":false,\"browserType\":null,\"certificateId\":\"\",\"classification\":\"Trojan\",\"classificationSource\":\"Cloud\",\"cloudFilesHashVerdict\":\"black\",\"collectionId\":\"1234567890123456789\",\"confidenceLevel\":\"malicious\",\"createdAt\":\"2022-04-06T08:45:54.519988Z\",\"detectionEngines\":[{\"key\":\"sentinelone_cloud\",\"title\":\"SentinelOne Cloud\"}],\"detectionType\":\"static\",\"engines\":[\"SentinelOne Cloud\"],\"externalTicketExists\":false,\"externalTicketId\":null,\"failedActions\":false,\"fileExtension\":\"EXE\",\"fileExtensionType\":\"Executable\",\"filePath\":\"default.exe\",\"fileSize\":1234,\"fileVerificationType\":\"NotSigned\",\"identifiedAt\":\"2022-04-06T08:45:53.968000Z\",\"incidentStatus\":\"unresolved\",\"incidentStatusDescription\":\"Unresolved\",\"initiatedBy\":\"agent_policy\",\"initiatedByDescription\":\"Agent Policy\",\"initiatingUserId\":null,\"initiatingUsername\":null,\"isFileless\":false,\"isValidCertificate\":false,\"maliciousProcessArguments\":null,\"md5\":null,\"mitigatedPreemptively\":false,\"mitigationStatus\":\"not_mitigated\",\"mitigationStatusDescription\":\"Not mitigated\",\"originatorProcess\":\"default.exe\",\"pendingActions\":false,\"processUser\":\"test user\",\"publisherName\":\"\",\"reachedEventsLimit\":false,\"rebootRequired\":false,\"sha1\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"sha256\":null,\"storyline\":\"D0XXXXXXXXXXAF4D\",\"threatId\":\"1234567890123456789\",\"threatName\":\"default.exe\",\"updatedAt\":\"2022-04-06T08:54:17.194122Z\"},\"whiteningOptions\":[\"hash\"]}",
         "type": [
@@ -1051,6 +1054,7 @@ An example event for `threat` looks as following:
     "input": {
         "type": "httpjson"
     },
+    "message": "Threat Detected: default.exe (malicious)",
     "observer": {
         "version": "21.x.x.1234"
     },
@@ -1259,6 +1263,9 @@ An example event for `threat` looks as following:
                 "size": 1234
             }
         }
+    },
+    "user": {
+        "name": "test user"
     }
 }
 ```

--- a/packages/sentinel_one/manifest.yml
+++ b/packages/sentinel_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.2.3"
 name: sentinel_one
 title: SentinelOne
-version: "1.33.0"
+version: "1.34.0"
 description: Collect logs from SentinelOne with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
sentinel_one: populate ECS field message for threat, alert and activity datastreams

This will populate the correct alert title when 'External Alerts' rule is enabled.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/sentinel_one directory.
- Run the following command to run tests.
> elastic-package test

## Related issues

- Closes #12564 
