### PR TITLE
[CI] Update configuration updatecli for 8.x snapshot

### DIFF
--- a/.github/workflows/updatecli/updatecli.d/bump-latest-8x-snapshot-version.yml
+++ b/.github/workflows/updatecli/updatecli.d/bump-latest-8x-snapshot-version.yml
@@ -29,13 +29,13 @@ sources:
     name: Get latest snapshot
     kind: json
     spec:
-      file: https://storage.googleapis.com/artifacts-api/snapshots/8.x.json
+      file: https://storage.googleapis.com/artifacts-api/snapshots/8.19.json
       key: .version
   latestSnapshotMajorMinor:
     name: Get latest snapshort major and minor
     kind: json
     spec:
-      file: https://storage.googleapis.com/artifacts-api/snapshots/8.x.json
+      file: https://storage.googleapis.com/artifacts-api/snapshots/8.19.json
       key: .version
     transformers:
       - findsubmatch:


### PR DESCRIPTION
This PR updates the URL used to check about 8.x snapshots.
The previous URL was not updated since a few weeks ago.

Updating this URL keeps in the same result, as it is reporting patches versions for the  same 8.19.x version minor.