### PR TITLE
[Cloud Security Posture] Add cloud connector support for Asset Discovery Integration

### DIFF
--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -1,6 +1,11 @@
 # newer versions go on top
 # version map:
 # 0.1.x - 8.15.x
+- version: "0.14.0"
+  changes:
+    - description: Add cloud connector support Asset Inventory for AWS
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/13866
 - version: "0.13.0"
   changes:
     - description: Remove GCP project and organization ID from validation

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/agent/stream/aws.yml.hbs
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/agent/stream/aws.yml.hbs
@@ -24,4 +24,7 @@ config:
         {{#if aws.role_arn}}
         role_arn: {{aws.role_arn}}
         {{/if}}
+        {{#if aws.credentials.external_id}}
+        external_id: {{aws.credentials.external_id}}
+        {{/if}}
         type: {{aws.credentials.type}}

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/manifest.yml
@@ -49,6 +49,12 @@ streams:
           value: cloud_formation
         - name: aws.account_type
           value: single-account
+      cloud_connectors:
+        - name: aws.credentials.type
+          value: cloud_connectors
+        - name: aws.account_type
+        - name: aws.role_arn
+        - name: aws.credentials.external_id
     vars:
       - name: aws.account_type
         title: Account type
@@ -79,6 +85,8 @@ streams:
             value: temporary_keys
           - text: Shared Credentials (Manual)
             value: shared_credentials
+          - text: Cloud Connectors
+            value: cloud_connectors
       - name: aws.access_key_id
         type: text
         title: Access Key ID
@@ -124,6 +132,20 @@ streams:
         required: false
         show_user: false
         description: Required when using Assume Role
+      - name: aws.supports_cloud_connectors
+        type: bool
+        title: Supports Cloud Connectors
+        multi: false
+        required: false
+        show_user: false
+        secret: false
+      - name: aws.credentials.external_id
+        type: password
+        title: External ID
+        multi: false
+        required: false
+        show_user: false
+        secret: true
   - input: cloudbeat/asset_inventory_azure
     title: Azure Asset Discovery
     description: Asset Discovery Discovery for Azure

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_asset_inventory
 title: "Cloud Asset Discovery"
-version: "0.13.0"
+version: "0.14.0"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Discovery"
@@ -67,6 +67,16 @@ policy_templates:
             description: Template URL to Cloud Formation Cloud Credentials Stack
             # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
             default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-asset-inventory-direct-access-key-ACCOUNT_TYPE-8.17.0.yml
+          - name: cloud_formation_cloud_connectors_template
+            type: text
+            title: CloudFormation Cloud Connectors Template
+            multi: false
+            required: true
+            show_user: false
+            description: Template URL to Cloud Formation Cloud Connectors Stack
+            # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
+            # RESOURCE_ID is the project id for serverless / kibana component id for ess
+            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-cloud-connectors-ACCOUNT_TYPE-8.19.0.yml&param_ElasticResourceId=RESOURCE_ID
       - type: cloudbeat/asset_inventory_azure
         title: Azure Asset Discovery
         description: Azure Asset Discovery


### PR DESCRIPTION


## Proposed commit message

Add configuration Cloud Connector configuration fields and settings such as
External ID field -  secret field used to assume role in Cloudbeat
Cloud Formation Template Url - link will create a cloud formatiion stack that generates Role ARN and External Id. 
The Role ARN field and External Id fields will be use to assume the role and establish trust between Elastic and AWS. In this PR, we are adding cloud connector support for Asset Discovery Integration  and enable  Agentless agent to use the trusted Cloud Connector authorization flow.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 




## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.
- Relates #12626


## Screenshots
