### PR TITLE
checkpoint_harmony_endpoint: fix typo when calculating next start time

### DIFF
--- a/packages/checkpoint_harmony_endpoint/changelog.yml
+++ b/packages/checkpoint_harmony_endpoint/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix typo when retrieving last timestamp from records.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/13642
 - version: "0.7.0"
   changes:
     - description: Base subsequent request ranges on the latest data received.

--- a/packages/checkpoint_harmony_endpoint/changelog.yml
+++ b/packages/checkpoint_harmony_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.7.1"
+  changes:
+    - description: Fix typo when retrieving last timestamp from records.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "0.7.0"
   changes:
     - description: Base subsequent request ranges on the latest data received.

--- a/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
@@ -176,6 +176,7 @@ program: |
   									{
   										"auth_data": auth_data,
   										"task_id": null,
+  										"next_startTime": state.cursor.current_startTime,
   									}
   								),
   							}

--- a/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antibot/agent/stream/cel.yml.hbs
@@ -318,8 +318,8 @@ program: |
   										"auth_data": auth_data,
   										"task_id": null,
   										"page_token": null,
-  										"next_startTime": has(body.?data.results) && body.data.results.size() > 0 ?
-  											optional.of(body.data.results.map(t, timestamp(t.time)).max().format(time_layout.RFC3339))
+  										"next_startTime": has(body.?data.records) && body.data.records.size() > 0 ?
+  											optional.of(body.data.records.map(t, timestamp(t.time)).max().format(time_layout.RFC3339))
   										:
   											state.cursor.current_endTime,
   										"next_endTime": null,

--- a/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
@@ -176,6 +176,7 @@ program: |
   									{
   										"auth_data": auth_data,
   										"task_id": null,
+  										"next_startTime": state.cursor.current_startTime,
   									}
   								),
   							}

--- a/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/antimalware/agent/stream/cel.yml.hbs
@@ -318,8 +318,8 @@ program: |
   										"auth_data": auth_data,
   										"task_id": null,
   										"page_token": null,
-  										"next_startTime": has(body.?data.results) && body.data.results.size() > 0 ?
-  											optional.of(body.data.results.map(t, timestamp(t.time)).max().format(time_layout.RFC3339))
+  										"next_startTime": has(body.?data.records) && body.data.records.size() > 0 ?
+  											optional.of(body.data.records.map(t, timestamp(t.time)).max().format(time_layout.RFC3339))
   										:
   											state.cursor.current_endTime,
   										"next_endTime": null,

--- a/packages/checkpoint_harmony_endpoint/data_stream/forensics/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/forensics/agent/stream/cel.yml.hbs
@@ -176,6 +176,7 @@ program: |
   									{
   										"auth_data": auth_data,
   										"task_id": null,
+  										"next_startTime": state.cursor.current_startTime,
   									}
   								),
   							}

--- a/packages/checkpoint_harmony_endpoint/data_stream/forensics/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/forensics/agent/stream/cel.yml.hbs
@@ -318,8 +318,8 @@ program: |
   										"auth_data": auth_data,
   										"task_id": null,
   										"page_token": null,
-  										"next_startTime": has(body.?data.results) && body.data.results.size() > 0 ?
-  											optional.of(body.data.results.map(t, timestamp(t.time)).max().format(time_layout.RFC3339))
+  										"next_startTime": has(body.?data.records) && body.data.records.size() > 0 ?
+  											optional.of(body.data.records.map(t, timestamp(t.time)).max().format(time_layout.RFC3339))
   										:
   											state.cursor.current_endTime,
   										"next_endTime": null,

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
@@ -176,6 +176,7 @@ program: |
   									{
   										"auth_data": auth_data,
   										"task_id": null,
+  										"next_startTime": state.cursor.current_startTime,
   									}
   								),
   							}

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatemulation/agent/stream/cel.yml.hbs
@@ -318,8 +318,8 @@ program: |
   										"auth_data": auth_data,
   										"task_id": null,
   										"page_token": null,
