### PR TITLE
[google_workspace] Handle lag time

### DIFF
--- a/packages/google_workspace/_dev/deploy/docker/config.yml
+++ b/packages/google_workspace/_dev/deploy/docker/config.yml
@@ -51,6 +51,7 @@ rules:
     methods: [GET]
     query_params:
       startTime: "{startTime:2022-04-04.*}"
+      endTime: "{endTime:.*}"
     request_headers:
       Accept:
         - "application/json"
@@ -70,6 +71,7 @@ rules:
     methods: [GET]
     query_params:
       startTime: "{startTime:.*}"
+      endTime: "{endTime:.*}"
       pageToken: page-2
     request_headers:
       Accept:
@@ -105,6 +107,7 @@ rules:
     methods: [GET]
     query_params:
       startTime: "{startTime:.*}"
+      endTime: "{endTime:.*}"
     request_headers:
       Accept:
         - "application/json"
@@ -1034,6 +1037,7 @@ rules:
     methods: [GET]
     query_params:
       startTime: "{startTime:2022-05-04.*}"
+      endTime: "{endTime:.*}"
     request_headers:
       Accept:
         - "application/json"
@@ -1056,6 +1060,7 @@ rules:
     methods: [GET]
     query_params:
       startTime: "{startTime:.*}"
+      endTime: "{endTime:.*}"
     request_headers:
       Accept:
         - "application/json"
@@ -1128,6 +1133,7 @@ rules:
     methods: [GET]
     query_params:
       startTime: "{startTime:2022-05-04.*}"
+      endTime: "{endTime:.*}"
     request_headers:
       Accept:
         - "application/json"
@@ -1145,6 +1151,7 @@ rules:
     methods: [GET]
     query_params:
       startTime: "{startTime:.*}"
+      endTime: "{endTime:.*}"
     request_headers:
       Accept:
         - "application/json"
@@ -1178,6 +1185,7 @@ rules:
     methods: [GET]
     query_params:
       startTime: "{startTime:2022-05-04.*}"
+      endTime: "{endTime:.*}"
     request_headers:
       Accept:
         - "application/json"
@@ -1195,6 +1203,7 @@ rules:
     methods: [GET]
     query_params:
       startTime: "{startTime:.*}"
+      endTime: "{endTime:.*}"
     request_headers:
       Accept:
         - "application/json"
@@ -1218,6 +1227,7 @@ rules:
     methods: [GET]
     query_params:
       startTime: "{startTime:2021-10-02.*}"
+      endTime: "{endTime:.*}"
     request_headers:
       Accept:
         - "application/json"
@@ -1236,6 +1246,7 @@ rules:
     methods: [GET]
     query_params:
       startTime: "{startTime:.*}"
+      endTime: "{endTime:.*}"
     request_headers:
       Accept:
         - "application/json"
@@ -1254,6 +1265,7 @@ rules:
     methods: [GET]
     query_params:
       startTime: "{startTime:2020-10-02.*}"
+      endTime: "{endTime:.*}"
     request_headers:
       Accept:
         - "application/json"
@@ -1270,6 +1282,7 @@ rules:
     methods: [GET]
     query_params:
       startTime: "{startTime:.*}"
+      endTime: "{endTime:.*}"
     request_headers:
       Accept:
         - "application/json"
@@ -1287,6 +1300,7 @@ rules:
     methods: [GET]
     query_params:
       startTime: "{startTime:2020-10-02.*}"
+      endTime: "{endTime:.*}"
     request_headers:
       Accept:
         - "application/json"
@@ -1303,6 +1317,7 @@ rules:
     methods: [GET]
     query_params:
       startTime: "{startTime:.*}"
+      endTime: "{endTime:.*}"
     request_headers:
       Accept:
         - "application/json"
@@ -1319,6 +1334,7 @@ rules:
     methods: [GET]
     query_params:
       startTime: "{startTime:.*}"
+      endTime: "{endTime:.*}"
     request_headers:
       Accept:
         - "application/json"
@@ -1335,6 +1351,7 @@ rules:
     methods: [GET]
     query_params:
       startTime: "{startTime:.*}"
+      endTime: "{endTime:.*}"
     request_headers:
       Accept:
         - "application/json"
@@ -1351,6 +1368,7 @@ rules:
     methods: [GET]
     query_params:
       startTime: "{startTime:.*}"
+      endTime: "{endTime:.*}"
     request_headers:
       Accept:
         - "application/json"
@@ -1367,6 +1385,7 @@ rules:
     methods: [GET]
     query_params:
       startTime: "{startTime:.*}"
+      endTime: "{endTime:.*}"
     request_headers:
       Accept:
         - "application/json"
@@ -1383,6 +1402,7 @@ rules:
     methods: [GET]
     query_params:
       startTime: "{startTime:.*}"
+      endTime: "{endTime:.*}"
     request_headers:
       Accept:
         - "application/json"
@@ -1399,6 +1419,7 @@ rules:
     methods: [GET]
     query_params:
       startTime: "{startTime:.*}"
+      endTime: "{endTime:.*}"
     request_headers:
       Accept:
         - "application/json"

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -4,6 +4,9 @@
     - description: Handle lag time.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/13703
+    - description: Add Proxy URL and SSL Configuration options where absent.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/13703
 - version: "2.39.1"
   changes:
     - description: Fix default request trace enabled behavior.

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.39.2"
+  changes:
+    - description: Handle lag time.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13703
 - version: "2.39.1"
   changes:
     - description: Fix default request trace enabled behavior.

--- a/packages/google_workspace/data_stream/access_transparency/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/access_transparency/agent/stream/httpjson.yml.hbs
@@ -34,7 +34,10 @@ request.transforms:
         [[- else -]]
           [[- .cursor.last_response_date -]]
         [[- end -]]
-      default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
+      default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
+  - set:
+      target: url.params.endTime
+      value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -73,7 +76,7 @@ cursor:
       [[- else if not (parseDate $time "2006-01-02T15:04:05 MST").IsZero -]]
         [[- formatDate (parseDate $time "2006-01-02T15:04:05 MST") -]]
       [[- else -]]
