### PR TITLE
[Cloudflare Logpush] map cloudflare_logpush.http_request.client.ssl.cipher to tls.cipher

### DIFF
--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.38.0"
   changes:
-    - description: Add tls.cipher ECS mapping for http_request.client.ssl.cipher.
+    - description: Add `tls.cipher` ECS mapping for `cloudflare_logpush.http_request.client.ssl.cipher`.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/13885
 - version: "1.37.4"

--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix the field type of http_request.client.ssl.cipher from text to keyword.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/13885
 - version: "1.37.4"
   changes:
     - description: Fix the field type of http_request.bot.detection_tags from long to keyword, aligning it with the log source type of string array. This resolves an issue where the field was being ignored due to the "ignored_malformed" index setting, making it unusable in searches.

--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.37.5"
+  changes:
+    - description: Fix the field type of http_request.client.ssl.cipher from text to keyword.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.37.4"
   changes:
     - description: Fix the field type of http_request.bot.detection_tags from long to keyword, aligning it with the log source type of string array. This resolves an issue where the field was being ignored due to the "ignored_malformed" index setting, making it unusable in searches.

--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -1,8 +1,8 @@
 # newer versions go on top
-- version: "1.37.5"
+- version: "1.38.0"
   changes:
-    - description: Fix the field type of http_request.client.ssl.cipher from text to keyword.
-      type: bugfix
+    - description: Add tls.cipher ECS mapping for http_request.client.ssl.cipher.
+      type: enhancement
       link: https://github.com/elastic/integrations/pull/13885
 - version: "1.37.4"
   changes:

--- a/packages/cloudflare_logpush/data_stream/http_request/_dev/test/pipeline/test-pipeline-http-request.log-expected.json
+++ b/packages/cloudflare_logpush/data_stream/http_request/_dev/test/pipeline/test-pipeline-http-request.log-expected.json
@@ -227,6 +227,7 @@
                 "preserve_duplicate_custom_fields"
             ],
             "tls": {
+                "cipher": "NONE",
                 "version": "1.2",
                 "version_protocol": "tls"
             },
@@ -476,6 +477,7 @@
                 "preserve_duplicate_custom_fields"
             ],
             "tls": {
+                "cipher": "NONE",
                 "version": "1.2",
                 "version_protocol": "tls"
             },
@@ -721,6 +723,7 @@
                 "preserve_duplicate_custom_fields"
             ],
             "tls": {
+                "cipher": "NONE",
                 "version": "1.2",
                 "version_protocol": "tls"
             },
@@ -985,6 +988,7 @@
                 "preserve_duplicate_custom_fields"
             ],
             "tls": {
+                "cipher": "NONE",
                 "version": "1.2",
                 "version_protocol": "tls"
             },
@@ -1262,6 +1266,7 @@
                 "preserve_duplicate_custom_fields"
             ],
             "tls": {
+                "cipher": "NONE",
                 "version": "1.2",
                 "version_protocol": "tls"
             },
@@ -1583,6 +1588,7 @@
                 "preserve_duplicate_custom_fields"
             ],
             "tls": {
+                "cipher": "NONE",
                 "version": "1.2",
                 "version_protocol": "tls"
             },

--- a/packages/cloudflare_logpush/data_stream/http_request/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/http_request/elasticsearch/ingest_pipeline/default.yml
@@ -440,6 +440,10 @@ processors:
       field: json.ClientSSLCipher
       target_field: cloudflare_logpush.http_request.client.ssl.cipher
       ignore_missing: true
+  - set:
+      field: tls.cipher
+      copy_from: cloudflare_logpush.http_request.client.ssl.cipher
+      ignore_empty_value: true
   - rename:
       field: json.ClientSSLProtocol
       target_field: cloudflare_logpush.http_request.client.ssl.protocol
@@ -922,6 +926,7 @@ processors:
         - cloudflare_logpush.http_request.client.country
         - cloudflare_logpush.http_request.client.ip
         - cloudflare_logpush.http_request.client.request.user.agent
+        - cloudflare_logpush.http_request.client.ssl.cipher
       if: ctx.tags == null || !(ctx.tags.contains('preserve_duplicate_custom_fields'))
       ignore_failure: true
       ignore_missing: true

--- a/packages/cloudflare_logpush/data_stream/http_request/fields/fields.yml
+++ b/packages/cloudflare_logpush/data_stream/http_request/fields/fields.yml
@@ -134,7 +134,7 @@
           type: group
           fields:
             - name: cipher
