### PR TITLE
[Windows] Stop enabling sysmon per default to avoid unhealthy agent status

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.0.1"
+  changes:
+    - description: Stop enabling sysmon per default to avoid unhealthy agent status.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13891
 - version: "3.0.0"
   changes:
     - description: Remove deprecated httpjson input.

--- a/packages/windows/data_stream/sysmon_operational/manifest.yml
+++ b/packages/windows/data_stream/sysmon_operational/manifest.yml
@@ -2,6 +2,7 @@ type: logs
 title: Windows Sysmon/Operational events
 streams:
   - input: winlog
+    enabled: false
     template_path: winlog.yml.hbs
     title: Sysmon Operational
     description: 'Collect Microsoft-Windows-Sysmon/Operational channel logs'

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 3.0.0
+version: 3.0.1
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Currently, Sysmon collection is enabled by default when you add the Windows integration.
Since Version 9 this can cause the Agent to be in an unhealthy state in fleet when the Channel does not exist.
See: https://github.com/elastic/elastic-agent/issues/7448

As sysmon isn't installed on Windows per default, it also shouldn't be enabled in the integration as default to improve user experience when they just add the Windows integration without changing the default values.