### PR TITLE
[Box Events] Update and expand ECS `user.*` field mappings

### DIFF
--- a/packages/box_events/changelog.yml
+++ b/packages/box_events/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.14.0"
+  changes:
+    - description: Update and expand ECS `user.*` field mappings.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.13.0"
   changes:
     - description: Handle collaboration invite events and improve user field handling.

--- a/packages/box_events/changelog.yml
+++ b/packages/box_events/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update and expand ECS `user.*` field mappings.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/14001
 - version: "2.13.0"
   changes:
     - description: Handle collaboration invite events and improve user field handling.

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-anomalous-download.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-anomalous-download.log-expected.json
@@ -146,8 +146,7 @@
                     "id": "567",
                     "name": "Some user"
                 },
-                "full_name": "Unknown User",
-                "id": "2"
+                "full_name": "Unknown User"
             }
         },
         {
@@ -285,8 +284,7 @@
                     "id": "567",
                     "name": "Some user"
                 },
-                "full_name": "Unknown User",
-                "id": "2"
+                "full_name": "Unknown User"
             }
         }
     ]

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-anomalous-download.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-anomalous-download.log-expected.json
@@ -146,7 +146,8 @@
                     "id": "567",
                     "name": "Some user"
                 },
-                "name": "Unknown User"
+                "full_name": "Unknown User",
+                "id": "2"
             }
         },
         {
@@ -284,7 +285,8 @@
                     "id": "567",
                     "name": "Some user"
                 },
-                "name": "Unknown User"
+                "full_name": "Unknown User",
+                "id": "2"
             }
         }
     ]

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-copy.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-copy.log-expected.json
@@ -92,7 +92,7 @@
                 "domain": "elastic.co",
                 "email": "info@elastic.co",
                 "full_name": "Elastic Integrations",
-                "id": "19530772260",
+                "id": "info@elastic.co",
                 "name": "info"
             }
         }

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-copy.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-copy.log-expected.json
@@ -90,8 +90,10 @@
             ],
             "user": {
                 "domain": "elastic.co",
-                "id": "info@elastic.co",
-                "name": "Elastic Integrations"
+                "email": "info@elastic.co",
+                "full_name": "Elastic Integrations",
+                "id": "19530772260",
+                "name": "info"
             }
         }
     ]

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-create.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-create.log-expected.json
@@ -102,8 +102,10 @@
             ],
             "user": {
                 "domain": "elastic.co",
-                "id": "info@elastic.co",
-                "name": "Elastic Integrations"
+                "email": "info@elastic.co",
+                "full_name": "Elastic Integrations",
+                "id": "19530772260",
+                "name": "info"
             }
         }
     ]

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-create.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-create.log-expected.json
@@ -104,7 +104,7 @@
                 "domain": "elastic.co",
                 "email": "info@elastic.co",
                 "full_name": "Elastic Integrations",
-                "id": "19530772260",
+                "id": "info@elastic.co",
                 "name": "info"
             }
         }

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-download.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-download.log-expected.json
@@ -113,8 +113,10 @@
             ],
             "user": {
                 "domain": "elastic.co",
-                "id": "info@elastic.co",
-                "name": "Elastic Integrations"
+                "email": "info@elastic.co",
+                "full_name": "Elastic Integrations",
+                "id": "19530772260",
+                "name": "info"
             }
         }
     ]

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-download.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-download.log-expected.json
@@ -115,7 +115,7 @@
                 "domain": "elastic.co",
                 "email": "info@elastic.co",
                 "full_name": "Elastic Integrations",
