### PR TITLE
Rename the log package from Legacy to Deprecated

### DIFF
--- a/packages/filestream/_dev/build/docs/README.md
+++ b/packages/filestream/_dev/build/docs/README.md
@@ -1,6 +1,6 @@
 # Custom Logs (Filestream) Package
 
-WARNING: Migrating from the "Custom Logs (Legacy)" to "Custom Logs
+WARNING: Migrating from the "Custom Logs (Deprecated)" to "Custom Logs
 (Filestream)" will cause files to be re-ingested because the state is not migrated.
 
 In future releases it's expected to have an automated way to migrate the state. However, this is not possible at the moment.

--- a/packages/filestream/changelog.yml
+++ b/packages/filestream/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.3"
+  changes:
+    - description: Correct the readme
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/13679
 - version: "1.1.2"
   changes:
     - description: |

--- a/packages/filestream/docs/README.md
+++ b/packages/filestream/docs/README.md
@@ -1,6 +1,6 @@
 # Custom Logs (Filestream) Package
 
-WARNING: Migrating from the "Custom Logs (Legacy)" to "Custom Logs
+WARNING: Migrating from the "Custom Logs (Deprecated)" to "Custom Logs
 (Filestream)" will cause files to be re-ingested because the state is not migrated.
 
 In future releases it's expected to have an automated way to migrate the state. However, this is not possible at the moment.

--- a/packages/filestream/manifest.yml
+++ b/packages/filestream/manifest.yml
@@ -3,7 +3,7 @@ name: filestream
 title: Custom Logs (Filestream)
 description: Collect log data using filestream with Elastic Agent.
 type: integration
-version: 1.1.2
+version: 1.1.3
 conditions:
   kibana:
     version: "^8.15.0 || ^9.0.0"

--- a/packages/log/changelog.yml
+++ b/packages/log/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.4"
+  changes:
+    - description: Rename from Legacy to Deprecated
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/13679
 - version: "2.4.3"
   changes:
     - description: |

--- a/packages/log/docs/README.md
+++ b/packages/log/docs/README.md
@@ -1,15 +1,15 @@
-# Custom Logs (Legacy) Package
+# Custom Logs (Deprecated) Package
 
-**This package is deprecated please use the Custom Logs (Filestream) package instead.**
+**This package is deprecated, please use the Custom Logs (Filestream) package instead.**
 
-WARNING: Migrating from the "Custom Logs (Legacy)" to "Custom Logs
+WARNING: Migrating from the "Custom Logs (Deprecated)" to "Custom Logs
 (Filestream)" will cause files to be re-ingested because the state is not migrated.
 
 In future releases it's expected to have an automated way to migrate the state. However, this is not possible at the moment.
 
 The current best option for minimizing the data duplication while migrating to "Custom Logs (Filestream)" is to use the 'Ignore Older' or 'Exclude Files' options.
 
-The **Custom Logs (Legacy)** package is used to ingest arbitrary log files and parse their contents using [Ingest Pipelines](https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html). Follow the steps below to set up and use this package.
+The **Custom Logs** package is used to ingest arbitrary log files and parse their contents using [Ingest Pipelines](https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html). Follow the steps below to set up and use this package.
 
 ## Get started
 

--- a/packages/log/manifest.yml
+++ b/packages/log/manifest.yml
@@ -1,10 +1,10 @@
 format_version: 3.1.5
 name: log
-title: Custom Logs (Legacy)
+title: Custom Logs (Deprecated)
 description: >-
   Collect custom logs with Elastic Agent.
 type: input
-version: 2.4.3
+version: 2.4.4
 categories:
   - custom
   - custom_logs


### PR DESCRIPTION
It better reflects its current state.

<img width="1180" alt="Screenshot 2025-04-25 at 10 54 36" src="https://github.com/user-attachments/assets/61f1d88c-1355-4ece-941c-78da867b442a" />
<img width="1195" alt="Screenshot 2025-04-25 at 10 53 32" src="https://github.com/user-attachments/assets/d7868e15-58b4-49b1-a39e-f042ea24a727" />
<img width="798" alt="Screenshot 2025-04-25 at 10 45 50" src="https://github.com/user-attachments/assets/a69c8d79-b2eb-4c14-a8a4-b6541be9aaa4" />
