### PR TITLE
[Ping_Federate] bug fixes error when msg field in extensions is empty

### DIFF
--- a/packages/ping_federate/changelog.yml
+++ b/packages/ping_federate/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.1"
+  changes:
+    - description: Check message status for null using contains
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "0.2.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/ping_federate/data_stream/audit/_dev/test/pipeline/test-audit.json
+++ b/packages/ping_federate/data_stream/audit/_dev/test/pipeline/test-audit.json
@@ -75,5 +75,192 @@
       "code": "AUTHN_SESSION_DELETED",
       "dataset": "ping_federate.audit"
     }
-  }
+  },
+  {
+    "agent": {
+      "name": "docker-fleet-agent",
+      "id": "ef463cd2-6fb1-4dce-b6d5-8d91577bfcb0",
+      "ephemeral_id": "439c1553-7391-4f08-84eb-bf451e322489",
+      "type": "filebeat",
+      "version": "8.16.0"
+    },
+    "log": {
+      "source": {
+        "address": "192.168.251.1:36962"
+      }
+    },
+    "cef": {
+      "severity": "0",
+      "extensions": {
+        "deviceCustomString3Label": "Protocol",
+        "externalId": "tid:ae14b5cea",
+        "sourceAddress":"81.2.69.142",
+        "deviceCustomString1Label": "Target Application URL",
+        "deviceReceiptTime": "2012-05-18T11:41:48.452Z",
+        "deviceCustomString6Label": "Attributes",
+        "deviceCustomString5Label": "SP Local User ID",
+        "deviceCustomString4Label": "Role",
+        "destinationUserId": "moe",
+        "deviceCustomString2Label": "Connection ID"
+      },
+      "name": "AUTHN_SESSION_USED",
+      "version": "0",
+      "device": {
+        "product": "PingFederate",
+        "event_class_id": "AUTHN_SESSION_USED",
+        "vendor": "Ping Identity",
+        "version": "6.4"
+      }
+    },
+    "elastic_agent": {
+      "id": "ef463cd2-6fb1-4dce-b6d5-8d91577bfcb0",
+      "version": "8.16.0",
+      "snapshot": false
+    },
+    "destination": {
+      "user": {
+        "id": "moe"
+      }
+    },
+    "message": "in progress",
+    "observer": {
+      "product": "PingFederate",
+      "vendor": "Ping Identity",
+      "version": "6.4"
+    },
+    "input": {
+      "type": "tcp"
+    },
+    "@timestamp": "2012-05-18T11:41:48.452Z",
+    "ecs": {
+      "version": "8.0.0"
+    },
+    "event": {
+      "severity": 0,
+      "agent_id_status": "verified",
+      "ingested": "2024-12-06T09:22:50Z",
+      "original": "CEF:0|Ping Identity|PingFederate|6.4|AUTHN_SESSION_USED|AUTHN_SESSION_USED|0|rt=May 18 2012 11:41:48.453 duid=moe src=81.2.69.142 msg=in progress cs1Label=Target Application URL cs1= cs2Label=Connection ID cs2= cs3Label=Protocol cs3= cs4Label=Role cs4= externalId=tid:ae14b5cea cs5Label=SP Local User ID cs5= cs6Label=Attributes cs6=",
+      "code": "AUTHN_SESSION_USED",
+      "dataset": "ping_federate.audit"
+    }
+  },
+    {
+      "agent": {
+        "name": "docker-fleet-agent",
+        "id": "ef463cd2-6fb1-4dce-b6d5-8d91577bfcb0",
+        "ephemeral_id": "439c1553-7391-4f08-84eb-bf451e322489",
+        "type": "filebeat",
+        "version": "8.16.0"
+      },
+      "log": {
+        "source": {
+          "address": "192.168.251.1:36962"
+        }
+      },
+      "cef": {
+        "severity": "0",
+        "extensions": {
+          "deviceCustomString3Label": "Protocol",
+          "externalId": "tid:ae14b5ce9",
+          "sourceAddress":"81.2.69.142",
+          "deviceCustomString1Label": "Target Application URL",
+          "deviceReceiptTime": "2012-05-18T11:41:48.452Z",
+          "deviceCustomString6Label": "Attributes",
+          "deviceCustomString5Label": "SP Local User ID",
+          "deviceCustomString4Label": "Role",
+          "destinationUserId": "moe",
+          "deviceCustomString2Label": "Connection ID"
+        },
+        "name": "AUTHN_SESSION_DELETED",
+        "version": "0",
+        "device": {
+          "product": "PingFederate",
+          "event_class_id": "AUTHN_SESSION_DELETED",
+          "vendor": "Ping Identity",
+          "version": "6.4"
+        }
+      },
+      "elastic_agent": {
+        "id": "ef463cd2-6fb1-4dce-b6d5-8d91577bfcb0",
+        "version": "8.16.0",
+        "snapshot": false
+      },
+      "destination": {
+        "user": {
+          "id": "moe"
+        }
+      },
+      "message": "failure",
+      "observer": {
+        "product": "PingFederate",
+        "vendor": "Ping Identity",
+        "version": "6.4"
+      },
+      "input": {
+        "type": "tcp"
+      },
+      "@timestamp": "2012-05-18T11:41:48.452Z",
+      "ecs": {
+        "version": "8.0.0"
+      },
+      "event": {
+        "severity": 0,
+        "agent_id_status": "verified",
+        "ingested": "2024-12-06T09:22:50Z",
+        "original": "CEF:0|Ping Identity|PingFederate|6.4|AUTHN_SESSION_DELETED|AUTHN_SESSION_DELETED|0|rt=May 18 2012 11:41:48.452 duid=moe src=81.2.69.142 msg= cs1Label=Target Application URL cs1= cs2Label=Connection ID cs2= cs3Label=Protocol cs3= cs4Label=Role cs4= externalId=tid:ae14b5ce9 cs5Label=SP Local User ID cs5= cs6Label=Attributes cs6=",
+        "code": "AUTHN_SESSION_DELETED",
+        "dataset": "ping_federate.audit"
+      }
+    },
+    {
+      "agent": {
+        "name": "docker-fleet-agent",
+        "id": "ef463cd2-6fb1-4dce-b6d5-8d91577bfcb0",
+        "ephemeral_id": "439c1553-7391-4f08-84eb-bf451e322489",
+        "type": "filebeat",
+        "version": "8.16.0"
+      },
+      "log": {
+        "source": {
+          "address": "192.168.251.1:36962"
+        }
+      },
+      "cef": {
+        "severity": "0",
+        "name": "UNKNOWN_TYPE",
+        "version": "0",
+        "device": {
+          "product": "PingFederate",
+          "event_class_id": "UNKNOWN_TYPE",
+          "vendor": "Ping Identity",
+          "version": "6.4"
+        }
+      },
+      "elastic_agent": {
+        "id": "ef463cd2-6fb1-4dce-b6d5-8d91577bfcb0",
+        "version": "8.16.0",
+        "snapshot": false
+      },
+      "message": "UNKNOWN_TYPE",
+      "observer": {
+        "product": "PingFederate",
+        "vendor": "Ping Identity",
+        "version": "6.4"
+      },
+      "input": {
+        "type": "tcp"
+      },
+      "@timestamp": "2012-05-18T11:41:48.452Z",
+      "ecs": {
+        "version": "8.0.0"
+      },
+      "event": {
+        "severity": 0,
+        "agent_id_status": "verified",
+        "ingested": "2024-12-06T09:22:50Z",
+        "original": "CEF:0|Ping Identity|PingFederate|6.4|UNKNOWN_TYPE|UNKNOWN_TYPE|0|",
+        "code": "UNKNOWN_TYPE",
+        "dataset": "ping_federate.audit"
+      }
+    }
 ]}

