### PR TITLE
[jamf_pro] Fix `flattened` field types for non-object values

### DIFF
--- a/packages/jamf_pro/data_stream/events/fields/fields.yml
+++ b/packages/jamf_pro/data_stream/events/fields/fields.yml
@@ -60,7 +60,7 @@
               type: group
               fields:
                 - name: action
-                  type: flattened
+                  type: keyword
             - name: patch_policy_id
               type: integer
             - name: patch_policy_name
@@ -120,7 +120,7 @@
             - name: name
               type: keyword
             - name: report_urls
-              type: flattened
+              type: keyword
             - name: bluetooth_mac_address
               type: keyword
             - name: icci_id
@@ -148,9 +148,9 @@
             - name: rest_api_operation_type
               type: keyword
             - name: group_added_user_ids
-              type: flattened
+              type: keyword
             - name: group_removed_user_ids
-              type: flattened
+              type: keyword
             - name: jssid
               type: integer
             - name: smart_group
@@ -220,7 +220,7 @@
             - name: payload_identifier
               type: keyword
             - name: payload_types
-              type: flattened
+              type: keyword
             - name: trigger
               type: keyword
             - name: host_address
@@ -238,11 +238,11 @@
             - name: group_added_devices
               type: flattened
             - name: group_added_devices_ids
-              type: flattened
+              type: keyword
             - name: group_removed_devices
               type: flattened
             - name: group_removed_devices_ids
-              type: flattened
+              type: keyword
             - name: asset_tag
               type: keyword
             - name: description

--- a/packages/jamf_pro/data_stream/inventory/fields/fields-disk-encryption.yml
+++ b/packages/jamf_pro/data_stream/inventory/fields/fields-disk-encryption.yml
@@ -25,4 +25,4 @@
             - name: file_vault2eligibility_message
               type: text
             - name: file_vault2enabled_user_names
-              type: flattened
+              type: keyword

--- a/packages/jamf_pro/data_stream/inventory/fields/fields.yml
+++ b/packages/jamf_pro/data_stream/inventory/fields/fields.yml
@@ -85,11 +85,11 @@
           type: group
           fields:
             - name: cached
-              type: flattened
+              type: keyword
             - name: installed_by_installer_swu
-              type: flattened
+              type: keyword
             - name: installed_by_jamf_pro
-              type: flattened
+              type: keyword
         - name: attachments
           type: nested
         - name: certificates


### PR DESCRIPTION
## Proposed commit message

```
[jamf_pro] Fix `flattened` field types for non-object values

Some fields have arrays of integers or strings as values and we were
attempting to index them as `flattened`. Although such values can be
valid JSON values or JSON documents, `flattened` fields can only index
objects.

The Jamf documentation of field values is:
- https://developer.jamf.com/jamf-pro/reference/get_v1-computers-inventory
- https://developer.jamf.com/developer-guide/docs/webhooks
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
