### PR TITLE
[slack-audit]: fix ingest where source address is empty in event

### DIFF
--- a/packages/slack/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/slack/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -202,6 +202,7 @@ processors:
       target_field: source.ip
       type: ip
       ignore_missing: true
+      if: ctx?.source?.address != ''
   - geoip:
       field: source.ip
       target_field: source.geo


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

Added a check to only process the IP address if it is present in the event.
In some cases Slack logs events that do not have an IP which causes the pipeline to fail.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

n/a

## How to test this PR locally

Use any Slack event and remove the source.address field and test using the the regular pipeline tester.

## Related issues

n/a

## Screenshots

n/a
