### PR TITLE
Allow deprecated mode for the `log` integration

### DIFF
--- a/packages/log/agent/input/input.yml.hbs
+++ b/packages/log/agent/input/input.yml.hbs
@@ -2,7 +2,7 @@ paths:
 {{#each paths}}
   - {{this}}
 {{/each}}
-
+allow_deprecated_use: true
 {{#if exclude_files}}
 exclude_files:
 {{#each exclude_files}}

--- a/packages/log/changelog.yml
+++ b/packages/log/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.1"
+  changes:
+    - description: Allow deprecated mode for 9.0.0+ stacks
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/13663
 - version: "2.4.0"
   changes:
     - description: Allow to be installed on 9.0.0+ stacks

--- a/packages/log/manifest.yml
+++ b/packages/log/manifest.yml
@@ -4,7 +4,7 @@ title: Custom Logs
 description: >-
   Collect custom logs with Elastic Agent.
 type: input
-version: 2.4.0
+version: 2.4.1
 categories:
   - custom
   - custom_logs


### PR DESCRIPTION
## Proposed commit message

The log input is disabled by default starting with the 9.0 stack version.

This additional parameter allows using the `log` integration despite that.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

I've tested it locally by building the package and running the 9.0.0 stack with `elastic-package`. An enrolled agent was able to ingest logs using this integration.

https://www.elastic.co/docs/extend/integrations/testing-validation

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/pull/12503