### PR TITLE
[ti_custom] Add user-configurable HTTP Client Timeout parameter

### DIFF
--- a/packages/ti_custom/changelog.yml
+++ b/packages/ti_custom/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add user-configurable HTTP Client Timeout parameter.
       type: enhancement
-      link: http://github.com/elastic/integrations/pull/1
+      link: http://github.com/elastic/integrations/pull/13960
 - version: "0.9.0"
   changes:
     - description: Make Accept and Content-Type headers configurable for the TAXII client.

--- a/packages/ti_custom/changelog.yml
+++ b/packages/ti_custom/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.10.0"
+  changes:
+    - description: Add user-configurable HTTP Client Timeout parameter.
+      type: enhancement
+      link: http://github.com/elastic/integrations/pull/1
 - version: "0.9.0"
   changes:
     - description: Make Accept and Content-Type headers configurable for the TAXII client.

--- a/packages/ti_custom/data_stream/indicator/agent/stream/cel.yml.hbs
+++ b/packages/ti_custom/data_stream/indicator/agent/stream/cel.yml.hbs
@@ -1,6 +1,8 @@
 config_version: 2
 interval: {{interval}}
-resource.timeout: 60s
+{{#if http_client_timeout}}
+resource.timeout: {{http_client_timeout}}
+{{/if}}
 resource.url: {{url}}
 {{#if ssl}}
 resource.ssl: {{ssl}}

--- a/packages/ti_custom/data_stream/indicator/manifest.yml
+++ b/packages/ti_custom/data_stream/indicator/manifest.yml
@@ -212,6 +212,14 @@ streams:
         required: false
         show_user: false
         description: Link reference to the source of the data. Used as metadata to enrich events.
+      - name: http_client_timeout
+        type: text
+        title: HTTP Client Timeout
+        description: Duration before declaring that the HTTP client connection has timed out. Supported time units are ns, us, ms, s, m, h.
+        multi: false
+        required: false
+        show_user: false
+        default: 60s
       - name: enable_request_tracer
         type: bool
         title: Enable request tracing

--- a/packages/ti_custom/manifest.yml
+++ b/packages/ti_custom/manifest.yml
@@ -3,7 +3,7 @@ name: ti_custom
 title: Custom Threat Intelligence
 description: Ingest threat intelligence data in STIX 2.1 format with Elastic Agent
 type: integration
-version: 0.9.0
+version: 0.10.0
 categories:
   - custom
   - security


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
ti_custom: add user-configurable HTTP Client Timeout parameter

This will give users the option to increase the resource.timeout parameter for CEL.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/ti_custom directory.
- Run the following command to run tests.
> elastic-package test

