### PR TITLE
[DOCS] Part 1 - Remove duplicated installation instructions

### DIFF
--- a/packages/opencanary/_dev/build/docs/README.md
+++ b/packages/opencanary/_dev/build/docs/README.md
@@ -4,41 +4,21 @@ This integration is for [Thinkst OpenCanary](https://github.com/thinkst/opencana
 
 ## Data streams
 
-The OpenCanary integration collects the following event types:
+The OpenCanary integration collects the following event types: 
 
-- **events**
+`events`: Collects the OpenCanary logs.
 
 ## Requirements
 
-Elastic Agent must be installed. For more details and installation instructions, please refer to the [Elastic Agent Installation Guide](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
+Elastic Agent must be installed. For more details, check the Elastic Agent [installation instructions](docs-content://reference/fleet/install-elastic-agents.md).
 
-### Installing and managing an Elastic Agent:
+### Enable the integration in Elastic
 
-There are several options for installing and managing Elastic Agent:
-
-### Install a Fleet-managed Elastic Agent (recommended):
-
-With this approach, you install Elastic Agent and use Fleet in Kibana to define, configure, and manage your agents in a central location. We recommend using Fleet management because it makes the management and upgrade of your agents considerably easier.
-
-### Install Elastic Agent in standalone mode (advanced users):
-
-With this approach, you install Elastic Agent and manually configure the agent locally on the system where it’s installed. You are responsible for managing and upgrading the agents. This approach is reserved for advanced users only.
-
-### Install Elastic Agent in a containerized environment:
-
-You can run Elastic Agent inside a container, either with Fleet Server or standalone. Docker images for all versions of Elastic Agent are available from the Elastic Docker registry, and we provide deployment manifests for running on Kubernetes.
-
-Please note, there are minimum requirements for running Elastic Agent. For more information, refer to the  [Elastic Agent Minimum Requirements](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html#elastic-agent-installation-minimum-requirements).
-
-
-### Enabling the integration in Elastic:
-
-1. In Kibana navigate to Management > Integrations.
-2. In "Search for integrations" top bar, search for `OpenCanary`.
-3. Select the "OpenCanary" integration from the search results.
-4. Select "Add OpenCanary" to add the integration.
-5. Add all the required integration configuration parameters.
-6. Select "Save and continue" to save the integration.
+1. In Kibana navigate to **Management** > **Integrations**.
+2. In the search top bar, type **OpenCanary**.
+3. Select the **OpenCanary** integration and add it.
+4. Add all the required integration configuration parameters.
+5. Save the integration.
 
 ## Logs
 

--- a/packages/opencanary/docs/README.md
+++ b/packages/opencanary/docs/README.md
@@ -4,41 +4,21 @@ This integration is for [Thinkst OpenCanary](https://github.com/thinkst/opencana
 
 ## Data streams
 
-The OpenCanary integration collects the following event types:
+The OpenCanary integration collects the following event types: 
 
-- **events**
+`events`: Collects the OpenCanary logs.
 
 ## Requirements
 
-Elastic Agent must be installed. For more details and installation instructions, please refer to the [Elastic Agent Installation Guide](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
+Elastic Agent must be installed. For more details, check the Elastic Agent [installation instructions](docs-content://reference/fleet/install-elastic-agents.md).
 
-### Installing and managing an Elastic Agent:
+### Enable the integration in Elastic
 
-There are several options for installing and managing Elastic Agent:
-
-### Install a Fleet-managed Elastic Agent (recommended):
-
-With this approach, you install Elastic Agent and use Fleet in Kibana to define, configure, and manage your agents in a central location. We recommend using Fleet management because it makes the management and upgrade of your agents considerably easier.
-
-### Install Elastic Agent in standalone mode (advanced users):
-
-With this approach, you install Elastic Agent and manually configure the agent locally on the system where it’s installed. You are responsible for managing and upgrading the agents. This approach is reserved for advanced users only.
-
-### Install Elastic Agent in a containerized environment:
-
-You can run Elastic Agent inside a container, either with Fleet Server or standalone. Docker images for all versions of Elastic Agent are available from the Elastic Docker registry, and we provide deployment manifests for running on Kubernetes.
-
-Please note, there are minimum requirements for running Elastic Agent. For more information, refer to the  [Elastic Agent Minimum Requirements](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html#elastic-agent-installation-minimum-requirements).
-
-
-### Enabling the integration in Elastic:
-
-1. In Kibana navigate to Management > Integrations.
-2. In "Search for integrations" top bar, search for `OpenCanary`.
-3. Select the "OpenCanary" integration from the search results.
-4. Select "Add OpenCanary" to add the integration.
-5. Add all the required integration configuration parameters.
-6. Select "Save and continue" to save the integration.
+1. In Kibana navigate to **Management** > **Integrations**.
+2. In the search top bar, type **OpenCanary**.
+3. Select the **OpenCanary** integration and add it.
+4. Add all the required integration configuration parameters.
+5. Save the integration.
 
 ## Logs
 


### PR DESCRIPTION
This PR:

- Removes the Install sections as these are the same [installation instructions] linked from the Requirements section.
- Updates the link format, compatible with the new doc system rules
- Adjusts the text in the Requirements section

Relates to:
- https://github.com/elastic/integration-docs/issues/653
- https://github.com/elastic/integration-docs/issues/747


This PR fixes the following packages:

- [ ] /packages/opencanary
- [ ] /packages/ping_federate
- [ ] /packages/pps
- [ ] /packages/prisma_access
- [ ] /packages/prisma_cloud
- [ ] /packages/proofpoint_itm
- [ ] /packages/proofpoint_on_demand
- [ ] /packages/qualys_vmdr
- [ ] /packages/sentinel_one_cloud_funnel
- [ ] /packages/servicenow
- [ ] /packages/splunk
- [ ] /packages/spycloud
- [ ] /packages/sublime_security
- [ ] /packages/symantec_endpoint_security
- [ ] /packages/teleport
- [ ] /packages/tenable_io
- [ ] /packages/ti_crowdstrike
- [ ] /packages/ti_eset
- [ ] /packages/ti_rapid7_threat_command
- [ ] /packages/ti_threatconnect
- [ ] /packages/ti_threatq
- [ ] /packages/trellix_edr_cloud
- [ ] /packages/trendmicro
- [ ] /packages/wiz
- [ ] /packages/zscaler_zia


_________________

<img width="909" alt="image" src="https://github.com/user-attachments/assets/e31a9bbb-780f-47f7-95d8-0e7d7f8788cb" />
