### PR TITLE
[prisma_cloud] Add support for REST API Input to the Incident Audit data stream

### DIFF
--- a/packages/prisma_cloud/_dev/build/docs/README.md
+++ b/packages/prisma_cloud/_dev/build/docs/README.md
@@ -34,8 +34,7 @@ The Prisma Cloud integration collects data for the following five events:
 
 **NOTE**:
 
-1. Alert and Audit data-streams are part of [CSPM](https://pan.dev/prisma-cloud/api/cspm/) module, whereas Host, Host Profile and Incident Audit are part of [CWP](https://pan.dev/prisma-cloud/api/cwpp/) module.
-2. Currently, we are unable to collect logs of Incident Audit datastream via defined API. Hence, we have not added the configuration of Incident Audit data stream via REST API.
+Alert and Audit data-streams are part of [CSPM](https://pan.dev/prisma-cloud/api/cspm/) module, whereas Host, Host Profile and Incident Audit are part of [CWP](https://pan.dev/prisma-cloud/api/cwpp/) module.
 
 ## Requirements
 

--- a/packages/prisma_cloud/_dev/deploy/docker/files/config.yml
+++ b/packages/prisma_cloud/_dev/deploy/docker/files/config.yml
@@ -83,3 +83,457 @@ rules:
       - status_code: 200
         body: |
           []
+  - path: /audits/incidents
+    methods: ['GET']
+    request_headers:
+      Authorization:
+        - 'Bearer xxxx'
+    query_params:
+      offset: 0
+      limit: 2
+    responses:
+      - status_code: 200
+        body: |
+          {{ minify_json `
+          [
+            {
+              "_id": "651c46b145d15228585exxxx",
+              "accountID": "123abc",
+              "acknowledged": false,
+              "app": "string",
+              "appID": "string",
+              "audits": [
+                {
+                  "_id": "651c46b145d15228585exxxx",
+                  "accountID": "abdcsfData",
+                  "app": "string",
+                  "appID": "abc123",
+                  "attackTechniques": [
+                    "exploitationForPrivilegeEscalation"
+                  ],
+                  "attackType": "cloudMetadataProbing",
+                  "cluster": "string",
+                  "collections": [
+                    "string"
+                  ],
+                  "command": "string",
+                  "container": true,
+                  "containerId": "5490e85a1a0c1c9f9c74591a9d3fcbf61beb84a952f14a17277be5fcf00xxxxx",
+                  "containerName": "nginx",
+                  "count": 0,
+                  "country": "string",
+                  "domain": "string",
+                  "effect": [
+                    "block",
+                    "prevent"
+                  ],
+                  "err": "string",
+                  "filepath": "string",
+                  "fqdn": "audits-fqdn-hostname",
+                  "function": "string",
+                  "functionID": "string",
+                  "hostname": "gke-tp-cluster-tp-pool1-9658xxxx-j87v",
+                  "imageId": "sha256:61395b4c586da2b9b3b7ca903ea6a448e6783dfdd7f768ff2c1a0f3360aaxxxx",
+                  "imageName": "docker.io/library/nginx:latest",
+                  "interactive": true,
+                  "ip": "0.0.0.0",
+                  "label": "string",
+                  "labels": {},
+                  "md5": "string",
+                  "msg": "string",
+                  "namespace": "string",
+                  "os": "Debian GNU/Linux 12 (bookworm)",
+                  "pid": 0,
+                  "port": 0,
+                  "processPath": "string",
+                  "profileId": "string",
+                  "provider": "alibaba",
+                  "rawEvent": "string",
+                  "region": "string",
+                  "requestID": "string",
+                  "resourceID": "string",
+                  "ruleName": "string",
+                  "runtime": [
+                    "python3.6"
+                  ],
+                  "severity": [
+                    "low",
+                    "medium",
+                    "high"
+                  ],
+                  "time": "2023-09-19T07:15:31.899Z",
+                  "type": [
+                    "processes"
+                  ],
+                  "user": "string",
+                  "version": "string",
+                  "vmID": "string",
+                  "wildFireReportURL": "string"
+                }
+              ],
+              "category": "malware",
+              "cluster": "string",
+              "collections": [
+                "string"
+              ],
+              "containerID": "container123",
+              "containerName": "Example Container",
+              "customRuleName": "Rule xyz",
+              "fqdn": "example.com",
+              "function": "string",
+              "functionID": "string",
+              "hostname": "string",
+              "imageID": "string",
+              "imageName": "string",
+              "labels": {},
+              "namespace": "string",
+              "profileID": "string",
+              "provider": "oci",
+              "region": "string",
+              "resourceID": "string",
+              "runtime": "string",
+              "serialNum": 0,
+              "shouldCollect": true,
+              "time": "2023-09-19T07:15:31.899Z",
+              "type": "host",
+              "vmID": "string",
+              "windows": true
+            },
+            {
+              "_id": "651c46b145d12345exxxx",
+              "accountID": "123def",
+              "acknowledged": true,
+              "app": "app123",
+              "appID": "string",
+              "audits": [
+                {
+                  "_id": "12abcd3435",
+                  "accountID": "abdcsfData",
+                  "app": "appid456",
+                  "appID": "abc123",
+                  "attackTechniques": [
+                    "exploitationForPrivilegeEscalation"
+                  ],
+                  "attackType": "cloudMetadataProbing",
+                  "cluster": "string",
+                  "collections": [
+                    "string"
+                  ],
+                  "command": "string",
+                  "container": true,
+                  "containerId": "5490e85a1a0c1c9f9c74591a9d3fcbf61beb84a952f14a17277be5fcf00xxxxx",
+                  "containerName": "nginx",
+                  "count": 0,
+                  "country": "string",
+                  "domain": "string",
+                  "effect": [
+                    "block",
+                    "prevent"
+                  ],
+                  "err": "string",
+                  "filepath": "string",
+                  "fqdn": "audits-fqdn-hostname",
+                  "function": "string",
+                  "functionID": "string",
+                  "hostname": "gke-tp-cluster-tp-pool1-9658xxxx-j87v",
+                  "imageId": "sha256:61395b4c586da2b9b3b7ca903ea6a448e6783dfdd7f768ff2c1a0f3360aaxxxx",
+                  "imageName": "docker.io/library/nginx:latest",
+                  "interactive": true,
+                  "ip": "0.0.0.0",
+                  "label": "string",
+                  "labels": {},
+                  "md5": "string",
+                  "msg": "string",
+                  "namespace": "string",
+                  "os": "Debian GNU/Linux 12 (bookworm)",
+                  "pid": 0,
+                  "port": 0,
+                  "processPath": "string",
+                  "profileId": "string",
+                  "provider": "alibaba",
+                  "rawEvent": "string",
+                  "region": "string",
+                  "requestID": "string",
+                  "resourceID": "string",
+                  "ruleName": "string",
+                  "runtime": [
+                    "python3.6"
+                  ],
+                  "severity": [
+                    "low",
+                    "medium",
+                    "high"
+                  ],
+                  "time": "2023-09-20T07:15:31.899Z",
+                  "type": [
+                    "processes"
+                  ],
+                  "user": "string",
+                  "version": "string",
+                  "vmID": "string",
+                  "wildFireReportURL": "string"
+                }
+              ],
+              "category": "malware",
+              "cluster": "string",
+              "collections": [
+                "string"
+              ],
+              "containerID": "container123",
+              "containerName": "Example Container",
+              "customRuleName": "Rule xyz",
+              "fqdn": "example.com",
+              "function": "string",
+              "functionID": "string",
+              "hostname": "string",
+              "imageID": "string",
+              "imageName": "string",
+              "labels": {},
+              "namespace": "string",
+              "profileID": "string",
+              "provider": "oci",
+              "region": "string",
+              "resourceID": "string",
+              "runtime": "string",
+              "serialNum": 0,
+              "shouldCollect": true,
+              "time": "2023-09-20T07:15:31.899Z",
+              "type": "host",
+              "vmID": "string",
+              "windows": true
+            }
+          ]
+          `}}
+  - path: /audits/incidents
+    methods: ['GET']
+    request_headers:
+      Authorization:
+        - 'Bearer xxxx'
+    query_params:
+      offset: 2
+      limit: 2
+    responses:
+      - status_code: 200
+        body: |
+          {{ minify_json `
+          [
+            {
+              "_id": "abcde89898989",
+              "accountID": "000abc",
+              "acknowledged": false,
+              "app": "string",
+              "appID": "string",
+              "audits": [
+                {
+                  "_id": "abcde89898989",
+                  "accountID": "ghjdata",
+                  "app": "string",
+                  "appID": "abc111",
+                  "attackTechniques": [
+                    "exploitationForPrivilegeEscalation"
+                  ],
+                  "attackType": "cloudMetadataProbing",
+                  "cluster": "string",
+                  "collections": [
+                    "string"
+                  ],
+                  "command": "string",
+                  "container": true,
+                  "containerId": "5490e85a1a0c1c9f9c74591a9d3fcbf61beb84a952f14a17277be5fcf00xxxxx",
+                  "containerName": "nginx",
+                  "count": 0,
+                  "country": "string",
+                  "domain": "string",
+                  "effect": [
+                    "block",
+                    "prevent"
+                  ],
+                  "err": "string",
+                  "filepath": "string",
+                  "fqdn": "audits-fqdn-hostname",
+                  "function": "string",
+                  "functionID": "string",
+                  "hostname": "gke-tp-cluster-tp-pool1-9658xxxx-j87v",
+                  "imageId": "sha256:61395b4c586da2b9b3b7ca903ea6a448e6783dfdd7f768ff2c1a0f3360aaxxxx",
+                  "imageName": "docker.io/library/nginx:latest",
+                  "interactive": true,
+                  "ip": "0.0.0.0",
+                  "label": "string",
+                  "labels": {},
+                  "md5": "string",
+                  "msg": "string",
+                  "namespace": "string",
+                  "os": "Debian GNU/Linux 12 (bookworm)",
+                  "pid": 0,
+                  "port": 0,
+                  "processPath": "string",
+                  "profileId": "string",
+                  "provider": "alibaba",
+                  "rawEvent": "string",
+                  "region": "string",
+                  "requestID": "string",
+                  "resourceID": "string",
+                  "ruleName": "string",
+                  "runtime": [
+                    "python3.6"
+                  ],
+                  "severity": [
+                    "low",
+                    "medium",
+                    "high"
+                  ],
+                  "time": "2023-09-19T08:15:31.899Z",
+                  "type": [
+                    "processes"
+                  ],
+                  "user": "string",
+                  "version": "string",
+                  "vmID": "string",
+                  "wildFireReportURL": "string"
+                }
+              ],
+              "category": "malware",
+              "cluster": "string",
+              "collections": [
+                "string"
+              ],
+              "containerID": "container123",
+              "containerName": "Example Container",
+              "customRuleName": "Rule xyz",
+              "fqdn": "example.com",
+              "function": "string",
+              "functionID": "string",
+              "hostname": "string",
+              "imageID": "string",
+              "imageName": "string",
+              "labels": {},
+              "namespace": "string",
+              "profileID": "string",
+              "provider": "oci",
+              "region": "string",
+              "resourceID": "string",
+              "runtime": "string",
+              "serialNum": 0,
+              "shouldCollect": true,
+              "time": "2023-09-19T08:15:31.899Z",
+              "type": "host",
+              "vmID": "string",
+              "windows": true
+            },
+            {
+              "_id": "abcjklm6666",
+              "accountID": "ghi012",
+              "acknowledged": false,
+              "app": "app133333",
+              "appID": "string",
+              "audits": [
+                {
+                  "_id": "abcjklm6666",
+                  "accountID": "abdcsfData",
+                  "app": "appid456",
+                  "appID": "abc123",
+                  "attackTechniques": [
+                    "exploitationForPrivilegeEscalation"
+                  ],
+                  "attackType": "cloudMetadataProbing",
+                  "cluster": "string",
+                  "collections": [
+                    "string"
+                  ],
+                  "command": "string",
+                  "container": true,
+                  "containerId": "5490e85a1a0c1c9f9c74591a9d3fcbf61beb84a952f14a17277be5fcf00xxxxx",
+                  "containerName": "nginx",
+                  "count": 0,
+                  "country": "string",
+                  "domain": "string",
+                  "effect": [
+                    "block",
+                    "prevent"
+                  ],
+                  "err": "string",
+                  "filepath": "string",
+                  "fqdn": "audits-fqdn-hostname",
+                  "function": "string",
+                  "functionID": "string",
+                  "hostname": "gke-tp-cluster-tp-pool1-9658xxxx-j87v",
+                  "imageId": "sha256:61395b4c586da2b9b3b7ca903ea6a448e6783dfdd7f768ff2c1a0f3360aaxxxx",
+                  "imageName": "docker.io/library/nginx:latest",
+                  "interactive": true,
+                  "ip": "0.0.0.0",
+                  "label": "string",
+                  "labels": {},
+                  "md5": "string",
+                  "msg": "string",
+                  "namespace": "string",
+                  "os": "Debian GNU/Linux 12 (bookworm)",
+                  "pid": 0,
+                  "port": 0,
+                  "processPath": "string",
+                  "profileId": "string",
+                  "provider": "alibaba",
+                  "rawEvent": "string",
+                  "region": "string",
+                  "requestID": "string",
+                  "resourceID": "string",
+                  "ruleName": "string",
+                  "runtime": [
+                    "python3.6"
+                  ],
+                  "severity": [
+                    "low",
+                    "low",
+                    "high"
+                  ],
+                  "time": "2023-09-20T09:15:31.899Z",
+                  "type": [
+                    "processes"
+                  ],
+                  "user": "string",
+                  "version": "string",
+                  "vmID": "string",
+                  "wildFireReportURL": "string"
+                }
+              ],
+              "category": "malware",
+              "cluster": "string",
+              "collections": [
+                "string"
+              ],
+              "containerID": "container123",
+              "containerName": "Example Container",
+              "customRuleName": "Rule xyz",
+              "fqdn": "example.com",
+              "function": "string",
+              "functionID": "string",
+              "hostname": "string",
+              "imageID": "string",
+              "imageName": "string",
+              "labels": {},
+              "namespace": "string",
+              "profileID": "string",
+              "provider": "oci",
+              "region": "string",
+              "resourceID": "string",
+              "runtime": "string",
+              "serialNum": 0,
+              "shouldCollect": true,
+              "time": "2023-09-20T09:15:31.899Z",
+              "type": "host",
+              "vmID": "string",
+              "windows": true
+            }
+          ]
+          `}}
+  - path: /audits/incidents
+    methods: ['GET']
+    request_headers:
+      Authorization:
+        - 'Bearer xxxx'
+    query_params:
+      offset: 4
+      limit: 2
+    responses:
+      - status_code: 200
+        body: |
+          []

--- a/packages/prisma_cloud/changelog.yml
+++ b/packages/prisma_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.2.0"
+  changes:
+    - description: Add support for REST API input to the Incident Audit data stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.1.1"
   changes:
     - description: Fix default request trace enabled behavior.

--- a/packages/prisma_cloud/changelog.yml
+++ b/packages/prisma_cloud/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add support for REST API input to the Incident Audit data stream.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/14011
 - version: "3.1.1"
   changes:
     - description: Fix default request trace enabled behavior.

--- a/packages/prisma_cloud/data_stream/incident_audit/_dev/test/system/test-cel-config.yml
+++ b/packages/prisma_cloud/data_stream/incident_audit/_dev/test/system/test-cel-config.yml
@@ -1,0 +1,13 @@
+input: cel
+service: prisma_cloud
+vars:
+  username: xxxx
+  password: xxxx
+data_stream:
+  vars:
+    url: http://{{Hostname}}:{{Port}}
+    batch_size: 2
+    preserve_original_event: true
+    preserve_duplicate_custom_fields: true
+assert:
+  hit_count: 4

--- a/packages/prisma_cloud/data_stream/incident_audit/agent/stream/cel.yml.hbs
+++ b/packages/prisma_cloud/data_stream/incident_audit/agent/stream/cel.yml.hbs
@@ -107,12 +107,12 @@ program: |
         }
       }).do_request().as(resp, resp.StatusCode == 200 ?
           resp.Body.decode_json().as(body,{
-            "events": (body != null ?
+            "events": (body != null && body.size() > 0 ?
               body.map(e, {
                 "message": e.encode_json(),
               })
             :
-              [{"message": "no_data"}]
+              []
             ),
             "cursor": {
               ?"last_timestamp": body != null && body.size() > 0 ?

--- a/packages/prisma_cloud/data_stream/incident_audit/agent/stream/cel.yml.hbs
+++ b/packages/prisma_cloud/data_stream/incident_audit/agent/stream/cel.yml.hbs
@@ -1,0 +1,184 @@
+config_version: 2
+interval: {{interval}}
+resource.tracer:
+  enabled: {{enable_request_tracer}}
+  filename: "../../logs/cel/http-request-trace-*.ndjson"
+  maxbackups: 5
+{{#if proxy_url}}
+resource.proxy_url: {{proxy_url}}
+{{/if}}
+{{#if ssl}}
+resource.ssl: {{ssl}}
+{{/if}}
+{{#if http_client_timeout}}
+resource.timeout: {{http_client_timeout}}
+{{/if}}
+resource.url: {{url}}
+state:
+  user: {{username}}
+  password: {{password}}
+  offset: 0
+  batch_size: {{batch_size}}
+  initial_interval: {{initial_interval}}
+redact:
+  fields:
+    - user
+    - password
+program: |
+  (
+    has(state.?next.access_token) ?
+      state
+    :
+      (
+        state.?want_more.orValue(false) ?
+          state
+        :
+          state.with({
+            "start_time": state.?cursor.last_timestamp.orValue((now - duration(state.initial_interval)).format(time_layout.RFC3339)),
+            "end_time": now.format(time_layout.RFC3339),
+          })
+      ).as(state,
+        // To generate the authentication token.
+        post_request(
+          state.url.trim_right("/") + "/authenticate",
+          "application/json",
+          {
+            "username": state.user,
+            "password": state.password,
+          }.encode_json()
+        ).do_request().as(resp, resp.StatusCode == 200 ?
+            resp.Body.decode_json().as(body, {
+              "next": {
+                "access_token": body.token,
+              },
+              "url": state.url,
+              "user": state.user,
+              "password": state.password,
+              "offset": state.offset,
+              "batch_size": state.batch_size,
+              "initial_interval": state.initial_interval,
+              "start_time": state.start_time,
+              "end_time": state.end_time,
+              "cursor": {
+                ?"last_timestamp": state.?cursor.last_timestamp,
+              },
+            })
+          :
+            {
+              "events": {
+                "error": {
+                  "code": string(resp.StatusCode),
+                  "id": string(resp.Status),
+                  "message": "POST " + state.url.trim_right("/") + "/authenticate: " + (
+                    size(resp.Body) != 0 ?
+                      string(resp.Body)
+                    :
+                      string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                  ),
+                },
+              },
+              "want_more": false,
+              "offset": 0,
+              "batch_size": state.batch_size,
+              "url": state.url,
+              "user": state.user,
+              "password": state.password,
+              "initial_interval": state.initial_interval,
+              "cursor": {
+                ?"last_timestamp": state.?cursor.last_timestamp,
+              },
+            }
+        )
+      )
+  ).as(state,
+    has(state.?events.error) ?
+    	state
+    :
+      request("GET",
+        state.url.trim_right("/") + "/audits/incidents?" + {
+          "from": [state.start_time],
+          "to": [state.end_time],
+          "limit": [string(state.batch_size)],
+          "offset": [string(state.offset)],
+        }.format_query()
+      ).with({
+        "Header":{
+          "Authorization": ["Bearer " + state.next.access_token],
+        }
+      }).do_request().as(resp, resp.StatusCode == 200 ?
+          resp.Body.decode_json().as(body,{
+            "events": (body != null ?
+              body.map(e, {
+                "message": e.encode_json(),
+              })
+            :
+              [{"message": "no_data"}]
+            ),
+            "cursor": {
+              ?"last_timestamp": body != null && body.size() > 0 ?
+                (
+                  has(state.?cursor.last_timestamp) && body.map(e, e.time).max() < state.cursor.last_timestamp ?
+                    optional.of(state.cursor.last_timestamp)
+                  :
+                    optional.of(body.map(e, e.time).max())
+                )
+              :
+                state.?cursor.last_timestamp
+            },
+            "next": {
+              ?"access_token": body != null && body.size() > 0 ? optional.of(state.next.access_token) : optional.none(),
+            },
+            "batch_size": state.batch_size,
+            "url": state.url,
+            "user": state.user,
+            "password": state.password,
+            "initial_interval": state.initial_interval,
+            "start_time": state.start_time,
+            "end_time": state.end_time,
+            "offset": body != null && body.size() > 0 ? int(state.offset) + body.size() : 0,
+            "want_more": body != null && body.size() > 0,
+          })
+        :
+          {
+            "events": {
+              "error": {
+                "code": string(resp.StatusCode),
+                "id": string(resp.Status),
+                "message": "GET " + state.url.trim_right("/") + "/audits/incidents: " + (
+                  size(resp.Body) != 0 ?
+                    string(resp.Body)
+                  :
+                    string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                ),
+              },
+            },
+            "want_more": false,
+            "offset": 0,
+            "batch_size": state.batch_size,
+            "url": state.url,
+            "user": state.user,
+            "password": state.password,
+            "initial_interval": state.initial_interval,
+            "cursor": {
+              ?"last_timestamp": state.?cursor.last_timestamp,
+            },
+          }
+      )
+  )
+tags:
+{{#if preserve_original_event}}
+  - preserve_original_event
+{{/if}}
+{{#if preserve_duplicate_custom_fields}}
+  - preserve_duplicate_custom_fields
+{{/if}}
+{{#each tags as |tag|}}
+  - {{tag}}
+{{/each}}
+{{#contains "forwarded" tags}}
+publisher_pipeline.disable_host: true
+{{/contains}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/prisma_cloud/data_stream/incident_audit/manifest.yml
+++ b/packages/prisma_cloud/data_stream/incident_audit/manifest.yml
@@ -1,6 +1,96 @@
 title: Collect Incident Audit logs from Prisma Cloud Workload Protection.
 type: logs
 streams:
+  - input: cel
+    title: Incident Audit Logs
+    description: Collect Incident Audit logs from Prisma Cloud Workload Protection.
+    template_path: cel.yml.hbs
+    enabled: false
+    vars:
+      - name: url
+        type: text
+        title: URL
+        description: Base URL of the Prisma Cloud Server API, in the form `https://<CONSOLE>/api/v<VERSION>`.
+        required: true
+        show_user: true
+      - name: initial_interval
+        type: text
+        title: Initial Interval
+        multi: false
+        required: true
+        show_user: true
+        default: 24h
+        description: How far back to pull the Prisma Cloud Incident Audit logs from the API. Supported units for this parameter are h/m/s.
+      - name: interval
+        type: text
+        title: Interval
+        description: Interval between two REST API calls. Supported units for this parameter are h/m/s.
+        default: 5m
+        multi: false
+        required: true
+        show_user: true
+      - name: batch_size
+        type: integer
+        title: Batch Size
+        description: Number of events to retrieve in a page. The maximum limit is 100.
+        default: 100
+        multi: false
+        required: true
+        show_user: false
+      - name: http_client_timeout
+        type: text
+        title: HTTP Client Timeout
+        description: Duration before declaring that the HTTP client connection has timed out. Supported time units are ns, us, ms, s, m, h.
+        multi: false
+        required: true
+        show_user: false
+        default: 60s
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        default: false
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          The request tracer logs requests and responses to the agent's local file-system for debugging configurations.
+          Enabling this request tracing compromises security and should only be used for debugging. Disabling the request
+          tracer will delete any stored traces.
+          See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_enable)
+          for details.
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        required: true
+        show_user: false
+        default:
+          - forwarded
+          - prisma_cloud-incident_audit
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`.
+        type: bool
+        multi: false
+        default: false
+      - name: preserve_duplicate_custom_fields
+        required: true
+        show_user: false
+        title: Preserve duplicate custom fields
+        description: Preserve prisma_cloud.incident_audit fields that were copied to Elastic Common Schema (ECS) fields.
+        type: bool
+        multi: false
+        default: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
   - input: tcp
     template_path: tcp.yml.hbs
     title: Incident Audit logs

--- a/packages/prisma_cloud/data_stream/incident_audit/sample_event.json
+++ b/packages/prisma_cloud/data_stream/incident_audit/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2023-09-19T07:15:31.899Z",
     "agent": {
-        "ephemeral_id": "2be27553-a973-4cdb-8c8d-e296a788b63a",
-        "id": "f2974986-16b8-49d0-803d-316e0e9f4e94",
-        "name": "docker-fleet-agent",
+        "ephemeral_id": "2bcef8c2-6ed9-42d7-9dac-cba99dc89ea3",
+        "id": "7bcfbb54-8fe1-48a5-85cd-23794e360014",
+        "name": "elastic-agent-61906",
         "type": "filebeat",
-        "version": "8.10.1"
+        "version": "8.18.0"
     },
     "cloud": {
         "account": {
@@ -21,7 +21,7 @@
         "region": "string"
     },
     "container": {
-        "id": "string",
+        "id": "container123",
         "image": {
             "name": [
                 "docker.io/library/nginx:latest",
@@ -30,21 +30,21 @@
         },
         "name": [
             "nginx",
-            "string"
+            "Example Container"
         ]
     },
     "data_stream": {
         "dataset": "prisma_cloud.incident_audit",
-        "namespace": "ep",
+        "namespace": "20978",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "f2974986-16b8-49d0-803d-316e0e9f4e94",
+        "id": "7bcfbb54-8fe1-48a5-85cd-23794e360014",
         "snapshot": false,
-        "version": "8.10.1"
+        "version": "8.18.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -53,9 +53,9 @@
         ],
         "dataset": "prisma_cloud.incident_audit",
         "id": "651c46b145d15228585exxxx",
-        "ingested": "2023-11-03T06:39:34Z",
+        "ingested": "2025-05-23T11:09:31Z",
         "kind": "event",
-        "original": "{\"_id\":\"651c46b145d15228585exxxx\",\"accountID\":\"123abc\",\"acknowledged\":false,\"app\":\"string\",\"appID\":\"string\",\"audits\":[{\"_id\":\"651c46b145d15228585exxxx\",\"accountID\":\"abdcsfData\",\"app\":\"string\",\"appID\":\"string\",\"attackTechniques\":[\"exploitationForPrivilegeEscalation\"],\"attackType\":\"cloudMetadataProbing\",\"cluster\":\"string\",\"collections\":[\"string\"],\"command\":\"string\",\"container\":true,\"containerId\":\"5490e85a1a0c1c9f9c74591a9d3fcbf61beb84a952f14a17277be5fcf00xxxxx\",\"containerName\":\"nginx\",\"count\":0,\"country\":\"string\",\"domain\":\"string\",\"effect\":[\"block\",\"prevent\"],\"err\":\"string\",\"filepath\":\"string\",\"fqdn\":\"audits-fqdn-hostname\",\"function\":\"string\",\"functionID\":\"string\",\"hostname\":\"gke-tp-cluster-tp-pool1-9658xxxx-j87v\",\"imageId\":\"sha256:61395b4c586da2b9b3b7ca903ea6a448e6783dfdd7f768ff2c1a0f3360aaxxxx\",\"imageName\":\"docker.io/library/nginx:latest\",\"interactive\":true,\"ip\":\"0.0.0.0\",\"label\":\"string\",\"labels\":{},\"md5\":\"string\",\"msg\":\"string\",\"namespace\":\"string\",\"os\":\"string\",\"pid\":0,\"port\":0,\"processPath\":\"string\",\"profileId\":\"string\",\"provider\":\"alibaba\",\"rawEvent\":\"string\",\"region\":\"string\",\"requestID\":\"string\",\"resourceID\":\"string\",\"ruleName\":\"string\",\"runtime\":[\"python3.6\"],\"severity\":[\"low\",\"medium\",\"high\"],\"time\":\"2023-09-19T07:15:31.899Z\",\"type\":[\"processes\"],\"user\":\"string\",\"version\":\"string\",\"vmID\":\"string\",\"wildFireReportURL\":\"string\"}],\"category\":\"malware\",\"cluster\":\"string\",\"collections\":[\"string\"],\"containerID\":\"string\",\"containerName\":\"string\",\"customRuleName\":\"string\",\"fqdn\":\"string\",\"function\":\"string\",\"functionID\":\"string\",\"hostname\":\"string\",\"imageID\":\"string\",\"imageName\":\"string\",\"labels\":{},\"namespace\":\"string\",\"profileID\":\"string\",\"provider\":\"oci\",\"region\":\"string\",\"resourceID\":\"string\",\"runtime\":\"string\",\"serialNum\":0,\"shouldCollect\":true,\"time\":\"2023-09-19T07:15:31.899Z\",\"type\":\"host\",\"vmID\":\"string\",\"windows\":true}",
+        "original": "{\"_id\":\"651c46b145d15228585exxxx\",\"accountID\":\"123abc\",\"acknowledged\":false,\"app\":\"string\",\"appID\":\"string\",\"audits\":[{\"_id\":\"651c46b145d15228585exxxx\",\"accountID\":\"abdcsfData\",\"app\":\"string\",\"appID\":\"abc123\",\"attackTechniques\":[\"exploitationForPrivilegeEscalation\"],\"attackType\":\"cloudMetadataProbing\",\"cluster\":\"string\",\"collections\":[\"string\"],\"command\":\"string\",\"container\":true,\"containerId\":\"5490e85a1a0c1c9f9c74591a9d3fcbf61beb84a952f14a17277be5fcf00xxxxx\",\"containerName\":\"nginx\",\"count\":0,\"country\":\"string\",\"domain\":\"string\",\"effect\":[\"block\",\"prevent\"],\"err\":\"string\",\"filepath\":\"string\",\"fqdn\":\"audits-fqdn-hostname\",\"function\":\"string\",\"functionID\":\"string\",\"hostname\":\"gke-tp-cluster-tp-pool1-9658xxxx-j87v\",\"imageId\":\"sha256:61395b4c586da2b9b3b7ca903ea6a448e6783dfdd7f768ff2c1a0f3360aaxxxx\",\"imageName\":\"docker.io/library/nginx:latest\",\"interactive\":true,\"ip\":\"0.0.0.0\",\"label\":\"string\",\"labels\":{},\"md5\":\"string\",\"msg\":\"string\",\"namespace\":\"string\",\"os\":\"Debian GNU/Linux 12 (bookworm)\",\"pid\":0,\"port\":0,\"processPath\":\"string\",\"profileId\":\"string\",\"provider\":\"alibaba\",\"rawEvent\":\"string\",\"region\":\"string\",\"requestID\":\"string\",\"resourceID\":\"string\",\"ruleName\":\"string\",\"runtime\":[\"python3.6\"],\"severity\":[\"low\",\"medium\",\"high\"],\"time\":\"2023-09-19T07:15:31.899Z\",\"type\":[\"processes\"],\"user\":\"string\",\"version\":\"string\",\"vmID\":\"string\",\"wildFireReportURL\":\"string\"}],\"category\":\"malware\",\"cluster\":\"string\",\"collections\":[\"string\"],\"containerID\":\"container123\",\"containerName\":\"Example Container\",\"customRuleName\":\"Rule xyz\",\"fqdn\":\"example.com\",\"function\":\"string\",\"functionID\":\"string\",\"hostname\":\"string\",\"imageID\":\"string\",\"imageName\":\"string\",\"labels\":{},\"namespace\":\"string\",\"profileID\":\"string\",\"provider\":\"oci\",\"region\":\"string\",\"resourceID\":\"string\",\"runtime\":\"string\",\"serialNum\":0,\"shouldCollect\":true,\"time\":\"2023-09-19T07:15:31.899Z\",\"type\":\"host\",\"vmID\":\"string\",\"windows\":true}",
         "type": [
             "info"
         ]
@@ -63,21 +63,16 @@
     "host": {
         "domain": [
             "audits-fqdn-hostname",
-            "string"
+            "example.com"
         ],
         "hostname": "string"
     },
     "input": {
-        "type": "udp"
-    },
-    "log": {
-        "source": {
-            "address": "192.168.243.5:50216"
-        }
+        "type": "cel"
     },
     "os": {
         "full": [
-            "string"
+            "Debian GNU/Linux 12 (bookworm)"
         ]
     },
     "prisma_cloud": {
@@ -95,16 +90,16 @@
                 "string"
             ],
             "container": {
-                "id": "string",
-                "name": "string"
+                "id": "container123",
+                "name": "Example Container"
             },
-            "custom_rule_name": "string",
+            "custom_rule_name": "Rule xyz",
             "data": [
                 {
                     "_id": "651c46b145d15228585exxxx",
                     "account_id": "abdcsfData",
                     "app": {
-                        "id": "string",
+                        "id": "abc123",
                         "value": "string"
                     },
                     "attack": {
@@ -148,7 +143,7 @@
                     "md5": "string",
                     "msg": "string",
                     "namespace": "string",
-                    "os": "string",
+                    "os": "Debian GNU/Linux 12 (bookworm)",
                     "pid": 0,
                     "port": 0,
                     "process_path": "string",
@@ -177,7 +172,7 @@
                     "wild_fire_report_url": "string"
                 }
             ],
-            "fqdn": "string",
+            "fqdn": "example.com",
             "function": {
                 "id": "string",
                 "value": "string"
@@ -205,6 +200,7 @@
         "hosts": [
             "audits-fqdn-hostname",
             "gke-tp-cluster-tp-pool1-9658xxxx-j87v",
+            "example.com",
             "string"
         ],
         "ip": [
@@ -216,7 +212,8 @@
     },
     "rule": {
         "name": [
-            "string"
+            "string",
+            "Rule xyz"
         ]
     },
     "tags": [

--- a/packages/prisma_cloud/docs/README.md
+++ b/packages/prisma_cloud/docs/README.md
@@ -34,8 +34,7 @@ The Prisma Cloud integration collects data for the following five events:
 
 **NOTE**:
 
-1. Alert and Audit data-streams are part of [CSPM](https://pan.dev/prisma-cloud/api/cspm/) module, whereas Host, Host Profile and Incident Audit are part of [CWP](https://pan.dev/prisma-cloud/api/cwpp/) module.
-2. Currently, we are unable to collect logs of Incident Audit datastream via defined API. Hence, we have not added the configuration of Incident Audit data stream via REST API.
+Alert and Audit data-streams are part of [CSPM](https://pan.dev/prisma-cloud/api/cspm/) module, whereas Host, Host Profile and Incident Audit are part of [CWP](https://pan.dev/prisma-cloud/api/cwpp/) module.
 
 ## Requirements
 
@@ -1431,11 +1430,11 @@ An example event for `incident_audit` looks as following:
 {
     "@timestamp": "2023-09-19T07:15:31.899Z",
     "agent": {
-        "ephemeral_id": "2be27553-a973-4cdb-8c8d-e296a788b63a",
-        "id": "f2974986-16b8-49d0-803d-316e0e9f4e94",
-        "name": "docker-fleet-agent",
+        "ephemeral_id": "2bcef8c2-6ed9-42d7-9dac-cba99dc89ea3",
+        "id": "7bcfbb54-8fe1-48a5-85cd-23794e360014",
+        "name": "elastic-agent-61906",
         "type": "filebeat",
-        "version": "8.10.1"
+        "version": "8.18.0"
     },
     "cloud": {
         "account": {
@@ -1451,7 +1450,7 @@ An example event for `incident_audit` looks as following:
         "region": "string"
     },
     "container": {
-        "id": "string",
+        "id": "container123",
         "image": {
             "name": [
                 "docker.io/library/nginx:latest",
@@ -1460,21 +1459,21 @@ An example event for `incident_audit` looks as following:
         },
         "name": [
             "nginx",
-            "string"
+            "Example Container"
         ]
     },
     "data_stream": {
         "dataset": "prisma_cloud.incident_audit",
-        "namespace": "ep",
+        "namespace": "20978",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "f2974986-16b8-49d0-803d-316e0e9f4e94",
+        "id": "7bcfbb54-8fe1-48a5-85cd-23794e360014",
         "snapshot": false,
-        "version": "8.10.1"
+        "version": "8.18.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -1483,9 +1482,9 @@ An example event for `incident_audit` looks as following:
         ],
         "dataset": "prisma_cloud.incident_audit",
         "id": "651c46b145d15228585exxxx",
-        "ingested": "2023-11-03T06:39:34Z",
+        "ingested": "2025-05-23T11:09:31Z",
         "kind": "event",
-        "original": "{\"_id\":\"651c46b145d15228585exxxx\",\"accountID\":\"123abc\",\"acknowledged\":false,\"app\":\"string\",\"appID\":\"string\",\"audits\":[{\"_id\":\"651c46b145d15228585exxxx\",\"accountID\":\"abdcsfData\",\"app\":\"string\",\"appID\":\"string\",\"attackTechniques\":[\"exploitationForPrivilegeEscalation\"],\"attackType\":\"cloudMetadataProbing\",\"cluster\":\"string\",\"collections\":[\"string\"],\"command\":\"string\",\"container\":true,\"containerId\":\"5490e85a1a0c1c9f9c74591a9d3fcbf61beb84a952f14a17277be5fcf00xxxxx\",\"containerName\":\"nginx\",\"count\":0,\"country\":\"string\",\"domain\":\"string\",\"effect\":[\"block\",\"prevent\"],\"err\":\"string\",\"filepath\":\"string\",\"fqdn\":\"audits-fqdn-hostname\",\"function\":\"string\",\"functionID\":\"string\",\"hostname\":\"gke-tp-cluster-tp-pool1-9658xxxx-j87v\",\"imageId\":\"sha256:61395b4c586da2b9b3b7ca903ea6a448e6783dfdd7f768ff2c1a0f3360aaxxxx\",\"imageName\":\"docker.io/library/nginx:latest\",\"interactive\":true,\"ip\":\"0.0.0.0\",\"label\":\"string\",\"labels\":{},\"md5\":\"string\",\"msg\":\"string\",\"namespace\":\"string\",\"os\":\"string\",\"pid\":0,\"port\":0,\"processPath\":\"string\",\"profileId\":\"string\",\"provider\":\"alibaba\",\"rawEvent\":\"string\",\"region\":\"string\",\"requestID\":\"string\",\"resourceID\":\"string\",\"ruleName\":\"string\",\"runtime\":[\"python3.6\"],\"severity\":[\"low\",\"medium\",\"high\"],\"time\":\"2023-09-19T07:15:31.899Z\",\"type\":[\"processes\"],\"user\":\"string\",\"version\":\"string\",\"vmID\":\"string\",\"wildFireReportURL\":\"string\"}],\"category\":\"malware\",\"cluster\":\"string\",\"collections\":[\"string\"],\"containerID\":\"string\",\"containerName\":\"string\",\"customRuleName\":\"string\",\"fqdn\":\"string\",\"function\":\"string\",\"functionID\":\"string\",\"hostname\":\"string\",\"imageID\":\"string\",\"imageName\":\"string\",\"labels\":{},\"namespace\":\"string\",\"profileID\":\"string\",\"provider\":\"oci\",\"region\":\"string\",\"resourceID\":\"string\",\"runtime\":\"string\",\"serialNum\":0,\"shouldCollect\":true,\"time\":\"2023-09-19T07:15:31.899Z\",\"type\":\"host\",\"vmID\":\"string\",\"windows\":true}",
+        "original": "{\"_id\":\"651c46b145d15228585exxxx\",\"accountID\":\"123abc\",\"acknowledged\":false,\"app\":\"string\",\"appID\":\"string\",\"audits\":[{\"_id\":\"651c46b145d15228585exxxx\",\"accountID\":\"abdcsfData\",\"app\":\"string\",\"appID\":\"abc123\",\"attackTechniques\":[\"exploitationForPrivilegeEscalation\"],\"attackType\":\"cloudMetadataProbing\",\"cluster\":\"string\",\"collections\":[\"string\"],\"command\":\"string\",\"container\":true,\"containerId\":\"5490e85a1a0c1c9f9c74591a9d3fcbf61beb84a952f14a17277be5fcf00xxxxx\",\"containerName\":\"nginx\",\"count\":0,\"country\":\"string\",\"domain\":\"string\",\"effect\":[\"block\",\"prevent\"],\"err\":\"string\",\"filepath\":\"string\",\"fqdn\":\"audits-fqdn-hostname\",\"function\":\"string\",\"functionID\":\"string\",\"hostname\":\"gke-tp-cluster-tp-pool1-9658xxxx-j87v\",\"imageId\":\"sha256:61395b4c586da2b9b3b7ca903ea6a448e6783dfdd7f768ff2c1a0f3360aaxxxx\",\"imageName\":\"docker.io/library/nginx:latest\",\"interactive\":true,\"ip\":\"0.0.0.0\",\"label\":\"string\",\"labels\":{},\"md5\":\"string\",\"msg\":\"string\",\"namespace\":\"string\",\"os\":\"Debian GNU/Linux 12 (bookworm)\",\"pid\":0,\"port\":0,\"processPath\":\"string\",\"profileId\":\"string\",\"provider\":\"alibaba\",\"rawEvent\":\"string\",\"region\":\"string\",\"requestID\":\"string\",\"resourceID\":\"string\",\"ruleName\":\"string\",\"runtime\":[\"python3.6\"],\"severity\":[\"low\",\"medium\",\"high\"],\"time\":\"2023-09-19T07:15:31.899Z\",\"type\":[\"processes\"],\"user\":\"string\",\"version\":\"string\",\"vmID\":\"string\",\"wildFireReportURL\":\"string\"}],\"category\":\"malware\",\"cluster\":\"string\",\"collections\":[\"string\"],\"containerID\":\"container123\",\"containerName\":\"Example Container\",\"customRuleName\":\"Rule xyz\",\"fqdn\":\"example.com\",\"function\":\"string\",\"functionID\":\"string\",\"hostname\":\"string\",\"imageID\":\"string\",\"imageName\":\"string\",\"labels\":{},\"namespace\":\"string\",\"profileID\":\"string\",\"provider\":\"oci\",\"region\":\"string\",\"resourceID\":\"string\",\"runtime\":\"string\",\"serialNum\":0,\"shouldCollect\":true,\"time\":\"2023-09-19T07:15:31.899Z\",\"type\":\"host\",\"vmID\":\"string\",\"windows\":true}",
         "type": [
             "info"
         ]
@@ -1493,21 +1492,16 @@ An example event for `incident_audit` looks as following:
     "host": {
         "domain": [
             "audits-fqdn-hostname",
-            "string"
+            "example.com"
         ],
         "hostname": "string"
     },
     "input": {
-        "type": "udp"
-    },
-    "log": {
-        "source": {
-            "address": "192.168.243.5:50216"
-        }
+        "type": "cel"
     },
     "os": {
         "full": [
-            "string"
+            "Debian GNU/Linux 12 (bookworm)"
         ]
     },
     "prisma_cloud": {
@@ -1525,16 +1519,16 @@ An example event for `incident_audit` looks as following:
                 "string"
             ],
             "container": {
-                "id": "string",
-                "name": "string"
+                "id": "container123",
+                "name": "Example Container"
             },
-            "custom_rule_name": "string",
+            "custom_rule_name": "Rule xyz",
             "data": [
                 {
                     "_id": "651c46b145d15228585exxxx",
                     "account_id": "abdcsfData",
                     "app": {
-                        "id": "string",
+                        "id": "abc123",
                         "value": "string"
                     },
                     "attack": {
@@ -1578,7 +1572,7 @@ An example event for `incident_audit` looks as following:
                     "md5": "string",
                     "msg": "string",
                     "namespace": "string",
-                    "os": "string",
+                    "os": "Debian GNU/Linux 12 (bookworm)",
                     "pid": 0,
                     "port": 0,
                     "process_path": "string",
@@ -1607,7 +1601,7 @@ An example event for `incident_audit` looks as following:
                     "wild_fire_report_url": "string"
                 }
             ],
-            "fqdn": "string",
+            "fqdn": "example.com",
             "function": {
                 "id": "string",
                 "value": "string"
@@ -1635,6 +1629,7 @@ An example event for `incident_audit` looks as following:
         "hosts": [
             "audits-fqdn-hostname",
             "gke-tp-cluster-tp-pool1-9658xxxx-j87v",
+            "example.com",
             "string"
         ],
         "ip": [
@@ -1646,7 +1641,8 @@ An example event for `incident_audit` looks as following:
     },
     "rule": {
         "name": [
-            "string"
+            "string",
+            "Rule xyz"
         ]
     },
     "tags": [

--- a/packages/prisma_cloud/manifest.yml
+++ b/packages/prisma_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.3
 name: prisma_cloud
 title: "Palo Alto Prisma Cloud"
-version: "3.1.1"
+version: "3.2.0"
 description: "Collect logs from Prisma Cloud with Elastic Agent."
 type: integration
 categories:


### PR DESCRIPTION
## Proposed Commit Message

```
prisma_cloud: add support for REST API input to the incident audit data stream.

Previously, REST API input was not supported in the Incident Audit data stream. 
This update adds support for REST API input using CEL.

The API specifications were sourced from the Prisma Cloud API for Incident Audit[1], and the
changes were validated against a mock server.

[1] https://pan.dev/prisma-cloud/api/cwpp/get-audits-incidents/
```


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

### To test prisma_cloud integration
Clone integrations repo.
Install the elastic package locally.
Start the elastic stack using the elastic package.
Move to integrations/packages/prisma_cloud directory.
Run the following command to run tests.
`elastic-package test -v`

## Related issues

- Enhancement repo - 24540