--- a/packages/ping_federate/data_stream/audit/_dev/test/pipeline/test-audit.json-expected.json
+++ b/packages/ping_federate/data_stream/audit/_dev/test/pipeline/test-audit.json-expected.json
@@ -111,6 +111,236 @@
                     "IdP"
                 ]
             }
+        },
+        {
+            "@timestamp": "2012-05-18T22:41:48.452+11:00",
+            "agent": {
+                "ephemeral_id": "439c1553-7391-4f08-84eb-bf451e322489",
+                "id": "ef463cd2-6fb1-4dce-b6d5-8d91577bfcb0",
+                "name": "docker-fleet-agent",
+                "type": "filebeat",
+                "version": "8.16.0"
+            },
+            "ecs": {
+                "version": "8.16.0"
+            },
+            "elastic_agent": {
+                "id": "ef463cd2-6fb1-4dce-b6d5-8d91577bfcb0",
+                "snapshot": false,
+                "version": "8.16.0"
+            },
+            "event": {
+                "action": "authn_session_used",
+                "agent_id_status": "verified",
+                "category": [
+                    "session"
+                ],
+                "code": "AUTHN_SESSION_USED",
+                "dataset": "ping_federate.audit",
+                "ingested": "2024-12-06T09:22:50Z",
+                "kind": "event",
+                "original": "CEF:0|Ping Identity|PingFederate|6.4|AUTHN_SESSION_USED|AUTHN_SESSION_USED|0|rt=May 18 2012 11:41:48.453 duid=moe src=81.2.69.142 msg=in progress cs1Label=Target Application URL cs1= cs2Label=Connection ID cs2= cs3Label=Protocol cs3= cs4Label=Role cs4= externalId=tid:ae14b5cea cs5Label=SP Local User ID cs5= cs6Label=Attributes cs6=",
+                "outcome": "unknown",
+                "severity": 0,
+                "timezone": "+11:00",
+                "type": [
+                    "info"
+                ]
+            },
+            "input": {
+                "type": "tcp"
+            },
+            "log": {
+                "source": {
+                    "address": "192.168.251.1:36962"
+                }
+            },
+            "observer": {
+                "product": "PingFederate",
+                "vendor": "Ping Identity",
+                "version": "6.4"
+            },
+            "ping_federate": {
+                "audit": {
+                    "event": "AUTHN_SESSION_USED",
+                    "ip": "81.2.69.142",
+                    "response_time": "2012-05-18T22:41:48.452+11:00",
+                    "severity": 0,
+                    "subject": "moe",
+                    "tracking_id": "tid:ae14b5cea"
+                }
+            },
+            "related": {
+                "ip": [
+                    "81.2.69.142"
+                ],
+                "user": [
+                    "moe"
+                ]
+            },
+            "source": {
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.142"
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ],
+            "user": {
+                "name": "moe"
+            }
+        },
+        {
+            "@timestamp": "2012-05-18T22:41:48.452+11:00",
+            "agent": {
+                "ephemeral_id": "439c1553-7391-4f08-84eb-bf451e322489",
+                "id": "ef463cd2-6fb1-4dce-b6d5-8d91577bfcb0",
+                "name": "docker-fleet-agent",
+                "type": "filebeat",
+                "version": "8.16.0"
+            },
+            "ecs": {
+                "version": "8.16.0"
+            },
+            "elastic_agent": {
+                "id": "ef463cd2-6fb1-4dce-b6d5-8d91577bfcb0",
+                "snapshot": false,
+                "version": "8.16.0"
+            },
+            "event": {
+                "action": "authn_session_deleted",
+                "agent_id_status": "verified",
+                "category": [
+                    "session"
+                ],
+                "code": "AUTHN_SESSION_DELETED",
+                "dataset": "ping_federate.audit",
+                "ingested": "2024-12-06T09:22:50Z",
+                "kind": "event",
+                "original": "CEF:0|Ping Identity|PingFederate|6.4|AUTHN_SESSION_DELETED|AUTHN_SESSION_DELETED|0|rt=May 18 2012 11:41:48.452 duid=moe src=81.2.69.142 msg= cs1Label=Target Application URL cs1= cs2Label=Connection ID cs2= cs3Label=Protocol cs3= cs4Label=Role cs4= externalId=tid:ae14b5ce9 cs5Label=SP Local User ID cs5= cs6Label=Attributes cs6=",
+                "outcome": "unknown",
+                "severity": 0,
+                "timezone": "+11:00",
+                "type": [
+                    "end"
+                ]
+            },
+            "input": {
+                "type": "tcp"
+            },
+            "log": {
+                "source": {
+                    "address": "192.168.251.1:36962"
+                }
+            },
+            "observer": {
+                "product": "PingFederate",
+                "vendor": "Ping Identity",
+                "version": "6.4"
+            },
+            "ping_federate": {
+                "audit": {
+                    "event": "AUTHN_SESSION_DELETED",
+                    "ip": "81.2.69.142",
+                    "response_time": "2012-05-18T22:41:48.452+11:00",
+                    "severity": 0,
+                    "subject": "moe",
+                    "tracking_id": "tid:ae14b5ce9"
+                }
+            },
+            "related": {
+                "ip": [
+                    "81.2.69.142"
+                ],
+                "user": [
+                    "moe"
+                ]
+            },
+            "source": {
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.142"
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ],
+            "user": {
+                "name": "moe"
+            }
+        },
+        {
+            "agent": {
+                "ephemeral_id": "439c1553-7391-4f08-84eb-bf451e322489",
+                "id": "ef463cd2-6fb1-4dce-b6d5-8d91577bfcb0",
+                "name": "docker-fleet-agent",
+                "type": "filebeat",
+                "version": "8.16.0"
+            },
+            "ecs": {
+                "version": "8.16.0"
+            },
+            "elastic_agent": {
+                "id": "ef463cd2-6fb1-4dce-b6d5-8d91577bfcb0",
+                "snapshot": false,
+                "version": "8.16.0"
+            },
+            "event": {
+                "action": "unknown_type",
+                "agent_id_status": "verified",
+                "code": "UNKNOWN_TYPE",
+                "dataset": "ping_federate.audit",
+                "ingested": "2024-12-06T09:22:50Z",
+                "kind": "event",
+                "original": "CEF:0|Ping Identity|PingFederate|6.4|UNKNOWN_TYPE|UNKNOWN_TYPE|0|",
+                "outcome": "unknown",
+                "severity": 0,
+                "timezone": "+11:00"
+            },
+            "input": {
+                "type": "tcp"
+            },
+            "log": {
+                "source": {
+                    "address": "192.168.251.1:36962"
+                }
+            },
+            "observer": {
+                "product": "PingFederate",
+                "vendor": "Ping Identity",
+                "version": "6.4"
+            },
+            "ping_federate": {
+                "audit": {
+                    "event": "UNKNOWN_TYPE",
+                    "severity": 0
+                }
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ]
         }
     ]
 }

