### PR TITLE
[Cribl] Fix handling of metric event type

### DIFF
--- a/packages/cribl/_dev/build/docs/README.md
+++ b/packages/cribl/_dev/build/docs/README.md
@@ -42,6 +42,6 @@ The Cribl integration offers users a way to ingest logs from either of Cribl's E
 
     1. Set **Cloud Id** for the Cloud destination or **Bulk API URLs** for the Elasticsearch destination to point to your Elastic cluster.
 
-    2. Set **Index or Data Stream** to `logs-cribl-default`.
+    2. Set **Index or Data Stream** to `logs-cribl-default` for log-type events and to `metrics-cribl-default` for metric-type events.
 
     3. **API key** should be a Base64 encoded Elastic API key, which you can create in Kibana by following the instructions under **Management** > **Stack Management** > **Security** > **API Keys**. If you are using an API key with “Restrict privileges”, be sure to review the Indices privileges to provide at least "auto_configure" and "write" permissions for the logs-* index, which you will be using for these Fleet integration data streams.

--- a/packages/cribl/_dev/build/docs/README.md
+++ b/packages/cribl/_dev/build/docs/README.md
@@ -42,6 +42,6 @@ The Cribl integration offers users a way to ingest logs from either of Cribl's E
 
     1. Set **Cloud Id** for the Cloud destination or **Bulk API URLs** for the Elasticsearch destination to point to your Elastic cluster.
 
-    2. Set **Index or Data Stream** to `logs-cribl-default` for log-type events and to `metrics-cribl-default` for metric-type events.
+    2. Set **Index or Data Stream** to `logs-cribl-default` for log-type events or to `metrics-cribl-default` for metric-type events.
 
     3. **API key** should be a Base64 encoded Elastic API key, which you can create in Kibana by following the instructions under **Management** > **Stack Management** > **Security** > **API Keys**. If you are using an API key with “Restrict privileges”, be sure to review the Indices privileges to provide at least "auto_configure" and "write" permissions for the logs-* index, which you will be using for these Fleet integration data streams.

--- a/packages/cribl/changelog.yml
+++ b/packages/cribl/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix handling of metric event type.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/13930
 - version: "0.5.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/cribl/changelog.yml
+++ b/packages/cribl/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.1"
+  changes:
+    - description: Fix handling of metric event type.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.5.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/cribl/data_stream/metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cribl/data_stream/metrics/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,27 @@
+---
+description: Pipeline for rerouting metric streams from Cribl.
+processors:
+  - set:
+      field: ecs.version
+      value: 8.11.0
+  - append:
+      field: tags
+      value: cribl
+      allow_duplicates: false
+  - rename:
+      field: _raw
+      target_field: message
+      ignore_missing: true
+  # removing id for metric type of event
+  - remove:
+      field: _id
+      tag: remove_id
+      ignore_missing: true
+  # The Cribl routing pipeline is managed by Kibana
+  # https://github.com/elastic/kibana/pull/176439
+  - pipeline:
+      name: 'cribl-routing-pipeline'
+on_failure:
+  - set:
+      field: error.message
+      value: "{{{ _ingest.on_failure_message }}}"

--- a/packages/cribl/data_stream/metrics/fields/base-fields.yml
+++ b/packages/cribl/data_stream/metrics/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.
+- name: '@timestamp'
+  type: date
+  description: Event timestamp.

--- a/packages/cribl/data_stream/metrics/manifest.yml
+++ b/packages/cribl/data_stream/metrics/manifest.yml
@@ -1,0 +1,8 @@
+title: "Metrics"
+type: metrics
+dataset: cribl
+# This integration includes predefined rules that automatically route AWS service metrics to the respective integrations.
+# Adding these permissions to ensure the agents have permissions to write data to `metrics-*-*`.
+elasticsearch:
+  dynamic_dataset: true
+  dynamic_namespace: true

--- a/packages/cribl/docs/README.md
+++ b/packages/cribl/docs/README.md
@@ -42,6 +42,6 @@ The Cribl integration offers users a way to ingest logs from either of Cribl's E
 
     1. Set **Cloud Id** for the Cloud destination or **Bulk API URLs** for the Elasticsearch destination to point to your Elastic cluster.
 
-    2. Set **Index or Data Stream** to `logs-cribl-default`.
+    2. Set **Index or Data Stream** to `logs-cribl-default` for log-type events and to `metrics-cribl-default` for metric-type events.
 
     3. **API key** should be a Base64 encoded Elastic API key, which you can create in Kibana by following the instructions under **Management** > **Stack Management** > **Security** > **API Keys**. If you are using an API key with “Restrict privileges”, be sure to review the Indices privileges to provide at least "auto_configure" and "write" permissions for the logs-* index, which you will be using for these Fleet integration data streams.

--- a/packages/cribl/docs/README.md
+++ b/packages/cribl/docs/README.md
@@ -42,6 +42,6 @@ The Cribl integration offers users a way to ingest logs from either of Cribl's E
 
     1. Set **Cloud Id** for the Cloud destination or **Bulk API URLs** for the Elasticsearch destination to point to your Elastic cluster.
 
-    2. Set **Index or Data Stream** to `logs-cribl-default` for log-type events and to `metrics-cribl-default` for metric-type events.
+    2. Set **Index or Data Stream** to `logs-cribl-default` for log-type events or to `metrics-cribl-default` for metric-type events.
 
     3. **API key** should be a Base64 encoded Elastic API key, which you can create in Kibana by following the instructions under **Management** > **Stack Management** > **Security** > **API Keys**. If you are using an API key with “Restrict privileges”, be sure to review the Indices privileges to provide at least "auto_configure" and "write" permissions for the logs-* index, which you will be using for these Fleet integration data streams.

--- a/packages/cribl/manifest.yml
+++ b/packages/cribl/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: cribl
 title: "Cribl"
-version: "0.5.0"
+version: "0.5.1"
 description: Stream logs from Cribl into Elastic.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
cribl: reroute to metrics datastreams

Updated the documentation to specify separate index templates for logs and metrics
and added a dedicated metrics pipeline, ensuring correct handling of metric events.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Closes #10700
- Relates #12480