-  										"next_startTime": has(body.?data.results) && body.data.results.size() > 0 ?
-  											optional.of(body.data.results.map(t, timestamp(t.time)).max().format(time_layout.RFC3339))
+  										"next_startTime": has(body.?data.records) && body.data.records.size() > 0 ?
+  											optional.of(body.data.records.map(t, timestamp(t.time)).max().format(time_layout.RFC3339))
   										:
   											state.cursor.current_endTime,
   										"next_endTime": null,

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
@@ -176,6 +176,7 @@ program: |
   									{
   										"auth_data": auth_data,
   										"task_id": null,
+  										"next_startTime": state.cursor.current_startTime,
   									}
   								),
   							}

--- a/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/threatextraction/agent/stream/cel.yml.hbs
@@ -318,8 +318,8 @@ program: |
   										"auth_data": auth_data,
   										"task_id": null,
   										"page_token": null,
-  										"next_startTime": has(body.?data.results) && body.data.results.size() > 0 ?
-  											optional.of(body.data.results.map(t, timestamp(t.time)).max().format(time_layout.RFC3339))
+  										"next_startTime": has(body.?data.records) && body.data.records.size() > 0 ?
+  											optional.of(body.data.records.map(t, timestamp(t.time)).max().format(time_layout.RFC3339))
   										:
   											state.cursor.current_endTime,
   										"next_endTime": null,

--- a/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
@@ -176,6 +176,7 @@ program: |
   									{
   										"auth_data": auth_data,
   										"task_id": null,
+  										"next_startTime": state.cursor.current_startTime,
   									}
   								),
   							}

--- a/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/urlfiltering/agent/stream/cel.yml.hbs
@@ -318,8 +318,8 @@ program: |
   										"auth_data": auth_data,
   										"task_id": null,
   										"page_token": null,
-  										"next_startTime": has(body.?data.results) && body.data.results.size() > 0 ?
-  											optional.of(body.data.results.map(t, timestamp(t.time)).max().format(time_layout.RFC3339))
+  										"next_startTime": has(body.?data.records) && body.data.records.size() > 0 ?
+  											optional.of(body.data.records.map(t, timestamp(t.time)).max().format(time_layout.RFC3339))
   										:
   											state.cursor.current_endTime,
   										"next_endTime": null,

--- a/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
@@ -176,6 +176,7 @@ program: |
   									{
   										"auth_data": auth_data,
   										"task_id": null,
+  										"next_startTime": state.cursor.current_startTime,
   									}
   								),
   							}

--- a/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
+++ b/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/agent/stream/cel.yml.hbs
@@ -318,8 +318,8 @@ program: |
   										"auth_data": auth_data,
   										"task_id": null,
   										"page_token": null,
-  										"next_startTime": has(body.?data.results) && body.data.results.size() > 0 ?
-  											optional.of(body.data.results.map(t, timestamp(t.time)).max().format(time_layout.RFC3339))
+  										"next_startTime": has(body.?data.records) && body.data.records.size() > 0 ?
+  											optional.of(body.data.records.map(t, timestamp(t.time)).max().format(time_layout.RFC3339))
   										:
   											state.cursor.current_endTime,
   										"next_endTime": null,

--- a/packages/checkpoint_harmony_endpoint/manifest.yml
+++ b/packages/checkpoint_harmony_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: checkpoint_harmony_endpoint
 title: "Check Point Harmony Endpoint"
-version: "0.7.0"
+version: "0.7.1"
 source:
   license: "Elastic-2.0"
 description: "Collect logs from Check Point Harmony Endpoint"


### PR DESCRIPTION
## Proposed commit message

Fix a typo that avoids reading properly the last timestamp from received data, as the incoming JSON body contains an array called `records` instead of `results`.

> [!NOTE]
> All data streams have identical `cel.yml.hbs` files.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