--- a/packages/ping_federate/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ping_federate/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -259,12 +259,12 @@ processors:
       field: event.outcome
       tag: set_event_outcome_success
       value: success
-      if: ctx.ping_federate?.audit?.status?.toLowerCase().contains("success")
+      if: ctx.ping_federate?.audit?.status != null && ctx.ping_federate?.audit?.status?.toLowerCase().contains("success")
   - set:
       field: event.outcome
       tag: set_event_outcome_failure
       value: failure
-      if: ctx.ping_federate?.audit?.status?.toLowerCase().contains("fail")
+      if: ctx.ping_federate?.audit?.status != null && ctx.ping_federate?.audit?.status?.toLowerCase().contains("fail")
   - set:
       field: ping_federate.audit.role
       tag: set_role_from_deviceCustomString4

--- a/packages/ping_federate/manifest.yml
+++ b/packages/ping_federate/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: ping_federate
 title: PingFederate
-version: "0.2.0"
+version: "0.2.1"
 description: Collect logs from PingFederate with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Fix a bug where if the 'msg' field in the CEF extensions section is empty the ingest pipeline errors. The extensions section of CEF is a set of key/value pairs with no guarantee about contents

Please explain:

- WHAT:  The integration comes in CEF format. The last section is the extensions section which are key/value pairs. The integration is expecting a 'msg' key. When that key exists with an empty value or is missing, the ingest pipeline fails due to a 'contains; function begin executed on a null value.  This bug fix checks for the existence of the field before executing 'contains'

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

## How to test this PR locally

The pipeline test has been modified with 2 logs that represents the output of converted CEF log that is 1. missing a value on the 'msg' field 2. missing the entire extensions section.