-              type: text
+              type: keyword
               description: Client SSL cipher.
             - name: protocol
               type: keyword

--- a/packages/cloudflare_logpush/data_stream/http_request/fields/fields.yml
+++ b/packages/cloudflare_logpush/data_stream/http_request/fields/fields.yml
@@ -134,7 +134,7 @@
           type: group
           fields:
             - name: cipher
-              type: keyword
+              type: text
               description: Client SSL cipher.
             - name: protocol
               type: keyword

--- a/packages/cloudflare_logpush/data_stream/http_request/sample_event.json
+++ b/packages/cloudflare_logpush/data_stream/http_request/sample_event.json
@@ -1,9 +1,9 @@
 {
     "@timestamp": "2022-05-25T13:25:26.000Z",
     "agent": {
-        "ephemeral_id": "5a075d70-14ab-4855-b550-a9251d7e6ba1",
-        "id": "a958e822-b2f5-4a62-95f8-6be3eb8422bb",
-        "name": "elastic-agent-59019",
+        "ephemeral_id": "73ffad76-a8c9-4685-b18c-c886b8035f8b",
+        "id": "0c9fd160-43b4-4f0c-838d-acd402893f43",
+        "name": "elastic-agent-20887",
         "type": "filebeat",
         "version": "8.16.5"
     },
@@ -191,7 +191,7 @@
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.http_request",
-        "namespace": "28989",
+        "namespace": "22099",
         "type": "logs"
     },
     "destination": {
@@ -201,7 +201,7 @@
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "a958e822-b2f5-4a62-95f8-6be3eb8422bb",
+        "id": "0c9fd160-43b4-4f0c-838d-acd402893f43",
         "snapshot": false,
         "version": "8.16.5"
     },
@@ -212,7 +212,7 @@
         ],
         "dataset": "cloudflare_logpush.http_request",
         "id": "710e98d9367f357d",
