### PR TITLE
[Falco] Fix Conflicting Field Types

### DIFF
--- a/packages/falco/changelog.yml
+++ b/packages/falco/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix conflicting field definitions.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/13800
 - version: "1.3.1"
   changes:
     - description: Align field definitions with ECS. The `process.group.id` and `process.group.name` fields were changed from text to keyword.

--- a/packages/falco/changelog.yml
+++ b/packages/falco/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.2"
+  changes:
+    - description: Fix conflicting field definitions.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.3.1"
   changes:
     - description: Align field definitions with ECS. The `process.group.id` and `process.group.name` fields were changed from text to keyword.

--- a/packages/falco/data_stream/alerts/_dev/test/pipeline/test-falco.log-expected.json
+++ b/packages/falco/data_stream/alerts/_dev/test/pipeline/test-falco.log-expected.json
@@ -10,7 +10,7 @@
                 "category": [
                     "process"
                 ],
-                "ingested": "2024-12-12T20:33:05.777758441Z",
+                "ingested": "2025-05-02T12:53:53.032987978Z",
                 "kind": "alert",
                 "original": "{\"hostname\":\"97ade2b595f0\",\"output\":\"2024-05-07T18:54:19.341081180+0000: Warning Sensitive file opened for reading by non-trusted program (file=/etc/shadow gparent=runc ggparent=init gggparent=init evt_type=openat user=root user_uid=0 user_loginuid=-1 process=event-generator proc_exepath=/bin/event-generator parent=containerd-shim command=event-generator run --loop terminal=0 container_id=9656db3bb358 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Warning\",\"rule\":\"Read sensitive file untrusted\",\"source\":\"syscall\",\"tags\":[\"T1555\",\"container\",\"filesystem\",\"host\",\"maturity_stable\",\"mitre_credential_access\"],\"time\":\"2024-05-07T18:54:19.341081180Z\", \"output_fields\": {\"container.id\":\"9656db3bb358\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"evt.time.iso8601\":1715108059341081180,\"evt.type\":\"openat\",\"fd.name\":\"/etc/shadow\",\"proc.cmdline\":\"event-generator run --loop\",\"proc.exepath\":\"/bin/event-generator\",\"proc.name\":\"event-generator\",\"proc.pname\":\"containerd-shim\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"root\",\"user.uid\":0}}",
                 "provider": "syscall",
@@ -116,7 +116,7 @@
                 "category": [
                     "process"
                 ],
-                "ingested": "2024-12-12T20:33:05.777766674Z",
+                "ingested": "2025-05-02T12:53:53.033066958Z",
                 "kind": "alert",
                 "original": "{\"hostname\":\"97ade2b595f0\",\"output\":\"2024-05-07T18:54:20.008519431+0000: Informational System user ran an interactive command (evt_type=execve user=daemon user_uid=2 user_loginuid=-1 process=login proc_exepath=/bin/busybox parent=event-generator command=login terminal=0 exe_flags=0 container_id=9656db3bb358 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Informational\",\"rule\":\"System user interactive\",\"source\":\"syscall\",\"tags\":[\"NIST_800-53_AC-2\",\"T1059\",\"container\",\"host\",\"maturity_stable\",\"mitre_execution\",\"users\"],\"time\":\"2024-05-07T18:54:20.008519431Z\", \"output_fields\": {\"container.id\":\"9656db3bb358\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"evt.time.iso8601\":1715108060008519431,\"evt.type\":\"execve\",\"proc.cmdline\":\"login\",\"proc.exepath\":\"/bin/busybox\",\"proc.name\":\"login\",\"proc.pname\":\"event-generator\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"daemon\",\"user.uid\":2}}",
                 "provider": "syscall",
@@ -228,7 +228,7 @@
                 "category": [
                     "process"
                 ],
-                "ingested": "2024-12-12T20:33:05.777768161Z",
+                "ingested": "2025-05-02T12:53:53.033070826Z",
                 "kind": "alert",
                 "original": "{\"hostname\":\"97ade2b595f0\",\"output\":\"2024-05-07T18:54:26.271403849+0000: Warning Sensitive file opened for reading by trusted program after startup (file=/etc/shadow pcmdline=event-generator run --loop gparent=containerd-shim ggparent=runc gggparent=init evt_type=openat user=root user_uid=0 user_loginuid=-1 process=httpd proc_exepath=/bin/event-generator parent=event-generator command=httpd --loglevel info run ^syscall.ReadSensitiveFileUntrusted$ --sleep 6s terminal=0 container_id=9656db3bb358 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Warning\",\"rule\":\"Read sensitive file trusted after startup\",\"source\":\"syscall\",\"tags\":[\"T1555\",\"container\",\"filesystem\",\"host\",\"maturity_stable\",\"mitre_credential_access\"],\"time\":\"2024-05-07T18:54:26.271403849Z\", \"output_fields\": {\"container.id\":\"9656db3bb358\",\"container.full_id\":\"9656db3bb3588e7b23da7d48fe889434573036c27ae5a74837233de441c3601e\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"container.image\": \"falcosecurity/event-generator:0.10.0\",\"container.image.tag\":\"0.10.0\",\"container.image.digest\":[\"sha256:d977378f890d445c15e51795296e4e5062f109ce6da83e0a355fc4ad8699d27\"],\"container.image.id\":\"16e0fa09a4f1018f22be6cce3ec21848dccaa566b063bda4c814c37dc36adfea\",\"container.image.repository\":\"falcosecurity/event-generator\",\"evt.time.iso8601\":1715108066271403849,\"evt.type\":\"openat\",\"fd.name\":\"/etc/shadow\",\"proc.cmdline\":\"httpd --loglevel info run ^syscall.ReadSensitiveFileUntrusted$ --sleep 6s\",\"proc.exepath\":\"/bin/event-generator\",\"proc.name\":\"httpd\",\"proc.pcmdline\":\"event-generator run --loop\",\"proc.pname\":\"event-generator\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"root\",\"user.uid\":0}}",
                 "provider": "syscall",
@@ -346,7 +346,7 @@
                 "category": [
                     "process"
                 ],
-                "ingested": "2024-12-12T20:33:05.777769389Z",
+                "ingested": "2025-05-02T12:53:53.033073346Z",
                 "kind": "alert",
                 "original": "{\"hostname\":\"97ade2b595f0\",\"output\":\"2024-05-07T18:54:27.767673017+0000: Notice Shell spawned by untrusted binary (parent_exe=/tmp/falco-event-generator3982217557/httpd parent_exepath=/bin/event-generator pcmdline=httpd --loglevel info run ^helper.RunShell$ gparent=event-generator ggparent=containerd-shim aname[4]=runc aname[5]=init aname[6]=init aname[7]=<NA> evt_type=execve user=root user_uid=0 user_loginuid=-1 process=bash proc_exepath=/bin/bash parent=httpd command=bash -c ls > /dev/null terminal=0 exe_flags=EXE_WRITABLE container_id=9656db3bb358 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Notice\",\"rule\":\"Run shell untrusted\",\"source\":\"syscall\",\"tags\":[\"T1059.004\",\"container\",\"host\",\"maturity_stable\",\"mitre_execution\",\"process\",\"shell\"],\"time\":\"2024-05-07T18:54:27.767673017Z\", \"output_fields\": {\"container.id\":\"9656db3bb358\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"evt.time.iso8601\":1715108067767673017,\"evt.type\":\"execve\",\"proc.cmdline\":\"bash -c ls > /dev/null\",\"proc.exepath\":\"/bin/bash\",\"proc.name\":\"bash\",\"proc.pcmdline\":\"httpd --loglevel info run ^helper.RunShell$\",\"proc.pexe\":\"/tmp/falco-event-generator3982217557/httpd\",\"proc.pexepath\":\"/bin/event-generator\",\"proc.pname\":\"httpd\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"root\",\"user.uid\":0}}",
                 "provider": "syscall",
@@ -458,7 +458,7 @@
                 "category": [
                     "process"
                 ],
-                "ingested": "2024-12-12T20:33:05.777770466Z",
+                "ingested": "2025-05-02T12:53:53.033075658Z",
                 "kind": "alert",
                 "original": "{\"hostname\":\"97ade2b595f0\",\"output\":\"2024-05-07T18:54:20.008519431+0000: Informational System user ran an interactive command (evt_type=execve user=daemon user_uid=2 user_loginuid=-1 process=login proc_exepath=/bin/busybox parent=event-generator command=login terminal=0 exe_flags=0 container_id=9656db3bb358 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Informational\",\"rule\":\"System user interactive\",\"source\":\"syscall\",\"tags\":[],\"time\":\"2024-05-07T18:54:20.008519431Z\", \"output_fields\": {\"container.id\":\"9656db3bb358\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"evt.time.iso8601\":1715108060008519431,\"evt.type\":\"execve\",\"proc.cmdline\":\"login\",\"proc.exepath\":\"/bin/busybox\",\"proc.name\":\"login\",\"proc.pname\":\"event-generator\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"daemon\",\"user.uid\":2}}",
                 "provider": "syscall",
@@ -551,7 +551,7 @@
                 "category": [
                     "process"
                 ],
