### PR TITLE
o365: validate field type in pipeline before accessing subfields

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Validate organization field type before accessing subfields.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/14056
 - version: "2.17.0"
   changes:
     - description: Set `application.name`, `device.id`, `session.id`, and `token.id` in audit dataset.

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.17.1"
+  changes:
+    - description: Validate organization field type before accessing subfields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "2.17.0"
   changes:
     - description: Set `application.name`, `device.id`, `session.id`, and `token.id` in audit dataset.

--- a/packages/o365/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/o365/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -1099,10 +1099,10 @@ processors:
   - set:
       field: host.id
       copy_from: organization.id
-      if: ctx.organization?.id != null
+      if: ctx.organization instanceof Map && ctx.organization?.id != null
   - script:
       lang: painless
-      if: 'ctx.organization?.id != null && ctx._conf?.tenants != null'
+      if: ctx.organization instanceof Map && ctx.organization?.id != null && ctx._conf?.tenants != null
       source: >
         def conftenants = ctx._conf.tenants;
         def orgid = ctx.organization.id;
@@ -1113,7 +1113,7 @@ processors:
   - set:
       field: host.name
       copy_from: organization.name
-      if: ctx.organization?.name != null && ctx.host?.name == null
+      if: ctx.organization instanceof Map && ctx.organization?.name != null && ctx.host?.name == null
   - set:
       field: host.name
       copy_from: user.domain

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft Office 365
-version: "2.17.0"
+version: "2.17.1"
 description: Collect logs from Microsoft Office 365 with Elastic Agent.
 type: integration
 format_version: "3.2.3"


### PR DESCRIPTION
## Proposed commit message

As `organization` field may be a string instead of an object, the following error can appear when accessing its subfields being a string value.

```
Processor 'conditional' with tag '' failed with message 'dynamic getter [java.lang.String, id] not found'
```

Added a type check before accessing its subfields to avoid the above error.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
