### PR TITLE
[Crowdstrike Alert] adjust batch size to API limit

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.65.1"
+  changes:
+    - description: Adjust alert batch size to 1000 to match the API limit.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13857
 - version: "1.65.0"
   changes:
     - description: Remove redundant installation instructions.

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Adjust alert batch size to 1000 to match the API limit.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/13857
+      link: https://github.com/elastic/integrations/pull/13862
 - version: "1.65.0"
   changes:
     - description: Remove redundant installation instructions.

--- a/packages/crowdstrike/data_stream/alert/manifest.yml
+++ b/packages/crowdstrike/data_stream/alert/manifest.yml
@@ -26,8 +26,8 @@ streams:
       - name: batch_size
         type: integer
         title: Batch Size
-        description: Batch size for the response of the CrowdStrike API. It must be between 1 - 10000.
-        default: 10000
+        description: Batch size for the response of the CrowdStrike API. It must be between 1 - 1000.
+        default: 1000
         multi: false
         required: true
         show_user: false

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "1.65.0"
+version: "1.65.1"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: "3.3.1"


### PR DESCRIPTION
The CrowdStrike alert integrations uses 2 API endpoints from CrowdStrike:
/alerts/queries/alerts/v2 → to get the composite IDs of all open alerts → limit of 10,000 (see https://www.falconpy.io/Service-Collections/Alerts.html#getqueriesalertsv2) as It's currently also defined as the default value for the batch size in the description.
The returned composite_ids of the first API call are then sent with a post again:
/alerts/entities/alerts/v2 → to get the alert details → limit of 1,000 (see https://www.falconpy.io/Service-Collections/Alerts.html#postentitiesalertsv2) 
which causes the integration to get an HTTP 413 request too large error if there are more than 1000 composite IDs returned from the first API which returns up to 10,000 IDs due to the limit.

As we already implemented a pagination using the want_more for the get, the batch size should be set to a maximum 10 1,000 instead of 10,000 to avoid the integration failing in environments with a lot of alerts.