-        "ingested": "2025-04-16T07:23:28Z",
+        "ingested": "2025-05-07T05:58:30Z",
         "kind": "event",
         "original": "{\"BotDetectionIDs\":[7,8,9],\"BotScore\":20,\"BotScoreSrc\":\"Verified Bot\",\"BotTags\":[\"bing\",\"api\"],\"CacheCacheStatus\":\"dynamic\",\"CacheResponseBytes\":983828,\"CacheResponseStatus\":200,\"CacheTieredFill\":false,\"ClientASN\":43766,\"ClientCountry\":\"sa\",\"ClientDeviceType\":\"desktop\",\"ClientIP\":\"175.16.199.0\",\"ClientIPClass\":\"noRecord\",\"ClientMTLSAuthCertFingerprint\":\"Fingerprint\",\"ClientMTLSAuthStatus\":\"unknown\",\"ClientRequestBytes\":5800,\"ClientRequestHost\":\"xyz.example.com\",\"ClientRequestMethod\":\"POST\",\"ClientRequestPath\":\"/xyz/checkout\",\"ClientRequestProtocol\":\"HTTP/1.1\",\"ClientRequestReferer\":\"https://example.com/s/example/default?sourcerer=(default:(id:!n,selectedPatterns:!(example,%27logs-endpoint.*-example%27,%27logs-system.*-example%27,%27logs-windows.*-example%27)))\\u0026timerange=(global:(linkTo:!(),timerange:(from:%272022-05-16T06:26:36.340Z%27,fromStr:now-24h,kind:relative,to:%272022-05-17T06:26:36.340Z%27,toStr:now)),timeline:(linkTo:!(),timerange:(from:%272022-04-17T22:00:00.000Z%27,kind:absolute,to:%272022-04-18T21:59:59.999Z%27)))\\u0026timeline=(activeTab:notes,graphEventId:%27%27,id:%279844bdd4-4dd6-5b22-ab40-3cd46fce8d6b%27,isOpen:!t)\",\"ClientRequestScheme\":\"https\",\"ClientRequestSource\":\"edgeWorkerFetch\",\"ClientRequestURI\":\"/s/example/api/telemetry/v2/clusters/_stats\",\"ClientRequestUserAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36\",\"ClientSSLCipher\":\"NONE\",\"ClientSSLProtocol\":\"TLSv1.2\",\"ClientSrcPort\":0,\"ClientTCPRTTMs\":0,\"ClientXRequestedWith\":\"Request With\",\"Cookies\":{\"key\":\"value\"},\"EdgeCFConnectingO2O\":false,\"EdgeColoCode\":\"RUH\",\"EdgeColoID\":339,\"EdgeEndTimestamp\":\"2022-05-25T13:25:32Z\",\"EdgePathingOp\":\"wl\",\"EdgePathingSrc\":\"macro\",\"EdgePathingStatus\":\"nr\",\"EdgeRateLimitAction\":\"unknown\",\"EdgeRateLimitID\":0,\"EdgeRequestHost\":\"abc.example.com\",\"EdgeResponseBodyBytes\":980397,\"EdgeResponseBytes\":981308,\"EdgeResponseCompressionRatio\":0,\"EdgeResponseContentType\":\"application/json\",\"EdgeResponseStatus\":200,\"EdgeServerIP\":\"1.128.0.0\",\"EdgeStartTimestamp\":\"2022-05-25T13:25:26Z\",\"EdgeTimeToFirstByteMs\":5333,\"OriginDNSResponseTimeMs\":3,\"OriginIP\":\"67.43.156.0\",\"OriginRequestHeaderSendDurationMs\":0,\"OriginResponseBytes\":0,\"OriginResponseDurationMs\":5319,\"OriginResponseHTTPExpires\":\"2022-05-27T13:25:26Z\",\"OriginResponseHTTPLastModified\":\"2022-05-26T13:25:26Z\",\"OriginResponseHeaderReceiveDurationMs\":5155,\"OriginResponseStatus\":200,\"OriginResponseTime\":5232000000,\"OriginSSLProtocol\":\"TLSv1.2\",\"OriginTCPHandshakeDurationMs\":24,\"OriginTLSHandshakeDurationMs\":53,\"ParentRayID\":\"710e98d93d50357d\",\"RayID\":\"710e98d9367f357d\",\"SecurityAction\":\"unknown\",\"SecurityLevel\":\"off\",\"SecurityRuleDescription\":\"matchad variable message\",\"SecurityRuleID\":\"98d93d5\",\"SmartRouteColoID\":20,\"UpperTierColoID\":0,\"WAFAttackScore\":50,\"WAFFlags\":\"0\",\"WAFMatchedVar\":\"example\",\"WAFProfile\":\"unknown\",\"WAFRCEAttackScore\":1,\"WAFSQLiAttackScore\":99,\"WAFXSSAttackScore\":90,\"WorkerCPUTime\":0,\"WorkerStatus\":\"unknown\",\"WorkerSubrequest\":true,\"WorkerSubrequestCount\":0,\"ZoneID\":393347122,\"ZoneName\":\"example.com\"}",
         "type": [

--- a/packages/cloudflare_logpush/data_stream/http_request/sample_event.json
+++ b/packages/cloudflare_logpush/data_stream/http_request/sample_event.json
@@ -1,9 +1,9 @@
 {
     "@timestamp": "2022-05-25T13:25:26.000Z",
     "agent": {
-        "ephemeral_id": "73ffad76-a8c9-4685-b18c-c886b8035f8b",
-        "id": "0c9fd160-43b4-4f0c-838d-acd402893f43",
-        "name": "elastic-agent-20887",
+        "ephemeral_id": "3d7bb881-29a8-487a-a69d-146c10236cf1",
+        "id": "c3e8acfc-07d7-4e90-868e-a0f2c762068d",
+        "name": "elastic-agent-47256",
         "type": "filebeat",
         "version": "8.16.5"
     },
@@ -191,7 +191,7 @@
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.http_request",
-        "namespace": "22099",
+        "namespace": "70990",
         "type": "logs"
     },
     "destination": {
@@ -201,7 +201,7 @@
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "0c9fd160-43b4-4f0c-838d-acd402893f43",
+        "id": "c3e8acfc-07d7-4e90-868e-a0f2c762068d",
         "snapshot": false,
         "version": "8.16.5"
     },
@@ -212,7 +212,7 @@
         ],
         "dataset": "cloudflare_logpush.http_request",
         "id": "710e98d9367f357d",