-                "id": "19530772260",
+                "id": "info@elastic.co",
                 "name": "info"
             }
         }

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-invite.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-invite.log-expected.json
@@ -4,7 +4,6 @@
             "box": {
                 "accessible_by": {
                     "id": "26570306658",
-                    "login": "target@example.com",
                     "name": "Target User",
                     "type": "user"
                 },
@@ -86,13 +85,13 @@
                 "domain": "example.com",
                 "email": "acting@example.com",
                 "full_name": "Acting User",
-                "id": "12345678942",
+                "id": "acting@example.com",
                 "name": "acting",
                 "target": {
                     "domain": "example.com",
                     "email": "target@example.com",
                     "full_name": "Target User",
-                    "id": "26570306658",
+                    "id": "target@example.com",
                     "name": "target"
                 }
             }

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-invite.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-invite.log-expected.json
@@ -4,6 +4,8 @@
             "box": {
                 "accessible_by": {
                     "id": "26570306658",
+                    "login": "target@example.com",
+                    "name": "Target User",
                     "type": "user"
                 },
                 "additional_details": {
@@ -82,12 +84,16 @@
             ],
             "user": {
                 "domain": "example.com",
-                "id": "acting@example.com",
-                "name": "Acting User",
+                "email": "acting@example.com",
+                "full_name": "Acting User",
+                "id": "12345678942",
+                "name": "acting",
                 "target": {
                     "domain": "example.com",
-                    "id": "target@example.com",
-                    "name": "Target User"
+                    "email": "target@example.com",
+                    "full_name": "Target User",
+                    "id": "26570306658",
+                    "name": "target"
                 }
             }
         }

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-malicious-content.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-malicious-content.log-expected.json
@@ -140,7 +140,8 @@
                     "id": "2320",
                     "name": "Some Name"
                 },
-                "name": "Unknown User"
+                "full_name": "Unknown User",
+                "id": "2"
             }
         },
         {
@@ -257,7 +258,8 @@
                     "id": "2320",
                     "name": "Some Name"
                 },
-                "name": "Unknown User"
+                "full_name": "Unknown User",
+                "id": "2"
             }
         }
     ]

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-malicious-content.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-malicious-content.log-expected.json
@@ -140,8 +140,7 @@
                     "id": "2320",
                     "name": "Some Name"
                 },
-                "full_name": "Unknown User",
-                "id": "2"
+                "full_name": "Unknown User"
             }
         },
         {
@@ -258,8 +257,7 @@
                     "id": "2320",
                     "name": "Some Name"
                 },
-                "full_name": "Unknown User",
-                "id": "2"
+                "full_name": "Unknown User"
             }
         }
     ]

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-preview.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-preview.log-expected.json
@@ -113,8 +113,10 @@
             ],
             "user": {
                 "domain": "elastic.co",
-                "id": "info@elastic.co",
-                "name": "Elastic Integrations"
+                "email": "info@elastic.co",
+                "full_name": "Elastic Integrations",
+                "id": "19530772260",
+                "name": "info"
             }
         }
     ]

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-preview.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-preview.log-expected.json
@@ -115,7 +115,7 @@
                 "domain": "elastic.co",
                 "email": "info@elastic.co",
                 "full_name": "Elastic Integrations",
-                "id": "19530772260",
+                "id": "info@elastic.co",
                 "name": "info"
             }
         }

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-rename.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-rename.log-expected.json
@@ -93,7 +93,7 @@
                 "domain": "elastic.co",
                 "email": "info@elastic.co",
                 "full_name": "Elastic Integrations",
-                "id": "19530772260",
+                "id": "info@elastic.co",
                 "name": "info"
             }
         }

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-rename.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-rename.log-expected.json
@@ -91,8 +91,10 @@
             ],
             "user": {
                 "domain": "elastic.co",
-                "id": "info@elastic.co",
-                "name": "Elastic Integrations"
+                "email": "info@elastic.co",
+                "full_name": "Elastic Integrations",
+                "id": "19530772260",
+                "name": "info"
             }
         }
     ]

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-suspicious-locations.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-suspicious-locations.log-expected.json
@@ -97,7 +97,8 @@
                     "id": "2320",
                     "name": "Some name"
                 },
-                "name": "Unknown User"
+                "full_name": "Unknown User",
+                "id": "2"
             }
         },
         {
@@ -179,7 +180,8 @@
                     "id": "2320",
                     "name": "Some name"
                 },
-                "name": "Unknown User"
+                "full_name": "Unknown User",
+                "id": "2"
             }
         }
     ]

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-suspicious-locations.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-suspicious-locations.log-expected.json
@@ -97,8 +97,7 @@
                     "id": "2320",
                     "name": "Some name"
                 },
-                "full_name": "Unknown User",
-                "id": "2"
+                "full_name": "Unknown User"
             }
         },
         {
@@ -180,8 +179,7 @@
                     "id": "2320",
                     "name": "Some name"
                 },