-                "ingested": "2024-12-12T20:33:05.777771567Z",
+                "ingested": "2025-05-02T12:53:53.033078246Z",
                 "kind": "alert",
                 "original": "{\"hostname\":\"a2000de987ff\",\"output\":\"2024-05-13T13:23:26.104747558+0000: Informational System user ran an interactive command (evt_type=execve user=daemon user_uid=2 user_loginuid=-1 process=login proc_exepath=/bin/busybox parent=event-generator command=login terminal=0 exe_flags=0 container_id=84c0b936c919 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Informational\",\"rule\":\"System user interactive\",\"source\":\"syscall\",\"tags\":[\"NIST_800-53_AC-2\",\"T1059\",\"container\",\"host\",\"maturity_stable\",\"mitre_execution\",\"users\"],\"time\":\"2024-05-13T13:23:26.104747558Z\", \"output_fields\": {\"container.id\":\"84c0b936c919\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"evt.arg.flags\":\"0\",\"evt.time.iso8601\":1715606606104747558,\"evt.type\":\"execve\",\"proc.cmdline\":\"login\",\"proc.exepath\":\"/bin/busybox\",\"proc.name\":\"login\",\"proc.pname\":\"event-generator\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"daemon\",\"user.uid\":2}}",
                 "provider": "syscall",
@@ -656,7 +656,7 @@
                 "category": [
                     "process"
                 ],
-                "ingested": "2024-12-12T20:33:05.777772661Z",
+                "ingested": "2025-05-02T12:53:53.033080464Z",
                 "kind": "alert",
                 "original": "{\"hostname\":\"a2000de987ff\",\"output\":\"2024-05-13T13:23:27.021777225+0000: Notice Shell spawned by untrusted binary (parent_exe=/tmp/falco-event-generator2286495765/httpd parent_exepath=/bin/event-generator pcmdline=httpd --loglevel info run ^helper.RunShell$ gparent=event-generator ggparent=containerd-shim aname[4]=runc aname[5]=init aname[6]=init aname[7]=<NA> evt_type=execve user=root user_uid=0 user_loginuid=-1 process=bash proc_exepath=/bin/bash parent=httpd command=bash -c ls > /dev/null terminal=0 exe_flags=EXE_WRITABLE container_id=84c0b936c919 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Notice\",\"rule\":\"Run shell untrusted\",\"source\":\"syscall\",\"tags\":[\"T1059.004\",\"container\",\"host\",\"maturity_stable\",\"mitre_execution\",\"process\",\"shell\"],\"time\":\"2024-05-13T13:23:27.021777225Z\", \"output_fields\": {\"container.id\":\"84c0b936c919\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"evt.arg.flags\":\"EXE_WRITABLE\",\"evt.time.iso8601\":1715606607021777225,\"evt.type\":\"execve\",\"proc.aname[2]\":\"event-generator\",\"proc.aname[3]\":\"containerd-shim\",\"proc.aname[4]\":\"runc\",\"proc.aname[5]\":\"init\",\"proc.aname[6]\":\"init\",\"proc.aname[7]\":null,\"proc.cmdline\":\"bash -c ls > /dev/null\",\"proc.exepath\":\"/bin/bash\",\"proc.name\":\"bash\",\"proc.pcmdline\":\"httpd --loglevel info run ^helper.RunShell$\",\"proc.pexe\":\"/tmp/falco-event-generator2286495765/httpd\",\"proc.pexepath\":\"/bin/event-generator\",\"proc.pname\":\"httpd\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"root\",\"user.uid\":0}}",
                 "provider": "syscall",
@@ -769,7 +769,7 @@
                 "category": [
                     "process"
                 ],
-                "ingested": "2024-12-12T20:33:05.777773799Z",
+                "ingested": "2025-05-02T12:53:53.033082715Z",
                 "kind": "alert",
                 "original": "{\"hostname\":\"a2000de987ff\",\"output\":\"2024-05-13T13:23:28.170686725+0000: Warning Sensitive file opened for reading by non-trusted program (file=/etc/shadow gparent=runc ggparent=init gggparent=init evt_type=openat user=root user_uid=0 user_loginuid=-1 process=event-generator proc_exepath=/bin/event-generator parent=containerd-shim command=event-generator run --loop terminal=0 container_id=84c0b936c919 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Warning\",\"rule\":\"Read sensitive file untrusted\",\"source\":\"syscall\",\"tags\":[\"T1555\",\"container\",\"filesystem\",\"host\",\"maturity_stable\",\"mitre_credential_access\"],\"time\":\"2024-05-13T13:23:28.170686725Z\", \"output_fields\": {\"container.id\":\"84c0b936c919\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"evt.time.iso8601\":1715606608170686725,\"evt.type\":\"openat\",\"fd.name\":\"/etc/shadow\",\"proc.aname[2]\":\"runc\",\"proc.aname[3]\":\"init\",\"proc.aname[4]\":\"init\",\"proc.cmdline\":\"event-generator run --loop\",\"proc.exepath\":\"/bin/event-generator\",\"proc.name\":\"event-generator\",\"proc.pname\":\"containerd-shim\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"root\",\"user.uid\":0}}",
                 "provider": "syscall",
@@ -875,7 +875,7 @@
                 "category": [
                     "process"
                 ],
-                "ingested": "2024-12-12T20:33:05.777774947Z",
+                "ingested": "2025-05-02T12:53:53.033084954Z",
                 "kind": "alert",
                 "original": "{\"hostname\":\"a2000de987ff\",\"output\":\"2024-05-13T13:23:29.089890892+0000: Warning Sensitive file opened for reading by non-trusted program (file=/etc/shadow gparent=runc ggparent=init gggparent=init evt_type=openat user=root user_uid=0 user_loginuid=-1 process=event-generator proc_exepath=/bin/event-generator parent=containerd-shim command=event-generator run --loop terminal=0 container_id=84c0b936c919 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Warning\",\"rule\":\"Read sensitive file untrusted\",\"source\":\"syscall\",\"tags\":[\"T1555\",\"container\",\"filesystem\",\"host\",\"maturity_stable\",\"mitre_credential_access\"],\"time\":\"2024-05-13T13:23:29.089890892Z\", \"output_fields\": {\"container.id\":\"84c0b936c919\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"evt.time.iso8601\":1715606609089890892,\"evt.type\":\"openat\",\"fd.name\":\"/etc/shadow\",\"proc.aname[2]\":\"runc\",\"proc.aname[3]\":\"init\",\"proc.aname[4]\":\"init\",\"proc.cmdline\":\"event-generator run --loop\",\"proc.exepath\":\"/bin/event-generator\",\"proc.name\":\"event-generator\",\"proc.pname\":\"containerd-shim\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"root\",\"user.uid\":0}}",
                 "provider": "syscall",
@@ -981,7 +981,7 @@
                 "category": [
                     "process"
                 ],
-                "ingested": "2024-12-12T20:33:05.777776018Z",
+                "ingested": "2025-05-02T12:53:53.033087134Z",
                 "kind": "alert",
                 "original": "{\"hostname\":\"a2000de987ff\",\"output\":\"2024-05-13T13:23:29.089890892+0000: Warning Sensitive file opened for reading by non-trusted program (file=/etc/shadow gparent=runc ggparent=init gggparent=init evt_type=openat user=root user_uid=0 user_loginuid=-1 process=event-generator proc_exepath=/bin/event-generator parent=containerd-shim command=event-generator run --loop terminal=0 container_id=84c0b936c919 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Warning\",\"rule\":\"Read sensitive file untrusted\",\"source\":\"syscall\",\"tags\":[\"T1555\",\"container\",\"filesystem\",\"host\",\"maturity_stable\",\"mitre_credential_access\"],\"time\":\"2024-05-13T13:23:29.089890892Z\", \"output_fields\": {\"container.id\":\"84c0b936c919\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"evt.time.iso8601\":1715606609089890892,\"evt.type\":\"openat\",\"evt.res\": \"SUCCESS\",\"fd.name\":\"/etc/shadow\",\"proc.aname[2]\":\"runc\",\"proc.aname[3]\":\"init\",\"proc.aname[4]\":\"init\",\"proc.cmdline\":\"event-generator run --loop\",\"proc.exepath\":\"/bin/event-generator\",\"proc.name\":\"event-generator\",\"proc.pname\":\"containerd-shim\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"root\",\"user.uid\":0}}",
                 "outcome": "success",
@@ -1089,7 +1089,7 @@
                 "category": [
                     "process"
                 ],
