### PR TITLE
Add enable_batch_api option in azure resource metrics

### DIFF
--- a/packages/azure_metrics/_dev/build/docs/README.md
+++ b/packages/azure_metrics/_dev/build/docs/README.md
@@ -167,7 +167,7 @@ The settings' main section contains all the options needed to access the Azure A
 
 ### Advanced options
 
-There are two additional advanced options:
+There are three additional advanced options:
 
 `Resource Manager Endpoint` _string_
 : Optional. By default, the integration uses the Azure public environment. To override, users can provide a specific resource manager endpoint to use a different Azure environment.
@@ -188,6 +188,11 @@ Examples:
 * `https://login.microsoftonline.de` for Azure GermanCloud
 * `https://login.microsoftonline.com` for Azure PublicCloud
 * `https://login.microsoftonline.us` for Azure USGovernmentCloud
+
+`Enable Batch Api` _boolean_
+: Optional, by default is set to False. Set this to True when facing scalability issues. When configured, the azure batch api will be used
+ to fetch metrics of multiple resources in one api call. 
+ Currently supported data streams are monitor, container_registry, container_instance, container_service, compute_vm, compute_vm_scaleset, database_account and storage_account. 
 
 ## Metrics reference
 

--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.8.0
+  changes:
+    - description: Add enable_batch_api option
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12641
 - version: 1.7.0
   changes:
     - description: Add support for Kibana `9.0.0` 

--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add enable_batch_api option
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/12641
+      link: https://github.com/elastic/integrations/pull/13783
 - version: 1.7.0
   changes:
     - description: Add support for Kibana `9.0.0` 

--- a/packages/azure_metrics/data_stream/compute_vm/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/compute_vm/agent/stream/stream.yml.hbs
@@ -23,6 +23,9 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if active_directory_endpoint}}
 active_directory_endpoint: {{active_directory_endpoint}}
 {{/if}}