-        "ingested": "2025-05-07T05:58:30Z",
+        "ingested": "2025-05-13T05:53:56Z",
         "kind": "event",
         "original": "{\"BotDetectionIDs\":[7,8,9],\"BotScore\":20,\"BotScoreSrc\":\"Verified Bot\",\"BotTags\":[\"bing\",\"api\"],\"CacheCacheStatus\":\"dynamic\",\"CacheResponseBytes\":983828,\"CacheResponseStatus\":200,\"CacheTieredFill\":false,\"ClientASN\":43766,\"ClientCountry\":\"sa\",\"ClientDeviceType\":\"desktop\",\"ClientIP\":\"175.16.199.0\",\"ClientIPClass\":\"noRecord\",\"ClientMTLSAuthCertFingerprint\":\"Fingerprint\",\"ClientMTLSAuthStatus\":\"unknown\",\"ClientRequestBytes\":5800,\"ClientRequestHost\":\"xyz.example.com\",\"ClientRequestMethod\":\"POST\",\"ClientRequestPath\":\"/xyz/checkout\",\"ClientRequestProtocol\":\"HTTP/1.1\",\"ClientRequestReferer\":\"https://example.com/s/example/default?sourcerer=(default:(id:!n,selectedPatterns:!(example,%27logs-endpoint.*-example%27,%27logs-system.*-example%27,%27logs-windows.*-example%27)))\\u0026timerange=(global:(linkTo:!(),timerange:(from:%272022-05-16T06:26:36.340Z%27,fromStr:now-24h,kind:relative,to:%272022-05-17T06:26:36.340Z%27,toStr:now)),timeline:(linkTo:!(),timerange:(from:%272022-04-17T22:00:00.000Z%27,kind:absolute,to:%272022-04-18T21:59:59.999Z%27)))\\u0026timeline=(activeTab:notes,graphEventId:%27%27,id:%279844bdd4-4dd6-5b22-ab40-3cd46fce8d6b%27,isOpen:!t)\",\"ClientRequestScheme\":\"https\",\"ClientRequestSource\":\"edgeWorkerFetch\",\"ClientRequestURI\":\"/s/example/api/telemetry/v2/clusters/_stats\",\"ClientRequestUserAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36\",\"ClientSSLCipher\":\"NONE\",\"ClientSSLProtocol\":\"TLSv1.2\",\"ClientSrcPort\":0,\"ClientTCPRTTMs\":0,\"ClientXRequestedWith\":\"Request With\",\"Cookies\":{\"key\":\"value\"},\"EdgeCFConnectingO2O\":false,\"EdgeColoCode\":\"RUH\",\"EdgeColoID\":339,\"EdgeEndTimestamp\":\"2022-05-25T13:25:32Z\",\"EdgePathingOp\":\"wl\",\"EdgePathingSrc\":\"macro\",\"EdgePathingStatus\":\"nr\",\"EdgeRateLimitAction\":\"unknown\",\"EdgeRateLimitID\":0,\"EdgeRequestHost\":\"abc.example.com\",\"EdgeResponseBodyBytes\":980397,\"EdgeResponseBytes\":981308,\"EdgeResponseCompressionRatio\":0,\"EdgeResponseContentType\":\"application/json\",\"EdgeResponseStatus\":200,\"EdgeServerIP\":\"1.128.0.0\",\"EdgeStartTimestamp\":\"2022-05-25T13:25:26Z\",\"EdgeTimeToFirstByteMs\":5333,\"OriginDNSResponseTimeMs\":3,\"OriginIP\":\"67.43.156.0\",\"OriginRequestHeaderSendDurationMs\":0,\"OriginResponseBytes\":0,\"OriginResponseDurationMs\":5319,\"OriginResponseHTTPExpires\":\"2022-05-27T13:25:26Z\",\"OriginResponseHTTPLastModified\":\"2022-05-26T13:25:26Z\",\"OriginResponseHeaderReceiveDurationMs\":5155,\"OriginResponseStatus\":200,\"OriginResponseTime\":5232000000,\"OriginSSLProtocol\":\"TLSv1.2\",\"OriginTCPHandshakeDurationMs\":24,\"OriginTLSHandshakeDurationMs\":53,\"ParentRayID\":\"710e98d93d50357d\",\"RayID\":\"710e98d9367f357d\",\"SecurityAction\":\"unknown\",\"SecurityLevel\":\"off\",\"SecurityRuleDescription\":\"matchad variable message\",\"SecurityRuleID\":\"98d93d5\",\"SmartRouteColoID\":20,\"UpperTierColoID\":0,\"WAFAttackScore\":50,\"WAFFlags\":\"0\",\"WAFMatchedVar\":\"example\",\"WAFProfile\":\"unknown\",\"WAFRCEAttackScore\":1,\"WAFSQLiAttackScore\":99,\"WAFXSSAttackScore\":90,\"WorkerCPUTime\":0,\"WorkerStatus\":\"unknown\",\"WorkerSubrequest\":true,\"WorkerSubrequestCount\":0,\"ZoneID\":393347122,\"ZoneName\":\"example.com\"}",
         "type": [
@@ -257,6 +257,7 @@
         "cloudflare_logpush-http_request"
     ],
     "tls": {
+        "cipher": "NONE",
         "version": "1.2",
         "version_protocol": "tls"
     },

