### PR TITLE
[qualys_vmdr] Update data collection to get unique identifiers for each interval of ingestion

### DIFF
--- a/packages/qualys_vmdr/changelog.yml
+++ b/packages/qualys_vmdr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "6.7.0"
+  changes:
+    - description: Enhance the data collection of the `asset_host_detection` data stream to generate unique identifiers for each interval of ingestion.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "6.6.1"
   changes:
     - description: Fix default request trace enabled behavior.

--- a/packages/qualys_vmdr/data_stream/asset_host_detection/agent/stream/input.yml.hbs
+++ b/packages/qualys_vmdr/data_stream/asset_host_detection/agent/stream/input.yml.hbs
@@ -26,240 +26,265 @@ redact:
   fields:
     - password
 program: |
-  (has(state.worklist) && size(state.worklist) > 0 
-  ?
-    state
-  :
-    state.with(
-      request("GET",
-        state.?want_more.orValue(false) ?
-          state.next_page.link
-        :
-          state.url.trim_right("/") + "/api/3.0/fo/asset/host/vm/detection/?" +
-          state.?params.orValue("").parse_query().with({
-            "action": ["list"],
-            "show_igs": [(state.show_igs? "1" : "0")],
-            "host_metadata": ["all"],
-            "show_qds": ["1"],
-            "show_qds_factors": ["1"],
-            "truncation_limit": [string(state.batch_size)],
-          }).format_query()
-      ).with({
-          "Header":{
-              "X-Requested-With": ["curl"],
-              "Authorization": ["Basic "+(state.user+":"+state.password).base64()],
-          }
-      }).do_request().as(resp,
-        resp.StatusCode == 200 
-        ?
-          (
-            has(resp.Body) && size(resp.Body) != 0
-            ?
-              (resp.Body.as(xml, try(xml.decode_xml('qualys_api_3_0_ahd'), "decode_xml_error_ahd").as(ahd_body, 
-                !has(ahd_body.decode_xml_error_ahd) 
-                ?
-                  (ahd_body.?doc.HOST_LIST_VM_DETECTION_OUTPUT.RESPONSE.hasValue() 
+  state.with({
+    ?"interval_start": state.?want_more.orValue(false) ? optional.none() : optional.of(now),
+    ?"interval_id": state.?want_more.orValue(false) ? optional.none() : optional.of(uuid()),
+  }).as(state,
+    (has(state.worklist) && size(state.worklist) > 0 
+    ?
+      state
+    :
+      state.with(
+        request("GET",
+          state.?want_more.orValue(false) ?
+            state.next_page.link
+          :
+            state.url.trim_right("/") + "/api/3.0/fo/asset/host/vm/detection/?" +
+            state.?params.orValue("").parse_query().with({
+              "action": ["list"],
+              "show_igs": [(state.show_igs? "1" : "0")],
+              "host_metadata": ["all"],
+              "show_qds": ["1"],
+              "show_qds_factors": ["1"],
+              "truncation_limit": [string(state.batch_size)],
+            }).format_query()
+        ).with({
+            "Header":{
+                "X-Requested-With": ["curl"],
+                "Authorization": ["Basic "+(state.user+":"+state.password).base64()],
+            }
+        }).do_request().as(resp,
+          resp.StatusCode == 200 
+          ?
+            (
+              has(resp.Body) && size(resp.Body) != 0
+              ?
+                (resp.Body.as(xml, try(xml.decode_xml('qualys_api_3_0_ahd'), "decode_xml_error_ahd").as(ahd_body, 
+                  !has(ahd_body.decode_xml_error_ahd) 
                   ?
-                    ({
-                      "worklist": {
-                        "AHD_LIST": (
-                          ahd_body.?doc.HOST_LIST_VM_DETECTION_OUTPUT.RESPONSE.HOST_LIST.HOST.orValue([]).flatten()
-                        ),
-                        // HOST_QID_LIST has unique QIDs from current batch of hosts.
-                        // When entire HOST_QID_LIST is sent to KB API && if size(HOST_QID_LIST) ~ 2000, this can lead to "414 Request-URI Too Long" response.
-                        // As a temporary workaround when unique QIDs >= 1000, it is split into even/odd.
-                        // This workaround will be updated with new tail and front functions added from https://github.com/elastic/mito/pull/81 in next beats version.
-                        "HOST_QID_LIST": (
-                          ahd_body.?doc.HOST_LIST_VM_DETECTION_OUTPUT.RESPONSE.HOST_LIST.HOST.orValue([]).collate("DETECTION_LIST.DETECTION.QID").flatten().as(qids,
-                            qids.map(qid, string(qid)).as(str_qids, zip(str_qids, qids))
-                          ).keys().as(qids_str, size(qids_str) < 1000 ?
-                            // Put all QIDs into list
-                            [
-                              qids_str
-                            ]
-                          :
-                            // Split QIDs into even and odd
-                            [
-                              qids_str.filter(i, int(i) % 2 == 0),
-                              qids_str.filter(i, int(i) % 2 > 0),
-                            ]
-                          )
-                        ),
-                        "KB_MAP": {},
-                      },
-                      "next_page": { 
-                        ?"link": ahd_body.?doc.HOST_LIST_VM_DETECTION_OUTPUT.RESPONSE.WARNING.URL
-                      },
-                      "next": 0,
-                    })
+                    (ahd_body.?doc.HOST_LIST_VM_DETECTION_OUTPUT.RESPONSE.hasValue() 
+                    ?
+                      ({
+                        "worklist": {
+                          "AHD_LIST": (
+                            ahd_body.?doc.HOST_LIST_VM_DETECTION_OUTPUT.RESPONSE.HOST_LIST.HOST.orValue([]).flatten()
+                          ),
+                          // HOST_QID_LIST has unique QIDs from current batch of hosts.
+                          // When entire HOST_QID_LIST is sent to KB API && if size(HOST_QID_LIST) ~ 2000, this can lead to "414 Request-URI Too Long" response.
+                          // As a temporary workaround when unique QIDs >= 1000, it is split into even/odd.
+                          // This workaround will be updated with new tail and front functions added from https://github.com/elastic/mito/pull/81 in next beats version.
+                          "HOST_QID_LIST": (
+                            ahd_body.?doc.HOST_LIST_VM_DETECTION_OUTPUT.RESPONSE.HOST_LIST.HOST.orValue([]).collate("DETECTION_LIST.DETECTION.QID").flatten().as(qids,
+                              qids.map(qid, string(qid)).as(str_qids, zip(str_qids, qids))
+                            ).keys().as(qids_str, size(qids_str) < 1000 ?
+                              // Put all QIDs into list
+                              [
+                                qids_str
+                              ]
+                            :
+                              // Split QIDs into even and odd
+                              [
+                                qids_str.filter(i, int(i) % 2 == 0),
+                                qids_str.filter(i, int(i) % 2 > 0),
+                              ]
+                            )
+                          ),
+                          "KB_MAP": {},
+                        },
+                        "next_page": { 
+                          ?"link": ahd_body.?doc.HOST_LIST_VM_DETECTION_OUTPUT.RESPONSE.WARNING.URL
+                        },
+                        "next": 0,
+                      })
+                    :
+                      {
+                        "events": {
+                          "error": {
+                            "message": "xsd and response mismatch in ahd:" + (
+                              string(resp.Body)
+                            ),
+                          },
+                          "interval_start": state.interval_start,
+                          "interval_id": state.interval_id,
+                        },
+                        "want_more": false,
+                      }
+                    )
                   :
                     {
                       "events": {
                         "error": {
-                          "message": "xsd and response mismatch in ahd:" + (
+                          "message": "decode_xml error in ahd:" + string(ahd_body.decode_xml_error_ahd) + ":" + (
                             string(resp.Body)
                           ),
                         },
+                        "interval_start": state.interval_start,
+                        "interval_id": state.interval_id,
                       },
                       "want_more": false,
                     }
-                  )
-                :
-                  {
-                    "events": {
-                      "error": {
-                        "message": "decode_xml error in ahd:" + string(ahd_body.decode_xml_error_ahd) + ":" + (
+                )))
+              :
+                // Qualys sends 200 success but with no response body. 
+                // Handling this case as okay.
+                {
+                  "events": [],
+                  "want_more": false,
+                }
+            )
+          :
+            ({
+              "events": {
+                "error": {
+                  "code": string(resp.StatusCode),
+                  "id": string(resp.Status),
+                  "message": "GET "+state.url.trim_right("/") + "/api/3.0/fo/asset/host/vm/detection/: "+(
+                    size(resp.Body) != 0 ?
+                      string(resp.Body)
+                    :
+                      string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                  ),
+                },
+                "interval_start": state.interval_start,
+                "interval_id": state.interval_id,
+              },
+              "want_more": false,
+            })
+        )
+      )
+    ).as(state, state.with(
+      !has(state.worklist) ? state : 
+        size(state.worklist) > 0 ?
+          request("GET", state.url.trim_right("/") + "/api/3.0/fo/knowledge_base/vuln/?" +
+            {
+              "ids": [state.worklist.HOST_QID_LIST[0].join(",")],
+              "action": ["list"],
+            }.format_query()
+          ).with({
+            "Header":{
+              "X-Requested-With": ["curl"],
+              "Authorization": ["Basic "+(state.user+":"+state.password).base64()],
+            }
+          }).do_request().as(resp, resp.StatusCode == 200 ?
+            resp.Body.as(xml, try(xml.decode_xml('qualys_api_3_0_kb'), "decode_xml_error_kb").as(kb_body, 
+              !has(kb_body.decode_xml_error_kb) 
+              ?
+                (
+                  has(kb_body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.VULN_LIST)
+                  ?
+                    kb_body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.VULN_LIST.VULN.map(e, e.with({
+                        "CVE_LIST": e.?CVE_LIST.CVE.orValue([]).map(c, c.ID),
+                    })).as(kb_list, kb_list.map(k, k.QID).as(qids, zip(qids, kb_list)).as(kb_map,
+                      state.worklist.KB_MAP.with(kb_map).as(wl_kb_map,
+                        size(state.worklist.HOST_QID_LIST) == 1 ?
+                          // Ready to publish events as last set of QIDs for this batch of hosts have been collected. Reset worklist.
+                          {
+                            "events": (
+                              state.worklist.AHD_LIST.map(h, 
+                                h.DETECTION_LIST.DETECTION.map(v,
+                                  h.with({
+                                    "DETECTION_LIST": v,
+                                    "KNOWLEDGE_BASE": try(wl_kb_map[v.QID], "map_has_no_key_error").as(kb_qid, 
+                                      !has(kb_qid.map_has_no_key_error)? 
+                                        kb_qid
+                                      : 
+                                        {}
+                                    ),
+                                  })
+                                )
+                              ).flatten().map(e, {
+                                "message": e.with({
+                                  "interval_start": state.interval_start,
+                                  "interval_id": state.interval_id,
+                                }).encode_json()
+                              })
+                            ),
+                            "worklist": {},
+                            "want_more": has(state.?next_page.link),
+                          }
+                        :
+                          // More QIDs need to be fetched for this batch of hosts. Update HOST_QID_LIST.
+                          {
+                            "events": [],
+                            "worklist": state.worklist.with({
+                              "HOST_QID_LIST": tail(state.worklist.HOST_QID_LIST),
+                              "KB_MAP": wl_kb_map,
+                            }),
+                            "want_more": true,
+                          }
+                      )))
+                  :
+                    {
+                      "events": [{
+                        "message": {
+                          "KNOWLEDGE_BASE": {
+                            "response_error": "response IDs values are missing: " + string(kb_body.?doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.ID_SET.orValue([])),
+                          },
+                          "interval_start": state.interval_start,
+                          "interval_id": state.interval_id,
+                        }.encode_json()
+                      }],
+                      "worklist": {},
+                      "want_more": false,
+                    }
+                ).as(state, 
+                  state.want_more && size(state.events) == 0 ?
+                    state.with({
+                      "events": [{
+                        "message": "retry",
+                        "interval_start": state.interval_start,
+                        "interval_id": state.interval_id,
+                      }]
+                    })
+                  :
+                    state
+                )
+              :
+                {
+                  "events": {
+                    "error": {
+                      "message": "decode_xml error in kb:" + string(kb_body.decode_xml_error_kb) + ":" + (
+                        size(resp.Body) != 0 ?
                           string(resp.Body)
-                        ),
-                      },
+                        :
+                          string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                      ),
                     },
-                    "want_more": false,
-                  }
-              )))
-            :
-              // Qualys sends 200 success but with no response body. 
-              // Handling this case as okay.
-              {
-                "events": [],
-                "want_more": false,
-              }
+                    "interval_start": state.interval_start,
+                    "interval_id": state.interval_id,
+                  },
+                  "worklist": {},
+                  "want_more": false,
+                }
+            ))
+          :
+            {
+              "events": {
+                "error": {
+                  "code": string(resp.StatusCode),
+                  "id": string(resp.Status),
+                  "message": "GET "+state.url.trim_right("/") + "/api/3.0/fo/knowledge_base/vuln/: "+(
+                    size(resp.Body) != 0 ?
+                      string(resp.Body)
+                    :
+                      string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                  ),
+                },
+                "interval_start": state.interval_start,
+                "interval_id": state.interval_id,
+              },
+              "want_more": false,
+            }
           )
         :
-          ({
-            "events": {
-              "error": {
-                "code": string(resp.StatusCode),
-                "id": string(resp.Status),
-                "message": "GET "+state.url.trim_right("/") + "/api/3.0/fo/asset/host/vm/detection/: "+(
-                  size(resp.Body) != 0 ?
-                    string(resp.Body)
-                  :
-                    string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-                ),
-              },
-            },
+          {
+            "events": [],
             "want_more": false,
-          })
+            "next_page": {},
+          }
       )
     )
-  ).as(state, state.with(
-    !has(state.worklist) ? state : 
-      size(state.worklist) > 0 ?
-        request("GET", state.url.trim_right("/") + "/api/3.0/fo/knowledge_base/vuln/?" +
-          {
-            "ids": [state.worklist.HOST_QID_LIST[0].join(",")],
-            "action": ["list"],
-          }.format_query()
-        ).with({
-          "Header":{
-            "X-Requested-With": ["curl"],
-            "Authorization": ["Basic "+(state.user+":"+state.password).base64()],
-          }
-        }).do_request().as(resp, resp.StatusCode == 200 ?
-          resp.Body.as(xml, try(xml.decode_xml('qualys_api_3_0_kb'), "decode_xml_error_kb").as(kb_body, 
-            !has(kb_body.decode_xml_error_kb) 
-            ?
-              (
-                has(kb_body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.VULN_LIST)
-                ?
-                  kb_body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.VULN_LIST.VULN.map(e, e.with({
-                      "CVE_LIST": e.?CVE_LIST.CVE.orValue([]).map(c, c.ID),
-                  })).as(kb_list, kb_list.map(k, k.QID).as(qids, zip(qids, kb_list)).as(kb_map,
-                    state.worklist.KB_MAP.with(kb_map).as(wl_kb_map,
-                      size(state.worklist.HOST_QID_LIST) == 1 ?
-                        // Ready to publish events as last set of QIDs for this batch of hosts have been collected. Reset worklist.
-                        {
-                          "events": (
-                            state.worklist.AHD_LIST.map(h, 
-                              h.DETECTION_LIST.DETECTION.map(v,
-                                h.with({
-                                  "DETECTION_LIST": v,
-                                  "KNOWLEDGE_BASE": try(wl_kb_map[v.QID], "map_has_no_key_error").as(kb_qid, 
-                                    !has(kb_qid.map_has_no_key_error)? 
-                                      kb_qid
-                                    : 
-                                      {}
-                                  ),
-                                })
-                              )
-                            ).flatten().map(e, 
-                              {"message": e.encode_json()}
-                            )
-                          ),
-                          "worklist": {},
-                          "want_more": has(state.?next_page.link),
-                        }
-                      :
-                        // More QIDs need to be fetched for this batch of hosts. Update HOST_QID_LIST.
-                        {
-                          "events": [],
-                          "worklist": state.worklist.with({
-                            "HOST_QID_LIST": tail(state.worklist.HOST_QID_LIST),
-                            "KB_MAP": wl_kb_map,
-                          }),
-                          "want_more": true,
-                        }
-                    )))
-                :
-                  {
-                    "events": [{
-                      "message": {
-                        "KNOWLEDGE_BASE": {
-                          "response_error": "response IDs values are missing: " + string(kb_body.?doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.ID_SET.orValue([])),
-                        }
-                      }.encode_json()
-                    }],
-                    "worklist": {},
-                    "want_more": false,
-                  }
-              ).as(state, 
-                state.want_more && size(state.events) == 0 ?
-                  state.with({"events": [{"message": "retry"}]})
-                :
-                  state
-              )
-            :
-              {
-                "events": {
-                  "error": {
-                    "message": "decode_xml error in kb:" + string(kb_body.decode_xml_error_kb) + ":" + (
-                      size(resp.Body) != 0 ?
-                        string(resp.Body)
-                      :
-                        string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-                    ),
-                  },
-                },
-                "worklist": {},
-                "want_more": false,
-              }
-          ))
-        :
-          {
-            "events": {
-              "error": {
-                "code": string(resp.StatusCode),
-                "id": string(resp.Status),
-                "message": "GET "+state.url.trim_right("/") + "/api/3.0/fo/knowledge_base/vuln/: "+(
-                  size(resp.Body) != 0 ?
-                    string(resp.Body)
-                  :
-                    string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-                ),
-              },
-            },
-            "want_more": false,
-          }
-        )
-      :
-        {
-          "events": [],
-          "want_more": false,
-          "next_page": {},
-        }
-    )
   )
-
 fields_under_root: true
 fields:
   _conf:

--- a/packages/qualys_vmdr/data_stream/asset_host_detection/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/qualys_vmdr/data_stream/asset_host_detection/elasticsearch/ingest_pipeline/default.yml
@@ -30,6 +30,22 @@ processors:
       ignore_missing: true
       ignore_failure: true
 
+  - rename:
+      field: interval_id
+      tag: rename_interval_id
+      target_field: qualys_vmdr.asset_host_detection.interval_id
+      ignore_missing: true
+  - date:
+      field: interval_start
+      tag: date_interval_start
+      target_field: qualys_vmdr.asset_host_detection.interval_start
+      formats:
+        - ISO8601
+      if: ctx.interval_start != null && ctx.interval_start != ''
+      on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - fail:
       tag: cel_failure
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
@@ -58,6 +74,22 @@ processors:
       field: message
       tag: json_message
       target_field: json
+      on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - rename:
+      field: json.interval_id
+      tag: rename_json_interval_id
+      target_field: qualys_vmdr.asset_host_detection.interval_id
+      ignore_missing: true
+  - date:
+      field: json.interval_start
+      tag: date_json_interval_start
+      target_field: qualys_vmdr.asset_host_detection.interval_start
+      formats:
+        - ISO8601
+      if: ctx.json?.interval_start != null && ctx.json.interval_start != ''
       on_failure:
         - append:
             field: error.message
@@ -1582,6 +1614,8 @@ processors:
       field:
         - json
         - message
+        - interval_id
+        - interval_start
         - _conf
         - qualys_vmdr.asset_host_detection.vulnerability.FIRST_FOUND_DATETIME
         - qualys_vmdr.asset_host_detection.vulnerability.FIRST_REOPENED_DATETIME

--- a/packages/qualys_vmdr/data_stream/asset_host_detection/fields/fields.yml
+++ b/packages/qualys_vmdr/data_stream/asset_host_detection/fields/fields.yml
@@ -36,6 +36,12 @@
       type: keyword
     - name: id
       type: keyword
+    - name: interval_id
+      type: keyword
+      description: The universally unique identifier (UUID) values will change with each interval of ingestion.
+    - name: interval_start
+      type: date
+      description: The start time of the interval of ingestion.
     - name: ip
       type: ip
     - name: ipv6

--- a/packages/qualys_vmdr/data_stream/asset_host_detection/sample_event.json
+++ b/packages/qualys_vmdr/data_stream/asset_host_detection/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2025-04-08T09:44:10.009Z",
+    "@timestamp": "2025-05-08T13:25:02.667Z",
     "agent": {
-        "ephemeral_id": "7e54ee7b-229e-4d8a-b4db-021a9755f3b6",
-        "id": "a6b5dc9a-fdd8-48e8-93df-bd12211c464a",
-        "name": "elastic-agent-13786",
+        "ephemeral_id": "e516bb88-e9ca-4c18-bb78-9811b958ff12",
+        "id": "9daa9753-02a6-4785-9629-923c6ca4bdec",
+        "name": "elastic-agent-85686",
         "type": "filebeat",
-        "version": "8.18.0"
+        "version": "8.19.0"
     },
     "cloud": {
         "instance": {
@@ -14,16 +14,16 @@
     },
     "data_stream": {
         "dataset": "qualys_vmdr.asset_host_detection",
-        "namespace": "92309",
+        "namespace": "66781",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "a6b5dc9a-fdd8-48e8-93df-bd12211c464a",
+        "id": "9daa9753-02a6-4785-9629-923c6ca4bdec",
         "snapshot": true,
-        "version": "8.18.0"
+        "version": "8.19.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -32,9 +32,9 @@
         ],
         "dataset": "qualys_vmdr.asset_host_detection",
         "id": "11111111",
-        "ingested": "2025-04-08T09:44:12Z",
+        "ingested": "2025-05-08T13:25:05Z",
         "kind": "alert",
-        "original": "{\"DETECTION_LIST\":{\"AFFECT_RUNNING_KERNEL\":\"0\",\"FIRST_FOUND_DATETIME\":\"2021-02-05T04:50:45Z\",\"IS_DISABLED\":\"0\",\"IS_IGNORED\":\"0\",\"LAST_FIXED_DATETIME\":\"2022-12-14T06:52:57Z\",\"LAST_FOUND_DATETIME\":\"2024-03-08T20:15:41Z\",\"LAST_PROCESSED_DATETIME\":\"2024-03-08T20:15:41Z\",\"LAST_TEST_DATETIME\":\"2024-03-08T20:15:41Z\",\"LAST_UPDATE_DATETIME\":\"2024-03-08T20:15:41Z\",\"QDS\":{\"#text\":\"35\",\"severity\":\"LOW\"},\"QDS_FACTORS\":{\"QDS_FACTOR\":[{\"#text\":\"7.7\",\"name\":\"CVSS\"},{\"#text\":\"v3.x\",\"name\":\"CVSS_version\"},{\"#text\":\"0.00232\",\"name\":\"epss\"},{\"#text\":\"AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:N/A:H\",\"name\":\"CVSS_vector\"}]},\"QID\":\"101\",\"RESULTS\":\"Package\\tInstalled Version\\tRequired Version\\nlinux-cloud-tools-4.4.0\\t1074-aws_4.4.0-1074.84\\t1092\\nlinux-aws-tools-4.4.0\\t1074_4.4.0-1074.84\\t1092\\nlinux-aws-headers-4.4.0\\t1074_4.15.0-1126.135\\t1092\\nlinux-tools-4.4.0\\t1074-aws_4.4.0-1074.84\\t1092\\nlinux-aws-cloud-tools-4.4.0\\t1074_4.4.0-1074.84\\t1092\",\"SEVERITY\":\"3\",\"SSL\":\"0\",\"STATUS\":\"Active\",\"TIMES_FOUND\":\"5393\",\"TYPE\":\"Confirmed\",\"UNIQUE_VULN_ID\":\"11111111\"},\"DNS\":\"adfssrvr.adfs.local\",\"DNS_DATA\":{\"DOMAIN\":\"adfs.local\",\"FQDN\":\"adfssrvr.adfs.local\",\"HOSTNAME\":\"adfssrvr\"},\"ID\":\"1\",\"IP\":\"10.50.2.111\",\"KNOWLEDGE_BASE\":{\"CATEGORY\":\"CGI\",\"CONSEQUENCE\":\"Depending on the vulnerability being exploited, an unauthenticated remote attacker could conduct cross-site scripting, clickjacking or MIME-type sniffing attacks.\",\"CVE_LIST\":[\"CVE-2022-31629\",\"CVE-2022-31628\"],\"DIAGNOSIS\":\"This QID reports the absence of the following\",\"DISCOVERY\":{\"REMOTE\":\"1\"},\"LAST_SERVICE_MODIFICATION_DATETIME\":\"2023-06-29T12:20:46Z\",\"PATCHABLE\":\"0\",\"PCI_FLAG\":\"1\",\"PUBLISHED_DATETIME\":\"2017-06-05T21:34:49Z\",\"QID\":\"101\",\"SEVERITY_LEVEL\":\"2\",\"SOFTWARE_LIST\":{\"SOFTWARE\":[{\"PRODUCT\":\"None\",\"VENDOR\":\"multi-vendor\"}]},\"SOLUTION\":\"\\u003cB\\u003eNote:\\u003c/B\\u003e To better debug the results of this QID\",\"THREAT_INTELLIGENCE\":{\"THREAT_INTEL\":[{\"id\":\"8\"}]},\"TITLE\":\"HTTP Security Header Not Detected\",\"VULN_TYPE\":\"Vulnerability\"},\"LAST_PC_SCANNED_DATE\":\"2023-06-28T09:58:12Z\",\"LAST_SCAN_DATETIME\":\"2023-07-03T06:25:17Z\",\"LAST_VM_SCANNED_DATE\":\"2023-07-03T06:23:47Z\",\"LAST_VM_SCANNED_DURATION\":\"1113\",\"NETBIOS\":\"ADFSSRVR\",\"OS\":\"Windows 2016/2019/10\",\"TRACKING_METHOD\":\"IP\"}",
+        "original": "{\"DETECTION_LIST\":{\"AFFECT_RUNNING_KERNEL\":\"0\",\"FIRST_FOUND_DATETIME\":\"2021-02-05T04:50:45Z\",\"IS_DISABLED\":\"0\",\"IS_IGNORED\":\"0\",\"LAST_FIXED_DATETIME\":\"2022-12-14T06:52:57Z\",\"LAST_FOUND_DATETIME\":\"2024-03-08T20:15:41Z\",\"LAST_PROCESSED_DATETIME\":\"2024-03-08T20:15:41Z\",\"LAST_TEST_DATETIME\":\"2024-03-08T20:15:41Z\",\"LAST_UPDATE_DATETIME\":\"2024-03-08T20:15:41Z\",\"QDS\":{\"#text\":\"35\",\"severity\":\"LOW\"},\"QDS_FACTORS\":{\"QDS_FACTOR\":[{\"#text\":\"7.7\",\"name\":\"CVSS\"},{\"#text\":\"v3.x\",\"name\":\"CVSS_version\"},{\"#text\":\"0.00232\",\"name\":\"epss\"},{\"#text\":\"AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:N/A:H\",\"name\":\"CVSS_vector\"}]},\"QID\":\"101\",\"RESULTS\":\"Package\\tInstalled Version\\tRequired Version\\nlinux-cloud-tools-4.4.0\\t1074-aws_4.4.0-1074.84\\t1092\\nlinux-aws-tools-4.4.0\\t1074_4.4.0-1074.84\\t1092\\nlinux-aws-headers-4.4.0\\t1074_4.15.0-1126.135\\t1092\\nlinux-tools-4.4.0\\t1074-aws_4.4.0-1074.84\\t1092\\nlinux-aws-cloud-tools-4.4.0\\t1074_4.4.0-1074.84\\t1092\",\"SEVERITY\":\"3\",\"SSL\":\"0\",\"STATUS\":\"Active\",\"TIMES_FOUND\":\"5393\",\"TYPE\":\"Confirmed\",\"UNIQUE_VULN_ID\":\"11111111\"},\"DNS\":\"adfssrvr.adfs.local\",\"DNS_DATA\":{\"DOMAIN\":\"adfs.local\",\"FQDN\":\"adfssrvr.adfs.local\",\"HOSTNAME\":\"adfssrvr\"},\"ID\":\"1\",\"IP\":\"10.50.2.111\",\"KNOWLEDGE_BASE\":{\"CATEGORY\":\"CGI\",\"CONSEQUENCE\":\"Depending on the vulnerability being exploited, an unauthenticated remote attacker could conduct cross-site scripting, clickjacking or MIME-type sniffing attacks.\",\"CVE_LIST\":[\"CVE-2022-31629\",\"CVE-2022-31628\"],\"DIAGNOSIS\":\"This QID reports the absence of the following\",\"DISCOVERY\":{\"REMOTE\":\"1\"},\"LAST_SERVICE_MODIFICATION_DATETIME\":\"2023-06-29T12:20:46Z\",\"PATCHABLE\":\"0\",\"PCI_FLAG\":\"1\",\"PUBLISHED_DATETIME\":\"2017-06-05T21:34:49Z\",\"QID\":\"101\",\"SEVERITY_LEVEL\":\"2\",\"SOFTWARE_LIST\":{\"SOFTWARE\":[{\"PRODUCT\":\"None\",\"VENDOR\":\"multi-vendor\"}]},\"SOLUTION\":\"\\u003cB\\u003eNote:\\u003c/B\\u003e To better debug the results of this QID\",\"THREAT_INTELLIGENCE\":{\"THREAT_INTEL\":[{\"id\":\"8\"}]},\"TITLE\":\"HTTP Security Header Not Detected\",\"VULN_TYPE\":\"Vulnerability\"},\"LAST_PC_SCANNED_DATE\":\"2023-06-28T09:58:12Z\",\"LAST_SCAN_DATETIME\":\"2023-07-03T06:25:17Z\",\"LAST_VM_SCANNED_DATE\":\"2023-07-03T06:23:47Z\",\"LAST_VM_SCANNED_DURATION\":\"1113\",\"NETBIOS\":\"ADFSSRVR\",\"OS\":\"Windows 2016/2019/10\",\"TRACKING_METHOD\":\"IP\",\"interval_id\":\"eee7bca3-41b7-4322-b1d5-effe92fe41cc\",\"interval_start\":\"2025-05-08T13:25:02.66152394Z\"}",
         "type": [
             "info"
         ]
@@ -91,6 +91,8 @@
                 "hostname": "adfssrvr"
             },
             "id": "1",
+            "interval_id": "eee7bca3-41b7-4322-b1d5-effe92fe41cc",
+            "interval_start": "2025-05-08T13:25:02.661Z",
             "ip": "10.50.2.111",
             "knowledge_base": {
                 "category": "CGI",

--- a/packages/qualys_vmdr/docs/README.md
+++ b/packages/qualys_vmdr/docs/README.md
@@ -125,13 +125,13 @@ An example event for `asset_host_detection` looks as following:
 
 ```json
 {
-    "@timestamp": "2025-04-08T09:44:10.009Z",
+    "@timestamp": "2025-05-08T13:25:02.667Z",
     "agent": {
-        "ephemeral_id": "7e54ee7b-229e-4d8a-b4db-021a9755f3b6",
-        "id": "a6b5dc9a-fdd8-48e8-93df-bd12211c464a",
-        "name": "elastic-agent-13786",
+        "ephemeral_id": "e516bb88-e9ca-4c18-bb78-9811b958ff12",
+        "id": "9daa9753-02a6-4785-9629-923c6ca4bdec",
+        "name": "elastic-agent-85686",
         "type": "filebeat",
-        "version": "8.18.0"
+        "version": "8.19.0"
     },
     "cloud": {
         "instance": {
@@ -140,16 +140,16 @@ An example event for `asset_host_detection` looks as following:
     },
     "data_stream": {
         "dataset": "qualys_vmdr.asset_host_detection",
-        "namespace": "92309",
+        "namespace": "66781",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "a6b5dc9a-fdd8-48e8-93df-bd12211c464a",
+        "id": "9daa9753-02a6-4785-9629-923c6ca4bdec",
         "snapshot": true,
-        "version": "8.18.0"
+        "version": "8.19.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -158,9 +158,9 @@ An example event for `asset_host_detection` looks as following:
         ],
         "dataset": "qualys_vmdr.asset_host_detection",
         "id": "11111111",
-        "ingested": "2025-04-08T09:44:12Z",
+        "ingested": "2025-05-08T13:25:05Z",
         "kind": "alert",
-        "original": "{\"DETECTION_LIST\":{\"AFFECT_RUNNING_KERNEL\":\"0\",\"FIRST_FOUND_DATETIME\":\"2021-02-05T04:50:45Z\",\"IS_DISABLED\":\"0\",\"IS_IGNORED\":\"0\",\"LAST_FIXED_DATETIME\":\"2022-12-14T06:52:57Z\",\"LAST_FOUND_DATETIME\":\"2024-03-08T20:15:41Z\",\"LAST_PROCESSED_DATETIME\":\"2024-03-08T20:15:41Z\",\"LAST_TEST_DATETIME\":\"2024-03-08T20:15:41Z\",\"LAST_UPDATE_DATETIME\":\"2024-03-08T20:15:41Z\",\"QDS\":{\"#text\":\"35\",\"severity\":\"LOW\"},\"QDS_FACTORS\":{\"QDS_FACTOR\":[{\"#text\":\"7.7\",\"name\":\"CVSS\"},{\"#text\":\"v3.x\",\"name\":\"CVSS_version\"},{\"#text\":\"0.00232\",\"name\":\"epss\"},{\"#text\":\"AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:N/A:H\",\"name\":\"CVSS_vector\"}]},\"QID\":\"101\",\"RESULTS\":\"Package\\tInstalled Version\\tRequired Version\\nlinux-cloud-tools-4.4.0\\t1074-aws_4.4.0-1074.84\\t1092\\nlinux-aws-tools-4.4.0\\t1074_4.4.0-1074.84\\t1092\\nlinux-aws-headers-4.4.0\\t1074_4.15.0-1126.135\\t1092\\nlinux-tools-4.4.0\\t1074-aws_4.4.0-1074.84\\t1092\\nlinux-aws-cloud-tools-4.4.0\\t1074_4.4.0-1074.84\\t1092\",\"SEVERITY\":\"3\",\"SSL\":\"0\",\"STATUS\":\"Active\",\"TIMES_FOUND\":\"5393\",\"TYPE\":\"Confirmed\",\"UNIQUE_VULN_ID\":\"11111111\"},\"DNS\":\"adfssrvr.adfs.local\",\"DNS_DATA\":{\"DOMAIN\":\"adfs.local\",\"FQDN\":\"adfssrvr.adfs.local\",\"HOSTNAME\":\"adfssrvr\"},\"ID\":\"1\",\"IP\":\"10.50.2.111\",\"KNOWLEDGE_BASE\":{\"CATEGORY\":\"CGI\",\"CONSEQUENCE\":\"Depending on the vulnerability being exploited, an unauthenticated remote attacker could conduct cross-site scripting, clickjacking or MIME-type sniffing attacks.\",\"CVE_LIST\":[\"CVE-2022-31629\",\"CVE-2022-31628\"],\"DIAGNOSIS\":\"This QID reports the absence of the following\",\"DISCOVERY\":{\"REMOTE\":\"1\"},\"LAST_SERVICE_MODIFICATION_DATETIME\":\"2023-06-29T12:20:46Z\",\"PATCHABLE\":\"0\",\"PCI_FLAG\":\"1\",\"PUBLISHED_DATETIME\":\"2017-06-05T21:34:49Z\",\"QID\":\"101\",\"SEVERITY_LEVEL\":\"2\",\"SOFTWARE_LIST\":{\"SOFTWARE\":[{\"PRODUCT\":\"None\",\"VENDOR\":\"multi-vendor\"}]},\"SOLUTION\":\"\\u003cB\\u003eNote:\\u003c/B\\u003e To better debug the results of this QID\",\"THREAT_INTELLIGENCE\":{\"THREAT_INTEL\":[{\"id\":\"8\"}]},\"TITLE\":\"HTTP Security Header Not Detected\",\"VULN_TYPE\":\"Vulnerability\"},\"LAST_PC_SCANNED_DATE\":\"2023-06-28T09:58:12Z\",\"LAST_SCAN_DATETIME\":\"2023-07-03T06:25:17Z\",\"LAST_VM_SCANNED_DATE\":\"2023-07-03T06:23:47Z\",\"LAST_VM_SCANNED_DURATION\":\"1113\",\"NETBIOS\":\"ADFSSRVR\",\"OS\":\"Windows 2016/2019/10\",\"TRACKING_METHOD\":\"IP\"}",
+        "original": "{\"DETECTION_LIST\":{\"AFFECT_RUNNING_KERNEL\":\"0\",\"FIRST_FOUND_DATETIME\":\"2021-02-05T04:50:45Z\",\"IS_DISABLED\":\"0\",\"IS_IGNORED\":\"0\",\"LAST_FIXED_DATETIME\":\"2022-12-14T06:52:57Z\",\"LAST_FOUND_DATETIME\":\"2024-03-08T20:15:41Z\",\"LAST_PROCESSED_DATETIME\":\"2024-03-08T20:15:41Z\",\"LAST_TEST_DATETIME\":\"2024-03-08T20:15:41Z\",\"LAST_UPDATE_DATETIME\":\"2024-03-08T20:15:41Z\",\"QDS\":{\"#text\":\"35\",\"severity\":\"LOW\"},\"QDS_FACTORS\":{\"QDS_FACTOR\":[{\"#text\":\"7.7\",\"name\":\"CVSS\"},{\"#text\":\"v3.x\",\"name\":\"CVSS_version\"},{\"#text\":\"0.00232\",\"name\":\"epss\"},{\"#text\":\"AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:N/A:H\",\"name\":\"CVSS_vector\"}]},\"QID\":\"101\",\"RESULTS\":\"Package\\tInstalled Version\\tRequired Version\\nlinux-cloud-tools-4.4.0\\t1074-aws_4.4.0-1074.84\\t1092\\nlinux-aws-tools-4.4.0\\t1074_4.4.0-1074.84\\t1092\\nlinux-aws-headers-4.4.0\\t1074_4.15.0-1126.135\\t1092\\nlinux-tools-4.4.0\\t1074-aws_4.4.0-1074.84\\t1092\\nlinux-aws-cloud-tools-4.4.0\\t1074_4.4.0-1074.84\\t1092\",\"SEVERITY\":\"3\",\"SSL\":\"0\",\"STATUS\":\"Active\",\"TIMES_FOUND\":\"5393\",\"TYPE\":\"Confirmed\",\"UNIQUE_VULN_ID\":\"11111111\"},\"DNS\":\"adfssrvr.adfs.local\",\"DNS_DATA\":{\"DOMAIN\":\"adfs.local\",\"FQDN\":\"adfssrvr.adfs.local\",\"HOSTNAME\":\"adfssrvr\"},\"ID\":\"1\",\"IP\":\"10.50.2.111\",\"KNOWLEDGE_BASE\":{\"CATEGORY\":\"CGI\",\"CONSEQUENCE\":\"Depending on the vulnerability being exploited, an unauthenticated remote attacker could conduct cross-site scripting, clickjacking or MIME-type sniffing attacks.\",\"CVE_LIST\":[\"CVE-2022-31629\",\"CVE-2022-31628\"],\"DIAGNOSIS\":\"This QID reports the absence of the following\",\"DISCOVERY\":{\"REMOTE\":\"1\"},\"LAST_SERVICE_MODIFICATION_DATETIME\":\"2023-06-29T12:20:46Z\",\"PATCHABLE\":\"0\",\"PCI_FLAG\":\"1\",\"PUBLISHED_DATETIME\":\"2017-06-05T21:34:49Z\",\"QID\":\"101\",\"SEVERITY_LEVEL\":\"2\",\"SOFTWARE_LIST\":{\"SOFTWARE\":[{\"PRODUCT\":\"None\",\"VENDOR\":\"multi-vendor\"}]},\"SOLUTION\":\"\\u003cB\\u003eNote:\\u003c/B\\u003e To better debug the results of this QID\",\"THREAT_INTELLIGENCE\":{\"THREAT_INTEL\":[{\"id\":\"8\"}]},\"TITLE\":\"HTTP Security Header Not Detected\",\"VULN_TYPE\":\"Vulnerability\"},\"LAST_PC_SCANNED_DATE\":\"2023-06-28T09:58:12Z\",\"LAST_SCAN_DATETIME\":\"2023-07-03T06:25:17Z\",\"LAST_VM_SCANNED_DATE\":\"2023-07-03T06:23:47Z\",\"LAST_VM_SCANNED_DURATION\":\"1113\",\"NETBIOS\":\"ADFSSRVR\",\"OS\":\"Windows 2016/2019/10\",\"TRACKING_METHOD\":\"IP\",\"interval_id\":\"eee7bca3-41b7-4322-b1d5-effe92fe41cc\",\"interval_start\":\"2025-05-08T13:25:02.66152394Z\"}",
         "type": [
             "info"
         ]
@@ -217,6 +217,8 @@ An example event for `asset_host_detection` looks as following:
                 "hostname": "adfssrvr"
             },
             "id": "1",
+            "interval_id": "eee7bca3-41b7-4322-b1d5-effe92fe41cc",
+            "interval_start": "2025-05-08T13:25:02.661Z",
             "ip": "10.50.2.111",
             "knowledge_base": {
                 "category": "CGI",
@@ -436,6 +438,8 @@ An example event for `asset_host_detection` looks as following:
 | qualys_vmdr.asset_host_detection.dns_data.hostname |  | keyword |
 | qualys_vmdr.asset_host_detection.ec2_instance_id |  | keyword |
 | qualys_vmdr.asset_host_detection.id |  | keyword |
+| qualys_vmdr.asset_host_detection.interval_id | The universally unique identifier (UUID) values will change with each interval of ingestion. | keyword |
+| qualys_vmdr.asset_host_detection.interval_start | The start time of the interval of ingestion. | date |
 | qualys_vmdr.asset_host_detection.ip |  | ip |
 | qualys_vmdr.asset_host_detection.ipv6 |  | ip |
 | qualys_vmdr.asset_host_detection.knowledge_base.automatic_pci_fail |  | keyword |

--- a/packages/qualys_vmdr/elasticsearch/transform/latest_cdr_vulnerabilities/fields/fields.yml
+++ b/packages/qualys_vmdr/elasticsearch/transform/latest_cdr_vulnerabilities/fields/fields.yml
@@ -36,6 +36,12 @@
       type: keyword
     - name: id
       type: keyword
+    - name: interval_id
+      type: keyword
+      description: The universally unique identifier (UUID) values will change with each interval of ingestion.
+    - name: interval_start
+      type: date
+      description: The start time of the interval of ingestion.
     - name: ip
       type: ip
     - name: ipv6

--- a/packages/qualys_vmdr/manifest.yml
+++ b/packages/qualys_vmdr/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.2.3"
 name: qualys_vmdr
 title: Qualys VMDR
-version: "6.6.1"
+version: "6.7.0"
 description: Collect data from Qualys VMDR platform with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
qualys_vmdr: Enhance the data collection of the asset_host_detection data stream to generate unique identifiers for each interval of ingestion.

This will help to debug if there is any issue in data ingestion.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/qualys_vmdr directory.
- Run the following command to run tests.
> elastic-package test

## Related issues

- Closes #13167 
