### PR TITLE
[Cloud Security] Fix Cloud Asset Inventory dataview name

### DIFF
--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -5,7 +5,7 @@
   changes:
     - description: Fix the dataview name for the asset inventory data stream
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/13748
+      link: https://github.com/elastic/integrations/pull/13768
 - version: "0.11.0"
   changes:
     - description: Change name to Cloud Asset Discovery

--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -1,6 +1,11 @@
 # newer versions go on top
 # version map:
 # 0.1.x - 8.15.x
+- version: "0.12.0"
+  changes:
+    - description: Fix the dataview name for the asset inventory data stream
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13748
 - version: "0.11.0"
   changes:
     - description: Change name to Cloud Asset Discovery

--- a/packages/cloud_asset_inventory/docs/README.md
+++ b/packages/cloud_asset_inventory/docs/README.md
@@ -8,7 +8,7 @@ The Cloud Asset Discovery integration helps you discover and track all the resou
 
 > ⚠️ (BETA) Please note: Multiple cloud providers per policy are not supported. Please select only one.
 
-[View the full list of supported services for discovery](https://github.com/elastic/cloudbeat/blob/main/internal/Discovery/ASSETS.md).
+[View the full list of supported services for discovery](https://github.com/elastic/cloudbeat/blob/main/internal/inventory/ASSETS.md).
 
 ### Why Use Cloud Asset Discovery?
 

--- a/packages/cloud_asset_inventory/kibana/index_pattern/cloud_asset_inventory-2773feaf-50bb-43f8-9fa9-8f9a5f85e566.json
+++ b/packages/cloud_asset_inventory/kibana/index_pattern/cloud_asset_inventory-2773feaf-50bb-43f8-9fa9-8f9a5f85e566.json
@@ -1,7 +1,8 @@
 {
   "attributes": {
     "namespaces": ["*", "default"],
-    "title": "Cloud Asset Discovery",
+    "name": "Cloud Asset Discovery",
+    "title": "logs-cloud_asset_inventory.asset_inventory-*",
     "timeFieldName": "@timestamp",
     "description": "Lists all the discovered Cloud Assets"
   },

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_asset_inventory
 title: "Cloud Asset Discovery"
-version: "0.11.0"
+version: "0.12.0"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Discovery"


### PR DESCRIPTION
## Proposed commit message
Fixes the Asset Inventory data view name.
## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 