--- a/packages/cloudflare_logpush/docs/README.md
+++ b/packages/cloudflare_logpush/docs/README.md
@@ -2450,9 +2450,9 @@ An example event for `http_request` looks as following:
 {
     "@timestamp": "2022-05-25T13:25:26.000Z",
     "agent": {
-        "ephemeral_id": "5a075d70-14ab-4855-b550-a9251d7e6ba1",
-        "id": "a958e822-b2f5-4a62-95f8-6be3eb8422bb",
-        "name": "elastic-agent-59019",
+        "ephemeral_id": "73ffad76-a8c9-4685-b18c-c886b8035f8b",
+        "id": "0c9fd160-43b4-4f0c-838d-acd402893f43",
+        "name": "elastic-agent-20887",
         "type": "filebeat",
         "version": "8.16.5"
     },
@@ -2640,7 +2640,7 @@ An example event for `http_request` looks as following:
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.http_request",
-        "namespace": "28989",
+        "namespace": "22099",
         "type": "logs"
     },
     "destination": {
@@ -2650,7 +2650,7 @@ An example event for `http_request` looks as following:
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "a958e822-b2f5-4a62-95f8-6be3eb8422bb",
+        "id": "0c9fd160-43b4-4f0c-838d-acd402893f43",
         "snapshot": false,
         "version": "8.16.5"
     },
@@ -2661,7 +2661,7 @@ An example event for `http_request` looks as following:
         ],
         "dataset": "cloudflare_logpush.http_request",
         "id": "710e98d9367f357d",
