### PR TITLE
apm: Add config for tail-based sampling discard on write

### DIFF
--- a/packages/apm/agent/input/template.yml.hbs
+++ b/packages/apm/agent/input/template.yml.hbs
@@ -73,3 +73,4 @@ apm-server:
         ttl: {{tail_sampling_ttl}}
         policies: {{tail_sampling_policies}}
         storage_limit: {{tail_sampling_storage_limit}}
+        discard_on_write_failure: {{tail_sampling_discard_on_write_failure}}

--- a/packages/apm/changelog.yml
+++ b/packages/apm/changelog.yml
@@ -1,3 +1,8 @@
+- version: 9.1.0-preview-1747764883
+  changes:
+    - description: Add integration policy variable `tail_sampling_discard_on_write_failure` to configure `apm-server.sampling.tail.discard_on_write_failure`
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/13950
 - version: 9.1.0-preview-1744129488
   changes:
     - description: Add integration policy variable `tail_sampling_ttl` to configure `apm-server.sampling.tail.ttl`

--- a/packages/apm/manifest.yml
+++ b/packages/apm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.0
 name: apm
 title: Elastic APM
-version: 9.1.0-preview-1744129488
+version: 9.1.0-preview-1747764883
 description: Monitor, detect, and diagnose complex application performance issues.
 type: integration
 categories: ["elastic_stack", "monitoring"]
@@ -175,6 +175,9 @@ policy_templates:
           - name: tail_sampling_storage_limit
             type: text
             default: "0GB"
+          - name: tail_sampling_discard_on_write_failure
+            type: bool
+            default: false
         template_path: template.yml.hbs
 owner:
   type: elastic


### PR DESCRIPTION
## Proposed commit message
apm: Add policy variable `tail_discard_on_write_failure` to configure `apm-server.sampling.tail.discard_on_write_failure`.


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
   - Version constraints will be updated to much the below PR for the apm til config
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist
- [x] Merge changes from apm ttl PR https://github.com/elastic/integrations/pull/13348 and match version and constraints

## How to test this PR locally

1. Validated the  config using `elastic-packge` to install the packaged.  Used the Kibana UI to add the APM Integration. Verified the agent policy contained the correct config
2. Installed elastic agent locally. Validated the computed-config.yaml and validated the apm-server behavior when `discard_on_write_failure` was enabled and disabled 

## Related issues

- Part of https://github.com/elastic/apm-server/issues/15330
- Related to https://github.com/elastic/apm-server/issues/13525

## Screenshots
### Agent Policy
<img width="1357" alt="Screenshot 2025-05-20 at 11 45 41 AM" src="https://github.com/user-attachments/assets/5c10f604-25fb-4428-aef3-94dc019c645c" />

## Elastic Agent Logs
### discard on write enabled
- computed-config.yaml:
```yaml
 sampling:
            tail:
                discard_on_write_failure: true
                enabled: true
                interval: 1m
                policies:
                    - sample_rate: 0.1
                storage_limit: 1B
                ttl: 30m
```
- Traces should be discarded. Verified log shows `discarding by default`:
```json
{
  "log.level": "info",
  "@timestamp": "2025-05-19T19:29:34.603Z",
  "message": "processing trace failed, discarding by default",
  "component": {
    "binary": "apm-server",
    "dataset": "elastic_agent.apm_server",
    "id": "apm-default",
    "type": "apm"
  },
  "log": {
    "source": "apm-default"
  },
  "log.logger": "sampling",
  "log.origin": {
    "file.line": 151,
    "file.name": "sampling/processor.go",
    "function": "github.com/elastic/apm-server/x-pack/apm-server/sampling.(*Processor).ProcessBatch"
  },
  "service.name": "apm-server",
  "ecs.version": "1.6.0"
}
```

### discard on write disabled
- computed-config.yaml:
```yaml
 sampling:
            tail:
                discard_on_write_failure: false
                enabled: true
                interval: 1m
                policies:
                    - sample_rate: 0.1
                storage_limit: 1B
                ttl: 30m
```
- Traces should be sampled. Verified log shows `indexing by default`
```json
{
  "log.level": "info",
  "@timestamp": "2025-05-19T19:54:16.723Z",
  "message": "processing trace failed, indexing by default",
  "component": {
    "binary": "apm-server",
    "dataset": "elastic_agent.apm_server",
    "id": "apm-default",
    "type": "apm"
  },
  "log": {
    "source": "apm-default"
  },
  "log.logger": "sampling",
  "log.origin": {
    "file.line": 154,
    "file.name": "sampling/processor.go",
    "function": "github.com/elastic/apm-server/x-pack/apm-server/sampling.(*Processor).ProcessBatch"
  },
  "service.name": "apm-server",
  "ecs.version": "1.6.0"
}
```
