### PR TITLE
sentinel_one: fix the Activities by OS Family visualization in the Activities dashboard

### DIFF
--- a/packages/sentinel_one/changelog.yml
+++ b/packages/sentinel_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.34.2"
+  changes:
+    - description: Fix the `Activities by OS Family` visualization in the Activities dashboard.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.34.1"
   changes:
     - description: Fix default request trace enabled behavior.

--- a/packages/sentinel_one/kibana/dashboard/sentinel_one-899f2630-bb27-11ec-82b7-8fcb232e9538.json
+++ b/packages/sentinel_one/kibana/dashboard/sentinel_one-899f2630-bb27-11ec-82b7-8fcb232e9538.json
@@ -1,7 +1,18 @@
 {
     "attributes": {
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": {
+                "ignoreFilters": false,
+                "ignoreQuery": false,
+                "ignoreTimerange": false,
+                "ignoreValidations": false
+            },
+            "panelsJSON": {},
+            "showApplySelections": false
+        },
         "description": "",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -36,6 +47,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": true,
             "useMargins": true
         },
         "panelsJSON": [
@@ -57,7 +70,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "3aa4f16e-85bd-466a-b665-445b6d5de2cd": {
                                             "columnOrder": [
@@ -71,7 +84,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -87,12 +100,15 @@
                             "visualization": {
                                 "accessor": "b9e2330d-e198-4126-a3b0-77e64079e984",
                                 "layerId": "3aa4f16e-85bd-466a-b665-445b6d5de2cd",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Total Number of Activities [Logs SentinelOne]",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {}
                 },
@@ -104,8 +120,7 @@
                     "y": 0
                 },
                 "panelIndex": "6b1d0060-0c72-441e-9901-855d5ee70a67",
-                "type": "lens",
-                "version": "7.17.0"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -125,7 +140,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "c1284ad1-7648-410f-b78f-78a997f797cd": {
                                             "columnOrder": [
@@ -159,7 +174,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -184,7 +199,9 @@
                                     }
                                 ],
                                 "layerId": "c1284ad1-7648-410f-b78f-78a997f797cd",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "custom",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Top 10 User ID [Logs SentinelOne]",
@@ -201,8 +218,7 @@
                     "y": 0
                 },
                 "panelIndex": "fe58dc4e-28bd-4efc-9995-4431b0128e73",
-                "type": "lens",
-                "version": "7.17.0"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -222,7 +238,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "c68f6ca1-bcfd-462e-8462-6c41882faa91": {
                                             "columnOrder": [
@@ -256,7 +272,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -273,15 +289,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "20baeaa0-d2a6-4fd1-94b2-e1b9face320d"
-                                        ],
                                         "layerId": "c68f6ca1-bcfd-462e-8462-6c41882faa91",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "ad264914-7ee8-4563-9165-5c2f2d0cbdde",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "ad264914-7ee8-4563-9165-5c2f2d0cbdde"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "20baeaa0-d2a6-4fd1-94b2-e1b9face320d"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -301,8 +320,7 @@
                     "y": 0
                 },
                 "panelIndex": "e9f9f5be-1784-4930-b656-b41e8baf100b",
-                "type": "lens",
-                "version": "7.17.0"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -322,7 +340,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "286fe5cf-c73d-4edf-9e11-04e266706ac0": {
                                             "columnOrder": [
@@ -337,7 +355,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "0c47280a-f6fa-4360-ab66-d64449fb9926": {
                                                     "customLabel": true,
@@ -381,7 +399,9 @@
                                     }
                                 ],
                                 "layerId": "286fe5cf-c73d-4edf-9e11-04e266706ac0",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "custom",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Top 10 Account Name [Logs SentinelOne]",
@@ -398,8 +418,7 @@
                     "y": 12
                 },
                 "panelIndex": "822b1071-df2f-43bd-84a8-da1bcdd97528",
-                "type": "lens",
-                "version": "7.17.0"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -408,18 +427,14 @@
                         "references": [
                             {
                                 "id": "logs-*",
-                                "name": "indexpattern-datasource-current-indexpattern",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-3398cd0c-0707-4e86-8138-7823fd3fe3ad",
                                 "type": "index-pattern"
                             }
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
+                                    "currentIndexPatternId": "logs-*",
                                     "layers": {
                                         "3398cd0c-0707-4e86-8138-7823fd3fe3ad": {
                                             "columnOrder": [
@@ -434,7 +449,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "b87b3729-1100-4fe2-82a0-fcc4b5b65999": {
                                                     "customLabel": true,
@@ -450,13 +465,17 @@
                                                         },
                                                         "orderDirection": "desc",
                                                         "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
                                                         "size": 5
                                                     },
                                                     "scale": "ordinal",
-                                                    "sourceField": "os.family"
+                                                    "sourceField": "observer.os.family"
                                                 }
                                             },
-                                            "incompleteColumns": {}
+                                            "incompleteColumns": {},
+                                            "indexPatternId": "logs-*"
                                         }
                                     }
                                 }