-        "ingested": "2025-04-16T07:23:28Z",
+        "ingested": "2025-05-07T05:58:30Z",
         "kind": "event",
         "original": "{\"BotDetectionIDs\":[7,8,9],\"BotScore\":20,\"BotScoreSrc\":\"Verified Bot\",\"BotTags\":[\"bing\",\"api\"],\"CacheCacheStatus\":\"dynamic\",\"CacheResponseBytes\":983828,\"CacheResponseStatus\":200,\"CacheTieredFill\":false,\"ClientASN\":43766,\"ClientCountry\":\"sa\",\"ClientDeviceType\":\"desktop\",\"ClientIP\":\"175.16.199.0\",\"ClientIPClass\":\"noRecord\",\"ClientMTLSAuthCertFingerprint\":\"Fingerprint\",\"ClientMTLSAuthStatus\":\"unknown\",\"ClientRequestBytes\":5800,\"ClientRequestHost\":\"xyz.example.com\",\"ClientRequestMethod\":\"POST\",\"ClientRequestPath\":\"/xyz/checkout\",\"ClientRequestProtocol\":\"HTTP/1.1\",\"ClientRequestReferer\":\"https://example.com/s/example/default?sourcerer=(default:(id:!n,selectedPatterns:!(example,%27logs-endpoint.*-example%27,%27logs-system.*-example%27,%27logs-windows.*-example%27)))\\u0026timerange=(global:(linkTo:!(),timerange:(from:%272022-05-16T06:26:36.340Z%27,fromStr:now-24h,kind:relative,to:%272022-05-17T06:26:36.340Z%27,toStr:now)),timeline:(linkTo:!(),timerange:(from:%272022-04-17T22:00:00.000Z%27,kind:absolute,to:%272022-04-18T21:59:59.999Z%27)))\\u0026timeline=(activeTab:notes,graphEventId:%27%27,id:%279844bdd4-4dd6-5b22-ab40-3cd46fce8d6b%27,isOpen:!t)\",\"ClientRequestScheme\":\"https\",\"ClientRequestSource\":\"edgeWorkerFetch\",\"ClientRequestURI\":\"/s/example/api/telemetry/v2/clusters/_stats\",\"ClientRequestUserAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36\",\"ClientSSLCipher\":\"NONE\",\"ClientSSLProtocol\":\"TLSv1.2\",\"ClientSrcPort\":0,\"ClientTCPRTTMs\":0,\"ClientXRequestedWith\":\"Request With\",\"Cookies\":{\"key\":\"value\"},\"EdgeCFConnectingO2O\":false,\"EdgeColoCode\":\"RUH\",\"EdgeColoID\":339,\"EdgeEndTimestamp\":\"2022-05-25T13:25:32Z\",\"EdgePathingOp\":\"wl\",\"EdgePathingSrc\":\"macro\",\"EdgePathingStatus\":\"nr\",\"EdgeRateLimitAction\":\"unknown\",\"EdgeRateLimitID\":0,\"EdgeRequestHost\":\"abc.example.com\",\"EdgeResponseBodyBytes\":980397,\"EdgeResponseBytes\":981308,\"EdgeResponseCompressionRatio\":0,\"EdgeResponseContentType\":\"application/json\",\"EdgeResponseStatus\":200,\"EdgeServerIP\":\"1.128.0.0\",\"EdgeStartTimestamp\":\"2022-05-25T13:25:26Z\",\"EdgeTimeToFirstByteMs\":5333,\"OriginDNSResponseTimeMs\":3,\"OriginIP\":\"67.43.156.0\",\"OriginRequestHeaderSendDurationMs\":0,\"OriginResponseBytes\":0,\"OriginResponseDurationMs\":5319,\"OriginResponseHTTPExpires\":\"2022-05-27T13:25:26Z\",\"OriginResponseHTTPLastModified\":\"2022-05-26T13:25:26Z\",\"OriginResponseHeaderReceiveDurationMs\":5155,\"OriginResponseStatus\":200,\"OriginResponseTime\":5232000000,\"OriginSSLProtocol\":\"TLSv1.2\",\"OriginTCPHandshakeDurationMs\":24,\"OriginTLSHandshakeDurationMs\":53,\"ParentRayID\":\"710e98d93d50357d\",\"RayID\":\"710e98d9367f357d\",\"SecurityAction\":\"unknown\",\"SecurityLevel\":\"off\",\"SecurityRuleDescription\":\"matchad variable message\",\"SecurityRuleID\":\"98d93d5\",\"SmartRouteColoID\":20,\"UpperTierColoID\":0,\"WAFAttackScore\":50,\"WAFFlags\":\"0\",\"WAFMatchedVar\":\"example\",\"WAFProfile\":\"unknown\",\"WAFRCEAttackScore\":1,\"WAFSQLiAttackScore\":99,\"WAFXSSAttackScore\":90,\"WorkerCPUTime\":0,\"WorkerStatus\":\"unknown\",\"WorkerSubrequest\":true,\"WorkerSubrequestCount\":0,\"ZoneID\":393347122,\"ZoneName\":\"example.com\"}",
         "type": [
@@ -2769,7 +2769,7 @@ An example event for `http_request` looks as following:
 | cloudflare_logpush.http_request.client.request.uri | URI requested by the client. | text |
 | cloudflare_logpush.http_request.client.request.user.agent | User agent reported by the client. | text |
 | cloudflare_logpush.http_request.client.src.port | Client source port. | long |
-| cloudflare_logpush.http_request.client.ssl.cipher | Client SSL cipher. | text |
+| cloudflare_logpush.http_request.client.ssl.cipher | Client SSL cipher. | keyword |
 | cloudflare_logpush.http_request.client.ssl.protocol | Client SSL (TLS) protocol. | keyword |
 | cloudflare_logpush.http_request.client.tcp_rtt.ms | The smoothed average of TCP round-trip time (SRTT), For the initial request on a connection, this is measured only during connection setup, For a subsequent request on the same connection, it is measured over the entire connection lifetime up until the time that request is received. | long |
 | cloudflare_logpush.http_request.client.xrequested_with | X-Requested-With HTTP header. | text |

--- a/packages/cloudflare_logpush/docs/README.md
+++ b/packages/cloudflare_logpush/docs/README.md
@@ -2450,9 +2450,9 @@ An example event for `http_request` looks as following:
 {
     "@timestamp": "2022-05-25T13:25:26.000Z",
     "agent": {
-        "ephemeral_id": "73ffad76-a8c9-4685-b18c-c886b8035f8b",
-        "id": "0c9fd160-43b4-4f0c-838d-acd402893f43",
-        "name": "elastic-agent-20887",
+        "ephemeral_id": "3d7bb881-29a8-487a-a69d-146c10236cf1",
+        "id": "c3e8acfc-07d7-4e90-868e-a0f2c762068d",
+        "name": "elastic-agent-47256",
         "type": "filebeat",
         "version": "8.16.5"
     },
@@ -2640,7 +2640,7 @@ An example event for `http_request` looks as following:
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.http_request",
-        "namespace": "22099",
+        "namespace": "70990",
         "type": "logs"
     },
     "destination": {
@@ -2650,7 +2650,7 @@ An example event for `http_request` looks as following:
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "0c9fd160-43b4-4f0c-838d-acd402893f43",
+        "id": "c3e8acfc-07d7-4e90-868e-a0f2c762068d",
         "snapshot": false,
         "version": "8.16.5"
     },
@@ -2661,7 +2661,7 @@ An example event for `http_request` looks as following:
         ],
         "dataset": "cloudflare_logpush.http_request",
         "id": "710e98d9367f357d",