-                "ingested": "2024-12-12T20:33:05.777777080Z",
+                "ingested": "2025-05-02T12:53:53.033089421Z",
                 "kind": "alert",
                 "original": "{\"hostname\":\"a2000de987ff\",\"output\":\"2024-05-13T13:23:29.089890892+0000: Warning Sensitive file opened for reading by non-trusted program (file=/etc/shadow gparent=runc ggparent=init gggparent=init evt_type=openat user=root user_uid=0 user_loginuid=-1 process=event-generator proc_exepath=/bin/event-generator parent=containerd-shim command=event-generator run --loop terminal=0 container_id=84c0b936c919 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Warning\",\"rule\":\"Read sensitive file untrusted\",\"source\":\"syscall\",\"tags\":[\"T1555\",\"container\",\"filesystem\",\"host\",\"maturity_stable\",\"mitre_credential_access\"],\"time\":\"2024-05-13T13:23:29.089890892Z\", \"output_fields\": {\"container.id\":\"84c0b936c919\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"evt.time.iso8601\":1715606609089890892,\"evt.type\":\"openat\",\"evt.res\": \"ENOENT\",\"evt.failed\":true,\"fd.name\":\"/etc/shadow\",\"proc.aname[2]\":\"runc\",\"proc.aname[3]\":\"init\",\"proc.aname[4]\":\"init\",\"proc.cmdline\":\"event-generator run --loop\",\"proc.exepath\":\"/bin/event-generator\",\"proc.name\":\"event-generator\",\"proc.pname\":\"containerd-shim\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"root\",\"user.uid\":0}}",
                 "outcome": "failure",
@@ -1198,7 +1198,7 @@
                 "category": [
                     "process"
                 ],
-                "ingested": "2024-12-12T20:33:05.777778317Z",
+                "ingested": "2025-05-02T12:53:53.033091796Z",
                 "kind": "alert",
                 "original": "{\"hostname\":\"a2000de987ff\",\"output\":\"2024-05-13T13:23:31.089890892+0000: Warning Sensitive file opened for reading by non-trusted program (file=/etc/shadow gparent=runc ggparent=init gggparent=init evt_type=openat user=root user_uid=0 user_loginuid=-1 process=event-generator proc_exepath=/bin/event-generator parent=containerd-shim command=event-generator run --loop terminal=0 container_id=84c0b936c919 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Warning\",\"rule\":\"Read sensitive file untrusted\",\"source\":\"syscall\",\"tags\":[\"T1555\",\"container\",\"filesystem\",\"host\",\"maturity_stable\",\"mitre_credential_access\"],\"time\":\"2024-05-13T13:23:31.089890892Z\", \"output_fields\": {\"container.id\":\"84c0b936c919\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"evt.time.iso8601\":1715606609089890892,\"evt.num\":4525,\"evt.type\":\"openat\",\"evt.res\": \"ENOENT\",\"evt.failed\":true,\"fd.name\":\"/etc/shadow\",\"k8s.ns.name\":\"kubernetes-ns\",\"k8s.pod.ip\":\"175.16.199.0/24\",\"k8s.pod.name\":\"kubernetes-pod-1\",\"k8s.pod.uid\":\"aadadjh763wiuh\",\"k8s.pod.labels\":[\"key1:value1\",\"key2:value2\",\"key3:value3\"],\"proc.aname[2]\":\"runc\",\"proc.aname[3]\":\"init\",\"proc.aname[4]\":\"init\",\"proc.cmdline\":\"event-generator run --loop\",\"proc.exepath\":\"/bin/event-generator\",\"proc.name\":\"event-generator\",\"proc.pname\":\"containerd-shim\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"root\",\"user.uid\":0}}",
                 "outcome": "failure",
@@ -1337,7 +1337,7 @@
                 "category": [
                     "process"
                 ],
-                "ingested": "2024-12-12T20:33:05.777779402Z",
+                "ingested": "2025-05-02T12:53:53.033094001Z",
                 "kind": "alert",
                 "original": "{\"hostname\":\"a2000de987ff\",\"output\":\"2024-05-13T13:23:33.089890892+0000: Warning Sensitive file opened for reading by non-trusted program (file=/etc/shadow gparent=runc ggparent=init gggparent=init evt_type=openat user=root user_uid=0 user_loginuid=-1 process=event-generator proc_exepath=/bin/event-generator parent=containerd-shim command=event-generator run --loop terminal=0 container_id=84c0b936c919 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Warning\",\"rule\":\"Read sensitive file untrusted\",\"source\":\"syscall\",\"tags\":[\"T1555\",\"container\",\"filesystem\",\"host\",\"maturity_stable\",\"mitre_credential_access\"],\"time\":\"2024-05-13T13:23:33.089890892Z\", \"output_fields\": {\"container.id\":\"84c0b936c919\",\"container.mounts\":\"/proc/sys/fs/binfmt_misc:/tmp/binary:bind:ro:private /var/log:/mnt/log:bind:rw:shared\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"evt.time.iso8601\":1715606609089890892,\"evt.type\":\"openat\",\"evt.res\": \"ENOENT\",\"evt.failed\":true,\"fd.name\":\"/etc/shadow\",\"proc.aname[2]\":\"runc\",\"proc.aname[3]\":\"init\",\"proc.aname[4]\":\"init\",\"proc.cmdline\":\"event-generator run --loop\",\"proc.exepath\":\"/bin/event-generator\",\"proc.name\":\"event-generator\",\"proc.pname\":\"containerd-shim\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"root\",\"user.uid\":0}}",
                 "outcome": "failure",
@@ -1472,7 +1472,7 @@
                 "category": [
                     "process"
                 ],
-                "ingested": "2024-12-12T20:33:05.777780500Z",
+                "ingested": "2025-05-02T12:53:53.033096182Z",
                 "kind": "alert",
                 "original": "{\"hostname\":\"a2000de987ff\",\"output\":\"2024-05-13T13:23:34.089890892+0000: Warning Sensitive file opened for reading by non-trusted program (file=/etc/shadow gparent=runc ggparent=init gggparent=init evt_type=openat user=root user_uid=0 user_loginuid=-1 process=event-generator proc_exepath=/bin/event-generator parent=containerd-shim command=event-generator run --loop terminal=0 container_id=84c0b936c919 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Warning\",\"rule\":\"Read sensitive file untrusted\",\"source\":\"syscall\",\"tags\":[\"T1555\",\"container\",\"filesystem\",\"host\",\"maturity_stable\",\"mitre_credential_access\"],\"time\":\"2024-05-13T13:23:34.089890892Z\", \"output_fields\": {\"container.id\":\"84c0b936c919\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"container.type\":\"docker\",\"container.privileged\":true,\"container.ip\":\"81.2.69.144\",\"evt.time.iso8601\":1715606609089890892,\"evt.type\":\"openat\",\"evt.res\": \"ENOENT\",\"fd.cip.name\":\"example.com\",\"fd.sip.name\":\"otherexample.com\",\"fd.rip.name\":\"fourthexample.com\",\"fd.lip.name\":\"thirdexample.com\",\"evt.failed\":true,\"fd.name\":\"/etc/shadow\",\"proc.aname[2]\":\"runc\",\"proc.aname[3]\":\"init\",\"proc.aname[4]\":\"init\",\"proc.cmdline\":\"event-generator run --loop\",\"proc.exepath\":\"/bin/event-generator\",\"proc.name\":\"event-generator\",\"proc.pname\":\"containerd-shim\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"root\",\"user.uid\":0}}",
                 "outcome": "failure",
@@ -1615,7 +1615,7 @@
                 "category": [
                     "process"
                 ],
-                "ingested": "2024-12-12T20:33:05.777782091Z",
+                "ingested": "2025-05-02T12:53:53.033098404Z",
                 "kind": "alert",
                 "original": "{\"hostname\":\"a2000de987ff\",\"output\":\"2024-05-13T13:23:36.089890892+0000: Warning Sensitive file opened for reading by non-trusted program (file=/etc/shadow gparent=runc ggparent=init gggparent=init evt_type=openat user=root user_uid=0 user_loginuid=-1 process=event-generator proc_exepath=/bin/event-generator parent=containerd-shim command=event-generator run --loop terminal=0 container_id=84c0b936c919 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Warning\",\"rule\":\"Read sensitive file untrusted\",\"source\":\"syscall\",\"tags\":[\"T1555\",\"container\",\"filesystem\",\"host\",\"maturity_stable\",\"mitre_credential_access\"],\"time\":\"2024-05-13T13:23:36.089890892Z\", \"output_fields\": {\"container.id\":\"84c0b936c919\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"evt.time.iso8601\":1715606609089890892,\"evt.type\":\"openat\",\"evt.res\": \"ENOENT\",\"evt.failed\":true,\"fd.name\":\"/etc/shadow\",\"fd.directory\":\"var/log/example\",\"fd.filename\":\"example.tar.gz\",\"fd.cip\":\"216.160.83.56\",\"fd.sip\":\"89.160.20.112\",\"fd.lip\":\"89.160.20.128\",\"fd.rip\":\"67.43.156.0\",\"fd.cport\":5400,\"fd.sport\":5700,\"fd.lport\":5689,\"fd.rport\":6789,\"fd.ino\":\"567874\",\"proc.aname[2]\":\"runc\",\"proc.aname[3]\":\"init\",\"proc.aname[4]\":\"init\",\"proc.cmdline\":\"event-generator run --loop\",\"proc.exepath\":\"/bin/event-generator\",\"proc.name\":\"event-generator\",\"proc.pname\":\"containerd-shim\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"root\",\"user.uid\":0}}",
                 "outcome": "failure",
@@ -1758,7 +1758,7 @@
                 "category": [
                     "process"
                 ],
