### PR TITLE
[osquery] Ensure event.type is an array

### DIFF
--- a/packages/osquery/changelog.yml
+++ b/packages/osquery/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Ensure event.type is an array.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/13667
 - version: "1.22.0"
   changes:
     - description: Support stack version 9.0.

--- a/packages/osquery/changelog.yml
+++ b/packages/osquery/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.1"
+  changes:
+    - description: Ensure event.type is an array.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.22.0"
   changes:
     - description: Support stack version 9.0.

--- a/packages/osquery/data_stream/result/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/osquery/data_stream/result/elasticsearch/ingest_pipeline/default.yml
@@ -66,7 +66,7 @@ processors:
       value: event
   - set:
       field: event.type
-      value: info
+      value: [info]
   - set:
       field: event.action
       value: "{{{osquery.result.action}}}"

--- a/packages/osquery/manifest.yml
+++ b/packages/osquery/manifest.yml
@@ -1,6 +1,6 @@
 name: osquery
 title: Osquery Logs
-version: "1.22.0"
+version: "1.22.1"
 description: Collect logs from Osquery with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## Proposed commit message

- Changed the set processor for event.type so it sets the value as an array to ensure compliance with ECS.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

## How to test this PR locally

```
cd packages/osquery
elastic-package test
```

## Related issues

- Closes #13600
