### PR TITLE
o365: Set subobjects false to conflict fields

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.15.2"
+  changes:
+    - description: Set subobjects false to `o365.audit.Parameters` and `o365.audit.ModifiedProperties` to avoid mapping conflicts.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "2.15.1"
   changes:
     - description: Ensure that empty results do not lead to subsequent invalid API requests.

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set subobjects false to `o365.audit.Parameters` and `o365.audit.ModifiedProperties` to avoid mapping conflicts.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/13925
 - version: "2.15.1"
   changes:
     - description: Ensure that empty results do not lead to subsequent invalid API requests.

--- a/packages/o365/data_stream/audit/fields/fields.yml
+++ b/packages/o365/data_stream/audit/fields/fields.yml
@@ -381,6 +381,12 @@
       type: object
       object_type: keyword
       object_type_mapping_type: '*'
+      subobjects: false
+    - name: ModifiedProperties
+      type: object
+      object_type: keyword
+      object_type_mapping_type: '*'
+      subobjects: false
     - name: Name
       type: keyword
     - name: NetworkMessageId
@@ -437,6 +443,12 @@
       type: object
       object_type: keyword
       object_type_mapping_type: '*'
+      subobjects: false
+    - name: Parameters
+      type: object
+      object_type: keyword
+      object_type_mapping_type: '*'
+      subobjects: false
     - name: PhishConfidenceLevel
       type: keyword
     - name: Platform

--- a/packages/o365/docs/README.md
+++ b/packages/o365/docs/README.md
@@ -367,6 +367,7 @@ An example event for `audit` looks as following:
 | o365.audit.Members |  | flattened |
 | o365.audit.MessageDate |  | keyword |
 | o365.audit.MessageTime |  | keyword |
+| o365.audit.ModifiedProperties |  | object |
 | o365.audit.ModifiedProperties.\*.\* |  | object |
 | o365.audit.ModifiedProperties.Role_DisplayName.NewValue |  | keyword |
 | o365.audit.Name |  | keyword |
@@ -387,6 +388,7 @@ An example event for `audit` looks as following:
 | o365.audit.P1SenderDomain |  | keyword |
 | o365.audit.P2Sender |  | keyword |
 | o365.audit.P2SenderDomain |  | keyword |
+| o365.audit.Parameters |  | object |
 | o365.audit.Parameters.\* |  | object |
 | o365.audit.Parameters.AccessRights |  | keyword |
 | o365.audit.Parameters.AllowFederatedUsers |  | keyword |

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft Office 365
-version: "2.15.1"
+version: "2.15.2"
 description: Collect logs from Microsoft Office 365 with Elastic Agent.
 type: integration
 format_version: "3.2.3"


### PR DESCRIPTION
## Proposed commit message

Fix a mapping conflict in Elasticsearch when ingesting documents with the `Parameters` or `ModifiedProperties` fields. These fields may sometimes be strings or arrays of strings instead of objects, which conflicts with the existing mapping that defines them as objects. Once a document with an object-type field is ingested, Elasticsearch will reject subsequent documents where the same field is of a different type.

```
(status=400): {\"type\":\"document_parsing_exception\",\"reason\":\"[1:600] object mapping for [o365audit.Parameters] tried to parse field [Parameters] as object, but found a concrete value\"}, dropping event!
```

```
(status=400): {\"type\":\"document_parsing_exception\",\"reason\":\"[1:2] object mapping for [o365audit.ModifiedProperties] tried to parse field [null] as object, but found a concrete value\"}, dropping event!
```

To resolve this, the PR sets `subobjects: false` in the mapping for these fields. This change allows Elasticsearch to handle both object and non-object values for these fields without triggering a mapping conflict.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