-                "ingested": "2024-12-12T20:33:05.777783205Z",
+                "ingested": "2025-05-02T12:53:53.033100575Z",
                 "kind": "alert",
                 "original": "{\"hostname\":\"a2000de987ff\",\"output\":\"2024-05-13T13:23:37.089890892+0000: Warning Sensitive file opened for reading by non-trusted program (file=/etc/shadow gparent=runc ggparent=init gggparent=init evt_type=openat user=root user_uid=0 user_loginuid=-1 process=event-generator proc_exepath=/bin/event-generator parent=containerd-shim command=event-generator run --loop terminal=0 container_id=84c0b936c919 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Critical\",\"rule\":\"Read sensitive file untrusted\",\"source\":\"syscall\",\"tags\":[\"T1555\",\"container\",\"filesystem\",\"host\",\"maturity_stable\",\"mitre_credential_access\"],\"time\":\"2024-05-13T13:23:37.089890892Z\", \"output_fields\": {\"container.id\":\"84c0b936c919\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"evt.time.iso8601\":1715606609089890892,\"evt.type\":\"openat\",\"evt.res\": \"ENOENT\",\"evt.failed\":true,\"fd.name\":\"/etc/shadow\",\"proc.aname[2]\":\"runc\",\"group.gid\":\"123355\",\"group.name\":\"test-1\",\"proc.aname[3]\":\"init\",\"proc.aname[4]\":\"init\",\"proc.cmdnargs\": 1,\"proc.env\":\"TEST_VALUE1=testvalue1 TEST_VALUE2=testvalue2\",\"proc.cwd\":\"/bin/event-generator\",\"proc.cmdline\":\"event-generator run --loop\",\"proc.exepath\":\"/bin/event-generator\",\"proc.args\":\"run --loop\",\"proc.name\":\"event-generator\",\"proc.pid\":133567,\"proc.ppid\":133568,\"proc.vpgid\":4555852,\"proc.vpgid.name\":\"generic-process\",\"proc.vpgid.exepath\":\"/bin/event-generator\",\"proc.ppid.duration\":2345,\"proc.ppid.ts\":\"23455\",\"proc.pid.ts\":\"23451\",\"proc.vpid\":133569,\"proc.pvpid\":133570,\"proc.sid\":133571,\"proc.sid.exepath\":\"/bin/event-generator\",\"proc.sname\":\"containerd-shim\",\"proc.is_sid_leader\":true,\"proc.is_vpgid_leader\":false,\"proc.pname\":\"containerd-shim\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"root\",\"user.uid\":0}}",
                 "outcome": "failure",
@@ -1940,7 +1940,7 @@
                 "category": [
                     "process"
                 ],
-                "ingested": "2024-12-12T20:33:05.777784375Z",
+                "ingested": "2025-05-02T12:53:53.033103221Z",
                 "kind": "alert",
                 "original": "{\"hostname\":\"a2000de987ff\",\"output\":\"2024-05-13T13:23:38.089890892+0000: Warning Sensitive file opened for reading by non-trusted program (file=/etc/shadow gparent=runc ggparent=init gggparent=init evt_type=openat user=root user_uid=0 user_loginuid=-1 process=event-generator proc_exepath=/bin/event-generator parent=containerd-shim command=event-generator run --loop terminal=0 container_id=84c0b936c919 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Informational\",\"rule\":\"Read sensitive file untrusted\",\"source\":\"syscall\",\"tags\":[\"T1555\",\"container\",\"filesystem\",\"host\",\"maturity_stable\",\"mitre_credential_access\"],\"time\":\"2024-05-13T13:23:38.089890892Z\", \"output_fields\": {\"container.id\":\"84c0b936c919\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"evt.time\":1715606609089890892,\"evt.type\":\"openat\",\"evt.res\": \"ENOENT\",\"evt.failed\":true,\"fd.name\":\"/etc/shadow\",\"proc.aname[2]\":\"runc\",\"proc.aname[3]\":\"init\",\"proc.aname[4]\":\"init\",\"proc.cmdline\":\"event-generator run --loop\",\"proc.pexepath\":\"/bin/event-generator\",\"proc.exepath\":\"/bin/event-generator\",\"proc.args\":\"run --loop -v\",\"proc.name\":\"event-generator\",\"proc.pname\":\"containerd-shim\",\"proc.duration\":\"662789\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"root\",\"user.uid\":0}}",
                 "outcome": "failure",
@@ -1958,10 +1958,12 @@
                         "id": "84c0b936c919",
                         "name": "elastic-package-service-falco-event-generator-1"
                     },
+                    "event": {
+                        "time": 1715606609089890892
+                    },
                     "evt": {
                         "failed": true,
                         "res": "ENOENT",
-                        "time": 1715606609089890892,
                         "type": "openat"
                     },
                     "fd": {
@@ -2058,7 +2060,7 @@
                 "category": [
                     "process"
                 ],
-                "ingested": "2024-12-12T20:33:05.777785460Z",
+                "ingested": "2025-05-02T12:53:53.033105398Z",
                 "kind": "alert",
                 "original": "{\"uuid\":\"7466e462-ddde-434d-8dee-390ca5656f83\",\"output\":\"21:35:04.518808525: Notice A shell was spawned in a container with an attached terminal (evt_type=execve user=root user_uid=0 user_loginuid=-1 process=sh proc_exepath=/bin/sh parent=containerd-shim command=sh terminal=34816 exe_flags=EXE_WRITABLE container_id=8645a7a530c3 container_image=docker.io/library/busybox container_image_tag=latest container_name=debug k8s_ns=default k8s_pod_name=debug)\",\"priority\":\"Notice\",\"rule\":\"Terminal shell in container\",\"time\":\"2024-08-28T21:35:04.518808525Z\",\"output_fields\":{\"container.id\":\"8645a7a530c3\",\"container.image.repository\":\"docker.io/library/busybox\",\"container.image.tag\":\"latest\",\"container.name\":\"debug\",\"evt.arg.flags\":\"EXE_WRITABLE\",\"evt.time\":1724880904518808600,\"evt.type\":\"execve\",\"k8s.ns.name\":\"default\",\"k8s.pod.name\":\"debug\",\"proc.cmdline\":\"sh\",\"proc.exepath\":\"/bin/sh\",\"proc.name\":\"sh\",\"proc.pname\":\"containerd-shim\",\"proc.tty\":34816,\"user.loginuid\":-1,\"user.name\":\"root\",\"user.uid\":0},\"source\":\"syscall\",\"tags\":[\"T1059\",\"container\",\"maturity_stable\",\"mitre_execution\",\"shell\"],\"hostname\":\"cluster-1-default-pool-131bf483-7km9\"}",
                 "provider": "syscall",
@@ -2079,9 +2081,11 @@
                         },
                         "name": "debug"
                     },
