### PR TITLE
Ensure all entries from the package are removed

### DIFF
--- a/.buildkite/scripts/backport_branch.sh
+++ b/.buildkite/scripts/backport_branch.sh
@@ -105,6 +105,7 @@ removeOtherPackages() {
       currentPackage=$(basename "${dir}")
       echo "Removing ${currentPackage} from .github/CODEOWNERS"
       sed -i "/^\/packages\/${currentPackage}\//d" .github/CODEOWNERS
+      sed -i "/^\/packages\/${currentPackage} /d" .github/CODEOWNERS
     fi
   done
 }


### PR DESCRIPTION
## Proposed commit message

Ensure that all entries related to the same package are removed in `.github/CODEOWNERS` file if `REMOVE_OTHER_PACKAGES` is set to true.

```
/packages/aws @team1
/packages/aws/manifest @team2
```

## Related issues

- Relates #13994 


