### PR TITLE
[CI] Add dev/coverage into backport script

### DIFF
--- a/.buildkite/scripts/backport_branch.sh
+++ b/.buildkite/scripts/backport_branch.sh
@@ -137,8 +137,11 @@ updateBackportBranchContents() {
   if git ls-tree -d --name-only main:${MAGEFILE_SCRIPTS_FOLDER} > /dev/null 2>&1 ; then
     echo "Copying $MAGEFILE_SCRIPTS_FOLDER from $SOURCE_BRANCH..."
     git checkout "$SOURCE_BRANCH" -- "${MAGEFILE_SCRIPTS_FOLDER}"
+    echo "Copying $TESTSREPORTER_SCRIPTS_FOLDER from $SOURCE_BRANCH..."
     git checkout "$SOURCE_BRANCH" -- "${TESTSREPORTER_SCRIPTS_FOLDER}"
+    echo "Copying $COVERAGE_SCRIPTS_FOLDER from $SOURCE_BRANCH..."
     git checkout "$SOURCE_BRANCH" -- "${COVERAGE_SCRIPTS_FOLDER}"
+    echo "Copying magefile.go from $SOURCE_BRANCH..."
     git checkout "$SOURCE_BRANCH" -- "magefile.go"
     # Run go mod tidy to update just the dependencies related to magefile and dev scripts
     go mod tidy

--- a/.buildkite/scripts/backport_branch.sh
+++ b/.buildkite/scripts/backport_branch.sh
@@ -175,7 +175,8 @@ updateBackportBranchContents() {
 
   if [ "$DRY_RUN" == "true" ];then
     echo "DRY_RUN mode, nothing will be pushed."
-    git --no-pager diff $SOURCE_BRANCH...$BACKPORT_BRANCH_NAME
+    # Show just the relevant files diff (go.mod, go.sum, .buildkite, .ci, dev and package to be backported)
+    git --no-pager diff $SOURCE_BRANCH...$BACKPORT_BRANCH_NAME go.mod go.sum .buildkite/ .ci/ dev/ "packages/${PACKAGE_NAME}"
   else
     echo "Pushing..."
     git push origin $BACKPORT_BRANCH_NAME

--- a/.buildkite/scripts/backport_branch.sh
+++ b/.buildkite/scripts/backport_branch.sh
@@ -133,10 +133,12 @@ updateBackportBranchContents() {
   # Update scripts used by mage
   local MAGEFILE_SCRIPTS_FOLDER="dev/citools"
   local TESTSREPORTER_SCRIPTS_FOLDER="dev/testsreporter"
+  local COVERAGE_SCRIPTS_FOLDER="dev/coverage"
   if git ls-tree -d --name-only main:${MAGEFILE_SCRIPTS_FOLDER} > /dev/null 2>&1 ; then
     echo "Copying $MAGEFILE_SCRIPTS_FOLDER from $SOURCE_BRANCH..."
     git checkout "$SOURCE_BRANCH" -- "${MAGEFILE_SCRIPTS_FOLDER}"
     git checkout "$SOURCE_BRANCH" -- "${TESTSREPORTER_SCRIPTS_FOLDER}"
+    git checkout "$SOURCE_BRANCH" -- "${COVERAGE_SCRIPTS_FOLDER}"
     git checkout "$SOURCE_BRANCH" -- "magefile.go"
     # Run go mod tidy to update just the dependencies related to magefile and dev scripts
     go mod tidy

--- a/.buildkite/scripts/backport_branch.sh
+++ b/.buildkite/scripts/backport_branch.sh
@@ -175,8 +175,8 @@ updateBackportBranchContents() {
 
   if [ "$DRY_RUN" == "true" ];then
     echo "DRY_RUN mode, nothing will be pushed."
-    # Show just the relevant files diff (go.mod, go.sum, .buildkite, .ci, dev and package to be backported)
-    git --no-pager diff $SOURCE_BRANCH...$BACKPORT_BRANCH_NAME go.mod go.sum .buildkite/ .ci/ dev/ "packages/${PACKAGE_NAME}"
+    # Show just the relevant files diff (go.mod, go.sum, .buildkite, dev and package to be backported)
+    git --no-pager diff $SOURCE_BRANCH...$BACKPORT_BRANCH_NAME go.mod go.sum .buildkite/ dev/ "packages/${PACKAGE_NAME}"
   else
     echo "Pushing..."
     git push origin $BACKPORT_BRANCH_NAME


### PR DESCRIPTION
## Proposed commit message

Add `dev/coverage` folder as another folder to sync in backport script.

Example of buildkite build failing:
https://buildkite.com/elastic/integrations-backport/builds/169#0196fd79-9677-43df-8892-0b7859d80f13

Tested in this buildkite build: https://buildkite.com/elastic/integrations-backport/builds/174