### PR TITLE
[CI] Do not use -q parameter together with git commands in pipe

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -768,12 +768,18 @@ is_pr_affected() {
 
     commit_merge=$(git merge-base "${from}" "${to}")
     echoerr "[${package}] git-diff: check non-package files (${commit_merge}..${to})"
-    if git diff --name-only "${commit_merge}" "${to}" | grep -q -E -v '^(packages/|\.github/(CODEOWNERS|ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)|README\.md|docs/)' ; then
+    # Avoid using "-q" in grep in this pipe, it could cause that some files updated are not detected due to SIGPIPE errors
+    # https://buildkite.com/elastic/integrations/builds/25606
+    # https://github.com/elastic/integrations/pull/13810/files
+    if git diff --name-only "${commit_merge}" "${to}" | grep -E -v '^(packages/|\.github/(CODEOWNERS|ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)|README\.md|docs/)' > /dev/null; then
         echo "[${package}] PR is affected: found non-package files"
         return 0
     fi
     echoerr "[${package}] git-diff: check package files (${commit_merge}..${to})"
-    if git diff --name-only "${commit_merge}" "${to}" | grep -q -E "^packages/${package}/" ; then
+    # Avoid using "-q" in grep in this pipe, it could cause that some files updated are not detected due to SIGPIPE errors
+    # https://buildkite.com/elastic/integrations/builds/25606
+    # https://github.com/elastic/integrations/pull/13810/files
+    if git diff --name-only "${commit_merge}" "${to}" | grep -E "^packages/${package}/" > /dev/null ; then
         echo "[${package}] PR is affected: found package files"
         return 0
     fi

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -301,7 +301,9 @@ use_elastic_package() {
 is_already_published() {
     local packageZip=$1
 
-    if curl -s --head "https://package-storage.elastic.co/artifacts/packages/${packageZip}" | grep -q "HTTP/2 200" ; then
+    # Avoid using "-q" in grep in this pipe, it could cause some weird behavior in some scenarios due to SIGPIPE errors when "set -o pipefail"
+    # https://tldp.org/LDP/lpg/node20.html
+    if curl -s --head "https://package-storage.elastic.co/artifacts/packages/${packageZip}" | grep "HTTP/2 200" > /dev/null; then
         echo "- Already published ${packageZip}"
         return 0
     fi
@@ -407,7 +409,9 @@ is_package_excluded_in_config() {
     local package_name=""
     package_name=$(package_name_manifest)
 
-    if echo "${excluded_packages}" | grep -q -E "\"${package_name}\""; then
+    # Avoid using "-q" in grep in this pipe, it could cause some weird behavior in some scenarios due to SIGPIPE errors when "set -o pipefail"
+    # https://tldp.org/LDP/lpg/node20.html
+    if echo "${excluded_packages}" | grep -E "\"${package_name}\"" > /dev/null; then
         return 0
     fi
     return 1
@@ -438,7 +442,9 @@ is_supported_capability() {
     fi
 
     for cap in ${capabilities}; do
-        if ! echo "${cap}" | grep -q -E "${capabilities_kibana_grep}"; then
+        # Avoid using "-q" in grep in this pipe, it could cause some weird behavior in some scenarios due to SIGPIPE errors when "set -o pipefail"
+        # https://tldp.org/LDP/lpg/node20.html
+        if ! echo "${cap}" | grep -E "${capabilities_kibana_grep}" > /dev/null; then
             return 1
         fi
     done
@@ -768,17 +774,19 @@ is_pr_affected() {
 
     commit_merge=$(git merge-base "${from}" "${to}")
     echoerr "[${package}] git-diff: check non-package files (${commit_merge}..${to})"
-    # Avoid using "-q" in grep in this pipe, it could cause that some files updated are not detected due to SIGPIPE errors
+    # Avoid using "-q" in grep in this pipe, it could cause that some files updated are not detected due to SIGPIPE errors when "set -o pipefail"
+    # Example:
     # https://buildkite.com/elastic/integrations/builds/25606
-    # https://github.com/elastic/integrations/pull/13810/files
+    # https://github.com/elastic/integrations/pull/13810
     if git diff --name-only "${commit_merge}" "${to}" | grep -E -v '^(packages/|\.github/(CODEOWNERS|ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)|README\.md|docs/)' > /dev/null; then
         echo "[${package}] PR is affected: found non-package files"
         return 0
     fi
     echoerr "[${package}] git-diff: check package files (${commit_merge}..${to})"
-    # Avoid using "-q" in grep in this pipe, it could cause that some files updated are not detected due to SIGPIPE errors
+    # Avoid using "-q" in grep in this pipe, it could cause that some files updated are not detected due to SIGPIPE errors when "set -o pipefail"
+    # Example:
     # https://buildkite.com/elastic/integrations/builds/25606
-    # https://github.com/elastic/integrations/pull/13810/files
+    # https://github.com/elastic/integrations/pull/13810
     if git diff --name-only "${commit_merge}" "${to}" | grep -E "^packages/${package}/" > /dev/null ; then
         echo "[${package}] PR is affected: found package files"
         return 0


### PR DESCRIPTION
## Proposed commit message

Remove the usage of the `-q` parameter when used as part of pipe with `git` commands.

It could report failure due to SIGPIPE errors. As it was, this code
```
if git diff --name-only "${commit_merge}" "${to}" | grep -q -E "^packages/${package}/" ; then
    echo "[${package}] PR is affected: found package files"
    return 0
fi
```

was returning failure (141 error code) even there were matching files with the given regex.

Related https://stackoverflow.com/questions/19120263/why-exit-code-141-with-grep-q

Buildkite build with tests:
- https://buildkite.com/elastic/integrations/builds/25683#0196ac79-4deb-448d-8609-c34b9a8a44d6

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
```bash
# get the changeset from the affected PR
git fetch upstream pull/13810/head:pr-13810

# try to check the modified files
# this should return zero code
(set -o pipefail ; git diff --name-only c08c07e2cd3268914d9c504d0a51273f33f63f4a befe8ead69811789c40cba2e907abf6d0bcd6046  | grep -q -E "^packages/security_detection_engine/")

# Without -q parameter, it works
(set -o pipefail ; git diff --name-only c08c07e2cd3268914d9c504d0a51273f33f63f4a befe8ead69811789c40cba2e907abf6d0bcd6046  | grep -E "^packages/security_detection_engine/" > /dev/null)

```

## Related issues

- Relates https://github.com/elastic/integrations/pull/13810
- Relates https://github.com/elastic/integrations/pull/13831/

