### PR TITLE
[Infoblox NIOS] Handle the parsing of IPv6 address

### DIFF
--- a/packages/infoblox_nios/changelog.yml
+++ b/packages/infoblox_nios/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Handle the parsing of octal encoded IPv6 address.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/13947
 - version: "1.29.0"
   changes:
     - description: Support AD authentication failure log messages.

--- a/packages/infoblox_nios/changelog.yml
+++ b/packages/infoblox_nios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.29.1"
+  changes:
+    - description: Handle the parsing of octal encoded IPv6 address.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.29.0"
   changes:
     - description: Support AD authentication failure log messages.

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-audit.log
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-audit.log
@@ -25,3 +25,4 @@
 <11>Feb 26 16:05:03  mygridmaster.mydom.tld 81.2.69.144 httpd: my-dc.mysubdom.mydom.tld: AD authentication for user myadminuser failed
 <46>Aug 24 19:50:09 10.0.0.1 -- MARK --
 <11>Apr 4 06:17:22  myhost.mydom.tld 81.2.69.144 httpd: 2025-04-22 06:17:22.110Z [adminUSER]: Login_Allowed - - to=AdminConnector ip=2a02\072cf40\072\072 auth=AD group=MySecureADGRroup apparently_via=GUI
+<11>Apr 4 06:17:22 myhost.mydom.tld 81.2.69.144 httpd: 2025-04-22 06:17:22.110Z [adminUSER]: Login_Allowed - - to=AdminConnector ip=2a02\143f40\072\072 auth=AD group=MySecureADGRroup apparently_via=GUI

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-audit.log
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-audit.log
@@ -24,3 +24,4 @@
 <29>Mar 18 13:40:05 10.0.0.1 httpd: 2022-03-29 18:30:58.656Z [admin]: Created Ruleset
 <11>Feb 26 16:05:03  mygridmaster.mydom.tld 81.2.69.144 httpd: my-dc.mysubdom.mydom.tld: AD authentication for user myadminuser failed
 <46>Aug 24 19:50:09 10.0.0.1 -- MARK --
+<11>Apr 4 06:17:22  myhost.mydom.tld 81.2.69.144 httpd: 2025-04-22 06:17:22.110Z [adminUSER]: Login_Allowed - - to=AdminConnector ip=2a02\072cf40\072\072 auth=AD group=MySecureADGRroup apparently_via=GUI

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-audit.log-expected.json
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-audit.log-expected.json
@@ -1259,6 +1259,67 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2025-04-22T06:17:22.110Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "login_allowed",
+                "category": [
+                    "authentication"
+                ],
+                "created": "2025-04-04T06:17:22.000Z",
+                "original": "<11>Apr 4 06:17:22  myhost.mydom.tld 81.2.69.144 httpd: 2025-04-22 06:17:22.110Z [adminUSER]: Login_Allowed - - to=AdminConnector ip=2a02\\072cf40\\072\\072 auth=AD group=MySecureADGRroup apparently_via=GUI",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
+            "host": {
+                "domain": "myhost.mydom.tld",
+                "ip": [
+                    "81.2.69.144"
+                ]
+            },
+            "infoblox_nios": {
+                "log": {
+                    "audit": {
+                        "apparently_via": "GUI",
+                        "auth": "AD",
+                        "group": "MySecureADGRroup",
+                        "ip": "2a02:cf40::",
+                        "to": "AdminConnector"
+                    },
+                    "service_name": "httpd",
+                    "type": "AUDIT"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 11
+                }
+            },
+            "message": "2025-04-22 06:17:22.110Z [adminUSER]: Login_Allowed - - to=AdminConnector ip=2a02\\072cf40\\072\\072 auth=AD group=MySecureADGRroup apparently_via=GUI",
+            "related": {
+                "hosts": [
+                    "myhost.mydom.tld"
+                ],
+                "ip": [
+                    "2a02:cf40::",
+                    "81.2.69.144"
+                ],
+                "user": [
+                    "adminUSER"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "adminUSER"
+            }
         }
     ]
 }

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-audit.log-expected.json
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-audit.log-expected.json
@@ -1320,6 +1320,67 @@
             "user": {
                 "name": "adminUSER"
             }