-                "full_name": "Unknown User",
-                "id": "2"
+                "full_name": "Unknown User"
             }
         }
     ]

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-suspicious-sessions.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-suspicious-sessions.log-expected.json
@@ -96,7 +96,8 @@
                     "id": "50500",
                     "name": "A b c"
                 },
-                "name": "Unknown User"
+                "full_name": "Unknown User",
+                "id": "2"
             }
         },
         {
@@ -181,7 +182,8 @@
                     "id": "50500",
                     "name": "A b c"
                 },
-                "name": "Unknown User"
+                "full_name": "Unknown User",
+                "id": "2"
             }
         }
     ]

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-suspicious-sessions.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-suspicious-sessions.log-expected.json
@@ -96,8 +96,7 @@
                     "id": "50500",
                     "name": "A b c"
                 },
-                "full_name": "Unknown User",
-                "id": "2"
+                "full_name": "Unknown User"
             }
         },
         {
@@ -182,8 +181,7 @@
                     "id": "50500",
                     "name": "A b c"
                 },
-                "full_name": "Unknown User",
-                "id": "2"
+                "full_name": "Unknown User"
             }
         }
     ]

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-trash.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-trash.log-expected.json
@@ -94,7 +94,7 @@
                 "domain": "elastic.co",
                 "email": "info@elastic.co",
                 "full_name": "Elastic Integrations",
-                "id": "19530772260",
+                "id": "info@elastic.co",
                 "name": "info"
             }
         }

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-trash.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-trash.log-expected.json
@@ -92,8 +92,10 @@
             ],
             "user": {
                 "domain": "elastic.co",
-                "id": "info@elastic.co",
-                "name": "Elastic Integrations"
+                "email": "info@elastic.co",
+                "full_name": "Elastic Integrations",
+                "id": "19530772260",
+                "name": "info"
             }
         }
     ]

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-upload.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-upload.log-expected.json
@@ -122,7 +122,7 @@
                 "domain": "elastic.co",
                 "email": "info@elastic.co",
                 "full_name": "Elastic Integrations",
-                "id": "19530772260",
+                "id": "info@elastic.co",
                 "name": "info"
             }
         }

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-upload.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-upload.log-expected.json
@@ -120,8 +120,10 @@
             ],
             "user": {
                 "domain": "elastic.co",
-                "id": "info@elastic.co",
-                "name": "Elastic Integrations"
+                "email": "info@elastic.co",
+                "full_name": "Elastic Integrations",
+                "id": "19530772260",
+                "name": "info"
             }
         }
     ]

--- a/packages/box_events/data_stream/events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/box_events/data_stream/events/elasticsearch/ingest_pipeline/default.yml
@@ -619,7 +619,7 @@ processors:
       if: ctx._tmp?.created_login instanceof List && ctx._tmp.created_login.length == 2
   - set:
       field: user.id
-      copy_from: box.created_by.id
+      copy_from: box.created_by.login
       ignore_empty_value: true
       if: ctx.user?.id == null && ctx.box?.created_by?.type == 'user'
   - append:
@@ -656,10 +656,10 @@ processors:
       field: user.target.domain
       copy_from: _tmp.accessible_login.1
       if: ctx._tmp?.accessible_login instanceof List && ctx._tmp.accessible_login.length == 2
-  - set:
-      field: user.target.id
-      copy_from: box.accessible_by.id
-      ignore_empty_value: true
+  - rename:
+      field: box.accessible_by.login
+      target_field: user.target.id
+      ignore_missing: true
       if: ctx.user?.target?.id == null && ctx.box?.accessible_by?.type == 'user'
   - append:
       field: related.user

--- a/packages/box_events/data_stream/events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/box_events/data_stream/events/elasticsearch/ingest_pipeline/default.yml
@@ -594,64 +594,82 @@ processors:
       target_field: event.id
       ignore_missing: true
 # User details: set rather than rename is used in these to avoid breaking change.
+  - set:
+      field: user.full_name
+      copy_from: box.created_by.name
+      ignore_empty_value: true
+      if: ctx.user?.full_name == null && ctx.box?.created_by?.type == 'user'
+  - set:
+      field: user.email
+      copy_from: box.created_by.login
+      ignore_empty_value: true
+      if: ctx.user?.email == null && ctx.box?.created_by?.login != null
   - split:
       field: box.created_by.login
       target_field: _tmp.created_login
       separator: '@'
       if: ctx.box?.created_by?.login instanceof String && ctx.box.created_by.login.length() > 2
   - set:
