### PR TITLE
Move Attributes to a flattened entity.raw

### DIFF
--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -1,6 +1,11 @@
 # newer versions go on top
 # version map:
 # 0.1.x - 8.15.x
+- version: "0.16.0"
+  changes:
+    - description: Move object Attributes to flattened entity.raw
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/14084
 - version: "0.15.0"
   changes:
     - description: Rename type to sub_type and category to type

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/fields/entity.yml
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/fields/entity.yml
@@ -1,11 +1,3 @@
-- name: Attributes
-  type: group    
-  dynamic: true
-  ignore_malformed: true
-  fields: 
-    - name: bucket_policy
-      type: flattened
-  
 - name: entity
   type: group  
   fields:
@@ -20,5 +12,8 @@
 
   - name: sub_type
     type: keyword
+  
+  - name: raw
+    type: flattened
 
   

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_asset_inventory
 title: "Cloud Asset Discovery"
-version: "0.15.0"
+version: "0.16.0"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Discovery"


### PR DESCRIPTION
Move `Attributes` (previously dynamic mapped object) to `entity.raw` flattened field

## Related issues
-  Related https://github.com/elastic/security-team/issues/12548

## Screenshots

![image](https://github.com/user-attachments/assets/63aa5f51-7148-4aa4-a449-a94b59b1d4fe)