+{{#if enable_batch_api}}
+enable_batch_api: {{enable_batch_api}}
+{{/if}}
 
 resources:
 {{#if resource_groups}}

--- a/packages/azure_metrics/data_stream/compute_vm_scaleset/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/compute_vm_scaleset/agent/stream/stream.yml.hbs
@@ -23,6 +23,9 @@ refresh_list_interval: {{refresh_list_interval}}
 {{#if active_directory_endpoint}}
     active_directory_endpoint: {{active_directory_endpoint}}
 {{/if}}
+{{#if enable_batch_api}}
+enable_batch_api: {{enable_batch_api}}
+{{/if}}
 
 resources:
 {{#if resource_groups}}

--- a/packages/azure_metrics/data_stream/container_instance/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/container_instance/agent/stream/stream.yml.hbs
@@ -21,6 +21,9 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if active_directory_endpoint}}
 active_directory_endpoint: {{active_directory_endpoint}}
 {{/if}}
+{{#if enable_batch_api}}
+enable_batch_api: {{enable_batch_api}}
+{{/if}}
 
 resources:
 {{#if resource_groups}}

--- a/packages/azure_metrics/data_stream/container_registry/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/container_registry/agent/stream/stream.yml.hbs
@@ -21,6 +21,9 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if active_directory_endpoint}}
 active_directory_endpoint: {{active_directory_endpoint}}
 {{/if}}
+{{#if enable_batch_api}}
+enable_batch_api: {{enable_batch_api}}
+{{/if}}
 
 resources:
 {{#if resource_groups}}

--- a/packages/azure_metrics/data_stream/container_service/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/container_service/agent/stream/stream.yml.hbs
@@ -21,6 +21,9 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if active_directory_endpoint}}
 active_directory_endpoint: {{active_directory_endpoint}}
 {{/if}}
+{{#if enable_batch_api}}
+enable_batch_api: {{enable_batch_api}}
+{{/if}}
 
 resources:
 {{#if resource_groups}}

--- a/packages/azure_metrics/data_stream/database_account/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/database_account/agent/stream/stream.yml.hbs
@@ -21,6 +21,9 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if active_directory_endpoint}}
 active_directory_endpoint: {{active_directory_endpoint}}
 {{/if}}
+{{#if enable_batch_api}}
+enable_batch_api: {{enable_batch_api}}
+{{/if}}
 
 resources:
 {{#if resource_groups}}

--- a/packages/azure_metrics/data_stream/monitor/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/monitor/agent/stream/stream.yml.hbs
@@ -21,6 +21,9 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if active_directory_endpoint}}
 active_directory_endpoint: {{active_directory_endpoint}}
 {{/if}}
+{{#if enable_batch_api}}
+enable_batch_api: {{enable_batch_api}}
+{{/if}}
 {{#if default_resource_type}}
 default_resource_type: {{default_resource_type}}
 {{/if}}

--- a/packages/azure_metrics/data_stream/storage_account/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/storage_account/agent/stream/stream.yml.hbs
@@ -21,6 +21,9 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if active_directory_endpoint}}
 active_directory_endpoint: {{active_directory_endpoint}}
 {{/if}}
+{{#if enable_batch_api}}
+enable_batch_api: {{enable_batch_api}}
+{{/if}}
 
 resources:
 {{#if resource_groups}}

--- a/packages/azure_metrics/docs/README.md
+++ b/packages/azure_metrics/docs/README.md
@@ -167,7 +167,7 @@ The settings' main section contains all the options needed to access the Azure A
 
 ### Advanced options
 
-There are two additional advanced options:
+There are three additional advanced options:
 
 `Resource Manager Endpoint` _string_
 : Optional. By default, the integration uses the Azure public environment. To override, users can provide a specific resource manager endpoint to use a different Azure environment.
@@ -188,6 +188,11 @@ Examples:
 * `https://login.microsoftonline.de` for Azure GermanCloud
 * `https://login.microsoftonline.com` for Azure PublicCloud
 * `https://login.microsoftonline.us` for Azure USGovernmentCloud
+
+`Enable Batch Api` _boolean_
+: Optional, by default is set to False. Set this to True when facing scalability issues. When configured, the azure batch api will be used
+ to fetch metrics of multiple resources in one api call. 
+ Currently supported data streams are monitor, container_registry, container_instance, container_service, compute_vm, compute_vm_scaleset, database_account and storage_account. 
 
 ## Metrics reference
 

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_metrics
 title: Azure Resource Metrics
-version: 1.7.0
+version: 1.8.0
 description: Collect metrics from Azure resources with Elastic Agent.
 type: integration
 icons:
@@ -21,7 +21,7 @@ categories:
   - custom
 conditions:
   kibana:
-    version: "^8.12.0 || ^9.0.0"
+    version: "^9.0.1"
 vars:
   - name: client_id
     type: text
@@ -67,6 +67,17 @@ vars:
     multi: false
     required: false
     show_user: true
+  - name: enable_batch_api
+    type: bool
+    title: Enable Batch Api
+    description: >
+      When enabled, the azure batch api will be used
+      to fetch metrics of multiple resources in one api call.
+      Enable this when facing scalability issues.
+    multi: false
+    required: false
+    show_user: false
+    default: false
 policy_templates:
   - name: monitor
     title: Azure Monitor Metrics

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -21,7 +21,7 @@ categories:
   - custom
 conditions:
   kibana:
-    version: "^9.0.1"
+    version: "~8.17.7 || ^8.18.2 || ^9.0.1"
 vars:
   - name: client_id
     type: text


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

Follow-up of [beats PR](https://github.com/elastic/beats/pull/41790)

## Proposed commit message
- WHAT: Adds `enable_batch_api` configuration parameter in azure resource metrics. 
- WHY:  Helps mitigating scalability problems

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

It can be easily tested by installing Azure Resource Metrics. Enable the `enable_batch_api` advanced setting.
Then the metrics will be collected from the azure batch api.

## Related issues

- Closes https://github.com/elastic/beats/issues/38624

## Screenshots
![enable](https://github.com/user-attachments/assets/cf0dbd48-c711-428c-bfb6-581a81c4d834)

![data](https://github.com/user-attachments/assets/f143e033-30d4-49e0-b97f-23afbfd5e93b)