+                    "event": {
+                        "time": 1724880904518808600
+                    },
                     "evt": {
                         "arg": {},
-                        "time": 1724880904518808600,
                         "type": "execve"
                     },
                     "k8s": {

--- a/packages/falco/data_stream/alerts/_dev/test/pipeline/test-nopreserve.log-expected.json
+++ b/packages/falco/data_stream/alerts/_dev/test/pipeline/test-nopreserve.log-expected.json
@@ -10,7 +10,7 @@
                 "category": [
                     "process"
                 ],
-                "ingested": "2024-12-12T20:33:07.859130398Z",
+                "ingested": "2025-05-02T12:53:54.342369151Z",
                 "kind": "alert",
                 "original": "{\"hostname\":\"97ade2b595f0\",\"output\":\"2024-05-07T18:54:19.341081180+0000: Warning Sensitive file opened for reading by non-trusted program (file=/etc/shadow gparent=runc ggparent=init gggparent=init evt_type=openat user=root user_uid=0 user_loginuid=-1 process=event-generator proc_exepath=/bin/event-generator parent=containerd-shim command=event-generator run --loop terminal=0 container_id=9656db3bb358 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Warning\",\"rule\":\"Read sensitive file untrusted\",\"source\":\"syscall\",\"tags\":[\"T1555\",\"container\",\"filesystem\",\"host\",\"maturity_stable\",\"mitre_credential_access\"],\"time\":\"2024-05-07T18:54:19.341081180Z\", \"output_fields\": {\"container.id\":\"9656db3bb358\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"evt.time.iso8601\":1715108059341081180,\"evt.type\":\"openat\",\"fd.name\":\"/etc/shadow\",\"proc.cmdline\":\"event-generator run --loop\",\"proc.exepath\":\"/bin/event-generator\",\"proc.name\":\"event-generator\",\"proc.pname\":\"containerd-shim\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"root\",\"user.uid\":0}}",
                 "provider": "syscall",
@@ -100,7 +100,7 @@
                 "category": [
                     "process"
                 ],
-                "ingested": "2024-12-12T20:33:07.859148459Z",
+                "ingested": "2025-05-02T12:53:54.342387355Z",
                 "kind": "alert",
                 "original": "{\"hostname\":\"97ade2b595f0\",\"output\":\"2024-05-07T18:54:20.008519431+0000: Informational System user ran an interactive command (evt_type=execve user=daemon user_uid=2 user_loginuid=-1 process=login proc_exepath=/bin/busybox parent=event-generator command=login terminal=0 exe_flags=0 container_id=9656db3bb358 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Informational\",\"rule\":\"System user interactive\",\"source\":\"syscall\",\"tags\":[\"NIST_800-53_AC-2\",\"T1059\",\"container\",\"host\",\"maturity_stable\",\"mitre_execution\",\"users\"],\"time\":\"2024-05-07T18:54:20.008519431Z\", \"output_fields\": {\"container.id\":\"9656db3bb358\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"evt.time.iso8601\":1715108060008519431,\"evt.type\":\"execve\",\"proc.cmdline\":\"login\",\"proc.exepath\":\"/bin/busybox\",\"proc.name\":\"login\",\"proc.pname\":\"event-generator\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"daemon\",\"user.uid\":2}}",
                 "provider": "syscall",
@@ -188,7 +188,7 @@
                 "category": [
                     "process"
                 ],
-                "ingested": "2024-12-12T20:33:07.859154222Z",
+                "ingested": "2025-05-02T12:53:54.342390433Z",
                 "kind": "alert",
                 "original": "{\"hostname\":\"97ade2b595f0\",\"output\":\"2024-05-07T18:54:19.341081180+0000: Warning Sensitive file opened for reading by non-trusted program (file=/etc/shadow gparent=runc ggparent=init gggparent=init evt_type=openat user=root user_uid=0 user_loginuid=-1 process=event-generator proc_exepath=/bin/event-generator parent=containerd-shim command=event-generator run --loop terminal=0 container_id=9656db3bb358 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Warning\",\"rule\":\"Read sensitive file untrusted\",\"source\":\"syscall\",\"tags\":[\"T1555\",\"container\",\"filesystem\",\"host\",\"maturity_stable\",\"mitre_credential_access\"],\"time\":\"2024-05-07T18:54:19.341081180Z\", \"output_fields\": {\"container.id\":\"9656db3bb358\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"evt.time.iso8601\":1715108059341081180,\"evt.type\":\"openat\",\"fd.name\":\"/etc/shadow\",\"fd.type\":\"file\",\"proc.cmdline\":\"event-generator run --loop\",\"proc.exepath\":\"/bin/event-generator\",\"proc.name\":\"event-generator\",\"proc.pname\":\"containerd-shim\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"root\",\"user.uid\":0}}",
                 "provider": "syscall",

--- a/packages/falco/data_stream/alerts/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/falco/data_stream/alerts/elasticsearch/ingest_pipeline/default.yml
@@ -72,6 +72,15 @@ processors:
 - dot_expander:
     field: 'proc.vpgid'
     path: falco.output_fields
+- dot_expander:
+    field: 'evt.time'
+    path: falco.output_fields
+- dot_expander:
+    field: 'syslog.facility'
+    path: falco.output_fields
+- dot_expander:
+    field: 'syslog.severity'
+    path: falco.output_fields
 - rename:
     field: falco.output_fields.container.image
     target_field: falco.output_fields.container.image.name
@@ -107,6 +116,18 @@ processors:
 - rename:
     field: falco.output_fields.proc.vpgid
     target_field: falco.output_fields.process.group_leader.vpid
+    ignore_missing: true
+- rename:
+    field: falco.output_fields.syslog.facility
+    target_field: falco.output_fields.syslog_facility
+    ignore_missing: true
+- rename:
+    field: falco.output_fields.evt.time
+    target_field: falco.output_fields.event.time
+    ignore_missing: true
+- rename:
+    field: falco.output_fields.syslog.severity
+    target_field: falco.output_fields.syslog_severity
     ignore_missing: true
 - dot_expander:
     field: '*'
@@ -168,7 +189,7 @@ processors:
     source: |
         def allowedValues = [
             'access',
-            'admin', 
+            'admin',
             'allowed',
             'change',
             'connection',
@@ -303,8 +324,6 @@ processors:
         if (ctx.falco?.output_fields?.evt?.time != null) {
             def timeField = ctx.falco.output_fields.evt.time;
             def inputFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-
-            if (timeField instanceof Map) {
                 if (timeField.iso8601 != null) {
                     if (timeField.iso8601 instanceof String) {
                         def formatted = inputFormat.parse(timeField.iso8601);
@@ -332,14 +351,17 @@ processors:
                         ctx['@timestamp'] = new Date(milliseconds);
                     }
                 }
-            } else {
-                if (timeField instanceof String) {
-                    def formatted = inputFormat.parse(timeField);
-                    ctx['@timestamp'] = formatted;
-                } else if (timeField instanceof Long) {
-                    long milliseconds = timeField / 1000000;
-                    ctx['@timestamp'] = new Date(milliseconds);
-                }
+        } else {
+            def timeField = ctx.falco.output_fields.event.time;
+            def inputFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+            if (ctx.falco?.output_fields?.event?.time != null) {
+              if (timeField instanceof String) {
+                  def formatted = inputFormat.parse(timeField);
+                  ctx['@timestamp'] = formatted;
+              } else if (timeField instanceof Long) {
+                  long milliseconds = timeField / 1000000;
+                  ctx['@timestamp'] = new Date(milliseconds);
+              }
             }
         }
 - set:

--- a/packages/falco/data_stream/alerts/fields/fields.yml
+++ b/packages/falco/data_stream/alerts/fields/fields.yml
@@ -459,8 +459,11 @@
         - name: evt.num
           type: integer
           description: Preserved Falco field
-        - name: evt.time
-          type: date
+        - name: event
+          type: group
+          fields:
+            - name: time
+              type: date
           description: Preserved Falco field
         - name: evt.source
           type: text
@@ -498,16 +501,10 @@
         - name: proc.cwd
           type: text
           description: Preserved Falco field
-        - name: proc.ppid
-          type: integer
-          description: Preserved Falco field
         - name: proc.vpid
           type: integer
           description: Preserved Falco field
         - name: proc.pvpid
-          type: integer
-          description: Preserved Falco field
-        - name: proc.sid
           type: integer
           description: Preserved Falco field
         - name: proc.sname
@@ -515,9 +512,6 @@
           description: Preserved Falco field
         - name: proc.sid.exepath
           type: text
-          description: Preserved Falco field
-        - name: proc.vpgid
-          type: integer
           description: Preserved Falco field
         - name: proc.vpgid.name
           type: text
@@ -627,16 +621,16 @@
         - name: fd.ino
           type: text
           description: Preserved Falco field
+        - name: syslog_facility
+          type: text
+          description: Preserved Falco field
         - name: syslog.facility.str
           type: text
           description: Preserved Falco field
-        - name: syslog.facility
+        - name: syslog_severity
           type: text
           description: Preserved Falco field
         - name: syslog.severity.str
-          type: text
-          description: Preserved Falco field
-        - name: syslog.severity
           type: text
           description: Preserved Falco field
         - name: k8s.ns.name

--- a/packages/falco/data_stream/alerts/sample_event.json
+++ b/packages/falco/data_stream/alerts/sample_event.json
@@ -1,68 +1,67 @@
 {
-    "@timestamp": "2024-08-07T13:49:16.479Z",
+    "@timestamp": "2024-05-07T18:54:19.341Z",
     "agent": {
-        "ephemeral_id": "e24920c4-6d15-4f8f-b432-f643a642b923",
-        "id": "3cce77a3-202d-48b6-955c-bde66f5021b2",
-        "name": "docker-fleet-agent",
+        "ephemeral_id": "e34b6aee-8a34-4453-9886-bcd7d86cc1ae",
+        "id": "7f656253-e996-42c6-92ed-2c256a8ffde9",
+        "name": "elastic-agent-40498",
         "type": "filebeat",
-        "version": "8.14.1"
+        "version": "8.13.3"
     },
     "container": {
-        "id": "2ae6a7f15b6e",
-        "name": "elastic-package-service-10413-falco-event-generator-1"
+        "id": "9656db3bb358",
+        "name": "elastic-package-service-falco-event-generator-1"
     },
     "data_stream": {
         "dataset": "falco.alerts",
-        "namespace": "94205",
+        "namespace": "16320",
         "type": "logs"
     },
     "ecs": {
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "3cce77a3-202d-48b6-955c-bde66f5021b2",
+        "id": "7f656253-e996-42c6-92ed-2c256a8ffde9",
         "snapshot": false,
-        "version": "8.14.1"
+        "version": "8.13.3"
     },
     "event": {
         "agent_id_status": "verified",
+        "category": [
+            "process"
+        ],
         "dataset": "falco.alerts",
-        "ingested": "2024-08-14T12:08:25Z",
+        "ingested": "2025-05-02T12:05:55Z",
         "kind": "alert",
-        "original": "<5>2024-08-07T13:49:16Z a72f9a747cf8 Falco[1]: {\"uuid\":\"23716645-4d9d-4254-9429-2a287a9af199\",\"output\":\"2024-08-07T13:49:16.479964318+0000: Notice Shell spawned by untrusted binary (parent_exe=/tmp/falco-event-generator3282684109/httpd parent_exepath=/bin/event-generator pcmdline=httpd --loglevel info run ^helper.RunShell$ gparent=event-generator ggparent=containerd-shim aname[4]=containerd-shim aname[5]=init aname[6]=\\u003cNA\\u003e aname[7]=\\u003cNA\\u003e evt_type=execve user=root user_uid=0 user_loginuid=-1 process=bash proc_exepath=/bin/bash parent=httpd command=bash -c ls \\u003e /dev/null terminal=0 exe_flags=EXE_WRITABLE container_id=2ae6a7f15b6e container_name=elastic-package-service-10413-falco-event-generator-1)\",\"priority\":\"Notice\",\"rule\":\"Run shell untrusted\",\"time\":\"2024-08-07T13:49:16.479964318Z\",\"output_fields\":{\"container.id\":\"2ae6a7f15b6e\",\"container.name\":\"elastic-package-service-10413-falco-event-generator-1\",\"evt.arg.flags\":\"EXE_WRITABLE\",\"evt.time.iso8601\":1723038556479964318,\"evt.type\":\"execve\",\"proc.aname[2]\":\"event-generator\",\"proc.aname[3]\":\"containerd-shim\",\"proc.aname[4]\":\"containerd-shim\",\"proc.aname[5]\":\"init\",\"proc.aname[6]\":null,\"proc.aname[7]\":null,\"proc.cmdline\":\"bash -c ls \\u003e /dev/null\",\"proc.exepath\":\"/bin/bash\",\"proc.name\":\"bash\",\"proc.pcmdline\":\"httpd --loglevel info run ^helper.RunShell$\",\"proc.pexe\":\"/tmp/falco-event-generator3282684109/httpd\",\"proc.pexepath\":\"/bin/event-generator\",\"proc.pname\":\"httpd\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"root\",\"user.uid\":0},\"source\":\"syscall\",\"tags\":[\"T1059.004\",\"container\",\"host\",\"maturity_stable\",\"mitre_execution\",\"process\",\"shell\"],\"hostname\":\"e822ea6618ae\"}",
+        "original": "{\"hostname\":\"97ade2b595f0\",\"output\":\"2024-05-07T18:54:19.341081180+0000: Warning Sensitive file opened for reading by non-trusted program (file=/etc/shadow gparent=runc ggparent=init gggparent=init evt_type=openat user=root user_uid=0 user_loginuid=-1 process=event-generator proc_exepath=/bin/event-generator parent=containerd-shim command=event-generator run --loop terminal=0 container_id=9656db3bb358 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Warning\",\"rule\":\"Read sensitive file untrusted\",\"source\":\"syscall\",\"tags\":[\"T1555\",\"container\",\"filesystem\",\"host\",\"maturity_stable\",\"mitre_credential_access\"],\"time\":\"2024-05-07T18:54:19.341081180Z\", \"output_fields\": {\"container.id\":\"9656db3bb358\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"evt.time.iso8601\":1715108059341081180,\"evt.type\":\"openat\",\"fd.name\":\"/etc/shadow\",\"proc.cmdline\":\"event-generator run --loop\",\"proc.exepath\":\"/bin/event-generator\",\"proc.name\":\"event-generator\",\"proc.pname\":\"containerd-shim\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"root\",\"user.uid\":0}}",
         "provider": "syscall",
-        "timezone": "+00:00"
+        "severity": 47,
+        "timezone": "+00:00",
+        "type": [
+            "access"
+        ]
     },
-    "event.category": [
-        "process"
-    ],
-    "event.severity": 2,
-    "event.type": [
-        "start"
-    ],
     "falco": {
-        "hostname": "e822ea6618ae",
-        "output": "2024-08-07T13:49:16.479964318+0000: Notice Shell spawned by untrusted binary (parent_exe=/tmp/falco-event-generator3282684109/httpd parent_exepath=/bin/event-generator pcmdline=httpd --loglevel info run ^helper.RunShell$ gparent=event-generator ggparent=containerd-shim aname[4]=containerd-shim aname[5]=init aname[6]=<NA> aname[7]=<NA> evt_type=execve user=root user_uid=0 user_loginuid=-1 process=bash proc_exepath=/bin/bash parent=httpd command=bash -c ls > /dev/null terminal=0 exe_flags=EXE_WRITABLE container_id=2ae6a7f15b6e container_name=elastic-package-service-10413-falco-event-generator-1)",
+        "hostname": "97ade2b595f0",
+        "output": "2024-05-07T18:54:19.341081180+0000: Warning Sensitive file opened for reading by non-trusted program (file=/etc/shadow gparent=runc ggparent=init gggparent=init evt_type=openat user=root user_uid=0 user_loginuid=-1 process=event-generator proc_exepath=/bin/event-generator parent=containerd-shim command=event-generator run --loop terminal=0 container_id=9656db3bb358 container_name=elastic-package-service-falco-event-generator-1)",
         "output_fields": {
             "container": {
-                "id": "2ae6a7f15b6e",
-                "name": "elastic-package-service-10413-falco-event-generator-1"
+                "id": "9656db3bb358",
+                "name": "elastic-package-service-falco-event-generator-1"
             },
             "evt": {
-                "arg": {},
                 "time": {
-                    "iso8601": 1723038556479
+                    "iso8601": 1715108059341
                 },
-                "type": "execve"
+                "type": "openat"
+            },
+            "fd": {
+                "name": "/etc/shadow"
             },
             "proc": {
-                "cmdline": "bash -c ls > /dev/null",
-                "exepath": "/bin/bash",
-                "name": "bash",
-                "pcmdline": "httpd --loglevel info run ^helper.RunShell$",
-                "pexe": "/tmp/falco-event-generator3282684109/httpd",
-                "pexepath": "/bin/event-generator",
-                "pname": "httpd",
+                "cmdline": "event-generator run --loop",
+                "exepath": "/bin/event-generator",
+                "name": "event-generator",
+                "pname": "containerd-shim",
                 "tty": 0
             },
             "user": {
@@ -71,38 +70,38 @@
                 "uid": "0"
             }
         },
-        "priority": "Notice",
-        "rule": "Run shell untrusted",
+        "priority": "Warning",
+        "rule": "Read sensitive file untrusted",
         "source": "syscall",
         "tags": [
-            "T1059.004",
+            "T1555",
             "container",
+            "filesystem",
             "host",
             "maturity_stable",
-            "mitre_execution",
-            "process",
-            "shell"
+            "mitre_credential_access"
         ],
-        "time": "2024-08-07T13:49:16.479964318Z",
-        "uuid": "23716645-4d9d-4254-9429-2a287a9af199"
+        "time": "2024-05-07T18:54:19.341081180Z"
     },
     "falco.container.mounts": null,
     "host": {
-        "architecture": "aarch64",
-        "containerized": false,
-        "hostname": "docker-fleet-agent",
-        "id": "bec788532d91483489ff64145e57effe",
+        "architecture": "x86_64",
+        "containerized": true,
+        "hostname": "elastic-agent-40498",
+        "id": "e2673383c29c4c6e92abf0f43543814c",
         "ip": [
-            "192.168.160.9"
+            "192.168.251.2",
+            "192.168.247.6"
         ],
         "mac": [
-            "02-42-C0-A8-A0-09"
+            "02-42-C0-A8-F7-06",
+            "02-42-C0-A8-FB-02"
         ],
-        "name": "docker-fleet-agent",
+        "name": "97ade2b595f0",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "6.6.12-linuxkit",
+            "kernel": "3.10.0-1160.92.1.el7.x86_64",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
@@ -110,41 +109,27 @@
         }
     },
     "input": {
-        "type": "tcp"
+        "type": "log"
     },
     "log": {
-        "source": {
-            "address": "192.168.160.5:34984"
+        "file": {
+            "path": "/tmp/service_logs/sample.log"
         },
-        "syslog": {
-            "appname": "Falco",
-            "facility": {
-                "code": 0,
-                "name": "kernel"
-            },
-            "hostname": "a72f9a747cf8",
-            "priority": 5,
-            "procid": "1",
-            "severity": {
-                "code": 5,
-                "name": "Notice"
-            }
-        }
+        "offset": 0
     },
+    "message": "Read sensitive file untrusted",
     "observer": {
-        "hostname": "e822ea6618ae",
+        "hostname": "97ade2b595f0",
         "product": "falco",
         "type": "sensor",
         "vendor": "sysdig"
     },
     "process": {
-        "command_line": "bash -c ls > /dev/null",
-        "executable": "/bin/bash",
-        "name": "bash",
+        "command_line": "event-generator run --loop",
+        "executable": "/bin/event-generator",
+        "name": "event-generator",
         "parent": {
-            "command_line": "httpd --loglevel info run ^helper.RunShell$",
-            "executable": "/bin/event-generator",
-            "name": "httpd"
+            "name": "containerd-shim"
         },
         "user": {
             "id": "0",
@@ -153,20 +138,17 @@
     },
     "related": {
         "hosts": [
-            "e822ea6618ae"
+            "97ade2b595f0"
         ]
     },
     "rule": {
-        "name": "Run shell untrusted"
+        "name": "Read sensitive file untrusted"
     },
     "tags": [
         "preserve_original_event",
         "preserve_falco_fields"
     ],
     "threat.technique.id": [
-        "T1059"
-    ],
-    "threat.technique.subtechnique.id": [
-        "T1059.004"
+        "T1555"
     ]
 }

--- a/packages/falco/docs/README.md
+++ b/packages/falco/docs/README.md
@@ -18,7 +18,7 @@ This integration is compatible with Falco version 0.37 and above, and should not
 
 ## Setup
 
-For step-by-step instructions on how to set up an integration, see the [Getting started](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) guide.
+For step-by-step instructions on how to set up an integration, see the [Getting started](https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/getting-started-observability.html) guide.
 
 In order to capture alerts from Falco you **must** configure Falco to output Alerts as JSON to one of the supported channels: [Logfile](#logfile-input) or [TCP Syslog](#tcp-syslog-input).
 

--- a/packages/falco/docs/README.md
+++ b/packages/falco/docs/README.md
@@ -18,7 +18,7 @@ This integration is compatible with Falco version 0.37 and above, and should not
 
 ## Setup
 
-For step-by-step instructions on how to set up an integration, see the [Getting started](https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/getting-started-observability.html) guide.
+For step-by-step instructions on how to set up an integration, see the [Getting started](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) guide.
 
 In order to capture alerts from Falco you **must** configure Falco to output Alerts as JSON to one of the supported channels: [Logfile](#logfile-input) or [TCP Syslog](#tcp-syslog-input).
 
@@ -82,6 +82,7 @@ Falco alerts can contain a multitude of various fields pertaining to the type of
 | falco.output_fields.container.start_ts | Container start as epoch timestamp. | date_nanos |  |
 | falco.output_fields.container.type | Preserved Falco field | text |  |
 | falco.output_fields.destination.ip | Falco copy of the ECS field of the same name | ip |  |
+| falco.output_fields.event.time |  | date |  |
 | falco.output_fields.evt.abspath | Calculated absolute path. | text |  |
 | falco.output_fields.evt.abspath_dst | Destination of the absolute path. | text |  |
 | falco.output_fields.evt.abspath_src | Source of the absolute path. | text |  |
@@ -121,7 +122,6 @@ Falco alerts can contain a multitude of various fields pertaining to the type of
 | falco.output_fields.evt.rawres | Return value of the event, as a number. | long |  |
 | falco.output_fields.evt.res | Return value of the event. | text |  |
 | falco.output_fields.evt.source | Preserved Falco field | text |  |
-| falco.output_fields.evt.time | Preserved Falco field | date |  |
 | falco.output_fields.evt.time.iso8601 | Time event occurred | date |  |
 | falco.output_fields.evt.type | Preserved Falco field | text |  |
 | falco.output_fields.evt.wait_latency | Time spent waiting for events to return, in cases where the thread is forced to wait. | long | nanos |
@@ -211,11 +211,9 @@ Falco alerts can contain a multitude of various fields pertaining to the type of
 | falco.output_fields.proc.pid.ts | Preserved Falco field | text |  |
 | falco.output_fields.proc.pidns_init_start_ts | Start of PID namespace as epoch timestamp. | date_nanos |  |
 | falco.output_fields.proc.pname | Preserved Falco field | text |  |
-| falco.output_fields.proc.ppid | Preserved Falco field | integer |  |
 | falco.output_fields.proc.ppid.duration | Preserved Falco field | long |  |
 | falco.output_fields.proc.ppid.ts | Preserved Falco field | text |  |
 | falco.output_fields.proc.pvpid | Preserved Falco field | integer |  |
-| falco.output_fields.proc.sid | Preserved Falco field | integer |  |
 | falco.output_fields.proc.sid.exe | First command line argument of the current process's session leader. | text |  |
 | falco.output_fields.proc.sid.exepath | Preserved Falco field | text |  |
 | falco.output_fields.proc.sname | Preserved Falco field | text |  |
@@ -224,7 +222,6 @@ Falco alerts can contain a multitude of various fields pertaining to the type of
 | falco.output_fields.proc.vmrss | Resident non-swapped memory for the process. | unsigned_long | byte |
 | falco.output_fields.proc.vmsize | Total virtual memory for the process. | unsigned_long | byte |
 | falco.output_fields.proc.vmswap | Swapped memory for the process. | unsigned_long |  |
-| falco.output_fields.proc.vpgid | Preserved Falco field | integer |  |
 | falco.output_fields.proc.vpgid.exe | First command line argument of the current process's group leader. | text |  |
 | falco.output_fields.proc.vpgid.exepath | Preserved Falco field | text |  |
 | falco.output_fields.proc.vpgid.name | Preserved Falco field | text |  |
@@ -237,10 +234,10 @@ Falco alerts can contain a multitude of various fields pertaining to the type of
 | falco.output_fields.rule | Preserved Falco field | text |  |
 | falco.output_fields.server.ip | Falco copy of the ECS field of the same name | ip |  |
 | falco.output_fields.source.ip | Falco copy of the ECS field of the same name | ip |  |
-| falco.output_fields.syslog.facility | Preserved Falco field | text |  |
 | falco.output_fields.syslog.facility.str | Preserved Falco field | text |  |
-| falco.output_fields.syslog.severity | Preserved Falco field | text |  |
 | falco.output_fields.syslog.severity.str | Preserved Falco field | text |  |
+| falco.output_fields.syslog_facility | Preserved Falco field | text |  |
+| falco.output_fields.syslog_severity | Preserved Falco field | text |  |
 | falco.output_fields.thread.cap_effective | Preserved Falco field | text |  |
 | falco.output_fields.thread.cap_permitted | Preserved Falco field | text |  |
 | falco.output_fields.thread.cgroups | Aggregated string of cgroups the thread belongs to. | flattened |  |
@@ -282,70 +279,69 @@ An example event for `alerts` looks as following:
 
 ```json
 {
-    "@timestamp": "2024-08-07T13:49:16.479Z",
+    "@timestamp": "2024-05-07T18:54:19.341Z",
     "agent": {
-        "ephemeral_id": "e24920c4-6d15-4f8f-b432-f643a642b923",
-        "id": "3cce77a3-202d-48b6-955c-bde66f5021b2",
-        "name": "docker-fleet-agent",
+        "ephemeral_id": "e34b6aee-8a34-4453-9886-bcd7d86cc1ae",
+        "id": "7f656253-e996-42c6-92ed-2c256a8ffde9",
+        "name": "elastic-agent-40498",
         "type": "filebeat",
-        "version": "8.14.1"
+        "version": "8.13.3"
     },
     "container": {
-        "id": "2ae6a7f15b6e",
-        "name": "elastic-package-service-10413-falco-event-generator-1"
+        "id": "9656db3bb358",
+        "name": "elastic-package-service-falco-event-generator-1"
     },
     "data_stream": {
         "dataset": "falco.alerts",
-        "namespace": "94205",
+        "namespace": "16320",
         "type": "logs"
     },
     "ecs": {
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "3cce77a3-202d-48b6-955c-bde66f5021b2",
+        "id": "7f656253-e996-42c6-92ed-2c256a8ffde9",
         "snapshot": false,
-        "version": "8.14.1"
+        "version": "8.13.3"
     },
     "event": {
         "agent_id_status": "verified",
+        "category": [
+            "process"
+        ],
         "dataset": "falco.alerts",
-        "ingested": "2024-08-14T12:08:25Z",
+        "ingested": "2025-05-02T12:05:55Z",
         "kind": "alert",
-        "original": "<5>2024-08-07T13:49:16Z a72f9a747cf8 Falco[1]: {\"uuid\":\"23716645-4d9d-4254-9429-2a287a9af199\",\"output\":\"2024-08-07T13:49:16.479964318+0000: Notice Shell spawned by untrusted binary (parent_exe=/tmp/falco-event-generator3282684109/httpd parent_exepath=/bin/event-generator pcmdline=httpd --loglevel info run ^helper.RunShell$ gparent=event-generator ggparent=containerd-shim aname[4]=containerd-shim aname[5]=init aname[6]=\\u003cNA\\u003e aname[7]=\\u003cNA\\u003e evt_type=execve user=root user_uid=0 user_loginuid=-1 process=bash proc_exepath=/bin/bash parent=httpd command=bash -c ls \\u003e /dev/null terminal=0 exe_flags=EXE_WRITABLE container_id=2ae6a7f15b6e container_name=elastic-package-service-10413-falco-event-generator-1)\",\"priority\":\"Notice\",\"rule\":\"Run shell untrusted\",\"time\":\"2024-08-07T13:49:16.479964318Z\",\"output_fields\":{\"container.id\":\"2ae6a7f15b6e\",\"container.name\":\"elastic-package-service-10413-falco-event-generator-1\",\"evt.arg.flags\":\"EXE_WRITABLE\",\"evt.time.iso8601\":1723038556479964318,\"evt.type\":\"execve\",\"proc.aname[2]\":\"event-generator\",\"proc.aname[3]\":\"containerd-shim\",\"proc.aname[4]\":\"containerd-shim\",\"proc.aname[5]\":\"init\",\"proc.aname[6]\":null,\"proc.aname[7]\":null,\"proc.cmdline\":\"bash -c ls \\u003e /dev/null\",\"proc.exepath\":\"/bin/bash\",\"proc.name\":\"bash\",\"proc.pcmdline\":\"httpd --loglevel info run ^helper.RunShell$\",\"proc.pexe\":\"/tmp/falco-event-generator3282684109/httpd\",\"proc.pexepath\":\"/bin/event-generator\",\"proc.pname\":\"httpd\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"root\",\"user.uid\":0},\"source\":\"syscall\",\"tags\":[\"T1059.004\",\"container\",\"host\",\"maturity_stable\",\"mitre_execution\",\"process\",\"shell\"],\"hostname\":\"e822ea6618ae\"}",
+        "original": "{\"hostname\":\"97ade2b595f0\",\"output\":\"2024-05-07T18:54:19.341081180+0000: Warning Sensitive file opened for reading by non-trusted program (file=/etc/shadow gparent=runc ggparent=init gggparent=init evt_type=openat user=root user_uid=0 user_loginuid=-1 process=event-generator proc_exepath=/bin/event-generator parent=containerd-shim command=event-generator run --loop terminal=0 container_id=9656db3bb358 container_name=elastic-package-service-falco-event-generator-1)\",\"priority\":\"Warning\",\"rule\":\"Read sensitive file untrusted\",\"source\":\"syscall\",\"tags\":[\"T1555\",\"container\",\"filesystem\",\"host\",\"maturity_stable\",\"mitre_credential_access\"],\"time\":\"2024-05-07T18:54:19.341081180Z\", \"output_fields\": {\"container.id\":\"9656db3bb358\",\"container.name\":\"elastic-package-service-falco-event-generator-1\",\"evt.time.iso8601\":1715108059341081180,\"evt.type\":\"openat\",\"fd.name\":\"/etc/shadow\",\"proc.cmdline\":\"event-generator run --loop\",\"proc.exepath\":\"/bin/event-generator\",\"proc.name\":\"event-generator\",\"proc.pname\":\"containerd-shim\",\"proc.tty\":0,\"user.loginuid\":-1,\"user.name\":\"root\",\"user.uid\":0}}",
         "provider": "syscall",
-        "timezone": "+00:00"
+        "severity": 47,
+        "timezone": "+00:00",
+        "type": [
+            "access"
+        ]
     },
-    "event.category": [
-        "process"
-    ],
-    "event.severity": 2,
-    "event.type": [
-        "start"
-    ],
     "falco": {
-        "hostname": "e822ea6618ae",
-        "output": "2024-08-07T13:49:16.479964318+0000: Notice Shell spawned by untrusted binary (parent_exe=/tmp/falco-event-generator3282684109/httpd parent_exepath=/bin/event-generator pcmdline=httpd --loglevel info run ^helper.RunShell$ gparent=event-generator ggparent=containerd-shim aname[4]=containerd-shim aname[5]=init aname[6]=<NA> aname[7]=<NA> evt_type=execve user=root user_uid=0 user_loginuid=-1 process=bash proc_exepath=/bin/bash parent=httpd command=bash -c ls > /dev/null terminal=0 exe_flags=EXE_WRITABLE container_id=2ae6a7f15b6e container_name=elastic-package-service-10413-falco-event-generator-1)",
+        "hostname": "97ade2b595f0",
+        "output": "2024-05-07T18:54:19.341081180+0000: Warning Sensitive file opened for reading by non-trusted program (file=/etc/shadow gparent=runc ggparent=init gggparent=init evt_type=openat user=root user_uid=0 user_loginuid=-1 process=event-generator proc_exepath=/bin/event-generator parent=containerd-shim command=event-generator run --loop terminal=0 container_id=9656db3bb358 container_name=elastic-package-service-falco-event-generator-1)",
         "output_fields": {
             "container": {
-                "id": "2ae6a7f15b6e",
-                "name": "elastic-package-service-10413-falco-event-generator-1"
+                "id": "9656db3bb358",
+                "name": "elastic-package-service-falco-event-generator-1"
             },
             "evt": {
-                "arg": {},
                 "time": {
-                    "iso8601": 1723038556479
+                    "iso8601": 1715108059341
                 },
-                "type": "execve"
+                "type": "openat"
+            },
+            "fd": {
+                "name": "/etc/shadow"
             },
             "proc": {
-                "cmdline": "bash -c ls > /dev/null",
-                "exepath": "/bin/bash",
-                "name": "bash",
-                "pcmdline": "httpd --loglevel info run ^helper.RunShell$",
-                "pexe": "/tmp/falco-event-generator3282684109/httpd",
-                "pexepath": "/bin/event-generator",
-                "pname": "httpd",
+                "cmdline": "event-generator run --loop",
+                "exepath": "/bin/event-generator",
+                "name": "event-generator",
+                "pname": "containerd-shim",
                 "tty": 0
             },
             "user": {
@@ -354,38 +350,38 @@ An example event for `alerts` looks as following:
                 "uid": "0"
             }
         },
-        "priority": "Notice",
-        "rule": "Run shell untrusted",
+        "priority": "Warning",
+        "rule": "Read sensitive file untrusted",
         "source": "syscall",
         "tags": [
-            "T1059.004",
+            "T1555",
             "container",
+            "filesystem",
             "host",
             "maturity_stable",
-            "mitre_execution",
-            "process",
-            "shell"
+            "mitre_credential_access"
         ],
-        "time": "2024-08-07T13:49:16.479964318Z",
-        "uuid": "23716645-4d9d-4254-9429-2a287a9af199"
+        "time": "2024-05-07T18:54:19.341081180Z"
     },
     "falco.container.mounts": null,
     "host": {
-        "architecture": "aarch64",
-        "containerized": false,
-        "hostname": "docker-fleet-agent",
-        "id": "bec788532d91483489ff64145e57effe",
+        "architecture": "x86_64",
+        "containerized": true,
+        "hostname": "elastic-agent-40498",
+        "id": "e2673383c29c4c6e92abf0f43543814c",
         "ip": [
-            "192.168.160.9"
+            "192.168.251.2",
+            "192.168.247.6"
         ],
         "mac": [
-            "02-42-C0-A8-A0-09"
+            "02-42-C0-A8-F7-06",
+            "02-42-C0-A8-FB-02"
         ],
-        "name": "docker-fleet-agent",
+        "name": "97ade2b595f0",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "6.6.12-linuxkit",
+            "kernel": "3.10.0-1160.92.1.el7.x86_64",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
@@ -393,41 +389,27 @@ An example event for `alerts` looks as following:
         }
     },
     "input": {
-        "type": "tcp"
+        "type": "log"
     },
     "log": {
-        "source": {
-            "address": "192.168.160.5:34984"
+        "file": {
+            "path": "/tmp/service_logs/sample.log"
         },
-        "syslog": {
-            "appname": "Falco",
-            "facility": {
-                "code": 0,
-                "name": "kernel"
-            },
-            "hostname": "a72f9a747cf8",
-            "priority": 5,
-            "procid": "1",
-            "severity": {
-                "code": 5,
-                "name": "Notice"
-            }
-        }
+        "offset": 0
     },
+    "message": "Read sensitive file untrusted",
     "observer": {
-        "hostname": "e822ea6618ae",
+        "hostname": "97ade2b595f0",
         "product": "falco",
         "type": "sensor",
         "vendor": "sysdig"
     },
     "process": {
-        "command_line": "bash -c ls > /dev/null",
-        "executable": "/bin/bash",
-        "name": "bash",
+        "command_line": "event-generator run --loop",
+        "executable": "/bin/event-generator",
+        "name": "event-generator",
         "parent": {
-            "command_line": "httpd --loglevel info run ^helper.RunShell$",
-            "executable": "/bin/event-generator",
-            "name": "httpd"
+            "name": "containerd-shim"
         },
         "user": {
             "id": "0",
@@ -436,21 +418,18 @@ An example event for `alerts` looks as following:
     },
     "related": {
         "hosts": [
-            "e822ea6618ae"
+            "97ade2b595f0"
         ]
     },
     "rule": {
-        "name": "Run shell untrusted"
+        "name": "Read sensitive file untrusted"
     },
     "tags": [
         "preserve_original_event",
         "preserve_falco_fields"
     ],
     "threat.technique.id": [
-        "T1059"
-    ],
-    "threat.technique.subtechnique.id": [
-        "T1059.004"
+        "T1555"
     ]
 }
 ```

--- a/packages/falco/manifest.yml
+++ b/packages/falco/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: falco
 title: Falco
-version: "1.3.1"
+version: "1.3.2"
 description: Collect events and alerts from Falco using Elastic Agent
 type: integration
 categories:


### PR DESCRIPTION
## Proposed Commit Message

```
falco: fix conflicting field definitions for falco output fields and correct field types.

Resolved issues where scalar fields in the alerts data stream had children fieldscausing mapping conflicts.  
Specifically fixed the types for the following fields:
- `falco.output_fields.evt.time`
- `falco.output_fields.proc.ppid`
- `falco.output_fields.proc.sid`
- `falco.output_fields.proc.vpgid`
- `falco.output_fields.syslog.facility`
- `falco.output_fields.syslog.severity`

Updated field mappings to ensure consistent types and avoid hierarchy/type conflicts in the schema.

This change has been tested on the data available in the test folder.

```


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally
Clone integrations repo.
Install the elastic package locally.
Start the elastic stack using the elastic package.
Move to integrations/packages/falco directory.
Run the following command to run tests.
`elastic-package test -v`

## Related issues

- Closes https://github.com/elastic/integrations/issues/13590

