### PR TITLE
[Cloud Security] Backport cloud security posture 1.13: remove GCP project and org Id from validation 

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -12,6 +12,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "1.13.1"
+  changes:
+    - description: Remove GCP project and organization id from required vars
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13714
 - version: "1.13.0"
   changes:
     - description: Promote integration

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -16,7 +16,7 @@
   changes:
     - description: Remove GCP project and organization id from required vars
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/13714
+      link: https://github.com/elastic/integrations/pull/13806
 - version: "1.13.0"
   changes:
     - description: Promote integration

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -208,42 +208,34 @@ streams:
           value: organization-account
         - name: gcp.credentials.type
           value: credentials-none
-        - name: gcp.organization_id
-        - name: gcp.project_id
       organization_account_manual_file:
         - name: gcp.account_type
           value: organization-account
         - name: gcp.credentials.type
           value: credentials-file
-        - name: gcp.organization_id
-        - name: gcp.project_id
         - name: gcp.credentials.file
       organization_account_manual_json:
         - name: gcp.account_type
           value: organization-account
         - name: gcp.credentials.type
           value: credentials-json
-        - name: gcp.organization_id
         - name: gcp.credentials.json
       single_account_cloud_shell:
         - name: gcp.account_type
           value: single-account
         - name: gcp.credentials.type
           value: credentials-none
-        - name: gcp.project_id
       single_account_manual_file:
         - name: gcp.account_type
           value: single-account
         - name: gcp.credentials.type
           value: credentials-file
-        - name: gcp.project_id
         - name: gcp.credentials.file
       single_account_manual_json:
         - name: gcp.account_type
           value: single-account
         - name: gcp.credentials.type
           value: credentials-json
-        - name: gcp.project_id
         - name: gcp.credentials.json
     vars:
       - name: condition

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.13.0"
+version: "1.13.1"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION

## Proposed commit message
Remove Cloud Security Posture GCP project and organization Id from form validation.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

