### PR TITLE
[Atlassian JIRA and Atlassian Confluence] Fix Time Parsing in Cursor Logic

### DIFF
--- a/packages/atlassian_confluence/changelog.yml
+++ b/packages/atlassian_confluence/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.29.2"
+  changes:
+    - description: Expected timestamp layout added in cursor logic.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.29.1"
   changes:
     - description: Update cursor logic to remove duplicate events.

--- a/packages/atlassian_confluence/changelog.yml
+++ b/packages/atlassian_confluence/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Expected timestamp layout added in cursor logic.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/13784
 - version: "1.29.1"
   changes:
     - description: Update cursor logic to remove duplicate events.

--- a/packages/atlassian_confluence/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/atlassian_confluence/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -110,7 +110,7 @@ response.pagination:
 
 cursor:
   last_timestamp:
-    value: '[[formatDate (parseTimestampMilli (add (parseDate .first_event.timestamp).UnixMilli 1))]]'
+    value: '[[formatDate (parseTimestampMilli (add (parseDate .first_event.timestamp).UnixMilli 1)) "2006-01-02T15:04:05.999Z"]]'
 {{/if}}
 
 tags:

--- a/packages/atlassian_confluence/manifest.yml
+++ b/packages/atlassian_confluence/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: atlassian_confluence
 title: Atlassian Confluence
-version: "1.29.1"
+version: "1.29.2"
 description: Collect logs from Atlassian Confluence with Elastic Agent.
 type: integration
 categories:

--- a/packages/atlassian_jira/changelog.yml
+++ b/packages/atlassian_jira/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.30.3"
+  changes:
+    - description: Expected timestamp layout added in cursor logic.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.30.2"
   changes:
     - description: Update cursor logic to remove duplicate events.

--- a/packages/atlassian_jira/changelog.yml
+++ b/packages/atlassian_jira/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Expected timestamp layout added in cursor logic.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/13784
 - version: "1.30.2"
   changes:
     - description: Update cursor logic to remove duplicate events.

--- a/packages/atlassian_jira/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/atlassian_jira/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -62,7 +62,7 @@ response.pagination:
       value: '{{limit}}'
 cursor:
   last_timestamp:
-    value: '[[formatDate (parseTimestampMilli (add (parseDate .first_event.created).UnixMilli 1))]]'
+    value: '[[formatDate (parseTimestampMilli (add (parseDate .first_event.created "2006-01-02T15:04:05.999+0000").UnixMilli 1)) "2006-01-02T15:04:05.999Z"]]'
 {{else}}
 {{#unless username}}
 {{#unless password}}
@@ -91,7 +91,7 @@ response.pagination:
 
 cursor:
   last_timestamp:
-    value: '[[formatDate (parseTimestampMilli (add (parseDate .first_event.timestamp).UnixMilli 1))]]'
+    value: '[[formatDate (parseTimestampMilli (add (parseDate .first_event.timestamp).UnixMilli 1)) "2006-01-02T15:04:05.999Z"]]'
 {{/if}}
 
 tags:

--- a/packages/atlassian_jira/manifest.yml
+++ b/packages/atlassian_jira/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: atlassian_jira
 title: Atlassian Jira
-version: "1.30.2"
+version: "1.30.3"
 description: Collect logs from Atlassian Jira with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed Commit Message

```
atlassian_jira and atlassian_confluence: fix time parsing in cursor logic.

After reviewing the live request tracer, it was observed that the timestamps from Atlassian Jira Cloud include a
timezone offset (+0000), which was not being parsed correctly. To fix this, the expected timestamp layout
was added in parseDate.

Additionally, the expected timestamp layouts were added in formatDate for both Atlassian Jira and Atlassian Confluence
to ensure the full timestamp is captured accurately.

Tested the changes using mock server and the data available in the test folder.
```


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

### To test atlassian_jira integration
Clone integrations repo.
Install the elastic package locally.
Start the elastic stack using the elastic package.
Move to integrations/packages/atlassian_jira directory.
Run the following command to run tests.
`elastic-package test -v`

### To test atlassian_confluence integration
Clone integrations repo.
Install the elastic package locally.
Start the elastic stack using the elastic package.
Move to integrations/packages/atlassian_confluence directory.
Run the following command to run tests.
`elastic-package test -v`

## Related issues

- It relates to sdh beats Issue 5901