-        "ingested": "2025-05-07T05:58:30Z",
+        "ingested": "2025-05-13T05:53:56Z",
         "kind": "event",
         "original": "{\"BotDetectionIDs\":[7,8,9],\"BotScore\":20,\"BotScoreSrc\":\"Verified Bot\",\"BotTags\":[\"bing\",\"api\"],\"CacheCacheStatus\":\"dynamic\",\"CacheResponseBytes\":983828,\"CacheResponseStatus\":200,\"CacheTieredFill\":false,\"ClientASN\":43766,\"ClientCountry\":\"sa\",\"ClientDeviceType\":\"desktop\",\"ClientIP\":\"175.16.199.0\",\"ClientIPClass\":\"noRecord\",\"ClientMTLSAuthCertFingerprint\":\"Fingerprint\",\"ClientMTLSAuthStatus\":\"unknown\",\"ClientRequestBytes\":5800,\"ClientRequestHost\":\"xyz.example.com\",\"ClientRequestMethod\":\"POST\",\"ClientRequestPath\":\"/xyz/checkout\",\"ClientRequestProtocol\":\"HTTP/1.1\",\"ClientRequestReferer\":\"https://example.com/s/example/default?sourcerer=(default:(id:!n,selectedPatterns:!(example,%27logs-endpoint.*-example%27,%27logs-system.*-example%27,%27logs-windows.*-example%27)))\\u0026timerange=(global:(linkTo:!(),timerange:(from:%272022-05-16T06:26:36.340Z%27,fromStr:now-24h,kind:relative,to:%272022-05-17T06:26:36.340Z%27,toStr:now)),timeline:(linkTo:!(),timerange:(from:%272022-04-17T22:00:00.000Z%27,kind:absolute,to:%272022-04-18T21:59:59.999Z%27)))\\u0026timeline=(activeTab:notes,graphEventId:%27%27,id:%279844bdd4-4dd6-5b22-ab40-3cd46fce8d6b%27,isOpen:!t)\",\"ClientRequestScheme\":\"https\",\"ClientRequestSource\":\"edgeWorkerFetch\",\"ClientRequestURI\":\"/s/example/api/telemetry/v2/clusters/_stats\",\"ClientRequestUserAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36\",\"ClientSSLCipher\":\"NONE\",\"ClientSSLProtocol\":\"TLSv1.2\",\"ClientSrcPort\":0,\"ClientTCPRTTMs\":0,\"ClientXRequestedWith\":\"Request With\",\"Cookies\":{\"key\":\"value\"},\"EdgeCFConnectingO2O\":false,\"EdgeColoCode\":\"RUH\",\"EdgeColoID\":339,\"EdgeEndTimestamp\":\"2022-05-25T13:25:32Z\",\"EdgePathingOp\":\"wl\",\"EdgePathingSrc\":\"macro\",\"EdgePathingStatus\":\"nr\",\"EdgeRateLimitAction\":\"unknown\",\"EdgeRateLimitID\":0,\"EdgeRequestHost\":\"abc.example.com\",\"EdgeResponseBodyBytes\":980397,\"EdgeResponseBytes\":981308,\"EdgeResponseCompressionRatio\":0,\"EdgeResponseContentType\":\"application/json\",\"EdgeResponseStatus\":200,\"EdgeServerIP\":\"1.128.0.0\",\"EdgeStartTimestamp\":\"2022-05-25T13:25:26Z\",\"EdgeTimeToFirstByteMs\":5333,\"OriginDNSResponseTimeMs\":3,\"OriginIP\":\"67.43.156.0\",\"OriginRequestHeaderSendDurationMs\":0,\"OriginResponseBytes\":0,\"OriginResponseDurationMs\":5319,\"OriginResponseHTTPExpires\":\"2022-05-27T13:25:26Z\",\"OriginResponseHTTPLastModified\":\"2022-05-26T13:25:26Z\",\"OriginResponseHeaderReceiveDurationMs\":5155,\"OriginResponseStatus\":200,\"OriginResponseTime\":5232000000,\"OriginSSLProtocol\":\"TLSv1.2\",\"OriginTCPHandshakeDurationMs\":24,\"OriginTLSHandshakeDurationMs\":53,\"ParentRayID\":\"710e98d93d50357d\",\"RayID\":\"710e98d9367f357d\",\"SecurityAction\":\"unknown\",\"SecurityLevel\":\"off\",\"SecurityRuleDescription\":\"matchad variable message\",\"SecurityRuleID\":\"98d93d5\",\"SmartRouteColoID\":20,\"UpperTierColoID\":0,\"WAFAttackScore\":50,\"WAFFlags\":\"0\",\"WAFMatchedVar\":\"example\",\"WAFProfile\":\"unknown\",\"WAFRCEAttackScore\":1,\"WAFSQLiAttackScore\":99,\"WAFXSSAttackScore\":90,\"WorkerCPUTime\":0,\"WorkerStatus\":\"unknown\",\"WorkerSubrequest\":true,\"WorkerSubrequestCount\":0,\"ZoneID\":393347122,\"ZoneName\":\"example.com\"}",
         "type": [
@@ -2706,6 +2706,7 @@ An example event for `http_request` looks as following:
         "cloudflare_logpush-http_request"
     ],
     "tls": {
+        "cipher": "NONE",
         "version": "1.2",
         "version_protocol": "tls"
     },
