### PR TITLE
[crowdstrike] Correct network.direction mapping

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.69.1"
   changes:
-    - description: orrect network.direction mapping.
+    - description: Correct network.direction mapping.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/13961
 - version: "1.69.0"

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.69.1"
+  changes:
+    - description: orrect network.direction mapping.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13961
 - version: "1.69.0"
   changes:
     - description: Improve user ECS field mappings for FDR.

--- a/packages/crowdstrike/data_stream/falcon/elasticsearch/ingest_pipeline/firewall_match.yml
+++ b/packages/crowdstrike/data_stream/falcon/elasticsearch/ingest_pipeline/firewall_match.yml
@@ -102,11 +102,32 @@ processors:
       target_field: event.code
       ignore_missing: true
       tag: rename_event_type
-  - set:
-      field: network.direction
-      value: ingress
-      tag: set_ingress_direction
-      if: ctx.crowdstrike?.event?.ConnectionDirection == "1"
+  - script:
+        tag: script-set-network-direction
+        description: Set network.direction
+        lang: painless
+        if : ctx.crowdstrike?.event?.ConnectionDirection != null
+        source: |
+          def result = [];
+          if (ctx.crowdstrike.event.ConnectionDirection == "0") {
+            result.add('egress');
+          } else if (ctx.crowdstrike.event.ConnectionDirection == "1") {
+            result.add('ingress');
+          } else if (ctx.crowdstrike.event.ConnectionDirection == "3") {
+            result.add('egress');
+            result.add('ingress');
+          } else if (ctx.crowdstrike.event.ConnectionDirection == "4") {
+            result.add('unknown');
+          }
+          if (result.size() > 0) {
+            ctx.network = ctx.network ?: [:];
+            ctx.network.direction = ctx.network.direction ?: [:];
+          }
+          if (result.size() == 1) {
+            ctx.network.direction = result[0];
+          } else if (result.size() > 1) {
+            ctx.network.direction = result;
+          }
   - rename:
       field: crowdstrike.event.RemoteAddress
       target_field: source.ip
@@ -133,11 +154,6 @@ processors:
       ignore_missing: true
       tag: convert_remote_port
       if: ctx.crowdstrike?.event?.RemotePort != null && ctx.network?.direction == "ingress"
-  - set:
-      field: network.direction
-      value: egress
-      tag: set_egress_direction
-      if: ctx.crowdstrike?.event?.ConnectionDirection == "2"
   - rename:
       field: crowdstrike.event.RemoteAddress
       target_field: destination.ip

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "1.69.0"
+version: "1.69.1"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: "3.3.1"


### PR DESCRIPTION
## Proposed commit message

```
[crowdstrike] Correct network.direction mapping

In the falcon data stream, correct the mapping of `ConnectionDirection`
to `network.direction` to match the documentation.

Previously, the `ConnectionDirection` field was being incorrectly mapped
according to the values used for `TrafficDirection`.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Screenshots

Here's the meaning of the field values for `ConnectionDirection`, and `TrafficDirection`, from the documentation:

![image](https://github.com/user-attachments/assets/a43fd899-816f-4af4-9b46-6d994454cb8e)