+        },
+        {
+            "@timestamp": "2025-04-22T06:17:22.110Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "login_allowed",
+                "category": [
+                    "authentication"
+                ],
+                "created": "2025-04-04T06:17:22.000Z",
+                "original": "<11>Apr 4 06:17:22 myhost.mydom.tld 81.2.69.144 httpd: 2025-04-22 06:17:22.110Z [adminUSER]: Login_Allowed - - to=AdminConnector ip=2a02\\143f40\\072\\072 auth=AD group=MySecureADGRroup apparently_via=GUI",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
+            "host": {
+                "domain": "myhost.mydom.tld",
+                "ip": [
+                    "81.2.69.144"
+                ]
+            },
+            "infoblox_nios": {
+                "log": {
+                    "audit": {
+                        "apparently_via": "GUI",
+                        "auth": "AD",
+                        "group": "MySecureADGRroup",
+                        "ip": "2a02:cf40::",
+                        "to": "AdminConnector"
+                    },
+                    "service_name": "httpd",
+                    "type": "AUDIT"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 11
+                }
+            },
+            "message": "2025-04-22 06:17:22.110Z [adminUSER]: Login_Allowed - - to=AdminConnector ip=2a02\\143f40\\072\\072 auth=AD group=MySecureADGRroup apparently_via=GUI",
+            "related": {
+                "hosts": [
+                    "myhost.mydom.tld"
+                ],
+                "ip": [
+                    "2a02:cf40::",
+                    "81.2.69.144"
+                ],
+                "user": [
+                    "adminUSER"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "adminUSER"
+            }
         }
     ]
 }

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_audit.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_audit.yml
@@ -116,19 +116,22 @@ processors:
       lang: painless
       if: ctx.infoblox_nios?.log?.audit?.ip != null
       source: >
-        String ip = ctx.infoblox_nios.log.audit.ip;
-        StringBuilder output = new StringBuilder();
-        int i = 0;
-        while (i < ip.length()) {
-          if (ip.charAt(i) == (char)92) {
-            output.append(':');
-            i += 4;
-          } else {
-            output.append(ip.charAt(i));
+        String s = ctx.infoblox_nios.log.audit.ip;
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < s.length();) {
+            if (s.charAt(i) == (char)'\\') {
+                sb.append(':');
+                int b = Integer.parseInt(s.substring(i+1,i+4), 8);
+                if (b != (char)':') {
+                    sb.append((char)b);
+                }
+                i+=4;
+                continue;
+            }
+            sb.append(s.charAt(i));
             i++;
-          }
         }
-        ctx.infoblox_nios.log.audit.ip = output.toString();
+        ctx.infoblox_nios.log.audit.ip = sb.toString();
       on_failure:
         - append:
             field: error.message

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_audit.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_audit.yml
@@ -111,6 +111,32 @@ processors:
           }
           ctx.infoblox_nios.log.audit[m.getKey()] = value;
         }
+  - script:
+      description: Decode octal escape sequences in IP address.
+      lang: painless
+      if: ctx.infoblox_nios?.log?.audit?.ip != null
+      source: >
+        String ip = ctx.infoblox_nios.log.audit.ip;
+        StringBuilder output = new StringBuilder();
+        int i = 0;
+        while (i < ip.length()) {
+          if (ip.charAt(i) == (char)92) {
+            output.append(':');
+            i += 4;
+          } else {
+            output.append(ip.charAt(i));
+            i++;
+          }
+        }
+        ctx.infoblox_nios.log.audit.ip = output.toString();
+      on_failure:
+        - append:
+            field: error.message
+            value: >-
+              Processor '{{{ _ingest.on_failure_processor_type }}}'
+              {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+              {{{/_ingest.on_failure_processor_tag}}}in pipeline {{{_ingest.pipeline}}}
+              failed with message '{{{ _ingest.on_failure_message }}}'
   - convert:
       field: infoblox_nios.log.audit.ip
       if: ctx.infoblox_nios?.log?.audit?.ip != null && ctx.infoblox_nios.log.audit.ip != ''

--- a/packages/infoblox_nios/manifest.yml
+++ b/packages/infoblox_nios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: infoblox_nios
 title: Infoblox NIOS
-version: "1.29.0"
+version: "1.29.1"
 description: Collect logs from Infoblox NIOS with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
infoblox_nios: handle the parsing of ipv6 address

The convert processor failed to parse IPv6 addresses with octal
encoding. So a script processor has been added to parse the
octal-encoded IPv6 address before applying the convert processor.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/infoblox_nios directory.
- Run the following command to run tests.
> elastic-package test

## Related issues

- Closes #13782
