### PR TITLE
Rename `Custom Filestream Logs` -> `Custom Logs (Filestream)`

### DIFF
--- a/packages/filestream/_dev/build/docs/README.md
+++ b/packages/filestream/_dev/build/docs/README.md
@@ -1,4 +1,4 @@
-# Custom Filestream Log integration
+# Custom Logs (Filestream) Package
 
 The `filestream` custom input is used to read lines from active log files. It is the
 new, improved alternative to the `log` input. It comes with various improvements

--- a/packages/filestream/changelog.yml
+++ b/packages/filestream/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.1"
+  changes:
+    - description: Rename the package
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/13666
 - version: "1.1.0"
   changes:
     - description: Add support for defining Conditions

--- a/packages/filestream/docs/README.md
+++ b/packages/filestream/docs/README.md
@@ -1,4 +1,4 @@
-# Custom Filestream Log integration
+# Custom Logs (Filestream) Package
 
 The `filestream` custom input is used to read lines from active log files. It is the
 new, improved alternative to the `log` input. It comes with various improvements

--- a/packages/filestream/manifest.yml
+++ b/packages/filestream/manifest.yml
@@ -1,9 +1,9 @@
 format_version: 3.1.5
 name: filestream
-title: Custom Filestream Logs
+title: Custom Logs (Filestream)
 description: Collect log data using filestream with Elastic Agent.
 type: integration
-version: 1.1.0
+version: 1.1.1
 conditions:
   kibana:
     version: "^8.15.0 || ^9.0.0"


### PR DESCRIPTION
So, it's consistent with the previous `Custom Logs` package it's to replace.

<img width="867" alt="Screenshot 2025-04-24 at 14 18 00" src="https://github.com/user-attachments/assets/c8181a2e-5286-41b8-a61d-684f6b2a2b2e" />
<img width="1147" alt="Screenshot 2025-04-24 at 14 32 02" src="https://github.com/user-attachments/assets/0cabac59-f58b-4bd0-b7ba-08df3b8b637c" />

