### PR TITLE
[Cloud Security] Cloud Asset Inventory:  fixed cloud formation URL

### DIFF
--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -5,7 +5,7 @@
   changes:
     - description: Fix cloud formation template URL
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/13866
+      link: https://github.com/elastic/integrations/pull/13971
 - version: "0.13.0"
   changes:
     - description: Remove GCP project and organization ID from validation

--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -1,6 +1,11 @@
 # newer versions go on top
 # version map:
 # 0.1.x - 8.15.x
+- version: "0.14.0"
+  changes:
+    - description: Fix cloud formation template URL
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13866
 - version: "0.13.0"
   changes:
     - description: Remove GCP project and organization ID from validation

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_asset_inventory
 title: "Cloud Asset Discovery"
-version: "0.13.0"
+version: "0.14.0"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Discovery"
@@ -66,7 +66,7 @@ policy_templates:
             show_user: false
             description: Template URL to Cloud Formation Cloud Credentials Stack
             # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
-            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-asset-inventory-direct-access-key-ACCOUNT_TYPE-8.17.0.yml
+            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-asset-inventory-ACCOUNT_TYPE-8.17.0.yml
       - type: cloudbeat/asset_inventory_azure
         title: Azure Asset Discovery
         description: Azure Asset Discovery


### PR DESCRIPTION

## Proposed commit message

Cloud Asset Inventory:  fixed cloud formation URL

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

