### PR TITLE
[Cloud Security] Asset Inventory and CSPM - remove GCP project and org id from validation

### DIFF
--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 # version map:
 # 0.1.x - 8.15.x
-- version: "0.15.0"
+- version: "0.13.0"
   changes:
     - description: Remove GCP project and organization ID from validation
       type: bugfix

--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -5,7 +5,7 @@
   changes:
     - description: Remove GCP project and organization ID from validation
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/13768
+      link: https://github.com/elastic/integrations/pull/13866
 - version: "0.12.0"
   changes:
     - description: Fix the dataview name for the asset inventory data stream

--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -1,6 +1,11 @@
 # newer versions go on top
 # version map:
 # 0.1.x - 8.15.x
+- version: "0.15.0"
+  changes:
+    - description: Remove GCP project and organization ID from validation
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13768
 - version: "0.12.0"
   changes:
     - description: Fix the dataview name for the asset inventory data stream

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/manifest.yml
@@ -260,42 +260,34 @@ streams:
           value: organization-account
         - name: gcp.credentials.type
           value: credentials-none
-        - name: gcp.organization_id
-        - name: gcp.project_id
       organization_account_manual_file:
         - name: gcp.account_type
           value: organization-account
         - name: gcp.credentials.type
           value: credentials-file
-        - name: gcp.organization_id
-        - name: gcp.project_id
         - name: gcp.credentials.file
       organization_account_manual_json:
         - name: gcp.account_type
           value: organization-account
         - name: gcp.credentials.type
           value: credentials-json
-        - name: gcp.organization_id
         - name: gcp.credentials.json
       single_account_cloud_shell:
         - name: gcp.account_type
           value: single-account
         - name: gcp.credentials.type
           value: credentials-none
-        - name: gcp.project_id
       single_account_manual_file:
         - name: gcp.account_type
           value: single-account
         - name: gcp.credentials.type
           value: credentials-file
-        - name: gcp.project_id
         - name: gcp.credentials.file
       single_account_manual_json:
         - name: gcp.account_type
           value: single-account
         - name: gcp.credentials.type
           value: credentials-json
-        - name: gcp.project_id
         - name: gcp.credentials.json
     vars:
       - name: gcp.account_type

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_asset_inventory
 title: "Cloud Asset Discovery"
-version: "0.15.0"
+version: "0.13.0"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Discovery"

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_asset_inventory
 title: "Cloud Asset Discovery"
-version: "0.12.0"
+version: "0.15.0"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Discovery"

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -16,8 +16,8 @@
 - version: "2.0.0-preview03"
   changes:
     - description: Remove project_id and organization_id from validation
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/13714
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13866
 - version: "2.0.0-preview02"
   changes:
     - description: Fix the Azure credentials validation

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -13,6 +13,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "2.0.0-preview03"
+  changes:
+    - description: Remove project_id and organization_id from validation
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/13714
 - version: "2.0.0-preview02"
   changes:
     - description: Fix the Azure credentials validation

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -214,42 +214,35 @@ streams:
           value: organization-account
         - name: gcp.credentials.type
           value: credentials-none
-        - name: gcp.organization_id
-        - name: gcp.project_id
       organization_account_manual_file:
         - name: gcp.account_type
           value: organization-account
         - name: gcp.credentials.type
           value: credentials-file
         - name: gcp.organization_id
-        - name: gcp.project_id
         - name: gcp.credentials.file
       organization_account_manual_json:
         - name: gcp.account_type
           value: organization-account
         - name: gcp.credentials.type
           value: credentials-json
-        - name: gcp.organization_id
         - name: gcp.credentials.json
       single_account_cloud_shell:
         - name: gcp.account_type
           value: single-account
         - name: gcp.credentials.type
           value: credentials-none
-        - name: gcp.project_id
       single_account_manual_file:
         - name: gcp.account_type
           value: single-account
         - name: gcp.credentials.type
           value: credentials-file
-        - name: gcp.project_id
         - name: gcp.credentials.file
       single_account_manual_json:
         - name: gcp.account_type
           value: single-account
         - name: gcp.credentials.type
           value: credentials-json
-        - name: gcp.project_id
         - name: gcp.credentials.json
     vars:
       - name: condition

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "2.0.0-preview02"
+version: "2.0.0-preview03"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION

## Proposed commit message
Remove GCP project and organization required validation from Cloud Security Posture and Cloud Asset Discovery 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## Related issues
- relates https://github.com/elastic/kibana/pull/219001
- relates https://github.com/elastic/kibana/issues/220232
