### PR TITLE
[Teleport] Add support for configuring which cloud metadata to use

### DIFF
--- a/packages/teleport/changelog.yml
+++ b/packages/teleport/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Allow user configuration of cloud metadata collection.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.3.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/teleport/changelog.yml
+++ b/packages/teleport/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Allow user configuration of cloud metadata collection.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/13634
 - version: "1.3.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/teleport/data_stream/audit/_dev/test/pipeline/test-common-config.yml
+++ b/packages/teleport/data_stream/audit/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,4 @@
 fields:
   tags:
     - preserve_original_event
+    - both

--- a/packages/teleport/data_stream/audit/_dev/test/pipeline/test-teleport-all-events.log-expected.json
+++ b/packages/teleport/data_stream/audit/_dev/test/pipeline/test-teleport-all-events.log-expected.json
@@ -41,7 +41,8 @@
                 "type": "spanner"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -114,7 +115,8 @@
                 "type": "spanner"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -207,7 +209,8 @@
                 "name": "ddb1"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -279,7 +282,8 @@
                 "name": "ddb1"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -337,7 +341,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -394,7 +399,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "benarent"
@@ -425,7 +431,8 @@
                 }
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -526,7 +533,8 @@
                 "ip": "67.43.156.254"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -585,7 +593,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -648,7 +657,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -686,7 +696,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -728,7 +739,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -762,7 +774,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -850,7 +863,8 @@
                 "bytes": 4730
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -893,7 +907,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -940,7 +955,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -988,7 +1004,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -1033,7 +1050,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "user@example.com"
@@ -1073,7 +1091,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "user@example.com"
@@ -1114,7 +1133,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "user@example.com"
@@ -1150,7 +1170,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "unimplemented"
@@ -1186,7 +1207,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "unimplemented"
@@ -1222,7 +1244,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "unimplemented"
@@ -1258,7 +1281,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "unimplemented"
@@ -1294,7 +1318,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "unimplemented"
@@ -1330,7 +1355,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "unimplemented"
@@ -1366,7 +1392,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "unimplemented"
@@ -1402,7 +1429,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "unimplemented"
@@ -1438,7 +1466,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "unimplemented"
@@ -1474,7 +1503,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -1520,7 +1550,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "Ivan_Jordan"
@@ -1604,7 +1635,8 @@
                 "bytes": 4730
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -1644,7 +1676,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -1687,7 +1720,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "admin@example.com"
@@ -1723,7 +1757,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -1803,7 +1838,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -1855,7 +1891,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -1925,7 +1962,8 @@
                 "port": 32962
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -1988,7 +2026,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -2056,7 +2095,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -2138,7 +2178,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -2195,7 +2236,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -2268,7 +2310,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -2338,7 +2381,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -2408,7 +2452,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -2464,7 +2509,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -2552,7 +2598,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -2641,7 +2688,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -2724,7 +2772,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -2815,7 +2864,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -2900,7 +2950,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -2991,7 +3042,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -3076,7 +3128,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -3167,7 +3220,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -3253,7 +3307,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -3345,7 +3400,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -3430,7 +3486,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -3521,7 +3578,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -3606,7 +3664,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -3697,7 +3756,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -3782,7 +3842,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -3873,7 +3934,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -3958,7 +4020,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -4049,7 +4112,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -4134,7 +4198,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -4225,7 +4290,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -4310,7 +4376,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -4401,7 +4468,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -4486,7 +4554,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -4577,7 +4646,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -4662,7 +4732,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -4753,7 +4824,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -4838,7 +4910,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -4929,7 +5002,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -5014,7 +5088,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -5105,7 +5180,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -5190,7 +5266,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -5281,7 +5358,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -5366,7 +5444,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -5457,7 +5536,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -5542,7 +5622,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -5633,7 +5714,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -5679,7 +5761,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -5732,7 +5815,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -5783,7 +5867,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -5856,7 +5941,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -5939,7 +6025,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -5999,7 +6086,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -6043,7 +6131,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -6087,7 +6176,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -6164,7 +6254,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -6261,7 +6352,8 @@
                 "port": 3027
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "url": {
                 "path": "/api/v1/namespaces/teletest/pods/test-pod"
@@ -6304,7 +6396,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -6357,7 +6450,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -6410,7 +6504,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -6454,7 +6549,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -6500,7 +6596,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -6546,7 +6643,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "root"
@@ -6583,7 +6681,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "root"
@@ -6620,7 +6719,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "root"
@@ -6657,7 +6757,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "root"
@@ -6706,7 +6807,8 @@
                 "name": "mongo-primary"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -6766,7 +6868,8 @@
                 "name": "mongo-primary"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -6829,7 +6932,8 @@
                 "name": "mongo-primary"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -6888,7 +6992,8 @@
                 "name": "mongo-primary"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -6947,7 +7052,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -7008,7 +7114,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -7066,7 +7173,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -7116,7 +7224,8 @@
                 "name": "local"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -7180,7 +7289,8 @@
                 "name": "local"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -7246,7 +7356,8 @@
                 "name": "local"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -7306,7 +7417,8 @@
                 "name": "local"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -7369,7 +7481,8 @@
                 "name": "local"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -7432,7 +7545,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -7479,7 +7593,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -7570,7 +7685,8 @@
                 }
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -7646,7 +7762,8 @@
                 }
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -7725,7 +7842,8 @@
                 }
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -7800,7 +7918,8 @@
                 "port": 3389
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -7865,7 +7984,8 @@
                 "port": 3389
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -7931,7 +8051,8 @@
                 "port": 3389
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -8000,7 +8121,8 @@
                 "port": 3389
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -8071,7 +8193,8 @@
                 "port": 3389
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -8143,7 +8266,8 @@
                 "port": 3389
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -8216,7 +8340,8 @@
                 "port": 3389
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -8289,7 +8414,8 @@
                 "port": 3389
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -8377,7 +8503,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "lisa"
@@ -8457,7 +8584,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "lisa"
@@ -8511,7 +8639,8 @@
                 "port": 43858
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ]
         },
         {
@@ -8538,7 +8667,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -8584,7 +8714,8 @@
                 "name": "self-hosted-mysql"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -8642,7 +8773,8 @@
                 "name": "sqlserver02"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -8706,7 +8838,8 @@
                 "name": "sqlserver02"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -8766,7 +8899,8 @@
                 "name": "postgres-local"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -8850,7 +8984,8 @@
                 "name": "postgres-local"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -8919,7 +9054,8 @@
                 "name": "postgres-local"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -8996,7 +9132,8 @@
                 "name": "postgres-local"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -9066,7 +9203,8 @@
                 "name": "postgres-local"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -9137,7 +9275,8 @@
                 "name": "postgres-local"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -9209,7 +9348,8 @@
                 "name": "postgres-local"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -9276,7 +9416,8 @@
                 "name": "cassandra"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -9335,7 +9476,8 @@
                 "name": "cassandra"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -9396,7 +9538,8 @@
                 "name": "cassandra"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -9466,7 +9609,8 @@
                 "name": "cassandra"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -9545,7 +9689,8 @@
                 "name": "myelastic"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -9630,7 +9775,8 @@
                 "name": "myelastic"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -9725,7 +9871,8 @@
                 "name": "myelastic"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -9816,7 +9963,8 @@
                 "name": "opensearch-aws"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -9901,7 +10049,8 @@
                 "name": "opensearch-aws"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -9960,7 +10109,8 @@
                 "name": "self-hosted-mysql"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -10016,7 +10166,8 @@
                 "name": "self-hosted-mysql"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -10074,7 +10225,8 @@
                 "name": "self-hosted-mysql"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -10131,7 +10283,8 @@
                 "name": "self-hosted-mysql"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -10188,7 +10341,8 @@
                 "name": "self-hosted-mysql"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -10245,7 +10399,8 @@
                 "name": "self-hosted-mysql"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -10300,7 +10455,8 @@
                 "name": "self-hosted-mysql"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -10355,7 +10511,8 @@
                 "name": "self-hosted-mysql"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -10410,7 +10567,8 @@
                 "name": "self-hosted-mysql"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -10465,7 +10623,8 @@
                 "name": "self-hosted-mysql"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -10517,7 +10676,8 @@
                 "name": "self-hosted-mysql"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -10572,7 +10732,8 @@
                 "name": "self-hosted-mysql"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -10624,7 +10785,8 @@
                 "name": "self-hosted-mysql"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -10680,7 +10842,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -10747,7 +10910,8 @@
                 }
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -10832,7 +10996,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -10899,7 +11064,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -10970,7 +11136,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -11037,7 +11204,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -11067,7 +11235,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -11107,7 +11276,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -11159,7 +11329,8 @@
                 "exit_code": 0
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -11212,7 +11383,8 @@
                 "exit_code": 1
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -11255,7 +11427,8 @@
                 }
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -11318,7 +11491,8 @@
                 }
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -11354,7 +11528,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -11390,7 +11565,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -11436,7 +11612,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -11485,7 +11662,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -11534,7 +11712,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -11581,7 +11760,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -11628,7 +11808,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -11675,7 +11856,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -11722,7 +11904,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -11771,7 +11954,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -11820,7 +12004,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -11869,7 +12054,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -11918,7 +12104,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "lisa"
@@ -11958,7 +12145,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "lisa"
@@ -11998,7 +12186,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -12047,7 +12236,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -12100,7 +12290,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -12149,7 +12340,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -12201,7 +12393,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -12253,7 +12446,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -12300,7 +12494,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -12340,7 +12535,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -12383,7 +12579,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -12427,7 +12624,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -12472,7 +12670,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -12517,7 +12716,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -12559,7 +12759,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -12604,7 +12805,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -12646,7 +12848,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -12691,7 +12894,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -12733,7 +12937,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "mike"
@@ -12771,7 +12976,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "mike"
@@ -12809,7 +13015,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "mike"
@@ -12833,7 +13040,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -12865,7 +13073,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -12897,7 +13106,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ]
         },
         {
@@ -12928,7 +13138,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -12974,7 +13185,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -13017,7 +13229,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -13063,7 +13276,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -13093,7 +13307,8 @@
                 "original": "{\"code\":\"TOK007I\",\"event\":\"okta.user.sync\",\"time\":\"2023-05-08T19:21:36.144Z\",\"num_users_created\":5,\"num_users_deleted\":1,\"num_users_modified\":7}"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -13125,7 +13340,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ]
         },
         {
@@ -13146,7 +13362,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ]
         },
         {
@@ -13170,7 +13387,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ]
         },
         {
@@ -13202,7 +13420,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "mike"
@@ -13240,7 +13459,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "mike"
@@ -13275,7 +13495,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "mike"
@@ -13313,7 +13534,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "mike"
@@ -13348,7 +13570,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "mike"
@@ -13386,7 +13609,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "mike"
@@ -13421,7 +13645,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "mike"
@@ -13459,7 +13684,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "user": {
                 "name": "mike"
@@ -13486,7 +13712,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -13528,7 +13755,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -13570,7 +13798,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -13615,7 +13844,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -13657,7 +13887,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -13702,7 +13933,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -13750,7 +13982,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -13790,7 +14023,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -13835,7 +14069,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -13885,7 +14120,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -13934,7 +14170,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -13981,7 +14218,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -14033,7 +14271,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -14083,7 +14322,8 @@
                 }
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -14140,7 +14380,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -14179,7 +14420,8 @@
                 }
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {

--- a/packages/teleport/data_stream/audit/_dev/test/pipeline/test-teleport-generated.log-expected.json
+++ b/packages/teleport/data_stream/audit/_dev/test/pipeline/test-teleport-generated.log-expected.json
@@ -53,7 +53,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -140,7 +141,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -248,7 +250,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -319,7 +322,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -414,7 +418,8 @@
                 "bytes": 8560
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -502,7 +507,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -622,7 +628,8 @@
                 "port": 443
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -671,7 +678,8 @@
                 }
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -739,7 +747,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -851,7 +860,8 @@
                 "bytes": 6828
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -944,7 +954,8 @@
                 "port": 3022
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -1028,7 +1039,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -1102,7 +1114,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -1184,7 +1197,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -1272,7 +1286,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -1348,7 +1363,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -1406,7 +1422,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -1483,7 +1500,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -1571,7 +1589,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -1674,7 +1693,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -1772,7 +1792,8 @@
                 "type": "dynamodb"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -1852,7 +1873,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -1935,7 +1957,8 @@
                 "type": "dynamodb"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -2010,7 +2033,8 @@
                 "type": "dynamodb"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -2085,7 +2109,8 @@
                 "type": "dynamodb"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -2165,7 +2190,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -2263,7 +2289,8 @@
                 "type": "dynamodb"
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {
@@ -2343,7 +2370,8 @@
                 ]
             },
             "tags": [
-                "preserve_original_event"
+                "preserve_original_event",
+                "provider_cloud_data"
             ],
             "teleport": {
                 "audit": {

--- a/packages/teleport/data_stream/audit/_dev/test/system/test-filestream-config.yml
+++ b/packages/teleport/data_stream/audit/_dev/test/system/test-filestream-config.yml
@@ -3,6 +3,7 @@ input: filestream
 data_stream:
   vars:
     preserve_original_event: true
+    cloud_data: both
     paths:
       - '{{SERVICE_LOGS_DIR}}/*.log'
 numeric_keyword_fields:

--- a/packages/teleport/data_stream/audit/agent/stream/filestream.yml.hbs
+++ b/packages/teleport/data_stream/audit/agent/stream/filestream.yml.hbs
@@ -18,6 +18,9 @@ tags:
 {{#each tags as |tag|}}
   - {{tag}}
 {{/each}}
+{{#if cloud_data}}
+  - {{cloud_data}}
+{{/if}}
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}

--- a/packages/teleport/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/teleport/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -13,12 +13,15 @@ processors:
       if: ctx.tags?.contains('both') == true
   - script:
       lang: painless
-      if: ctx.tags?.contains('both') == true
-      source: ctx.tags.remove(ctx.tags.indexOf('both'));
-  - script:
-      lang: painless
-      if: ctx.cloud == null && ctx.tags?.contains('elastic_cloud_data') == true
-      source: ctx.tags.remove(ctx.tags.indexOf('elastic_cloud_data'));
+      source: |
+        if (ctx.tags != null) {
+          if (ctx.tags.contains('both')) {
+            ctx.tags.remove(ctx.tags.indexOf('both'));
+          }
+          if (ctx.cloud == null && ctx.tags.contains('elastic_cloud_data')) {
+            ctx.tags.remove(ctx.tags.indexOf('elastic_cloud_data'));
+          }
+        }
   - set:
       field: _conf.want_provider_cloud
       value: true

--- a/packages/teleport/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/teleport/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -6,6 +6,29 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
+  # Set up tag logic for choosing which cloud metadata to include.
+  - append:
+      field: tags
+      value: ["elastic_cloud_data", "provider_cloud_data"]
+      if: ctx.tags?.contains('both') == true
+  - script:
+      lang: painless
+      if: ctx.tags?.contains('both') == true
+      source: ctx.tags.remove(ctx.tags.indexOf('both'));
+  - script:
+      lang: painless
+      if: ctx.cloud == null && ctx.tags?.contains('elastic_cloud_data') == true
+      source: ctx.tags.remove(ctx.tags.indexOf('elastic_cloud_data'));
+  - set:
+      field: _conf.want_provider_cloud
+      value: true
+      if: ctx.tags?.contains('provider_cloud_data') == true
+  - remove:
+      description: Remove elastic agent-provided cloud metadata fields if not requested.
+      field: cloud
+      if: ctx.tags != null && !ctx.tags.contains('elastic_cloud_data')
+      ignore_missing: true
+      ignore_failure: true
   - rename:
       field: message
       target_field: event.original

--- a/packages/teleport/data_stream/audit/elasticsearch/ingest_pipeline/event-groups.yml
+++ b/packages/teleport/data_stream/audit/elasticsearch/ingest_pipeline/event-groups.yml
@@ -867,12 +867,12 @@ processors:
   - set:
       field: cloud.provider
       value: aws
-      if: ctx.teleport?.audit?.aws_region != null
+      if: ctx._conf?.want_provider_cloud == true && ctx.teleport?.audit?.aws_region != null
   - rename:
       field: teleport.audit.aws_region
       target_field: cloud.region
       ignore_missing: true
-      if: ctx.cloud?.region == null
+      if: ctx._conf?.want_provider_cloud == true && ctx.cloud?.region == null
   - remove:
       field: teleport.audit.aws_region
       ignore_missing: true
@@ -880,7 +880,7 @@ processors:
       field: teleport.audit.aws_service
       target_field: cloud.service.name
       ignore_missing: true
-      if: ctx.cloud?.service?.name == null
+      if: ctx._conf?.want_provider_cloud == true && ctx.cloud?.service?.name == null
   - remove:
       field: teleport.audit.aws_service
       ignore_missing: true
@@ -888,7 +888,7 @@ processors:
       field: teleport.audit.aws_host
       target_field: cloud.instance.id
       ignore_missing: true
-      if: ctx.cloud?.instance?.id == null
+      if: ctx._conf?.want_provider_cloud == true && ctx.cloud?.instance?.id == null
   - remove:
       field: teleport.audit.aws_host
       ignore_missing: true
@@ -960,14 +960,14 @@ processors:
       field: teleport.audit.db_aws_region
       target_field: cloud.region
       ignore_missing: true
-      if: ctx.cloud?.region == null
+      if: ctx._conf?.want_provider_cloud == true && ctx.cloud?.region == null
   - remove:
       field: teleport.audit.db_aws_region
       ignore_missing: true
   - set:
       field: cloud.provider
       value: aws
-      if: ctx.teleport?.audit?.redshift_cluster_id != null
+      if: ctx._conf?.want_provider_cloud == true && ctx.teleport?.audit?.redshift_cluster_id != null
   - rename:
       field: teleport.audit.db_aws_redshift_cluster_id
       target_field: teleport.audit.database.aws.redshift_cluster_id
@@ -975,7 +975,7 @@ processors:
   - set:
       field: cloud.provider
       value: gcp
-      if: ctx.teleport?.audit?.db_gcp_project_id != null
+      if: ctx._conf?.want_provider_cloud == true && ctx.teleport?.audit?.db_gcp_project_id != null
   - rename:
       field: teleport.audit.db_gcp_project_id
       target_field: cloud.project.id
@@ -984,7 +984,7 @@ processors:
       field: teleport.audit.db_gcp_instance_id
       target_field: cloud.instance.id
       ignore_missing: true
-      if: ctx.cloud?.instance?.id == null
+      if: ctx._conf?.want_provider_cloud == true && ctx.cloud?.instance?.id == null
   - remove:
       field: teleport.audit.db_gcp_instance_id
       ignore_missing: true
@@ -1418,7 +1418,7 @@ processors:
   - set:
       field: cloud.provider
       value: aws
-      if: ctx.teleport?.audit?.command_id != null
+      if: ctx._conf?.want_provider_cloud == true && ctx.teleport?.audit?.command_id != null
   - rename:
       field: teleport.audit.command_id
       target_field: teleport.audit.database.aws.ssm_run.command_id
@@ -1427,7 +1427,7 @@ processors:
       field: teleport.audit.instance_id
       target_field: cloud.instance.id
       ignore_missing: true
-      if: ctx.cloud?.instance?.id == null
+      if: ctx._conf?.want_provider_cloud == true && ctx.cloud?.instance?.id == null
   - remove:
       field: teleport.audit.instance_id
       ignore_missing: true
@@ -1450,7 +1450,7 @@ processors:
       field: teleport.audit.account_id
       target_field: cloud.account.id
       ignore_missing: true
-      if: ctx.cloud?.account?.id == null
+      if: ctx._conf?.want_provider_cloud == true && ctx.cloud?.account?.id == null
   - remove:
       field: teleport.audit.account_id
       ignore_missing: true
@@ -1459,9 +1459,12 @@ processors:
       target_field: cloud.region
       ignore_missing: true
       ignore_failure: true
-      if: ctx.cloud?.region == null
+      if: ctx._conf?.want_provider_cloud == true && ctx.cloud?.region == null
   - remove:
       field: teleport.audit.region
+      ignore_missing: true
+  - remove:
+      field: _conf
       ignore_missing: true
   - rename:
       field: teleport.audit.stdout

--- a/packages/teleport/data_stream/audit/manifest.yml
+++ b/packages/teleport/data_stream/audit/manifest.yml
@@ -69,6 +69,23 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: cloud_data
+        title: Cloud Metadata Source
+        description: What source to use to populate `cloud.*` fields.
+        type: select
+        multi: false
+        required: true
+        show_user: false
+        options:
+          - text: Elastic Only
+            value: elastic_cloud_data
+          - text: Provider Only
+            value: provider_cloud_data
+          - text: Elastic and Provider
+            value: both
+          - text: None
+            value: ''
+        default: both
       - name: tags
         type: text
         title: Tags

--- a/packages/teleport/data_stream/audit/sample_event.json
+++ b/packages/teleport/data_stream/audit/sample_event.json
@@ -1,5 +1,12 @@
 {
-    "@timestamp": "2019-04-22T19:39:26.676Z",
+    "@timestamp": "2019-04-22T00:49:03.000Z",
+    "agent": {
+        "ephemeral_id": "6c572258-fcb8-48b0-bb7b-ffb396adb07a",
+        "id": "c12ead0e-edd3-4b3c-9a69-06eb2964d4cd",
+        "name": "elastic-agent-51912",
+        "type": "filebeat",
+        "version": "8.14.0"
+    },
     "client": {
         "address": "67.43.156.11",
         "as": {
@@ -15,63 +22,75 @@
             }
         },
         "ip": "67.43.156.11",
-        "port": 51454
+        "port": 42
+    },
+    "data_stream": {
+        "dataset": "teleport.audit",
+        "namespace": "41787",
+        "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
+    "elastic_agent": {
+        "id": "c12ead0e-edd3-4b3c-9a69-06eb2964d4cd",
+        "snapshot": false,
+        "version": "8.14.0"
+    },
     "event": {
-        "action": "session.start",
+        "action": "user.login",
+        "agent_id_status": "verified",
         "category": [
-            "session"
+            "authentication"
         ],
-        "code": "T2000I",
-        "id": "84c07a99-856c-419f-9de5-15560451a116",
+        "code": "T1012I",
+        "dataset": "teleport.audit",
+        "id": "173d6b6e-d613-44be-8ff6-f9f893791ef4",
+        "ingested": "2025-04-22T06:23:17Z",
         "kind": "event",
-        "original": "{\"addr.local\":\"172.31.28.130:3022\",\"addr.remote\":\"67.43.156.11:51454\",\"code\":\"T2000I\",\"ei\":0,\"event\":\"session.start\",\"login\":\"root\",\"namespace\":\"default\",\"server_id\":\"de3800ea-69d9-4d72-a108-97e57f8eb393\",\"sid\":\"56408539-6536-11e9-80a1-427cfde50f5a\",\"size\":\"80:25\",\"time\":\"2019-04-22T19:39:26.676Z\",\"uid\":\"84c07a99-856c-419f-9de5-15560451a116\",\"user\":\"admin@example.com\"}",
+        "original": "{\"addr.remote\":\"67.43.156.11:42\",\"code\":\"T1012I\",\"cluster_name\":\"root.cluster\",\"event\":\"user.login\",\"method\":\"headless\",\"ei\":0,\"success\":false,\"time\":\"2019-04-22T00:49:03Z\",\"uid\":\"173d6b6e-d613-44be-8ff6-f9f893791ef4\",\"user\":\"admin@example.com\"}",
+        "outcome": [
+            "failure"
+        ],
         "sequence": 0,
         "type": [
             "start"
         ]
     },
-    "group": {
-        "name": "default"
+    "input": {
+        "type": "filestream"
     },
-    "host": {
-        "id": "de3800ea-69d9-4d72-a108-97e57f8eb393"
-    },
-    "process": {
-        "tty": {
-            "columns": 80,
-            "rows": 25
+    "log": {
+        "file": {
+            "device_id": "64768",
+            "inode": "1615130",
+            "path": "/tmp/service_logs/test-teleport-all-events.log"
         },
-        "user": {
-            "name": "root"
+        "offset": 62632
+    },
+    "orchestrator": {
+        "cluster": {
+            "name": "root.cluster"
         }
     },
     "related": {
         "ip": [
-            "67.43.156.11",
-            "172.31.28.130"
+            "67.43.156.11"
         ],
         "user": [
-            "admin@example.com",
-            "root"
+            "admin@example.com"
         ]
     },
-    "server": {
-        "address": "172.31.28.130",
-        "ip": "172.31.28.130",
-        "port": 3022
-    },
     "tags": [
-        "preserve_original_event"
+        "preserve_original_event",
+        "forwarded",
+        "teleport-audit",
+        "provider_cloud_data"
     ],
     "teleport": {
         "audit": {
-            "session": {
-                "id": "56408539-6536-11e9-80a1-427cfde50f5a",
-                "terminal_size": "80:25"
+            "login": {
+                "method": "headless"
             }
         }
     },

--- a/packages/teleport/docs/README.md
+++ b/packages/teleport/docs/README.md
@@ -48,7 +48,7 @@ Please note, there are minimum requirements for running Elastic Agent. For more 
 Check out [the guide on configuring Teleport's Event Handler plugin](https://goteleport.com/docs/management/export-audit-events/)
 to make it send audit logs to the Elasticsearch instance.
 
-See the [Getting started guide](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) for instructions on setting up the Elastic Stack.
+See the [Getting started guide](https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/getting-started-observability.html) for instructions on setting up the Elastic Stack.
 
 ### Enabling the integration in Elastic:
 

--- a/packages/teleport/docs/README.md
+++ b/packages/teleport/docs/README.md
@@ -48,7 +48,7 @@ Please note, there are minimum requirements for running Elastic Agent. For more 
 Check out [the guide on configuring Teleport's Event Handler plugin](https://goteleport.com/docs/management/export-audit-events/)
 to make it send audit logs to the Elasticsearch instance.
 
-See the [Getting started guide](https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/getting-started-observability.html) for instructions on setting up the Elastic Stack.
+See the [Getting started guide](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) for instructions on setting up the Elastic Stack.
 
 ### Enabling the integration in Elastic:
 
@@ -78,7 +78,14 @@ An example event for `audit` looks as following:
 
 ```json
 {
-    "@timestamp": "2019-04-22T19:39:26.676Z",
+    "@timestamp": "2019-04-22T00:49:03.000Z",
+    "agent": {
+        "ephemeral_id": "6c572258-fcb8-48b0-bb7b-ffb396adb07a",
+        "id": "c12ead0e-edd3-4b3c-9a69-06eb2964d4cd",
+        "name": "elastic-agent-51912",
+        "type": "filebeat",
+        "version": "8.14.0"
+    },
     "client": {
         "address": "67.43.156.11",
         "as": {
@@ -94,63 +101,75 @@ An example event for `audit` looks as following:
             }
         },
         "ip": "67.43.156.11",
-        "port": 51454
+        "port": 42
+    },
+    "data_stream": {
+        "dataset": "teleport.audit",
+        "namespace": "41787",
+        "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
+    "elastic_agent": {
+        "id": "c12ead0e-edd3-4b3c-9a69-06eb2964d4cd",
+        "snapshot": false,
+        "version": "8.14.0"
+    },
     "event": {
-        "action": "session.start",
+        "action": "user.login",
+        "agent_id_status": "verified",
         "category": [
-            "session"
+            "authentication"
         ],
-        "code": "T2000I",
-        "id": "84c07a99-856c-419f-9de5-15560451a116",
+        "code": "T1012I",
+        "dataset": "teleport.audit",
+        "id": "173d6b6e-d613-44be-8ff6-f9f893791ef4",
+        "ingested": "2025-04-22T06:23:17Z",
         "kind": "event",
-        "original": "{\"addr.local\":\"172.31.28.130:3022\",\"addr.remote\":\"67.43.156.11:51454\",\"code\":\"T2000I\",\"ei\":0,\"event\":\"session.start\",\"login\":\"root\",\"namespace\":\"default\",\"server_id\":\"de3800ea-69d9-4d72-a108-97e57f8eb393\",\"sid\":\"56408539-6536-11e9-80a1-427cfde50f5a\",\"size\":\"80:25\",\"time\":\"2019-04-22T19:39:26.676Z\",\"uid\":\"84c07a99-856c-419f-9de5-15560451a116\",\"user\":\"admin@example.com\"}",
+        "original": "{\"addr.remote\":\"67.43.156.11:42\",\"code\":\"T1012I\",\"cluster_name\":\"root.cluster\",\"event\":\"user.login\",\"method\":\"headless\",\"ei\":0,\"success\":false,\"time\":\"2019-04-22T00:49:03Z\",\"uid\":\"173d6b6e-d613-44be-8ff6-f9f893791ef4\",\"user\":\"admin@example.com\"}",
+        "outcome": [
+            "failure"
+        ],
         "sequence": 0,
         "type": [
             "start"
         ]
     },
-    "group": {
-        "name": "default"
+    "input": {
+        "type": "filestream"
     },
-    "host": {
-        "id": "de3800ea-69d9-4d72-a108-97e57f8eb393"
-    },
-    "process": {
-        "tty": {
-            "columns": 80,
-            "rows": 25
+    "log": {
+        "file": {
+            "device_id": "64768",
+            "inode": "1615130",
+            "path": "/tmp/service_logs/test-teleport-all-events.log"
         },
-        "user": {
-            "name": "root"
+        "offset": 62632
+    },
+    "orchestrator": {
+        "cluster": {
+            "name": "root.cluster"
         }
     },
     "related": {
         "ip": [
-            "67.43.156.11",
-            "172.31.28.130"
+            "67.43.156.11"
         ],
         "user": [
-            "admin@example.com",
-            "root"
+            "admin@example.com"
         ]
     },
-    "server": {
-        "address": "172.31.28.130",
-        "ip": "172.31.28.130",
-        "port": 3022
-    },
     "tags": [
-        "preserve_original_event"
+        "preserve_original_event",
+        "forwarded",
+        "teleport-audit",
+        "provider_cloud_data"
     ],
     "teleport": {
         "audit": {
-            "session": {
-                "id": "56408539-6536-11e9-80a1-427cfde50f5a",
-                "terminal_size": "80:25"
+            "login": {
+                "method": "headless"
             }
         }
     },

--- a/packages/teleport/manifest.yml
+++ b/packages/teleport/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: teleport
 title: "Teleport"
-version: "1.3.0"
+version: "1.4.0"
 source:
   license: "Elastic-2.0"
 description: "Collect logs from Teleport with Elastic Agent."


### PR DESCRIPTION
## Proposed commit message

```
teleport: allow the user to decide which values should be set in
cloud.* fields.

This PR adds a UI configurator that allows the user to select
which of the two sources (or both) to use to populate the cloud fields. It
also tags the document with an indicator of which sources were available. 
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally



## Related issues

- Closes #12918

## Screenshots

![image](https://github.com/user-attachments/assets/1a9b82ab-9a28-4e06-9f58-d7cebc2f2ac9)
