### PR TITLE
[KeyClock] Set the ECS field `event.outcome` based on the value of `keycloak.login.type`

### DIFF
--- a/packages/keycloak/changelog.yml
+++ b/packages/keycloak/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.28.0"
+  changes:
+    - description: Set the ECS field `event.outcome` based on the value of `keycloak.login.type`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.27.0"
   changes:
     - description: Add dashboard.

--- a/packages/keycloak/changelog.yml
+++ b/packages/keycloak/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set the ECS field `event.outcome` based on the value of `keycloak.login.type`.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/14027
 - version: "1.27.0"
   changes:
     - description: Add dashboard.

--- a/packages/keycloak/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
+++ b/packages/keycloak/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
@@ -197,6 +197,7 @@
                 "code": "invalid_redirect_uri",
                 "kind": "event",
                 "original": "2021-10-22 21:01:45,403 WARN  [org.keycloak.events] (default task-1) type=LOGIN_ERROR, realmId=test, clientId=test, userId=null, ipAddress=172.18.0.1, error=invalid_redirect_uri, redirect_uri=http://localhost:8080",
+                "outcome": "failure",
                 "timezone": "America/Chicago",
                 "type": [
                     "info"
@@ -259,6 +260,7 @@
                 "code": "invalid_user_credentials",
                 "kind": "event",
                 "original": "2021-10-22 21:20:42,120 WARN  [org.keycloak.events] (default task-2) type=LOGIN_ERROR, realmId=test, clientId=test, userId=cc74404c-de7e-482a-98f7-b271ff3c49be, ipAddress=172.18.0.1, error=invalid_user_credentials, auth_method=openid-connect, auth_type=code, redirect_uri=http://127.0.0.1:8080, code_id=3a76b735-e324-42b1-aa15-7c1f69f22eb8, username=admin, authSessionParentId=3a76b735-e324-42b1-aa15-7c1f69f22eb8, authSessionTabId=oJpF-WjDC04",
+                "outcome": "failure",
                 "timezone": "America/Chicago",
                 "type": [
                     "info"
@@ -333,6 +335,7 @@
                 "code": "user_not_found",
                 "kind": "event",
                 "original": "2021-10-22 21:24:41,076 WARN  [org.keycloak.events] (default task-10) type=LOGIN_ERROR, realmId=master, clientId=security-admin-console, userId=null, ipAddress=172.18.0.1, error=user_not_found, auth_method=openid-connect, auth_type=code, redirect_uri=http://127.0.0.1:9090/auth/admin/master/console/, code_id=f9d4300d-d052-4eb6-9aeb-e8fcf642a21f, authSessionParentId=f9d4300d-d052-4eb6-9aeb-e8fcf642a21f, authSessionTabId=C8EtUrcFMsg",
+                "outcome": "failure",
                 "timezone": "America/Chicago",
                 "type": [
                     "info"
@@ -401,6 +404,7 @@
                 "code": "invalid_redirect_uri",
                 "kind": "event",
                 "original": "2021-10-22 21:31:31,555 WARN  [org.keycloak.events] (default task-10) type=LOGIN_ERROR, realmId=test, clientId=test, userId=null, ipAddress=172.18.0.1, error=invalid_redirect_uri, redirect_uri=http://localhost:8080",
+                "outcome": "failure",
                 "timezone": "America/Chicago",
                 "type": [
                     "info"
@@ -463,6 +467,7 @@
                 "code": "invalid_user_credentials",
                 "kind": "event",
                 "original": "2021-10-22 20:58:02,700 WARN  [org.keycloak.events] (default task-18) type=LOGIN_ERROR, realmId=ABCD TEST, clientId=https://www.example.com/shibboleth, userId=ce637d23-b89c-4fca-9088-1aea1d053e19, ipAddress=10.2.2.156, error=invalid_user_credentials, auth_method=saml, redirect_uri=https://www.example.com/Shibboleth.sso/SAML2/POST, code_id=cbefe0ca-bc11-48b4-b7fa-f1a59d220980, username=admin, authSessionParentId=cbefe0ca-bc11-48b4-b7fa-f1a59d220980, authSessionTabId=97qImXws36A",
+                "outcome": "failure",
                 "timezone": "America/Chicago",
                 "type": [
                     "info"
@@ -536,6 +541,7 @@
                 ],
                 "kind": "event",
                 "original": "2021-10-22 22:11:31,257 DEBUG [org.keycloak.events] (default task-2) type=LOGIN, realmId=test, clientId=security-admin-console, userId=ce637d23-b89c-4fca-9088-1aea1d053e19, ipAddress=10.2.2.156, auth_method=openid-connect, auth_type=code, redirect_uri=https://www.example.com/auth/admin/test/console/#/realms/test/events, consent=no_consent_required, code_id=bae6e56e-368f-4809-89f3-48cfb6279f5e, username=admin, authSessionParentId=bae6e56e-368f-4809-89f3-48cfb6279f5e, authSessionTabId=Kz_ye2UvP6M",
+                "outcome": "success",
                 "timezone": "America/Chicago",
                 "type": [
                     "info",
@@ -611,6 +617,7 @@
                 ],
                 "kind": "event",
                 "original": "2021-10-22 22:11:32,131 DEBUG [org.keycloak.events] (default task-3) type=CODE_TO_TOKEN, realmId=test, clientId=security-admin-console, userId=ce637d23-b89c-4fca-9088-1aea1d053e19, ipAddress=10.2.2.156, token_id=561459c0-75f1-46d4-986d-d1c96d12b513, grant_type=authorization_code, refresh_token_type=Refresh, scope=openid, refresh_token_id=07434488-ca99-412a-99a0-c2e47c93d6d1, code_id=bae6e56e-368f-4809-89f3-48cfb6279f5e, client_auth_method=client-secret",
+                "outcome": "unknown",
                 "timezone": "America/Chicago",
                 "type": [
                     "info"
@@ -670,6 +677,7 @@
                 "code": "CREATE-USER",
                 "kind": "event",
                 "original": "2021-10-22 22:12:09,871 DEBUG [org.keycloak.events] (default task-3) operationType=CREATE, realmId=test, clientId=7bcaf1cb-820a-40f1-91dd-75ced03ef03b, userId=ce637d23-b89c-4fca-9088-1aea1d053e19, ipAddress=10.2.2.156, resourceType=USER, resourcePath=users/07972d16-b173-4c99-803d-90f211080f40",
+                "outcome": "unknown",
                 "timezone": "America/Chicago",
                 "type": [
                     "info",
@@ -738,6 +746,7 @@
                 "code": "UPDATE-USER",
                 "kind": "event",
                 "original": "2021-10-22 22:12:13,599 DEBUG [org.keycloak.events] (default task-1) operationType=UPDATE, realmId=test, clientId=7bcaf1cb-820a-40f1-91dd-75ced03ef03b, userId=ce637d23-b89c-4fca-9088-1aea1d053e19, ipAddress=10.2.2.156, resourceType=USER, resourcePath=users/07972d16-b173-4c99-803d-90f211080f40",
+                "outcome": "unknown",
                 "timezone": "America/Chicago",
                 "type": [
                     "info",
@@ -806,6 +815,7 @@
                 "code": "CREATE-GROUP",
                 "kind": "event",
                 "original": "2021-10-22 22:14:29,031 DEBUG [org.keycloak.events] (default task-9) operationType=CREATE, realmId=test, clientId=7bcaf1cb-820a-40f1-91dd-75ced03ef03b, userId=ce637d23-b89c-4fca-9088-1aea1d053e19, ipAddress=10.2.2.156, resourceType=GROUP, resourcePath=groups/d043d5af-6100-483a-9c41-b1a30d5149f7",
+                "outcome": "unknown",
                 "timezone": "America/Chicago",
                 "type": [
                     "info",
@@ -873,6 +883,7 @@
                 "code": "CREATE-CLIENT_SCOPE",
                 "kind": "event",
                 "original": "2021-10-22 22:16:12,150 DEBUG [org.keycloak.events] (default task-8) operationType=CREATE, realmId=test, clientId=7bcaf1cb-820a-40f1-91dd-75ced03ef03b, userId=ce637d23-b89c-4fca-9088-1aea1d053e19, ipAddress=10.2.2.156, resourceType=CLIENT_SCOPE, resourcePath=client-scopes/3b4139b4-66e1-4309-88c1-63ee5abc93a6",
+                "outcome": "unknown",
                 "timezone": "America/Chicago",
                 "type": [
                     "info",
@@ -936,6 +947,7 @@
                 ],
                 "kind": "event",
                 "original": "2021-10-22 22:45:12,592 DEBUG [org.keycloak.events] (default task-8) type=LOGOUT, realmId=test, clientId=null, userId=ce637d23-b89c-4fca-9088-1aea1d053e19, ipAddress=10.2.2.156, redirect_uri=https://www.example.com/auth/admin/test/console/#/realms/test/admin-events, authSessionParentId=bae6e56e-368f-4809-89f3-48cfb6279f5e, authSessionTabId=GbBi74IWYc4",
+                "outcome": "unknown",
                 "timezone": "America/Chicago",
                 "type": [
                     "info",
@@ -1005,6 +1017,7 @@
                 "code": "DELETE-GROUP",
                 "kind": "event",
                 "original": "2021-10-22 22:46:14,913 DEBUG [org.keycloak.events] (default task-1) operationType=DELETE, realmId=test, clientId=7bcaf1cb-820a-40f1-91dd-75ced03ef03b, userId=ce637d23-b89c-4fca-9088-1aea1d053e19, ipAddress=10.2.2.156, resourceType=GROUP, resourcePath=groups/d043d5af-6100-483a-9c41-b1a30d5149f7",
+                "outcome": "unknown",
                 "timezone": "America/Chicago",
                 "type": [
                     "info",
@@ -1095,6 +1108,7 @@
                 "code": "CREATE-GROUP",
                 "kind": "event",
                 "original": "2021-10-22 23:05:03,371 DEBUG [org.keycloak.events] (default task-8) operationType=CREATE, realmId=test, clientId=7bcaf1cb-820a-40f1-91dd-75ced03ef03b, userId=ce637d23-b89c-4fca-9088-1aea1d053e19, ipAddress=10.2.2.156, resourceType=GROUP, resourcePath=groups/a57cd49f-fdfd-4d25-9fd2-2a46de44a9e6/children",
+                "outcome": "unknown",
                 "timezone": "America/Chicago",
                 "type": [
                     "info",
@@ -1161,6 +1175,7 @@
                 ],
                 "kind": "event",
                 "original": "2024-07-17 12:05:32,104 INFO [org.keycloak.events] (main-thread-1) type=\\\"LOGOUT\\\", realmId=\\\"12345678-9abc-def0-1234-56789abcdef0\\\", clientId=\\\"user-console\\\", userId=\\\"abcdef12-3456-7890-abcd-ef1234567890\\\", sessionId=\\\"abcd1234-5678-90ab-cdef-1234567890ab\\\", ipAddress=\\\"192.168.1.1\\\", auth_method=\\\"oauth2\\\", auth_type=\\\"token\\\", response_type=\\\"token\\\", redirect_uri=\\\"https://example.com/realms/demo/account/\\\", consent=\\\"consent_required\\\", code_id=\\\"abcd1234-5678-90ab-cdef-1234567890ab\\\", response_mode=\\\"fragment\\\", username=\\\"dummyuser\\\", authSessionParentId=\\\"abcd1234-5678-90ab-cdef-1234567890ab\\\", authSessionTabId=\\\"zXY987wvuTsr\\\"",
+                "outcome": "unknown",
                 "timezone": "America/Chicago",
                 "type": [
                     "info",

--- a/packages/keycloak/data_stream/log/elasticsearch/ingest_pipeline/events.yml
+++ b/packages/keycloak/data_stream/log/elasticsearch/ingest_pipeline/events.yml
@@ -13,6 +13,18 @@ processors:
     field: json.type
     target_field: keycloak.login.type
     ignore_missing: true
+- set:
+    field: event.outcome
+    value: success
+    if: ctx.keycloak?.login?.type != null && ctx.keycloak.login.type.equalsIgnoreCase('login')
+- set:
+    field: event.outcome
+    value: failure
+    if: ctx.keycloak?.login?.type != null && ctx.keycloak.login.type.equalsIgnoreCase('login_error')
+- set:
+    field: event.outcome
+    value: unknown
+    if: ctx.event?.outcome == null
 - rename:
     field: json.operationType
     target_field: keycloak.admin.operation

--- a/packages/keycloak/data_stream/log/sample_event.json
+++ b/packages/keycloak/data_stream/log/sample_event.json
@@ -1,48 +1,50 @@
 {
-    "@timestamp": "2021-10-22T21:01:42.667-05:00",
+    "@timestamp": "2021-10-22T21:01:42.667+05:00",
     "agent": {
-        "ephemeral_id": "bb6d890f-5c05-4247-b410-8f3b914e5293",
-        "id": "d053789b-7b04-4a8c-b06c-ca79014bb61a",
-        "name": "docker-fleet-agent",
+        "ephemeral_id": "9f6c0477-ed78-4030-8b72-4c0794d50c25",
+        "id": "3df05e3b-922c-4316-a0fa-fb72d095657d",
+        "name": "elastic-agent-22472",
         "type": "filebeat",
-        "version": "8.10.2"
+        "version": "8.13.0"
     },
     "data_stream": {
         "dataset": "keycloak.log",
-        "namespace": "ep",
+        "namespace": "68860",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "d053789b-7b04-4a8c-b06c-ca79014bb61a",
+        "id": "3df05e3b-922c-4316-a0fa-fb72d095657d",
         "snapshot": false,
-        "version": "8.10.2"
+        "version": "8.13.0"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "keycloak.log",
-        "ingested": "2023-10-03T10:29:46Z",
+        "ingested": "2025-05-28T08:34:57Z",
         "original": "2021-10-22 21:01:42,667 INFO  [org.jboss.resteasy.resteasy_jaxrs.i18n] (ServerService Thread Pool -- 64) RESTEASY002220: Adding singleton resource org.keycloak.services.resources.admin.AdminRoot from Application class org.keycloak.services.resources.KeycloakApplication",
-        "timezone": "-05:00"
+        "timezone": "+05:00"
     },
     "host": {
         "architecture": "x86_64",
         "containerized": true,
-        "hostname": "docker-fleet-agent",
-        "id": "efe661d97f0c4d9883075c393da6b0d8",
+        "hostname": "elastic-agent-22472",
+        "id": "8259e024976a406e8a54cdbffeb84fec",
         "ip": [
-            "172.30.0.7"
+            "192.168.255.2",
+            "192.168.252.6"
         ],
         "mac": [
-            "02-42-AC-1E-00-07"
+            "02-42-C0-A8-FC-06",
+            "02-42-C0-A8-FF-02"
         ],
-        "name": "docker-fleet-agent",
+        "name": "elastic-agent-22472",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.15.90.1-microsoft-standard-WSL2",
+            "kernel": "3.10.0-1160.92.1.el7.x86_64",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
@@ -54,8 +56,8 @@
     },
     "log": {
         "file": {
-            "device_id": 2080,
-            "inode": 90612,
+            "device_id": "64768",
+            "inode": "19004628",
             "path": "/tmp/service_logs/test-log.log"
         },
         "level": "INFO",

--- a/packages/keycloak/docs/README.md
+++ b/packages/keycloak/docs/README.md
@@ -71,46 +71,46 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2021-10-22T21:01:42.667+05:00",
     "agent": {
-        "ephemeral_id": "03e0d0ad-162e-44f5-a7c2-5126fa84c0c7",
-        "id": "1ec0b954-4169-44b5-8084-b93ffd22c093",
-        "name": "elastic-agent-30208",
+        "ephemeral_id": "9f6c0477-ed78-4030-8b72-4c0794d50c25",
+        "id": "3df05e3b-922c-4316-a0fa-fb72d095657d",
+        "name": "elastic-agent-22472",
         "type": "filebeat",
         "version": "8.13.0"
     },
     "data_stream": {
         "dataset": "keycloak.log",
-        "namespace": "63087",
+        "namespace": "68860",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "1ec0b954-4169-44b5-8084-b93ffd22c093",
+        "id": "3df05e3b-922c-4316-a0fa-fb72d095657d",
         "snapshot": false,
         "version": "8.13.0"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "keycloak.log",
-        "ingested": "2025-05-26T11:22:48Z",
+        "ingested": "2025-05-28T08:34:57Z",
         "original": "2021-10-22 21:01:42,667 INFO  [org.jboss.resteasy.resteasy_jaxrs.i18n] (ServerService Thread Pool -- 64) RESTEASY002220: Adding singleton resource org.keycloak.services.resources.admin.AdminRoot from Application class org.keycloak.services.resources.KeycloakApplication",
         "timezone": "+05:00"
     },
     "host": {
         "architecture": "x86_64",
         "containerized": true,
-        "hostname": "elastic-agent-30208",
+        "hostname": "elastic-agent-22472",
         "id": "8259e024976a406e8a54cdbffeb84fec",
         "ip": [
-            "192.168.243.2",
-            "192.168.240.7"
+            "192.168.255.2",
+            "192.168.252.6"
         ],
         "mac": [
-            "02-42-C0-A8-F0-07",
-            "02-42-C0-A8-F3-02"
+            "02-42-C0-A8-FC-06",
+            "02-42-C0-A8-FF-02"
         ],
-        "name": "elastic-agent-30208",
+        "name": "elastic-agent-22472",
         "os": {
             "codename": "focal",
             "family": "debian",
@@ -127,7 +127,7 @@ An example event for `log` looks as following:
     "log": {
         "file": {
             "device_id": "64768",
-            "inode": "10072278",
+            "inode": "19004628",
             "path": "/tmp/service_logs/test-log.log"
         },
         "level": "INFO",

--- a/packages/keycloak/docs/README.md
+++ b/packages/keycloak/docs/README.md
@@ -69,50 +69,52 @@ An example event for `log` looks as following:
 
 ```json
 {
-    "@timestamp": "2021-10-22T21:01:42.667-05:00",
+    "@timestamp": "2021-10-22T21:01:42.667+05:00",
     "agent": {
-        "ephemeral_id": "bb6d890f-5c05-4247-b410-8f3b914e5293",
-        "id": "d053789b-7b04-4a8c-b06c-ca79014bb61a",
-        "name": "docker-fleet-agent",
+        "ephemeral_id": "03e0d0ad-162e-44f5-a7c2-5126fa84c0c7",
+        "id": "1ec0b954-4169-44b5-8084-b93ffd22c093",
+        "name": "elastic-agent-30208",
         "type": "filebeat",
-        "version": "8.10.2"
+        "version": "8.13.0"
     },
     "data_stream": {
         "dataset": "keycloak.log",
-        "namespace": "ep",
+        "namespace": "63087",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "d053789b-7b04-4a8c-b06c-ca79014bb61a",
+        "id": "1ec0b954-4169-44b5-8084-b93ffd22c093",
         "snapshot": false,
-        "version": "8.10.2"
+        "version": "8.13.0"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "keycloak.log",
-        "ingested": "2023-10-03T10:29:46Z",
+        "ingested": "2025-05-26T11:22:48Z",
         "original": "2021-10-22 21:01:42,667 INFO  [org.jboss.resteasy.resteasy_jaxrs.i18n] (ServerService Thread Pool -- 64) RESTEASY002220: Adding singleton resource org.keycloak.services.resources.admin.AdminRoot from Application class org.keycloak.services.resources.KeycloakApplication",
-        "timezone": "-05:00"
+        "timezone": "+05:00"
     },
     "host": {
         "architecture": "x86_64",
         "containerized": true,
-        "hostname": "docker-fleet-agent",
-        "id": "efe661d97f0c4d9883075c393da6b0d8",
+        "hostname": "elastic-agent-30208",
+        "id": "8259e024976a406e8a54cdbffeb84fec",
         "ip": [
-            "172.30.0.7"
+            "192.168.243.2",
+            "192.168.240.7"
         ],
         "mac": [
-            "02-42-AC-1E-00-07"
+            "02-42-C0-A8-F0-07",
+            "02-42-C0-A8-F3-02"
         ],
-        "name": "docker-fleet-agent",
+        "name": "elastic-agent-30208",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.15.90.1-microsoft-standard-WSL2",
+            "kernel": "3.10.0-1160.92.1.el7.x86_64",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
@@ -124,8 +126,8 @@ An example event for `log` looks as following:
     },
     "log": {
         "file": {
-            "device_id": 2080,
-            "inode": 90612,
+            "device_id": "64768",
+            "inode": "10072278",
             "path": "/tmp/service_logs/test-log.log"
         },
         "level": "INFO",

--- a/packages/keycloak/manifest.yml
+++ b/packages/keycloak/manifest.yml
@@ -1,6 +1,6 @@
 name: keycloak
 title: Keycloak
-version: "1.27.0"
+version: "1.28.0"
 description: Collect logs from Keycloak with Elastic Agent.
 type: integration
 format_version: "3.0.3"


### PR DESCRIPTION
## Proposed commit message

```
keycloak: parse event.outcome field

This PR sets the ecs field `event.outcome` based on the value of `keycloak.login.type`.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/keyclock directory.
- Run the following command to run tests.

> elastic-package test