### PR TITLE
[cisco_meraki_metrics] scale values in device channel utilization so they display correctly as percentages

### DIFF
--- a/packages/cisco_meraki_metrics/changelog.yml
+++ b/packages/cisco_meraki_metrics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.1"
+  changes:
+    - description: scale values in device channel utilization so they display correctly as percentages.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13638
 - version: "0.4.0"
   changes:
     - description: Rename channel utilization bands 2.5 and 5 to wifi0 and wifi1 for backwards compatibility.

--- a/packages/cisco_meraki_metrics/data_stream/device_health/_dev/test/pipeline/test-pipeline-device-health.json-expected.json
+++ b/packages/cisco_meraki_metrics/data_stream/device_health/_dev/test/pipeline/test-pipeline-device-health.json-expected.json
@@ -51,14 +51,14 @@
                 "device": {
                     "channel_utilization": {
                         "wifi0": {
-                            "utilization_80211": 8.46,
-                            "utilization_non_80211": 0.65,
-                            "utilization_total": 9.11
+                            "utilization_80211": 0.0846,
+                            "utilization_non_80211": 0.0065,
+                            "utilization_total": 0.0911
                         },
                         "wifi1": {
-                            "utilization_80211": 3.81,
-                            "utilization_non_80211": 0.03,
-                            "utilization_total": 3.84
+                            "utilization_80211": 0.0381,
+                            "utilization_non_80211": 0.0003,
+                            "utilization_total": 0.0384
                         }
                     },
                     "network_id": "L_113272913626746984",

--- a/packages/cisco_meraki_metrics/data_stream/device_health/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_meraki_metrics/data_stream/device_health/elasticsearch/ingest_pipeline/default.yml
@@ -4,8 +4,42 @@ processors:
   - script:
       lang: painless
       source: >
-        if (ctx.meraki != null && ctx.meraki.uplink != null && ctx.meraki.uplink.loss != null && ctx.meraki.uplink.loss.pct != null) {
-            ctx.meraki.uplink.loss.pct = ctx.meraki.uplink.loss.pct / 100;
+        // some values have unit 'percent' in the mappings; we need to scale them down from 0->100 to 0->1.
+        // we round to 4 decimal places to avoid floating point errors.
+
+        if (ctx.meraki != null) {
+            if (ctx.meraki.uplink != null && ctx.meraki.uplink.loss != null && ctx.meraki.uplink.loss.pct != null) {
+                ctx.meraki.uplink.loss.pct = Math.round((ctx.meraki.uplink.loss.pct / 100) * 10000) / 10000.0;
+            }
+
+            if (ctx.meraki.device != null && ctx.meraki.device.channel_utilization != null) {
+                def wifi0 = ctx.meraki.device.channel_utilization["2_4"];
+                def wifi1 = ctx.meraki.device.channel_utilization["5"];
+
+                if (wifi0 != null) {
+                    if (wifi0.utilization_80211 != null) {
+                        wifi0.utilization_80211 = Math.round((wifi0.utilization_80211 / 100) * 10000) / 10000.0;
+                    }
+                    if (wifi0.utilization_non_80211 != null) {
+                        wifi0.utilization_non_80211 = Math.round((wifi0.utilization_non_80211 / 100) * 10000) / 10000.0;
+                    }
+                    if (wifi0.utilization_total != null) {
+                        wifi0.utilization_total = Math.round((wifi0.utilization_total / 100) * 10000) / 10000.0;
+                    }
+                }
+
+                if (wifi1 != null) {
+                    if (wifi1.utilization_80211 != null) {
+                        wifi1.utilization_80211 = Math.round((wifi1.utilization_80211 / 100) * 10000) / 10000.0;
+                    }
+                    if (wifi1.utilization_non_80211 != null) {
+                        wifi1.utilization_non_80211 = Math.round((wifi1.utilization_non_80211 / 100) * 10000) / 10000.0;
+                    }
+                    if (wifi1.utilization_total != null) {
+                        wifi1.utilization_total = Math.round((wifi1.utilization_total / 100) * 10000) / 10000.0;
+                    }
+                }
+            }
         }
   - convert:
       field: meraki.uplink.rsrp

--- a/packages/cisco_meraki_metrics/manifest.yml
+++ b/packages/cisco_meraki_metrics/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.0
 name: cisco_meraki_metrics
 title: Cisco Meraki Metrics
-version: 0.4.0
+version: 0.4.1
 description: Collect metrics from Cisco Meraki with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

scale values in device channel utilization so they display correctly as percentages

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