@@ -470,15 +489,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "b87b3729-1100-4fe2-82a0-fcc4b5b65999"
-                                        ],
                                         "layerId": "3398cd0c-0707-4e86-8138-7823fd3fe3ad",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "b06e82de-dde9-4eae-a13d-4c4702f60694",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "b06e82de-dde9-4eae-a13d-4c4702f60694"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "b87b3729-1100-4fe2-82a0-fcc4b5b65999"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -488,7 +510,19 @@
                         "type": "lens",
                         "visualizationType": "lnsPie"
                     },
-                    "enhancements": {}
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [],
+                    "query": {
+                        "language": "kuery",
+                        "query": ""
+                    },
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": true
                 },
                 "gridData": {
                     "h": 15,
@@ -498,8 +532,7 @@
                     "y": 12
                 },
                 "panelIndex": "96472e81-2362-46b7-9a78-ced057e7f22b",
-                "type": "lens",
-                "version": "7.17.0"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -524,7 +557,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "27449a92-7952-4cb5-aec7-c18c8110f077": {
                                             "columnOrder": [
@@ -540,7 +573,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "c7d31b39-34dd-4c74-a4a9-bb34d381ff43": {
                                                     "customLabel": true,
@@ -594,7 +627,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "host.name",
                                         "negate": false,
                                         "type": "exists"
@@ -626,7 +659,9 @@
                                     }
                                 ],
                                 "layerId": "27449a92-7952-4cb5-aec7-c18c8110f077",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "custom",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Top 10 Primary Description by Computer Name [Logs SentinelOne]",
@@ -645,8 +680,7 @@
                 },
                 "panelIndex": "6776b675-6e78-4293-9419-abb2052779a9",
                 "title": "Top 10 Primary Description by Computer Name [Logs SentinelOne]",
-                "type": "lens",
-                "version": "7.17.0"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -666,7 +700,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "5abe3706-203c-48d8-afb0-96e3b47b163e": {
                                             "columnOrder": [
@@ -681,7 +715,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "bfb48360-d985-485c-8a3f-92e348223b55": {
                                                     "customLabel": true,
@@ -725,7 +759,9 @@
                                     }
                                 ],
                                 "layerId": "5abe3706-203c-48d8-afb0-96e3b47b163e",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "custom",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Top 10 Activities Count by Computer Name [Logs SentinelOne]",
@@ -742,24 +778,27 @@
                     "y": 27
                 },
                 "panelIndex": "60e34164-f433-4c23-bfa1-a84269e385dc",
-                "type": "lens",
-                "version": "7.17.0"
+                "type": "lens"
             }
         ],
         "timeRestore": false,
         "title": "[Logs SentinelOne] Activities",
-        "version": 1
+        "version": 3
     },
-    "coreMigrationVersion": "7.17.0",
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2025-05-12T10:12:44.999Z",
     "id": "sentinel_one-899f2630-bb27-11ec-82b7-8fcb232e9538",
-    "migrationVersion": {
-        "dashboard": "7.17.0"
-    },
+    "managed": false,
     "references": [
         {
             "id": "logs-*",
             "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
             "type": "index-pattern"
+        },
+        {
+            "id": "sentinel_one-security-solution-default",
+            "name": "tag-ref-security-solution-default",
+            "type": "tag"
         },
         {
             "id": "logs-*",
@@ -803,11 +842,6 @@
         },
         {
             "id": "logs-*",
-            "name": "96472e81-2362-46b7-9a78-ced057e7f22b:indexpattern-datasource-current-indexpattern",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
             "name": "96472e81-2362-46b7-9a78-ced057e7f22b:indexpattern-datasource-layer-3398cd0c-0707-4e86-8138-7823fd3fe3ad",
             "type": "index-pattern"
         },
@@ -835,7 +869,14 @@
             "id": "logs-*",
             "name": "60e34164-f433-4c23-bfa1-a84269e385dc:indexpattern-datasource-layer-5abe3706-203c-48d8-afb0-96e3b47b163e",
             "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
         }
     ],
-    "type": "dashboard"
+    "type": "dashboard",
+    "typeMigrationVersion": "10.2.0",
+    "updated_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
 }