@@ -2769,7 +2770,7 @@ An example event for `http_request` looks as following:
 | cloudflare_logpush.http_request.client.request.uri | URI requested by the client. | text |
 | cloudflare_logpush.http_request.client.request.user.agent | User agent reported by the client. | text |
 | cloudflare_logpush.http_request.client.src.port | Client source port. | long |
-| cloudflare_logpush.http_request.client.ssl.cipher | Client SSL cipher. | keyword |
+| cloudflare_logpush.http_request.client.ssl.cipher | Client SSL cipher. | text |
 | cloudflare_logpush.http_request.client.ssl.protocol | Client SSL (TLS) protocol. | keyword |
 | cloudflare_logpush.http_request.client.tcp_rtt.ms | The smoothed average of TCP round-trip time (SRTT), For the initial request on a connection, this is measured only during connection setup, For a subsequent request on the same connection, it is measured over the entire connection lifetime up until the time that request is received. | long |
 | cloudflare_logpush.http_request.client.xrequested_with | X-Requested-With HTTP header. | text |

--- a/packages/cloudflare_logpush/manifest.yml
+++ b/packages/cloudflare_logpush/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cloudflare_logpush
 title: Cloudflare Logpush
-version: "1.37.5"
+version: "1.38.0"
 description: Collect and parse logs from Cloudflare API with Elastic Agent.
 type: integration
 categories:

--- a/packages/cloudflare_logpush/manifest.yml
+++ b/packages/cloudflare_logpush/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cloudflare_logpush
 title: Cloudflare Logpush
-version: "1.37.4"
+version: "1.37.5"
 description: Collect and parse logs from Cloudflare API with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
cloudflare_logpush: map cloudflare_logpush.http_request.client.ssl.cipher to tls.cipher

Map cloudflare_logpush.http_request.client.ssl.cipher to the tls.cipher in order
to pick up its search behavior without risking potential breaking behavior.
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)  

## How to test this PR locally

Clone integrations repo.
Install elastic package locally.
Start elastic stack using elastic-package.
Move to integrations/packages/cloudflare_logpush directory.
Run the following command to run tests.
> elastic-package test

## Related issues

- Closes #13596