+      field: user.name
+      copy_from: _tmp.created_login.0
+      if: ctx._tmp?.created_login instanceof List && ctx._tmp.created_login.length == 2
+  - set:
       field: user.domain
       copy_from: _tmp.created_login.1
       if: ctx._tmp?.created_login instanceof List && ctx._tmp.created_login.length == 2
   - set:
       field: user.id
-      copy_from: box.created_by.login
+      copy_from: box.created_by.id
       ignore_empty_value: true
       if: ctx.user?.id == null && ctx.box?.created_by?.type == 'user'
   - append:
       field: related.user
-      value: '{{{user.id}}}'
-      if: ctx.user?.id != null && ctx.user.id != ''
+      value: '{{{user.email}}}'
+      if: ctx.user?.email != null && ctx.user.email != ''
       allow_duplicates: false
-  - set:
-      field: user.name
-      copy_from: box.created_by.name
-      ignore_empty_value: true
-      if: ctx.user?.name == null && ctx.box?.created_by?.type == 'user'
   - append:
       field: related.user
-      value: '{{{user.name}}}'
-      if: ctx.user?.name != null && ctx.user.name != ''
+      value: '{{{user.full_name}}}'
+      if: ctx.user?.full_name != null && ctx.user.full_name != ''
       allow_duplicates: false
 # Collaboration events.
+  - set:
+      field: user.target.full_name
+      copy_from: box.accessible_by.name
+      ignore_empty_value: true
+      if: ctx.user?.target?.full_name == null && ctx.box?.accessible_by?.name != null
+  - set:
+      field: user.target.email
+      copy_from: box.accessible_by.login
+      ignore_empty_value: true
+      if: ctx.user?.target?.email == null && ctx.box?.accessible_by?.login != null
   - split:
       field: box.accessible_by.login
       target_field: _tmp.accessible_login
       separator: '@'
       if: ctx.box?.accessible_by?.login instanceof String && ctx.box.accessible_by.login.length() > 2
   - set:
+      field: user.target.name
+      copy_from: _tmp.accessible_login.0
+      if: ctx._tmp?.accessible_login instanceof List && ctx._tmp.accessible_login.length == 2
+  - set:
       field: user.target.domain
       copy_from: _tmp.accessible_login.1
       if: ctx._tmp?.accessible_login instanceof List && ctx._tmp.accessible_login.length == 2
-  - rename:
-      field: box.accessible_by.login
-      target_field: user.target.id
-      ignore_missing: true
+  - set:
+      field: user.target.id
+      copy_from: box.accessible_by.id
+      ignore_empty_value: true
       if: ctx.user?.target?.id == null && ctx.box?.accessible_by?.type == 'user'
   - append:
       field: related.user
-      value: '{{{user.target.id}}}'
-      if: ctx.user?.target?.id != null && ctx.user.target.id != ''
+      value: '{{{user.target.email}}}'
+      if: ctx.user?.target?.email != null && ctx.user.target.email != ''
       allow_duplicates: false
-  - rename:
-      field: box.accessible_by.name
-      target_field: user.target.name
-      ignore_missing: true
-      if: ctx.user?.target?.name == null
   - append:
       field: related.user
-      value: '{{{user.target.name}}}'
-      if: ctx.user?.target?.name != null && ctx.user.target.name != ''
+      value: '{{{user.target.full_name}}}'
+      if: ctx.user?.target?.full_name != null && ctx.user.target.full_name != ''
       allow_duplicates: false
   - rename:
       field: box.source.folder_id

--- a/packages/box_events/manifest.yml
+++ b/packages/box_events/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: box_events
 title: Box Events
-version: "2.13.0"
+version: "2.14.0"
 description: "Collect logs from Box with Elastic Agent"
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
box_events: improve the ecs field mappings for `user.*` fields

This PR is based on the earlier PR [1] that addressed improvements to the user.* field mappings.
In this update, some of the existing mappings have been revised and several new ones have been added.

[1] https://github.com/elastic/integrations/pull/12944
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

Clone integrations repo.
Install elastic package locally.
Start elastic stack using elastic-package.
Move to integrations/packages/box_events directory.
Run the following command to run tests.
> elastic-package test

## Related issues

- Closes #12971
