### PR TITLE
[Asset Discovery] Add `entity.source` to asset discovery

### DIFF
--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -1,6 +1,11 @@
 # newer versions go on top
 # version map:
 # 0.1.x - 8.15.x
+- version: "0.18.0"
+  changes:
+    - description: Add entity.source
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/14087
 - version: "0.17.0"
   changes:
     - description: Add cloud connector support Asset Inventory for AWS

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/fields/entity.yml
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/fields/entity.yml
@@ -13,6 +13,9 @@
   - name: sub_type
     type: keyword
   
+  - name: source
+    type: keyword
+  
   - name: raw
     type: flattened
 

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_asset_inventory
 title: "Cloud Asset Discovery"
-version: "0.17.0"
+version: "0.18.0"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Discovery"


### PR DESCRIPTION
Add `entity.source` ([ECS field](https://github.com/elastic/ecs/blob/main/rfcs/text/0049/entity.yml#L30))

- Related to https://github.com/elastic/security-team/issues/12550
- Complimentary of https://github.com/elastic/cloudbeat/pull/3317