-        [[- formatDate now -]]
+        [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
 tags:
 {{#if preserve_original_event}}

--- a/packages/google_workspace/data_stream/access_transparency/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/access_transparency/agent/stream/httpjson.yml.hbs
@@ -10,7 +10,7 @@ auth.oauth2.google.jwt_json: {{jwt_json}}
 auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly
-request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/access_transparency
+request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/{{application_name_for_url}}
 {{#if proxy_url}}
 request.proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/google_workspace/data_stream/access_transparency/manifest.yml
+++ b/packages/google_workspace/data_stream/access_transparency/manifest.yml
@@ -10,11 +10,20 @@ streams:
         type: text
         title: Interval
         description: >-
-          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay. For more details on this, you can read more at https://support.google.com/a/answer/7061566. NOTE: Supported units for this parameter are h/m/s.
+          Duration between requests to the API. NOTE: Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true
-        default: 2h
+        default: 15m
+      - name: lag_time
+        type: text
+        title: Lag Time
+        description: >-
+          The lag time allowed for when fetching this report. Lag times vary by report, and go up to a few hours. There are more details in the [Google Workspace Admin documentation](https://support.google.com/a/answer/7061566). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: true
+        show_user: true
+        default: 3m
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/access_transparency/manifest.yml
+++ b/packages/google_workspace/data_stream/access_transparency/manifest.yml
@@ -84,3 +84,10 @@ streams:
           #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
           #    sxSmbIUfc2SGJGCJD4I=
           #    -----END CERTIFICATE-----
+      - name: application_name_for_url
+        type: text
+        title: Application Name for the URL
+        default: access_transparency
+        required: true
+        description: Do not modify. The application name used to build the endpoint URL.
+        show_user: false

--- a/packages/google_workspace/data_stream/admin/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/admin/agent/stream/httpjson.yml.hbs
@@ -11,13 +11,19 @@ auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly
 request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/admin
+{{#if proxy_url}}
+request.proxy_url: {{proxy_url}}
+{{/if}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}
 {{#if http_client_timeout}}
 request.timeout: {{http_client_timeout}}
 {{/if}}
 request.transforms:
   - set:
       target: url.params.startTime
-      # If last pagination cycle was finished successully
+      # If last pagination cycle was finished successfully
       # we move the startDate pointer forward
       # else we reprocess the last interval from the beginning.
       # If none of the values are in the cursor it means is a fresh start
@@ -69,12 +75,14 @@ cursor:
       [[- else -]]
         [[- formatDate now -]]
       [[- end -]]
-
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event
 {{/if}}
-{{#each tags as |tag i|}}
+{{#if preserve_duplicate_custom_fields}}
+  - preserve_duplicate_custom_fields
+{{/if}}
+{{#each tags as |tag|}}
   - {{tag}}
 {{/each}}
 {{#contains "forwarded" tags}}

--- a/packages/google_workspace/data_stream/admin/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/admin/agent/stream/httpjson.yml.hbs
@@ -10,7 +10,7 @@ auth.oauth2.google.jwt_json: {{jwt_json}}
 auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly
-request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/admin
+request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/{{application_name_for_url}}
 {{#if proxy_url}}
 request.proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/google_workspace/data_stream/admin/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/admin/agent/stream/httpjson.yml.hbs
@@ -34,7 +34,10 @@ request.transforms:
         [[- else -]]
           [[- .cursor.last_response_date -]]
         [[- end -]]
-      default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
+      default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
+  - set:
+      target: url.params.endTime
+      value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -73,7 +76,7 @@ cursor:
       [[- else if not (parseDate $time "2006-01-02T15:04:05 MST").IsZero -]]
         [[- formatDate (parseDate $time "2006-01-02T15:04:05 MST") -]]
       [[- else -]]
-        [[- formatDate now -]]
+        [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
 tags:
 {{#if preserve_original_event}}

--- a/packages/google_workspace/data_stream/admin/manifest.yml
+++ b/packages/google_workspace/data_stream/admin/manifest.yml
@@ -76,3 +76,10 @@ streams:
           #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
           #    sxSmbIUfc2SGJGCJD4I=
           #    -----END CERTIFICATE-----
+      - name: application_name_for_url
+        type: text
+        title: Application Name for the URL
+        default: admin
+        required: true
+        description: Do not modify. The application name used to build the endpoint URL.
+        show_user: false

--- a/packages/google_workspace/data_stream/admin/manifest.yml
+++ b/packages/google_workspace/data_stream/admin/manifest.yml
@@ -10,11 +10,20 @@ streams:
         type: text
         title: Interval
         description: >-
-          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay. For more details on this, you can read more at https://support.google.com/a/answer/7061566. NOTE: Supported units for this parameter are h/m/s.
+          Duration between requests to the API. NOTE: Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true
-        default: 2h
+        default: 15m
+      - name: lag_time
+        type: text
+        title: Lag Time
+        description: >-
+          The lag time allowed for when fetching this report. Lag times vary by report, and go up to a few hours. There are more details in the [Google Workspace Admin documentation](https://support.google.com/a/answer/7061566). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: true
+        show_user: true
+        default: 3m
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/admin/manifest.yml
+++ b/packages/google_workspace/data_stream/admin/manifest.yml
@@ -24,6 +24,13 @@ streams:
         default:
           - forwarded
           - google_workspace-admin
+      - name: proxy_url
+        type: text
+        title: Proxy URL
+        multi: false
+        required: false
+        show_user: false
+        description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>. Please ensure your username and password are in URL encoded format.
       - name: preserve_original_event
         required: true
         show_user: true
@@ -40,3 +47,32 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: ssl
+        type: yaml
+        title: SSL Configuration
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #certificate_authorities:
+          #  - |
+          #    -----BEGIN CERTIFICATE-----
+          #    MIIDCjCCAfKgAwIBAgITJ706Mu2wJlKckpIvkWxEHvEyijANBgkqhkiG9w0BAQsF
+          #    ADAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwIBcNMTkwNzIyMTkyOTA0WhgPMjExOTA2
+          #    MjgxOTI5MDRaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEB
+          #    BQADggEPADCCAQoCggEBANce58Y/JykI58iyOXpxGfw0/gMvF0hUQAcUrSMxEO6n
+          #    fZRA49b4OV4SwWmA3395uL2eB2NB8y8qdQ9muXUdPBWE4l9rMZ6gmfu90N5B5uEl
+          #    94NcfBfYOKi1fJQ9i7WKhTjlRkMCgBkWPkUokvBZFRt8RtF7zI77BSEorHGQCk9t
+          #    /D7BS0GJyfVEhftbWcFEAG3VRcoMhF7kUzYwp+qESoriFRYLeDWv68ZOvG7eoWnP
+          #    PsvZStEVEimjvK5NSESEQa9xWyJOmlOKXhkdymtcUd/nXnx6UTCFgnkgzSdTWV41
+          #    CI6B6aJ9svCTI2QuoIq2HxX/ix7OvW1huVmcyHVxyUECAwEAAaNTMFEwHQYDVR0O
+          #    BBYEFPwN1OceFGm9v6ux8G+DZ3TUDYxqMB8GA1UdIwQYMBaAFPwN1OceFGm9v6ux
+          #    8G+DZ3TUDYxqMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAG5D
+          #    874A4YI7YUwOVsVAdbWtgp1d0zKcPRR+r2OdSbTAV5/gcS3jgBJ3i1BN34JuDVFw
+          #    3DeJSYT3nxy2Y56lLnxDeF8CUTUtVQx3CuGkRg1ouGAHpO/6OqOhwLLorEmxi7tA
+          #    H2O8mtT0poX5AnOAhzVy7QW0D/k4WaoLyckM5hUa6RtvgvLxOwA0U+VGurCDoctu
+          #    8F4QOgTAWyh8EZIwaKCliFRSynDpv3JTUwtfZkxo6K6nce1RhCWFAsMvDZL8Dgc0
+          #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
+          #    sxSmbIUfc2SGJGCJD4I=
+          #    -----END CERTIFICATE-----

--- a/packages/google_workspace/data_stream/calendar/agent/stream/cel.yml.hbs
+++ b/packages/google_workspace/data_stream/calendar/agent/stream/cel.yml.hbs
@@ -27,6 +27,7 @@ state:
   user_key: {{user_key}}
   initial_interval: {{initial_interval}}
   batch_size: {{batch_size}}
+  application_name_for_url: {{application_name_for_url}}
 redact:
   fields: ~
 program: |
@@ -41,7 +42,7 @@ program: |
   ).as(state, state.with(
     request(
       "GET",
-      state.url.trim_right("/") + "/admin/reports/v1/activity/users/" + state.user_key + "/applications/calendar?"+ {
+      state.url.trim_right("/") + "/admin/reports/v1/activity/users/" + state.user_key + "/applications/" + state.application_name_for_url + "?"+ {
         "maxResults": [string(state.batch_size)],
         "endTime": [state.end_time],
         "startTime": [state.start_time],
@@ -82,7 +83,7 @@ program: |
           "error": {
             "code": string(resp.StatusCode),
             "id": string(resp.Status),
-            "message": "GET "+state.url.trim_right("/")+"/admin/reports/v1/activity/users/"+state.user_key+"/applications/calendar:"+(
+            "message": "GET "+state.url.trim_right("/")+"/admin/reports/v1/activity/users/"+state.user_key+"/applications/" + state.application_name_for_url + ":"+(
               size(resp.Body) != 0 ?
                 string(resp.Body)
               :

--- a/packages/google_workspace/data_stream/calendar/agent/stream/cel.yml.hbs
+++ b/packages/google_workspace/data_stream/calendar/agent/stream/cel.yml.hbs
@@ -26,6 +26,7 @@ resource.url: {{api_host}}
 state:
   user_key: {{user_key}}
   initial_interval: {{initial_interval}}
+  lag_time: {{lag_time}}
   batch_size: {{batch_size}}
   application_name_for_url: {{application_name_for_url}}
 redact:
@@ -36,8 +37,10 @@ program: |
       state
     :
       state.with({
-        "start_time": state.?cursor.last_timestamp.orValue((now - duration(state.initial_interval)).format(time_layout.RFC3339)),
-        "end_time": now.format(time_layout.RFC3339),
+        "start_time": state.?cursor.last_timestamp.orValue(
+          (now - duration(state.initial_interval) - duration(state.lag_time)).format(time_layout.RFC3339)
+        ),
+        "end_time": (now - duration(state.lag_time)).format(time_layout.RFC3339),
       })
   ).as(state, state.with(
     request(

--- a/packages/google_workspace/data_stream/calendar/manifest.yml
+++ b/packages/google_workspace/data_stream/calendar/manifest.yml
@@ -19,7 +19,16 @@ streams:
         type: text
         title: Interval
         description: >-
-          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay. For more details on this, you can read more at https://support.google.com/a/answer/7061566. NOTE: Supported units for this parameter are h/m/s.
+          Duration between requests to the API. NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: true
+        show_user: true
+        default: 15m
+      - name: lag_time
+        type: text
+        title: Lag Time
+        description: >-
+          The lag time allowed for when fetching this report. Lag times vary by report, and go up to a few hours. There are more details in the [Google Workspace Admin documentation](https://support.google.com/a/answer/7061566). NOTE: Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true

--- a/packages/google_workspace/data_stream/calendar/manifest.yml
+++ b/packages/google_workspace/data_stream/calendar/manifest.yml
@@ -101,3 +101,10 @@ streams:
           #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
           #    sxSmbIUfc2SGJGCJD4I=
           #    -----END CERTIFICATE-----
+      - name: application_name_for_url
+        type: text
+        title: Application Name for the URL
+        default: calendar
+        required: true
+        description: Do not modify. The application name used to build the endpoint URL.
+        show_user: false

--- a/packages/google_workspace/data_stream/chat/agent/stream/cel.yml.hbs
+++ b/packages/google_workspace/data_stream/chat/agent/stream/cel.yml.hbs
@@ -27,6 +27,7 @@ state:
   user_key: {{user_key}}
   initial_interval: {{initial_interval}}
   batch_size: {{batch_size}}
+  application_name_for_url: {{application_name_for_url}}
 redact:
   fields: ~
 program: |
@@ -41,7 +42,7 @@ program: |
   ).as(state, state.with(
     request(
       "GET",
-      state.url.trim_right("/") + "/admin/reports/v1/activity/users/" + state.user_key + "/applications/chat?"+ {
+      state.url.trim_right("/") + "/admin/reports/v1/activity/users/" + state.user_key + "/applications/" + state.application_name_for_url + "?"+ {
         "maxResults": [string(state.batch_size)],
         "endTime": [state.end_time],
         "startTime": [state.start_time],
@@ -67,7 +68,7 @@ program: |
             :
               optional.of(state.end_time)
           )
-         },
+        },
         "want_more": has(body.nextPageToken),
         // The provided page token must be generated within the same time interval as the request.
         // Using a page token from a previous interval may lead to unexpected results.
@@ -82,7 +83,7 @@ program: |
           "error": {
             "code": string(resp.StatusCode),
             "id": string(resp.Status),
-            "message": "GET "+state.url.trim_right("/")+"/admin/reports/v1/activity/users/"+state.user_key+"/applications/chat:"+(
+            "message": "GET "+state.url.trim_right("/")+"/admin/reports/v1/activity/users/"+state.user_key+"/applications/" + state.application_name_for_url + ":"+(
               size(resp.Body) != 0 ?
                 string(resp.Body)
               :

--- a/packages/google_workspace/data_stream/chat/agent/stream/cel.yml.hbs
+++ b/packages/google_workspace/data_stream/chat/agent/stream/cel.yml.hbs
@@ -26,6 +26,7 @@ resource.url: {{api_host}}
 state:
   user_key: {{user_key}}
   initial_interval: {{initial_interval}}
+  lag_time: {{lag_time}}
   batch_size: {{batch_size}}
   application_name_for_url: {{application_name_for_url}}
 redact:
@@ -36,8 +37,10 @@ program: |
       state
     :
       state.with({
-        "start_time": state.?cursor.last_timestamp.orValue((now - duration(state.initial_interval)).format(time_layout.RFC3339)),
-        "end_time": now.format(time_layout.RFC3339),
+        "start_time": state.?cursor.last_timestamp.orValue(
+          (now - duration(state.initial_interval) - duration(state.lag_time)).format(time_layout.RFC3339)
+        ),
+        "end_time": (now - duration(state.lag_time)).format(time_layout.RFC3339),
       })
   ).as(state, state.with(
     request(

--- a/packages/google_workspace/data_stream/chat/manifest.yml
+++ b/packages/google_workspace/data_stream/chat/manifest.yml
@@ -19,11 +19,20 @@ streams:
         type: text
         title: Interval
         description: >-
-          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay. For more details on this, you can read more at https://support.google.com/a/answer/7061566. NOTE: Supported units for this parameter are h/m/s.
+          Duration between requests to the API. NOTE: Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true
-        default: 2h
+        default: 15m
+      - name: lag_time
+        type: text
+        title: Lag Time
+        description: >-
+          The lag time allowed for when fetching this report. Lag times vary by report, and go up to a few hours. There are more details in the [Google Workspace Admin documentation](https://support.google.com/a/answer/7061566). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: true
+        show_user: true
+        default: 3m
       - name: batch_size
         type: text
         title: Batch Size

--- a/packages/google_workspace/data_stream/chat/manifest.yml
+++ b/packages/google_workspace/data_stream/chat/manifest.yml
@@ -101,3 +101,10 @@ streams:
           #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
           #    sxSmbIUfc2SGJGCJD4I=
           #    -----END CERTIFICATE-----
+      - name: application_name_for_url
+        type: text
+        title: Application Name for the URL
+        default: chat
+        required: true
+        description: Do not modify. The application name used to build the endpoint URL.
+        show_user: false

--- a/packages/google_workspace/data_stream/chrome/agent/stream/cel.yml.hbs
+++ b/packages/google_workspace/data_stream/chrome/agent/stream/cel.yml.hbs
@@ -14,17 +14,20 @@ resource.ssl: {{ssl}}
 {{#if http_client_timeout}}
 resource.timeout: {{http_client_timeout}}
 {{/if}}
-auth.oauth2.provider: google
-auth.oauth2.google.jwt_file: {{jwt_file}}
-auth.oauth2.google.jwt_json: {{jwt_json}}
-auth.oauth2.google.delegated_account: {{delegated_account}}
-auth.oauth2.scopes:
-  - https://www.googleapis.com/auth/admin.reports.audit.readonly
+auth.oauth2:
+  provider: google
+  google:
+    jwt_file: {{jwt_file}}
+    jwt_json: {{jwt_json}}
+    delegated_account: {{delegated_account}}
+  scopes:
+    - https://www.googleapis.com/auth/admin.reports.audit.readonly
 resource.url: {{api_host}}
 state:
   user_key: {{user_key}}
   initial_interval: {{initial_interval}}
   batch_size: {{batch_size}}
+  application_name_for_url: {{application_name_for_url}}
 redact:
   fields: ~
 program: |
@@ -39,7 +42,7 @@ program: |
   ).as(state, state.with(
     request(
       "GET",
-      state.url.trim_right("/") + "/admin/reports/v1/activity/users/" + state.user_key + "/applications/chrome?"+ {
+      state.url.trim_right("/") + "/admin/reports/v1/activity/users/" + state.user_key + "/applications/" + state.application_name_for_url + "?"+ {
         "maxResults": [string(state.batch_size)],
         "endTime": [state.end_time],
         "startTime": [state.start_time],
@@ -80,7 +83,7 @@ program: |
           "error": {
             "code": string(resp.StatusCode),
             "id": string(resp.Status),
-            "message": "GET "+state.url.trim_right("/")+"/admin/reports/v1/activity/users/"+state.user_key+"/applications/chrome:"+(
+            "message": "GET "+state.url.trim_right("/")+"/admin/reports/v1/activity/users/"+state.user_key+"/applications/" + state.application_name_for_url + ":"+(
               size(resp.Body) != 0 ?
                 string(resp.Body)
               :

--- a/packages/google_workspace/data_stream/chrome/agent/stream/cel.yml.hbs
+++ b/packages/google_workspace/data_stream/chrome/agent/stream/cel.yml.hbs
@@ -26,6 +26,7 @@ resource.url: {{api_host}}
 state:
   user_key: {{user_key}}
   initial_interval: {{initial_interval}}
+  lag_time: {{lag_time}}
   batch_size: {{batch_size}}
   application_name_for_url: {{application_name_for_url}}
 redact:
@@ -36,8 +37,10 @@ program: |
       state
     :
       state.with({
-        "start_time": state.?cursor.last_timestamp.orValue((now - duration(state.initial_interval)).format(time_layout.RFC3339)),
-        "end_time": now.format(time_layout.RFC3339),
+        "start_time": state.?cursor.last_timestamp.orValue(
+          (now - duration(state.initial_interval) - duration(state.lag_time)).format(time_layout.RFC3339)
+        ),
+        "end_time": (now - duration(state.lag_time)).format(time_layout.RFC3339),
       })
   ).as(state, state.with(
     request(

--- a/packages/google_workspace/data_stream/chrome/manifest.yml
+++ b/packages/google_workspace/data_stream/chrome/manifest.yml
@@ -18,11 +18,20 @@ streams:
         type: text
         title: Interval
         description: >-
-          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay. For more details on this, you can read more at https://support.google.com/a/answer/7061566. NOTE: Supported units for this parameter are h/m/s.
+          Duration between requests to the API. NOTE: Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true
-        default: 2h
+        default: 15m
+      - name: lag_time
+        type: text
+        title: Lag Time
+        description: >-
+          The lag time allowed for when fetching this report. Lag times vary by report, and go up to a few hours. There are more details in the [Google Workspace Admin documentation](https://support.google.com/a/answer/7061566). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: true
+        show_user: true
+        default: 3m
       - name: batch_size
         type: text
         title: Batch Size

--- a/packages/google_workspace/data_stream/chrome/manifest.yml
+++ b/packages/google_workspace/data_stream/chrome/manifest.yml
@@ -100,3 +100,10 @@ streams:
           #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
           #    sxSmbIUfc2SGJGCJD4I=
           #    -----END CERTIFICATE-----
+      - name: application_name_for_url
+        type: text
+        title: Application Name for the URL
+        default: chrome
+        required: true
+        description: Do not modify. The application name used to build the endpoint URL.
+        show_user: false

--- a/packages/google_workspace/data_stream/context_aware_access/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/context_aware_access/agent/stream/httpjson.yml.hbs
@@ -10,7 +10,7 @@ auth.oauth2.google.jwt_json: {{jwt_json}}
 auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly
-request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/context_aware_access
+request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/{{application_name_for_url}}
 {{#if proxy_url}}
 request.proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/google_workspace/data_stream/context_aware_access/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/context_aware_access/agent/stream/httpjson.yml.hbs
@@ -34,7 +34,10 @@ request.transforms:
         [[- else -]]
           [[- .cursor.last_response_date -]]
         [[- end -]]
-      default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
+      default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
+  - set:
+      target: url.params.endTime
+      value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -73,7 +76,7 @@ cursor:
       [[- else if not (parseDate $time "2006-01-02T15:04:05 MST").IsZero -]]
         [[- formatDate (parseDate $time "2006-01-02T15:04:05 MST") -]]
       [[- else -]]
-        [[- formatDate now -]]
+        [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
 tags:
 {{#if preserve_original_event}}

--- a/packages/google_workspace/data_stream/context_aware_access/manifest.yml
+++ b/packages/google_workspace/data_stream/context_aware_access/manifest.yml
@@ -10,11 +10,20 @@ streams:
         type: text
         title: Interval
         description: >-
-          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay. For more details on this, you can read more at https://support.google.com/a/answer/7061566. NOTE: Supported units for this parameter are h/m/s.
+          Duration between requests to the API. NOTE: Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true
-        default: 2h
+        default: 15m
+      - name: lag_time
+        type: text
+        title: Lag Time
+        description: >-
+          The lag time allowed for when fetching this report. Lag times vary by report, and go up to a few hours. There are more details in the [Google Workspace Admin documentation](https://support.google.com/a/answer/7061566). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: true
+        show_user: true
+        default: 3m
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/context_aware_access/manifest.yml
+++ b/packages/google_workspace/data_stream/context_aware_access/manifest.yml
@@ -84,3 +84,10 @@ streams:
           #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
           #    sxSmbIUfc2SGJGCJD4I=
           #    -----END CERTIFICATE-----
+      - name: application_name_for_url
+        type: text
+        title: Application Name for the URL
+        default: context_aware_access
+        required: true
+        description: Do not modify. The application name used to build the endpoint URL.
+        show_user: false

--- a/packages/google_workspace/data_stream/data_studio/agent/stream/cel.yml.hbs
+++ b/packages/google_workspace/data_stream/data_studio/agent/stream/cel.yml.hbs
@@ -27,6 +27,7 @@ state:
   user_key: {{user_key}}
   initial_interval: {{initial_interval}}
   batch_size: {{batch_size}}
+  application_name_for_url: {{application_name_for_url}}
 redact:
   fields: ~
 program: |
@@ -41,7 +42,7 @@ program: |
   ).as(state, state.with(
     request(
       "GET",
-      state.url.trim_right("/") + "/admin/reports/v1/activity/users/" + state.user_key + "/applications/data_studio?"+ {
+      state.url.trim_right("/") + "/admin/reports/v1/activity/users/" + state.user_key + "/applications/" + state.application_name_for_url + "?"+ {
         "maxResults": [string(state.batch_size)],
         "endTime": [state.end_time],
         "startTime": [state.start_time],
@@ -82,7 +83,7 @@ program: |
           "error": {
             "code": string(resp.StatusCode),
             "id": string(resp.Status),
-            "message": "GET "+state.url.trim_right("/")+"/admin/reports/v1/activity/users/"+state.user_key+"/applications/data_studio:"+(
+            "message": "GET "+state.url.trim_right("/")+"/admin/reports/v1/activity/users/"+state.user_key+"/applications/" + state.application_name_for_url + ":"+(
               size(resp.Body) != 0 ?
                 string(resp.Body)
               :

--- a/packages/google_workspace/data_stream/data_studio/agent/stream/cel.yml.hbs
+++ b/packages/google_workspace/data_stream/data_studio/agent/stream/cel.yml.hbs
@@ -26,6 +26,7 @@ resource.url: {{api_host}}
 state:
   user_key: {{user_key}}
   initial_interval: {{initial_interval}}
+  lag_time: {{lag_time}}
   batch_size: {{batch_size}}
   application_name_for_url: {{application_name_for_url}}
 redact:
@@ -36,8 +37,10 @@ program: |
       state
     :
       state.with({
-        "start_time": state.?cursor.last_timestamp.orValue((now - duration(state.initial_interval)).format(time_layout.RFC3339)),
-        "end_time": now.format(time_layout.RFC3339),
+        "start_time": state.?cursor.last_timestamp.orValue(
+          (now - duration(state.initial_interval) - duration(state.lag_time)).format(time_layout.RFC3339)
+        ),
+        "end_time": (now - duration(state.lag_time)).format(time_layout.RFC3339),
       })
   ).as(state, state.with(
     request(

--- a/packages/google_workspace/data_stream/data_studio/manifest.yml
+++ b/packages/google_workspace/data_stream/data_studio/manifest.yml
@@ -101,3 +101,10 @@ streams:
           #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
           #    sxSmbIUfc2SGJGCJD4I=
           #    -----END CERTIFICATE-----
+      - name: application_name_for_url
+        type: text
+        title: Application Name for the URL
+        default: data_studio
+        required: true
+        description: Do not modify. The application name used to build the endpoint URL.
+        show_user: false

--- a/packages/google_workspace/data_stream/data_studio/manifest.yml
+++ b/packages/google_workspace/data_stream/data_studio/manifest.yml
@@ -19,11 +19,20 @@ streams:
         type: text
         title: Interval
         description: >-
-          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay. For more details on this, you can read more at https://support.google.com/a/answer/7061566. NOTE: Supported units for this parameter are h/m/s.
+          Duration between requests to the API. NOTE: Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true
-        default: 2h
+        default: 15m
+      - name: lag_time
+        type: text
+        title: Lag Time
+        description: >-
+          The lag time allowed for when fetching this report. Lag times vary by report, and go up to a few hours. There are more details in the [Google Workspace Admin documentation](https://support.google.com/a/answer/7061566). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: true
+        show_user: true
+        default: 3m
       - name: batch_size
         type: text
         title: Batch Size

--- a/packages/google_workspace/data_stream/device/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/device/agent/stream/httpjson.yml.hbs
@@ -10,7 +10,7 @@ auth.oauth2.google.jwt_json: {{jwt_json}}
 auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly
-request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/mobile
+request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/{{application_name_for_url}}
 {{#if proxy_url}}
 request.proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/google_workspace/data_stream/device/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/device/agent/stream/httpjson.yml.hbs
@@ -34,7 +34,10 @@ request.transforms:
         [[- else -]]
           [[- .cursor.last_response_date -]]
         [[- end -]]
-      default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
+      default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
+  - set:
+      target: url.params.endTime
+      value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -73,7 +76,7 @@ cursor:
       [[- else if not (parseDate $time "2006-01-02T15:04:05 MST").IsZero -]]
         [[- formatDate (parseDate $time "2006-01-02T15:04:05 MST") -]]
       [[- else -]]
-        [[- formatDate now -]]
+        [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
 tags:
 {{#if preserve_original_event}}

--- a/packages/google_workspace/data_stream/device/manifest.yml
+++ b/packages/google_workspace/data_stream/device/manifest.yml
@@ -84,3 +84,10 @@ streams:
           #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
           #    sxSmbIUfc2SGJGCJD4I=
           #    -----END CERTIFICATE-----
+      - name: application_name_for_url
+        type: text
+        title: Application Name for the URL
+        default: mobile # Note the difference from the data stream name!
+        required: true
+        description: Do not modify. The application name used to build the endpoint URL.
+        show_user: false

--- a/packages/google_workspace/data_stream/device/manifest.yml
+++ b/packages/google_workspace/data_stream/device/manifest.yml
@@ -10,11 +10,20 @@ streams:
         type: text
         title: Interval
         description: >-
-          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay. For more details on this, you can read more at https://support.google.com/a/answer/7061566. NOTE: Supported units for this parameter are h/m/s.
+          Duration between requests to the API. NOTE: Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true
-        default: 2h
+        default: 15m
+      - name: lag_time
+        type: text
+        title: Lag Time
+        description: >-
+          The lag time allowed for when fetching this report. Lag times vary by report, and go up to a few hours. There are more details in the [Google Workspace Admin documentation](https://support.google.com/a/answer/7061566). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: true
+        show_user: true
+        default: 3m
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/drive/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/drive/agent/stream/httpjson.yml.hbs
@@ -11,13 +11,19 @@ auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly
 request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/drive
+{{#if proxy_url}}
+request.proxy_url: {{proxy_url}}
+{{/if}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}
 {{#if http_client_timeout}}
 request.timeout: {{http_client_timeout}}
 {{/if}}
 request.transforms:
   - set:
       target: url.params.startTime
-      # If last pagination cycle was finished successully
+      # If last pagination cycle was finished successfully
       # we move the startDate pointer forward
       # else we reprocess the last interval from the beginning.
       # If none of the values are in the cursor it means is a fresh start
@@ -73,7 +79,10 @@ tags:
 {{#if preserve_original_event}}
   - preserve_original_event
 {{/if}}
-{{#each tags as |tag i|}}
+{{#if preserve_duplicate_custom_fields}}
+  - preserve_duplicate_custom_fields
+{{/if}}
+{{#each tags as |tag|}}
   - {{tag}}
 {{/each}}
 {{#contains "forwarded" tags}}

--- a/packages/google_workspace/data_stream/drive/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/drive/agent/stream/httpjson.yml.hbs
@@ -10,7 +10,7 @@ auth.oauth2.google.jwt_json: {{jwt_json}}
 auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly
-request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/drive
+request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/{{application_name_for_url}}
 {{#if proxy_url}}
 request.proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/google_workspace/data_stream/drive/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/drive/agent/stream/httpjson.yml.hbs
@@ -34,7 +34,10 @@ request.transforms:
         [[- else -]]
           [[- .cursor.last_response_date -]]
         [[- end -]]
-      default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
+      default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
+  - set:
+      target: url.params.endTime
+      value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -73,7 +76,7 @@ cursor:
       [[- else if not (parseDate $time "2006-01-02T15:04:05 MST").IsZero -]]
         [[- formatDate (parseDate $time "2006-01-02T15:04:05 MST") -]]
       [[- else -]]
-        [[- formatDate now -]]
+        [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
 tags:
 {{#if preserve_original_event}}

--- a/packages/google_workspace/data_stream/drive/manifest.yml
+++ b/packages/google_workspace/data_stream/drive/manifest.yml
@@ -76,3 +76,10 @@ streams:
           #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
           #    sxSmbIUfc2SGJGCJD4I=
           #    -----END CERTIFICATE-----
+      - name: application_name_for_url
+        type: text
+        title: Application Name for the URL
+        default: drive
+        required: true
+        description: Do not modify. The application name used to build the endpoint URL.
+        show_user: false

--- a/packages/google_workspace/data_stream/drive/manifest.yml
+++ b/packages/google_workspace/data_stream/drive/manifest.yml
@@ -10,11 +10,20 @@ streams:
         type: text
         title: Interval
         description: >-
-          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay. For more details on this, you can read more at https://support.google.com/a/answer/7061566. NOTE: Supported units for this parameter are h/m/s.
+          Duration between requests to the API. NOTE: Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true
-        default: 2h
+        default: 15m
+      - name: lag_time
+        type: text
+        title: Lag Time
+        description: >-
+          The lag time allowed for when fetching this report. Lag times vary by report, and go up to a few hours. There are more details in the [Google Workspace Admin documentation](https://support.google.com/a/answer/7061566). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: true
+        show_user: true
+        default: 3m
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/drive/manifest.yml
+++ b/packages/google_workspace/data_stream/drive/manifest.yml
@@ -24,6 +24,13 @@ streams:
         default:
           - forwarded
           - google_workspace-drive
+      - name: proxy_url
+        type: text
+        title: Proxy URL
+        multi: false
+        required: false
+        show_user: false
+        description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>. Please ensure your username and password are in URL encoded format.
       - name: preserve_original_event
         required: true
         show_user: true
@@ -40,3 +47,32 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: ssl
+        type: yaml
+        title: SSL Configuration
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #certificate_authorities:
+          #  - |
+          #    -----BEGIN CERTIFICATE-----
+          #    MIIDCjCCAfKgAwIBAgITJ706Mu2wJlKckpIvkWxEHvEyijANBgkqhkiG9w0BAQsF
+          #    ADAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwIBcNMTkwNzIyMTkyOTA0WhgPMjExOTA2
+          #    MjgxOTI5MDRaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEB
+          #    BQADggEPADCCAQoCggEBANce58Y/JykI58iyOXpxGfw0/gMvF0hUQAcUrSMxEO6n
+          #    fZRA49b4OV4SwWmA3395uL2eB2NB8y8qdQ9muXUdPBWE4l9rMZ6gmfu90N5B5uEl
+          #    94NcfBfYOKi1fJQ9i7WKhTjlRkMCgBkWPkUokvBZFRt8RtF7zI77BSEorHGQCk9t
+          #    /D7BS0GJyfVEhftbWcFEAG3VRcoMhF7kUzYwp+qESoriFRYLeDWv68ZOvG7eoWnP
+          #    PsvZStEVEimjvK5NSESEQa9xWyJOmlOKXhkdymtcUd/nXnx6UTCFgnkgzSdTWV41
+          #    CI6B6aJ9svCTI2QuoIq2HxX/ix7OvW1huVmcyHVxyUECAwEAAaNTMFEwHQYDVR0O
+          #    BBYEFPwN1OceFGm9v6ux8G+DZ3TUDYxqMB8GA1UdIwQYMBaAFPwN1OceFGm9v6ux
+          #    8G+DZ3TUDYxqMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAG5D
+          #    874A4YI7YUwOVsVAdbWtgp1d0zKcPRR+r2OdSbTAV5/gcS3jgBJ3i1BN34JuDVFw
+          #    3DeJSYT3nxy2Y56lLnxDeF8CUTUtVQx3CuGkRg1ouGAHpO/6OqOhwLLorEmxi7tA
+          #    H2O8mtT0poX5AnOAhzVy7QW0D/k4WaoLyckM5hUa6RtvgvLxOwA0U+VGurCDoctu
+          #    8F4QOgTAWyh8EZIwaKCliFRSynDpv3JTUwtfZkxo6K6nce1RhCWFAsMvDZL8Dgc0
+          #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
+          #    sxSmbIUfc2SGJGCJD4I=
+          #    -----END CERTIFICATE-----

--- a/packages/google_workspace/data_stream/gcp/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/gcp/agent/stream/httpjson.yml.hbs
@@ -10,7 +10,7 @@ auth.oauth2.google.jwt_json: {{jwt_json}}
 auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly
-request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/gcp
+request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/{{application_name_for_url}}
 {{#if proxy_url}}
 request.proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/google_workspace/data_stream/gcp/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/gcp/agent/stream/httpjson.yml.hbs
@@ -34,7 +34,10 @@ request.transforms:
         [[- else -]]
           [[- .cursor.last_response_date -]]
         [[- end -]]
-      default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
+      default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
+  - set:
+      target: url.params.endTime
+      value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -73,7 +76,7 @@ cursor:
       [[- else if not (parseDate $time "2006-01-02T15:04:05 MST").IsZero -]]
         [[- formatDate (parseDate $time "2006-01-02T15:04:05 MST") -]]
       [[- else -]]
-        [[- formatDate now -]]
+        [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
 tags:
 {{#if preserve_original_event}}

--- a/packages/google_workspace/data_stream/gcp/manifest.yml
+++ b/packages/google_workspace/data_stream/gcp/manifest.yml
@@ -84,3 +84,10 @@ streams:
           #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
           #    sxSmbIUfc2SGJGCJD4I=
           #    -----END CERTIFICATE-----
+      - name: application_name_for_url
+        type: text
+        title: Application Name for the URL
+        default: gcp
+        required: true
+        description: Do not modify. The application name used to build the endpoint URL.
+        show_user: false

--- a/packages/google_workspace/data_stream/gcp/manifest.yml
+++ b/packages/google_workspace/data_stream/gcp/manifest.yml
@@ -10,11 +10,20 @@ streams:
         type: text
         title: Interval
         description: >-
-          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay. For more details on this, you can read more at https://support.google.com/a/answer/7061566. NOTE: Supported units for this parameter are h/m/s.
+          Duration between requests to the API. NOTE: Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true
-        default: 2h
+        default: 15m
+      - name: lag_time
+        type: text
+        title: Lag Time
+        description: >-
+          The lag time allowed for when fetching this report. Lag times vary by report, and go up to a few hours. There are more details in the [Google Workspace Admin documentation](https://support.google.com/a/answer/7061566). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: true
+        show_user: true
+        default: 3h
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/group_enterprise/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/group_enterprise/agent/stream/httpjson.yml.hbs
@@ -34,7 +34,10 @@ request.transforms:
         [[- else -]]
           [[- .cursor.last_response_date -]]
         [[- end -]]
-      default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
+      default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
+  - set:
+      target: url.params.endTime
+      value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -73,7 +76,7 @@ cursor:
       [[- else if not (parseDate $time "2006-01-02T15:04:05 MST").IsZero -]]
         [[- formatDate (parseDate $time "2006-01-02T15:04:05 MST") -]]
       [[- else -]]
-        [[- formatDate now -]]
+        [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
 tags:
 {{#if preserve_original_event}}

--- a/packages/google_workspace/data_stream/group_enterprise/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/group_enterprise/agent/stream/httpjson.yml.hbs
@@ -10,7 +10,7 @@ auth.oauth2.google.jwt_json: {{jwt_json}}
 auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly
-request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/groups_enterprise
+request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/{{application_name_for_url}}
 {{#if proxy_url}}
 request.proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/google_workspace/data_stream/group_enterprise/manifest.yml
+++ b/packages/google_workspace/data_stream/group_enterprise/manifest.yml
@@ -10,7 +10,16 @@ streams:
         type: text
         title: Interval
         description: >-
-          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay. For more details on this, you can read more at https://support.google.com/a/answer/7061566. NOTE: Supported units for this parameter are h/m/s.
+          Duration between requests to the API. NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: true
+        show_user: true
+        default: 15m
+      - name: lag_time
+        type: text
+        title: Lag Time
+        description: >-
+          The lag time allowed for when fetching this report. Lag times vary by report, and go up to a few hours. There are more details in the [Google Workspace Admin documentation](https://support.google.com/a/answer/7061566). NOTE: Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true

--- a/packages/google_workspace/data_stream/group_enterprise/manifest.yml
+++ b/packages/google_workspace/data_stream/group_enterprise/manifest.yml
@@ -84,3 +84,10 @@ streams:
           #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
           #    sxSmbIUfc2SGJGCJD4I=
           #    -----END CERTIFICATE-----
+      - name: application_name_for_url
+        type: text
+        title: Application Name for the URL
+        default: groups_enterprise # Note the difference from the data stream name!
+        required: true
+        description: Do not modify. The application name used to build the endpoint URL.
+        show_user: false

--- a/packages/google_workspace/data_stream/groups/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/groups/agent/stream/httpjson.yml.hbs
@@ -11,13 +11,19 @@ auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly
 request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/groups
+{{#if proxy_url}}
+request.proxy_url: {{proxy_url}}
+{{/if}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}
 {{#if http_client_timeout}}
 request.timeout: {{http_client_timeout}}
 {{/if}}
 request.transforms:
   - set:
       target: url.params.startTime
-      # If last pagination cycle was finished successully
+      # If last pagination cycle was finished successfully
       # we move the startDate pointer forward
       # else we reprocess the last interval from the beginning.
       # If none of the values are in the cursor it means is a fresh start
@@ -73,7 +79,10 @@ tags:
 {{#if preserve_original_event}}
   - preserve_original_event
 {{/if}}
-{{#each tags as |tag i|}}
+{{#if preserve_duplicate_custom_fields}}
+  - preserve_duplicate_custom_fields
+{{/if}}
+{{#each tags as |tag|}}
   - {{tag}}
 {{/each}}
 {{#contains "forwarded" tags}}

--- a/packages/google_workspace/data_stream/groups/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/groups/agent/stream/httpjson.yml.hbs
@@ -10,7 +10,7 @@ auth.oauth2.google.jwt_json: {{jwt_json}}
 auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly
-request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/groups
+request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/{{application_name_for_url}}
 {{#if proxy_url}}
 request.proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/google_workspace/data_stream/groups/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/groups/agent/stream/httpjson.yml.hbs
@@ -34,7 +34,10 @@ request.transforms:
         [[- else -]]
           [[- .cursor.last_response_date -]]
         [[- end -]]
-      default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
+      default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
+  - set:
+      target: url.params.endTime
+      value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -73,7 +76,7 @@ cursor:
       [[- else if not (parseDate $time "2006-01-02T15:04:05 MST").IsZero -]]
         [[- formatDate (parseDate $time "2006-01-02T15:04:05 MST") -]]
       [[- else -]]
-        [[- formatDate now -]]
+        [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
 tags:
 {{#if preserve_original_event}}

--- a/packages/google_workspace/data_stream/groups/manifest.yml
+++ b/packages/google_workspace/data_stream/groups/manifest.yml
@@ -24,6 +24,13 @@ streams:
         default:
           - forwarded
           - google_workspace-groups
+      - name: proxy_url
+        type: text
+        title: Proxy URL
+        multi: false
+        required: false
+        show_user: false
+        description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>. Please ensure your username and password are in URL encoded format.
       - name: preserve_original_event
         required: true
         show_user: true
@@ -40,3 +47,32 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: ssl
+        type: yaml
+        title: SSL Configuration
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #certificate_authorities:
+          #  - |
+          #    -----BEGIN CERTIFICATE-----
+          #    MIIDCjCCAfKgAwIBAgITJ706Mu2wJlKckpIvkWxEHvEyijANBgkqhkiG9w0BAQsF
+          #    ADAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwIBcNMTkwNzIyMTkyOTA0WhgPMjExOTA2
+          #    MjgxOTI5MDRaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEB
+          #    BQADggEPADCCAQoCggEBANce58Y/JykI58iyOXpxGfw0/gMvF0hUQAcUrSMxEO6n
+          #    fZRA49b4OV4SwWmA3395uL2eB2NB8y8qdQ9muXUdPBWE4l9rMZ6gmfu90N5B5uEl
+          #    94NcfBfYOKi1fJQ9i7WKhTjlRkMCgBkWPkUokvBZFRt8RtF7zI77BSEorHGQCk9t
+          #    /D7BS0GJyfVEhftbWcFEAG3VRcoMhF7kUzYwp+qESoriFRYLeDWv68ZOvG7eoWnP
+          #    PsvZStEVEimjvK5NSESEQa9xWyJOmlOKXhkdymtcUd/nXnx6UTCFgnkgzSdTWV41
+          #    CI6B6aJ9svCTI2QuoIq2HxX/ix7OvW1huVmcyHVxyUECAwEAAaNTMFEwHQYDVR0O
+          #    BBYEFPwN1OceFGm9v6ux8G+DZ3TUDYxqMB8GA1UdIwQYMBaAFPwN1OceFGm9v6ux
+          #    8G+DZ3TUDYxqMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAG5D
+          #    874A4YI7YUwOVsVAdbWtgp1d0zKcPRR+r2OdSbTAV5/gcS3jgBJ3i1BN34JuDVFw
+          #    3DeJSYT3nxy2Y56lLnxDeF8CUTUtVQx3CuGkRg1ouGAHpO/6OqOhwLLorEmxi7tA
+          #    H2O8mtT0poX5AnOAhzVy7QW0D/k4WaoLyckM5hUa6RtvgvLxOwA0U+VGurCDoctu
+          #    8F4QOgTAWyh8EZIwaKCliFRSynDpv3JTUwtfZkxo6K6nce1RhCWFAsMvDZL8Dgc0
+          #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
+          #    sxSmbIUfc2SGJGCJD4I=
+          #    -----END CERTIFICATE-----

--- a/packages/google_workspace/data_stream/groups/manifest.yml
+++ b/packages/google_workspace/data_stream/groups/manifest.yml
@@ -76,3 +76,10 @@ streams:
           #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
           #    sxSmbIUfc2SGJGCJD4I=
           #    -----END CERTIFICATE-----
+      - name: application_name_for_url
+        type: text
+        title: Application Name for the URL
+        default: groups
+        required: true
+        description: Do not modify. The application name used to build the endpoint URL.
+        show_user: false

--- a/packages/google_workspace/data_stream/groups/manifest.yml
+++ b/packages/google_workspace/data_stream/groups/manifest.yml
@@ -10,7 +10,16 @@ streams:
         type: text
         title: Interval
         description: >-
-          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay. For more details on this, you can read more at https://support.google.com/a/answer/7061566. NOTE: Supported units for this parameter are h/m/s.
+          Duration between requests to the API. NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: true
+        show_user: true
+        default: 15m
+      - name: lag_time
+        type: text
+        title: Lag Time
+        description: >-
+          The lag time allowed for when fetching this report. Lag times vary by report, and go up to a few hours. There are more details in the [Google Workspace Admin documentation](https://support.google.com/a/answer/7061566). NOTE: Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true

--- a/packages/google_workspace/data_stream/login/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/login/agent/stream/httpjson.yml.hbs
@@ -11,13 +11,19 @@ auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly
 request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/login
+{{#if proxy_url}}
+request.proxy_url: {{proxy_url}}
+{{/if}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}
 {{#if http_client_timeout}}
 request.timeout: {{http_client_timeout}}
 {{/if}}
 request.transforms:
   - set:
       target: url.params.startTime
-      # If last pagination cycle was finished successully
+      # If last pagination cycle was finished successfully
       # we move the startDate pointer forward
       # else we reprocess the last interval from the beginning.
       # If none of the values are in the cursor it means is a fresh start
@@ -73,7 +79,10 @@ tags:
 {{#if preserve_original_event}}
   - preserve_original_event
 {{/if}}
-{{#each tags as |tag i|}}
+{{#if preserve_duplicate_custom_fields}}
+  - preserve_duplicate_custom_fields
+{{/if}}
+{{#each tags as |tag|}}
   - {{tag}}
 {{/each}}
 {{#contains "forwarded" tags}}

--- a/packages/google_workspace/data_stream/login/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/login/agent/stream/httpjson.yml.hbs
@@ -34,7 +34,10 @@ request.transforms:
         [[- else -]]
           [[- .cursor.last_response_date -]]
         [[- end -]]
-      default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
+      default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
+  - set:
+      target: url.params.endTime
+      value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -73,7 +76,7 @@ cursor:
       [[- else if not (parseDate $time "2006-01-02T15:04:05 MST").IsZero -]]
         [[- formatDate (parseDate $time "2006-01-02T15:04:05 MST") -]]
       [[- else -]]
-        [[- formatDate now -]]
+        [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
 tags:
 {{#if preserve_original_event}}

--- a/packages/google_workspace/data_stream/login/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/login/agent/stream/httpjson.yml.hbs
@@ -10,7 +10,7 @@ auth.oauth2.google.jwt_json: {{jwt_json}}
 auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly
-request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/login
+request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/{{application_name_for_url}}
 {{#if proxy_url}}
 request.proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/google_workspace/data_stream/login/manifest.yml
+++ b/packages/google_workspace/data_stream/login/manifest.yml
@@ -76,3 +76,10 @@ streams:
           #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
           #    sxSmbIUfc2SGJGCJD4I=
           #    -----END CERTIFICATE-----
+      - name: application_name_for_url
+        type: text
+        title: Application Name for the URL
+        default: login
+        required: true
+        description: Do not modify. The application name used to build the endpoint URL.
+        show_user: false

--- a/packages/google_workspace/data_stream/login/manifest.yml
+++ b/packages/google_workspace/data_stream/login/manifest.yml
@@ -24,6 +24,13 @@ streams:
         default:
           - forwarded
           - google_workspace-login
+      - name: proxy_url
+        type: text
+        title: Proxy URL
+        multi: false
+        required: false
+        show_user: false
+        description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>. Please ensure your username and password are in URL encoded format.
       - name: preserve_original_event
         required: true
         show_user: true
@@ -40,3 +47,32 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: ssl
+        type: yaml
+        title: SSL Configuration
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #certificate_authorities:
+          #  - |
+          #    -----BEGIN CERTIFICATE-----
+          #    MIIDCjCCAfKgAwIBAgITJ706Mu2wJlKckpIvkWxEHvEyijANBgkqhkiG9w0BAQsF
+          #    ADAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwIBcNMTkwNzIyMTkyOTA0WhgPMjExOTA2
+          #    MjgxOTI5MDRaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEB
+          #    BQADggEPADCCAQoCggEBANce58Y/JykI58iyOXpxGfw0/gMvF0hUQAcUrSMxEO6n
+          #    fZRA49b4OV4SwWmA3395uL2eB2NB8y8qdQ9muXUdPBWE4l9rMZ6gmfu90N5B5uEl
+          #    94NcfBfYOKi1fJQ9i7WKhTjlRkMCgBkWPkUokvBZFRt8RtF7zI77BSEorHGQCk9t
+          #    /D7BS0GJyfVEhftbWcFEAG3VRcoMhF7kUzYwp+qESoriFRYLeDWv68ZOvG7eoWnP
+          #    PsvZStEVEimjvK5NSESEQa9xWyJOmlOKXhkdymtcUd/nXnx6UTCFgnkgzSdTWV41
+          #    CI6B6aJ9svCTI2QuoIq2HxX/ix7OvW1huVmcyHVxyUECAwEAAaNTMFEwHQYDVR0O
+          #    BBYEFPwN1OceFGm9v6ux8G+DZ3TUDYxqMB8GA1UdIwQYMBaAFPwN1OceFGm9v6ux
+          #    8G+DZ3TUDYxqMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAG5D
+          #    874A4YI7YUwOVsVAdbWtgp1d0zKcPRR+r2OdSbTAV5/gcS3jgBJ3i1BN34JuDVFw
+          #    3DeJSYT3nxy2Y56lLnxDeF8CUTUtVQx3CuGkRg1ouGAHpO/6OqOhwLLorEmxi7tA
+          #    H2O8mtT0poX5AnOAhzVy7QW0D/k4WaoLyckM5hUa6RtvgvLxOwA0U+VGurCDoctu
+          #    8F4QOgTAWyh8EZIwaKCliFRSynDpv3JTUwtfZkxo6K6nce1RhCWFAsMvDZL8Dgc0
+          #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
+          #    sxSmbIUfc2SGJGCJD4I=
+          #    -----END CERTIFICATE-----

--- a/packages/google_workspace/data_stream/login/manifest.yml
+++ b/packages/google_workspace/data_stream/login/manifest.yml
@@ -10,11 +10,20 @@ streams:
         type: text
         title: Interval
         description: >-
-          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay. For more details on this, you can read more at https://support.google.com/a/answer/7061566. NOTE: Supported units for this parameter are h/m/s.
+          Duration between requests to the API. NOTE: Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true
-        default: 2h
+        default: 15m
+      - name: lag_time
+        type: text
+        title: Lag Time
+        description: >-
+          The lag time allowed for when fetching this report. Lag times vary by report, and go up to a few hours. There are more details in the [Google Workspace Admin documentation](https://support.google.com/a/answer/7061566). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: true
+        show_user: true
+        default: 3h
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/rules/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/rules/agent/stream/httpjson.yml.hbs
@@ -23,7 +23,7 @@ request.timeout: {{http_client_timeout}}
 request.transforms:
   - set:
       target: url.params.startTime
-      # If last pagination cycle was finished successully
+      # If last pagination cycle was finished successfully
       # we move the startDate pointer forward
       # else we reprocess the last interval from the beginning.
       # If none of the values are in the cursor it means is a fresh start

--- a/packages/google_workspace/data_stream/rules/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/rules/agent/stream/httpjson.yml.hbs
@@ -34,7 +34,10 @@ request.transforms:
         [[- else -]]
           [[- .cursor.last_response_date -]]
         [[- end -]]
-      default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
+      default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
+  - set:
+      target: url.params.endTime
+      value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -73,7 +76,7 @@ cursor:
       [[- else if not (parseDate $time "2006-01-02T15:04:05 MST").IsZero -]]
         [[- formatDate (parseDate $time "2006-01-02T15:04:05 MST") -]]
       [[- else -]]
-        [[- formatDate now -]]
+        [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
 tags:
 {{#if preserve_original_event}}

--- a/packages/google_workspace/data_stream/rules/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/rules/agent/stream/httpjson.yml.hbs
@@ -10,7 +10,7 @@ auth.oauth2.google.jwt_json: {{jwt_json}}
 auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly
-request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/rules
+request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/{{application_name_for_url}}
 {{#if proxy_url}}
 request.proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/google_workspace/data_stream/rules/manifest.yml
+++ b/packages/google_workspace/data_stream/rules/manifest.yml
@@ -84,3 +84,10 @@ streams:
           #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
           #    sxSmbIUfc2SGJGCJD4I=
           #    -----END CERTIFICATE-----
+      - name: application_name_for_url
+        type: text
+        title: Application Name for the URL
+        default: rules
+        required: true
+        description: Do not modify. The application name used to build the endpoint URL.
+        show_user: false

--- a/packages/google_workspace/data_stream/rules/manifest.yml
+++ b/packages/google_workspace/data_stream/rules/manifest.yml
@@ -10,11 +10,20 @@ streams:
         type: text
         title: Interval
         description: >-
-          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay. For more details on this, you can read more at https://support.google.com/a/answer/7061566. NOTE: Supported units for this parameter are h/m/s.
+          Duration between requests to the API. NOTE: Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true
-        default: 2h
+        default: 15m
+      - name: lag_time
+        type: text
+        title: Lag Time
+        description: >-
+          The lag time allowed for when fetching this report. Lag times vary by report, and go up to a few hours. There are more details in the [Google Workspace Admin documentation](https://support.google.com/a/answer/7061566). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: true
+        show_user: true
+        default: 5m
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/saml/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/saml/agent/stream/httpjson.yml.hbs
@@ -11,13 +11,19 @@ auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly
 request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/saml
+{{#if proxy_url}}
+request.proxy_url: {{proxy_url}}
+{{/if}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}
 {{#if http_client_timeout}}
 request.timeout: {{http_client_timeout}}
 {{/if}}
 request.transforms:
   - set:
       target: url.params.startTime
-      # If last pagination cycle was finished successully
+      # If last pagination cycle was finished successfully
       # we move the startDate pointer forward
       # else we reprocess the last interval from the beginning.
       # If none of the values are in the cursor it means is a fresh start
@@ -73,7 +79,10 @@ tags:
 {{#if preserve_original_event}}
   - preserve_original_event
 {{/if}}
-{{#each tags as |tag i|}}
+{{#if preserve_duplicate_custom_fields}}
+  - preserve_duplicate_custom_fields
+{{/if}}
+{{#each tags as |tag|}}
   - {{tag}}
 {{/each}}
 {{#contains "forwarded" tags}}

--- a/packages/google_workspace/data_stream/saml/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/saml/agent/stream/httpjson.yml.hbs
@@ -34,7 +34,10 @@ request.transforms:
         [[- else -]]
           [[- .cursor.last_response_date -]]
         [[- end -]]
-      default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
+      default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
+  - set:
+      target: url.params.endTime
+      value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -73,7 +76,7 @@ cursor:
       [[- else if not (parseDate $time "2006-01-02T15:04:05 MST").IsZero -]]
         [[- formatDate (parseDate $time "2006-01-02T15:04:05 MST") -]]
       [[- else -]]
-        [[- formatDate now -]]
+        [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
 tags:
 {{#if preserve_original_event}}

--- a/packages/google_workspace/data_stream/saml/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/saml/agent/stream/httpjson.yml.hbs
@@ -10,7 +10,7 @@ auth.oauth2.google.jwt_json: {{jwt_json}}
 auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly
-request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/saml
+request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/{{application_name_for_url}}
 {{#if proxy_url}}
 request.proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/google_workspace/data_stream/saml/manifest.yml
+++ b/packages/google_workspace/data_stream/saml/manifest.yml
@@ -24,6 +24,13 @@ streams:
         default:
           - forwarded
           - google_workspace-saml
+      - name: proxy_url
+        type: text
+        title: Proxy URL
+        multi: false
+        required: false
+        show_user: false
+        description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>. Please ensure your username and password are in URL encoded format.
       - name: preserve_original_event
         required: true
         show_user: true
@@ -40,3 +47,32 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: ssl
+        type: yaml
+        title: SSL Configuration
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #certificate_authorities:
+          #  - |
+          #    -----BEGIN CERTIFICATE-----
+          #    MIIDCjCCAfKgAwIBAgITJ706Mu2wJlKckpIvkWxEHvEyijANBgkqhkiG9w0BAQsF
+          #    ADAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwIBcNMTkwNzIyMTkyOTA0WhgPMjExOTA2
+          #    MjgxOTI5MDRaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEB
+          #    BQADggEPADCCAQoCggEBANce58Y/JykI58iyOXpxGfw0/gMvF0hUQAcUrSMxEO6n
+          #    fZRA49b4OV4SwWmA3395uL2eB2NB8y8qdQ9muXUdPBWE4l9rMZ6gmfu90N5B5uEl
+          #    94NcfBfYOKi1fJQ9i7WKhTjlRkMCgBkWPkUokvBZFRt8RtF7zI77BSEorHGQCk9t
+          #    /D7BS0GJyfVEhftbWcFEAG3VRcoMhF7kUzYwp+qESoriFRYLeDWv68ZOvG7eoWnP
+          #    PsvZStEVEimjvK5NSESEQa9xWyJOmlOKXhkdymtcUd/nXnx6UTCFgnkgzSdTWV41
+          #    CI6B6aJ9svCTI2QuoIq2HxX/ix7OvW1huVmcyHVxyUECAwEAAaNTMFEwHQYDVR0O
+          #    BBYEFPwN1OceFGm9v6ux8G+DZ3TUDYxqMB8GA1UdIwQYMBaAFPwN1OceFGm9v6ux
+          #    8G+DZ3TUDYxqMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAG5D
+          #    874A4YI7YUwOVsVAdbWtgp1d0zKcPRR+r2OdSbTAV5/gcS3jgBJ3i1BN34JuDVFw
+          #    3DeJSYT3nxy2Y56lLnxDeF8CUTUtVQx3CuGkRg1ouGAHpO/6OqOhwLLorEmxi7tA
+          #    H2O8mtT0poX5AnOAhzVy7QW0D/k4WaoLyckM5hUa6RtvgvLxOwA0U+VGurCDoctu
+          #    8F4QOgTAWyh8EZIwaKCliFRSynDpv3JTUwtfZkxo6K6nce1RhCWFAsMvDZL8Dgc0
+          #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
+          #    sxSmbIUfc2SGJGCJD4I=
+          #    -----END CERTIFICATE-----

--- a/packages/google_workspace/data_stream/saml/manifest.yml
+++ b/packages/google_workspace/data_stream/saml/manifest.yml
@@ -76,3 +76,10 @@ streams:
           #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
           #    sxSmbIUfc2SGJGCJD4I=
           #    -----END CERTIFICATE-----
+      - name: application_name_for_url
+        type: text
+        title: Application Name for the URL
+        default: saml
+        required: true
+        description: Do not modify. The application name used to build the endpoint URL.
+        show_user: false

--- a/packages/google_workspace/data_stream/saml/manifest.yml
+++ b/packages/google_workspace/data_stream/saml/manifest.yml
@@ -10,11 +10,20 @@ streams:
         type: text
         title: Interval
         description: >-
-          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay. For more details on this, you can read more at https://support.google.com/a/answer/7061566. NOTE: Supported units for this parameter are h/m/s.
+          Duration between requests to the API. NOTE: Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true
-        default: 2h
+        default: 15m
+      - name: lag_time
+        type: text
+        title: Lag Time
+        description: >-
+          The lag time allowed for when fetching this report. Lag times vary by report, and go up to a few hours. There are more details in the [Google Workspace Admin documentation](https://support.google.com/a/answer/7061566). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: true
+        show_user: true
+        default: 3m
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/token/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/token/agent/stream/httpjson.yml.hbs
@@ -34,7 +34,10 @@ request.transforms:
         [[- else -]]
           [[- .cursor.last_response_date -]]
         [[- end -]]
-      default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
+      default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
+  - set:
+      target: url.params.endTime
+      value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -73,7 +76,7 @@ cursor:
       [[- else if not (parseDate $time "2006-01-02T15:04:05 MST").IsZero -]]
         [[- formatDate (parseDate $time "2006-01-02T15:04:05 MST") -]]
       [[- else -]]
-        [[- formatDate now -]]
+        [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
 tags:
 {{#if preserve_original_event}}

--- a/packages/google_workspace/data_stream/token/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/token/agent/stream/httpjson.yml.hbs
@@ -10,7 +10,7 @@ auth.oauth2.google.jwt_json: {{jwt_json}}
 auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly
-request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/token
+request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/{{application_name_for_url}}
 {{#if proxy_url}}
 request.proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/google_workspace/data_stream/token/manifest.yml
+++ b/packages/google_workspace/data_stream/token/manifest.yml
@@ -10,7 +10,16 @@ streams:
         type: text
         title: Interval
         description: >-
-          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay. For more details on this, you can read more at https://support.google.com/a/answer/7061566. NOTE: Supported units for this parameter are h/m/s.
+          Duration between requests to the API. NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: true
+        show_user: true
+        default: 15m
+      - name: lag_time
+        type: text
+        title: Lag Time
+        description: >-
+          The lag time allowed for when fetching this report. Lag times vary by report, and go up to a few hours. There are more details in the [Google Workspace Admin documentation](https://support.google.com/a/answer/7061566). NOTE: Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true

--- a/packages/google_workspace/data_stream/token/manifest.yml
+++ b/packages/google_workspace/data_stream/token/manifest.yml
@@ -84,3 +84,10 @@ streams:
           #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
           #    sxSmbIUfc2SGJGCJD4I=
           #    -----END CERTIFICATE-----
+      - name: application_name_for_url
+        type: text
+        title: Application Name for the URL
+        default: token
+        required: true
+        description: Do not modify. The application name used to build the endpoint URL.
+        show_user: false

--- a/packages/google_workspace/data_stream/user_accounts/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/user_accounts/agent/stream/httpjson.yml.hbs
@@ -11,13 +11,19 @@ auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly
 request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/user_accounts
+{{#if proxy_url}}
+request.proxy_url: {{proxy_url}}
+{{/if}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}
 {{#if http_client_timeout}}
 request.timeout: {{http_client_timeout}}
 {{/if}}
 request.transforms:
   - set:
       target: url.params.startTime
-      # If last pagination cycle was finished successully
+      # If last pagination cycle was finished successfully
       # we move the startDate pointer forward
       # else we reprocess the last interval from the beginning.
       # If none of the values are in the cursor it means is a fresh start
@@ -73,7 +79,10 @@ tags:
 {{#if preserve_original_event}}
   - preserve_original_event
 {{/if}}
-{{#each tags as |tag i|}}
+{{#if preserve_duplicate_custom_fields}}
+  - preserve_duplicate_custom_fields
+{{/if}}
+{{#each tags as |tag|}}
   - {{tag}}
 {{/each}}
 {{#contains "forwarded" tags}}

--- a/packages/google_workspace/data_stream/user_accounts/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/user_accounts/agent/stream/httpjson.yml.hbs
@@ -10,7 +10,7 @@ auth.oauth2.google.jwt_json: {{jwt_json}}
 auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly
-request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/user_accounts
+request.url: {{api_host}}/admin/reports/v1/activity/users/{{user_key}}/applications/{{application_name_for_url}}
 {{#if proxy_url}}
 request.proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/google_workspace/data_stream/user_accounts/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/user_accounts/agent/stream/httpjson.yml.hbs
@@ -34,7 +34,10 @@ request.transforms:
         [[- else -]]
           [[- .cursor.last_response_date -]]
         [[- end -]]
-      default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
+      default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
+  - set:
+      target: url.params.endTime
+      value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -73,7 +76,7 @@ cursor:
       [[- else if not (parseDate $time "2006-01-02T15:04:05 MST").IsZero -]]
         [[- formatDate (parseDate $time "2006-01-02T15:04:05 MST") -]]
       [[- else -]]
-        [[- formatDate now -]]
+        [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
 tags:
 {{#if preserve_original_event}}

--- a/packages/google_workspace/data_stream/user_accounts/manifest.yml
+++ b/packages/google_workspace/data_stream/user_accounts/manifest.yml
@@ -24,6 +24,13 @@ streams:
         default:
           - forwarded
           - google_workspace-user_accounts
+      - name: proxy_url
+        type: text
+        title: Proxy URL
+        multi: false
+        required: false
+        show_user: false
+        description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>. Please ensure your username and password are in URL encoded format.
       - name: preserve_original_event
         required: true
         show_user: true
@@ -40,3 +47,32 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata.  This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: ssl
+        type: yaml
+        title: SSL Configuration
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #certificate_authorities:
+          #  - |
+          #    -----BEGIN CERTIFICATE-----
+          #    MIIDCjCCAfKgAwIBAgITJ706Mu2wJlKckpIvkWxEHvEyijANBgkqhkiG9w0BAQsF
+          #    ADAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwIBcNMTkwNzIyMTkyOTA0WhgPMjExOTA2
+          #    MjgxOTI5MDRaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEB
+          #    BQADggEPADCCAQoCggEBANce58Y/JykI58iyOXpxGfw0/gMvF0hUQAcUrSMxEO6n
+          #    fZRA49b4OV4SwWmA3395uL2eB2NB8y8qdQ9muXUdPBWE4l9rMZ6gmfu90N5B5uEl
+          #    94NcfBfYOKi1fJQ9i7WKhTjlRkMCgBkWPkUokvBZFRt8RtF7zI77BSEorHGQCk9t
+          #    /D7BS0GJyfVEhftbWcFEAG3VRcoMhF7kUzYwp+qESoriFRYLeDWv68ZOvG7eoWnP
+          #    PsvZStEVEimjvK5NSESEQa9xWyJOmlOKXhkdymtcUd/nXnx6UTCFgnkgzSdTWV41
+          #    CI6B6aJ9svCTI2QuoIq2HxX/ix7OvW1huVmcyHVxyUECAwEAAaNTMFEwHQYDVR0O
+          #    BBYEFPwN1OceFGm9v6ux8G+DZ3TUDYxqMB8GA1UdIwQYMBaAFPwN1OceFGm9v6ux
+          #    8G+DZ3TUDYxqMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAG5D
+          #    874A4YI7YUwOVsVAdbWtgp1d0zKcPRR+r2OdSbTAV5/gcS3jgBJ3i1BN34JuDVFw
+          #    3DeJSYT3nxy2Y56lLnxDeF8CUTUtVQx3CuGkRg1ouGAHpO/6OqOhwLLorEmxi7tA
+          #    H2O8mtT0poX5AnOAhzVy7QW0D/k4WaoLyckM5hUa6RtvgvLxOwA0U+VGurCDoctu
+          #    8F4QOgTAWyh8EZIwaKCliFRSynDpv3JTUwtfZkxo6K6nce1RhCWFAsMvDZL8Dgc0
+          #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
+          #    sxSmbIUfc2SGJGCJD4I=
+          #    -----END CERTIFICATE-----

--- a/packages/google_workspace/data_stream/user_accounts/manifest.yml
+++ b/packages/google_workspace/data_stream/user_accounts/manifest.yml
@@ -10,11 +10,20 @@ streams:
         type: text
         title: Interval
         description: >-
-          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay. For more details on this, you can read more at https://support.google.com/a/answer/7061566. NOTE: Supported units for this parameter are h/m/s.
+          Duration between requests to the API. NOTE: Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true
-        default: 2h
+        default: 15m
+      - name: lag_time
+        type: text
+        title: Lag Time
+        description: >-
+          The lag time allowed for when fetching this report. Lag times vary by report, and go up to a few hours. There are more details in the [Google Workspace Admin documentation](https://support.google.com/a/answer/7061566). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: true
+        show_user: true
+        default: 1h
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/user_accounts/manifest.yml
+++ b/packages/google_workspace/data_stream/user_accounts/manifest.yml
@@ -76,3 +76,10 @@ streams:
           #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
           #    sxSmbIUfc2SGJGCJD4I=
           #    -----END CERTIFICATE-----
+      - name: application_name_for_url
+        type: text
+        title: Application Name for the URL
+        default: user_accounts
+        required: true
+        description: Do not modify. The application name used to build the endpoint URL.
+        show_user: false

--- a/packages/google_workspace/data_stream/vault/agent/stream/cel.yml.hbs
+++ b/packages/google_workspace/data_stream/vault/agent/stream/cel.yml.hbs
@@ -26,7 +26,9 @@ resource.url: {{api_host}}
 state:
   user_key: {{user_key}}
   initial_interval: {{initial_interval}}
+  lag_time: {{lag_time}}
   batch_size: {{batch_size}}
+  application_name_for_url: {{application_name_for_url}}
 redact:
   fields: ~
 program: |
@@ -35,13 +37,15 @@ program: |
       state
     :
       state.with({
-        "start_time": state.?cursor.last_timestamp.orValue((now - duration(state.initial_interval)).format(time_layout.RFC3339)),
-        "end_time": now.format(time_layout.RFC3339),
+        "start_time": state.?cursor.last_timestamp.orValue(
+          (now - duration(state.initial_interval) - duration(state.lag_time)).format(time_layout.RFC3339)
+        ),
+        "end_time": (now - duration(state.lag_time)).format(time_layout.RFC3339),
       })
   ).as(state, state.with(
     request(
       "GET",
-      state.url.trim_right("/") + "/admin/reports/v1/activity/users/" + state.user_key + "/applications/vault?"+ {
+      state.url.trim_right("/") + "/admin/reports/v1/activity/users/" + state.user_key + "/applications/" + state.application_name_for_url + "?"+ {
         "maxResults": [string(state.batch_size)],
         "endTime": [state.end_time],
         "startTime": [state.start_time],
@@ -82,7 +86,7 @@ program: |
           "error": {
             "code": string(resp.StatusCode),
             "id": string(resp.Status),
-            "message": "GET "+state.url.trim_right("/")+"/admin/reports/v1/activity/users/"+state.user_key+"/applications/vault:"+(
+            "message": "GET "+state.url.trim_right("/")+"/admin/reports/v1/activity/users/"+state.user_key+"/applications/" + state.application_name_for_url + ":"+(
               size(resp.Body) != 0 ?
                 string(resp.Body)
               :

--- a/packages/google_workspace/data_stream/vault/manifest.yml
+++ b/packages/google_workspace/data_stream/vault/manifest.yml
@@ -19,11 +19,20 @@ streams:
         type: text
         title: Interval
         description: >-
-          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay. For more details on this, you can read more at https://support.google.com/a/answer/7061566. NOTE: Supported units for this parameter are h/m/s.
+          Duration between requests to the API. NOTE: Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true
-        default: 2h
+        default: 15m
+      - name: lag_time
+        type: text
+        title: Lag Time
+        description: >-
+          The lag time allowed for when fetching this report. Lag times vary by report, and go up to a few hours. There are more details in the [Google Workspace Admin documentation](https://support.google.com/a/answer/7061566). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: true
+        show_user: true
+        default: 3m
       - name: batch_size
         type: text
         title: Batch Size
@@ -101,3 +110,10 @@ streams:
           #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
           #    sxSmbIUfc2SGJGCJD4I=
           #    -----END CERTIFICATE-----
+      - name: application_name_for_url
+        type: text
+        title: Application Name for the URL
+        default: vault
+        required: true
+        description: Do not modify. The application name used to build the endpoint URL.
+        show_user: false

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: "2.39.1"
+version: "2.39.2"
 source:
   license: Elastic-2.0
 description: Collect logs from Google Workspace with Elastic Agent.


### PR DESCRIPTION
## Proposed commit message

```
[google_workspace] Handle lag time, add proxy and SSL options

Avoid requesting data for time ranges that are expected to have
incomplete data. The lag times are different for each data set, and
default values have been chosen based on guidance in the Google
Workspace Admin documentation[1].

Waiting until the data is all available means we don't miss things if
it becomes available out of order.

HTTP JSON input config files were made identical where possible, which
involved adding Proxy URL and SSL Configuration options to the following
data streams: `admin`, `drive`, `groups`, `login`, `saml`,
`user_accounts`.

[1]: https://support.google.com/a/answer/7061566
```

## Notes for reviewers

Can be read commit-by-commit.

The initial commits refactor to make the relevant `httpjson.yml.hbs` and `cel.yml.hbs` files are identical. See via `find -name '*.yml.hbs' | xargs md5sum | sort`

The `alert` data stream uses a different API and is not relevant.

I manually checked via the system tests that the initial `startTime` and `endTime` values are being chosen correctly.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Closes #13081