--- a/packages/sentinel_one/kibana/tag/sentinel_one-security-solution-default.json
+++ b/packages/sentinel_one/kibana/tag/sentinel_one-security-solution-default.json
@@ -1,0 +1,14 @@
+{
+    "attributes": {
+        "color": "#00BFB3",
+        "description": "Tag defined in package-spec",
+        "name": "Security Solution"
+    },
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2025-05-09T10:41:46.010Z",
+    "id": "sentinel_one-security-solution-default",
+    "managed": true,
+    "references": [],
+    "type": "tag",
+    "typeMigrationVersion": "8.0.0"
+}

--- a/packages/sentinel_one/manifest.yml
+++ b/packages/sentinel_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.2.3"
 name: sentinel_one
 title: SentinelOne
-version: "1.34.1"
+version: "1.34.2"
 description: Collect logs from SentinelOne with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->
```
sentinel_one: fix the 'Activities by OS Family' visualization in the 'Activities' dashboard

There have been changes to the ingest pipeline to use 'observer.os.family' 
to hold the data that was formerly in 'os.family'. This change updates the 
'Distribution of Activities by OS Family [Logs SentinelOne]' visualization 
to use the 'observer.os.family' field instead of 'os.family.
```
## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Asset Tests:
```
--- Test results for package: sentinel_one - START ---
╭──────────────┬─────────────┬───────────┬───────────────────────────────────────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE      │ DATA STREAM │ TEST TYPE │ TEST NAME                                                             │ RESULT │ TIME ELAPSED │
├──────────────┼─────────────┼───────────┼───────────────────────────────────────────────────────────────────────┼────────┼──────────────┤
│ sentinel_one │             │ asset     │ dashboard sentinel_one-0dd17490-bbb8-11ec-82b7-8fcb232e9538 is loaded │ PASS   │      1.618µs │
│ sentinel_one │             │ asset     │ dashboard sentinel_one-5881f5f0-bb2c-11ec-82b7-8fcb232e9538 is loaded │ PASS   │        240ns │
│ sentinel_one │             │ asset     │ dashboard sentinel_one-67844880-bbb5-11ec-82b7-8fcb232e9538 is loaded │ PASS   │        214ns │
│ sentinel_one │             │ asset     │ dashboard sentinel_one-899f2630-bb27-11ec-82b7-8fcb232e9538 is loaded │ PASS   │        160ns │
│ sentinel_one │             │ asset     │ dashboard sentinel_one-bcf1f680-bba3-11ec-82b7-8fcb232e9538 is loaded │ PASS   │        238ns │
│ sentinel_one │             │ asset     │ search sentinel_one-89773b00-c1fa-11ec-a23a-27e16fe32bb9 is loaded    │ PASS   │        310ns │
│ sentinel_one │ activity    │ asset     │ index_template logs-sentinel_one.activity is loaded                   │ PASS   │        338ns │
│ sentinel_one │ activity    │ asset     │ ingest_pipeline logs-sentinel_one.activity-1.34.2 is loaded           │ PASS   │        204ns │
│ sentinel_one │ agent       │ asset     │ index_template logs-sentinel_one.agent is loaded                      │ PASS   │        177ns │
│ sentinel_one │ agent       │ asset     │ ingest_pipeline logs-sentinel_one.agent-1.34.2 is loaded              │ PASS   │        151ns │
│ sentinel_one │ alert       │ asset     │ index_template logs-sentinel_one.alert is loaded                      │ PASS   │        215ns │
│ sentinel_one │ alert       │ asset     │ ingest_pipeline logs-sentinel_one.alert-1.34.2 is loaded              │ PASS   │        158ns │
│ sentinel_one │ group       │ asset     │ index_template logs-sentinel_one.group is loaded                      │ PASS   │        176ns │
│ sentinel_one │ group       │ asset     │ ingest_pipeline logs-sentinel_one.group-1.34.2 is loaded              │ PASS   │        138ns │
│ sentinel_one │ threat      │ asset     │ index_template logs-sentinel_one.threat is loaded                     │ PASS   │        170ns │
│ sentinel_one │ threat      │ asset     │ ingest_pipeline logs-sentinel_one.threat-1.34.2 is loaded             │ PASS   │        178ns │
╰──────────────┴─────────────┴───────────┴───────────────────────────────────────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: sentinel_one - END   ---
Done
```
## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #12902 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
**Before the change**:
![before](https://github.com/user-attachments/assets/b77031af-df94-4a50-a35a-53a3fd808147)

**After the change**:
![after](https://github.com/user-attachments/assets/62fca584-df3f-43b5-85db-96eb6f2fdf1a)