### PR TITLE
[forgerock] Map `forgerock.response.elapsedTime` as a long not a date

### DIFF
--- a/packages/forgerock/changelog.yml
+++ b/packages/forgerock/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.21.1"
   changes:
-    - description: Map the duration elaspsedTime as a long not a date.
+    - description: Map the duration `forgerock.response.elapsedTime` as a long not a date.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/13959
 - version: "1.21.0"

--- a/packages/forgerock/changelog.yml
+++ b/packages/forgerock/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.21.1"
+  changes:
+    - description: Map the duration elaspsedTime as a long not a date.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13959
 - version: "1.21.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/forgerock/data_stream/am_access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/forgerock/data_stream/am_access/elasticsearch/ingest_pipeline/default.yml
@@ -95,9 +95,12 @@ processors:
       ignore_failure: true
   - convert:
       field: forgerock.response.elapsedTime
-      target_field: event.duration
       type: long
       ignore_failure: true
+  - set:
+      field: event.duration
+      copy_from: forgerock.response.elapsedTime
+      ignore_empty_value: true
   - script:
       lang: painless
       if: ctx.event?.duration != null && ctx.forgerock?.response?.elapsedTimeUnits == 'MILLISECONDS'

--- a/packages/forgerock/data_stream/am_access/fields/forgerock-fields.yml
+++ b/packages/forgerock/data_stream/am_access/fields/forgerock-fields.yml
@@ -66,7 +66,7 @@
   type: keyword
   description: The responses's username.
 - name: forgerock.response.elapsedTime
-  type: date
+  type: long
   description: Time to execute event.
 - name: forgerock.response.elapsedTimeUnits
   type: keyword

--- a/packages/forgerock/data_stream/idm_access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/forgerock/data_stream/idm_access/elasticsearch/ingest_pipeline/default.yml
@@ -87,9 +87,12 @@ processors:
       ignore_failure: true
   - convert:
       field: forgerock.response.elapsedTime
-      target_field: event.duration
       type: long
       ignore_failure: true
+  - set:
+      field: event.duration
+      copy_from: forgerock.response.elapsedTime
+      ignore_empty_value: true
   - script:
       lang: painless
       if: ctx.event?.duration != null && ctx.forgerock?.response?.elapsedTimeUnits == 'MILLISECONDS'

--- a/packages/forgerock/data_stream/idm_access/fields/forgerock-fields.yml
+++ b/packages/forgerock/data_stream/idm_access/fields/forgerock-fields.yml
@@ -20,7 +20,7 @@
   type: keyword
   description: The protocol associated with the request; REST or PLL.
 - name: forgerock.response.elapsedTime
-  type: date
+  type: long
   description: Time to execute event.
 - name: forgerock.response.elapsedTimeUnits
   type: keyword

--- a/packages/forgerock/docs/README.md
+++ b/packages/forgerock/docs/README.md
@@ -120,7 +120,7 @@ An example event for `am_access` looks as following:
 | forgerock.response.detail.scope | The responses's scope. | keyword |
 | forgerock.response.detail.token_type | The responses's token type. | keyword |
 | forgerock.response.detail.username | The responses's username. | keyword |
-| forgerock.response.elapsedTime | Time to execute event. | date |
+| forgerock.response.elapsedTime | Time to execute event. | long |
 | forgerock.response.elapsedTimeUnits | Units for response time. | keyword |
 | forgerock.response.status | Status indicator, usually SUCCESS/SUCCESSFUL or FAIL/FAILED. | keyword |
 | forgerock.roles | IDM roles associated with the request. | keyword |
@@ -618,7 +618,7 @@ An example event for `idm_access` looks as following:
 | forgerock.level | The log level. | keyword |
 | forgerock.request.operation | The request operation. | keyword |
 | forgerock.request.protocol | The protocol associated with the request; REST or PLL. | keyword |
-| forgerock.response.elapsedTime | Time to execute event. | date |
+| forgerock.response.elapsedTime | Time to execute event. | long |
 | forgerock.response.elapsedTimeUnits | Units for response time. | keyword |
 | forgerock.response.status | Status indicator, usually SUCCESS/SUCCESSFUL or FAIL/FAILED. | keyword |
 | forgerock.roles | IDM roles associated with the request. | keyword |

--- a/packages/forgerock/manifest.yml
+++ b/packages/forgerock/manifest.yml
@@ -1,6 +1,6 @@
 name: forgerock
 title: "ForgeRock"
-version: "1.21.0"
+version: "1.21.1"
 description: Collect audit logs from ForgeRock with Elastic Agent.
 type: integration
 format_version: "3.0.2"


### PR DESCRIPTION
## Proposed commit message

```
[forgerock] Map `forgerock.response.elapsedTime` as a long not a date (#)

The field represents a duration, not a point in time.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 