### PR TITLE
[atlassian-confluence]: fix ingest pipeline handling case where event does not have ip address

### DIFF
--- a/packages/atlassian_confluence/changelog.yml
+++ b/packages/atlassian_confluence/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.29.2"
+  changes:
+    - description: Handle events without IP gracefully.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13838
 - version: "1.29.1"
   changes:
     - description: Update cursor logic to remove duplicate events.

--- a/packages/atlassian_confluence/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/atlassian_confluence/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -50,7 +50,7 @@ processors:
       target_field: source.ip
       type: ip
       ignore_missing: true
-      if: ctx?.source?.address != ''
+      if: ctx.source?.address != ''
   - geoip:
       field: source.ip
       target_field: source.geo

--- a/packages/atlassian_confluence/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/atlassian_confluence/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -50,6 +50,7 @@ processors:
       target_field: source.ip
       type: ip
       ignore_missing: true
+      if: ctx?.source?.address != ''
   - geoip:
       field: source.ip
       target_field: source.geo

--- a/packages/atlassian_confluence/manifest.yml
+++ b/packages/atlassian_confluence/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: atlassian_confluence
 title: Atlassian Confluence
-version: "1.29.1"
+version: "1.29.2"
 description: Collect logs from Atlassian Confluence with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Added a check to only process the IP address if it is present in the event.
In some cases Confluence sends events that do not have an IP / or an empty sting as IP which causes the pipeline to fail.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

n/a

## How to test this PR locally

Use any Slack event and remove the source.address field and test using the the regular pipeline tester.

## Related issues

n/a

## Screenshots

n/a
