### PR TITLE
o365: ensure empty responses do not lead to invalid request ranges

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.15.1"
+  changes:
+    - description: Ensure that empty results do not lead to subsequent invalid API requests.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13834
 - version: "2.15.0"
   changes:
     - description: Improve clarity of CEL agent collector code.

--- a/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
@@ -92,7 +92,7 @@ program: |-
   			) ?
   				// When start-subscription API returns success or if already started subscription,
   				duration(state.base.batch_interval).as(batch_interval,
-  					((batch_interval > duration("24h")) ? duration("24h") : batch_interval).as(batch_interval,
+  					min(duration("24h"), batch_interval).as(batch_interval,
   						request(
   							"GET",
   							(
@@ -111,25 +111,18 @@ program: |-
   								state.cursor.content_types_state_as_list.filter(e, e.content_type == content_type).as(content_type_state,
   									content_type_state[0].content_created_at.as(content_type_state_created_at,
   										// if saved time inside state is more than 7 days old, then change it to 7 days.
-  										content_type_state_created_at.parse_time(time_layout.RFC3339).as(state_created_at,
-  											// The 168h API age limit is expressed as 167h55m to
-  											// prevent API call delay from causing a call to fail.
-  											(state_created_at < now - duration("167h55m")) ?
-  												(now - duration("167h55m"))
-  											:
-  												state_created_at
+  										max(
+  											// The 168h (7d) API age limit is expressed as 167h55m to prevent API call
+  											// delay from causing a call to fail.
+  											now - duration("167h55m"),
+  											content_type_state_created_at.parse_time(time_layout.RFC3339)
   										).as(state_created_at_calc,
   											state.url.trim_right("/") + "/api/v1.0/" + state.base.tenant_id + "/activity/feed/subscriptions/content?" +
   											{
   												"contentType": [content_type],
   												"PublisherIdentifier": [state.base.tenant_id],
-  												"startTime": [string(state_created_at_calc + duration("1s"))],
-  												"endTime": [string((state_created_at_calc + batch_interval).as(calc_end_time,
-  													(calc_end_time <= now) ?
-  														calc_end_time
-  													:
-  														now
-  												))],
+  												"startTime": [string(min(now - duration("1s"), state_created_at_calc + duration("1s")))],
+  												"endTime": [string(min(now, state_created_at_calc + batch_interval))],
   											}.format_query()
   										)
   									)
@@ -140,13 +133,8 @@ program: |-
   								{
   									"contentType": [content_type],
   									"PublisherIdentifier": [state.base.tenant_id],
-  									"startTime": [string(now - duration(state.base.list_contents_start_time))],
-  									"endTime": [string((now - duration(state.base.list_contents_start_time) + batch_interval).as(calc_end_time,
-  										(calc_end_time <= now) ?
-  											calc_end_time
-  										:
-  											now
-  									))],
+  									"startTime": [string(min(now - duration("1s"), now - duration(state.base.list_contents_start_time)))],
+  									"endTime": [string(min(now, now - duration(state.base.list_contents_start_time) + batch_interval))],
   								}.format_query()
   						)
   					)

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft Office 365
-version: "2.15.0"
+version: "2.15.1"
 description: Collect logs from Microsoft Office 365 with Elastic Agent.
 type: integration
 format_version: "3.2.3"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
o365: ensure empty responses do not lead to invalid request ranges

It is possible for a content type to haev a content_created_at value
that is very close to the current time (less than 1s in the past). In
this case, the API timestamp range may end up with a time range that is
invalid for the API, with the startTime after the endTime. This change
ensures that in the case that the endTime has been clamped to now, the
startTime is clamped to 1s before now.

Also replace uses of the ternary operator with min and max function
calls where appropriate.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
