### PR TITLE
[CI] Add new entries to skip triggering Buildkite builds

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -13,7 +13,7 @@
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$|^/test benchmark fullreport$",
       "skip_ci_labels": [],
       "skip_target_branches": [],
-      "skip_ci_on_only_changed": ["^.github/workflows/", "^.github/dependabot.yml", "^.github/ISSUE_TEMPLATE/", "^docs/"],
+      "skip_ci_on_only_changed": ["^.github/workflows/", "^.github/dependabot.yml$", "^.github/ISSUE_TEMPLATE/", "^docs/", "^catalog-info.yaml$", "^.buildkite/pull-requests.json$"],
       "always_require_ci_on_changed": []
     },
     {


### PR DESCRIPTION
## Proposed commit message

Allow also to skip triggering Buildkite builds if Pull Requests just update:
- `.buildkite/pull-requests.json`
- `catalog-info.yaml`