### PR TITLE
[Bug]Fixed missing template_path for google_cloud_storage elastic connector

### DIFF
--- a/packages/elastic_connectors/manifest.yml
+++ b/packages/elastic_connectors/manifest.yml
@@ -175,6 +175,7 @@ policy_templates:
         title: Google Cloud Storage Connector
         description: *input_description
         vars: *connector_input_vars
+        template_path: google_cloud_storage.yml.hbs
   - name: jira
     title: Jira Connector
     icons:


### PR DESCRIPTION
## Proposed commit message

This PR adding the missing field `template_path` to `policy_templates` in [manifest.yml](https://github.com/elastic/integrations/blob/037cda7c46f84ca7c1d8055105f5d7fab59fda50/packages/elastic_connectors/manifest.yml#L163-L177) file for google_cloud_storage connector.
Due to the missing field the provisioning of the infrastructure for Elastic managed agentless connector was broken:

<img width="1309" alt="Screenshot 2025-04-29 at 11 47 07 AM" src="https://github.com/user-attachments/assets/6cd40e1c-a79b-4c89-826f-d2390f33ee32" />
