### PR TITLE
[panw_cortex_xdr] Improve rate limit configuration

### DIFF
--- a/packages/panw_cortex_xdr/changelog.yml
+++ b/packages/panw_cortex_xdr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.0"
+  changes:
+    - description: Improve rate limit configuration.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/14091
 - version: "2.2.0"
   changes:
     - description: Add event data stream to collect event forwarding logs via the Google Cloud Storage input and add dashboards for alert and incident data stream.

--- a/packages/panw_cortex_xdr/data_stream/alerts/agent/stream/cel.yml.hbs
+++ b/packages/panw_cortex_xdr/data_stream/alerts/agent/stream/cel.yml.hbs
@@ -5,6 +5,9 @@ resource.tracer.filename: "../../logs/cel/http-request-trace-*.ndjson"
 resource.tracer.maxbackups: 5
 {{/if}}
 resource.url: {{url}}
+# There is a limit of 10 API requests per second for each tenant. This includes all endpoints.
+resource.rate_limit.limit: 4
+resource.rate_limit.burst: 1
 state:
   token_id: "{{token_id}}"
   api_token: {{api_token}}

--- a/packages/panw_cortex_xdr/data_stream/alerts/agent/stream/httpjson.yml.hbs
+++ b/packages/panw_cortex_xdr/data_stream/alerts/agent/stream/httpjson.yml.hbs
@@ -18,10 +18,6 @@ request.timeout: {{request_timeout}}
 {{#if proxy_url }}
 request.proxy_url: {{proxy_url}}
 {{/if}}
-request.rate_limit:
-  limit: '[[.last_response.header.Get "X-Rate-Limit-Limit"]]'
-  remaining: '[[.last_response.header.Get "X-Rate-Limit-Remaining"]]'
-  reset: '[[(parseDate (.last_response.header.Get "X-Rate-Limit-Reset")).Unix]]'
 request.transforms:
 {{#if advanced_sec_level }}
 - set:

--- a/packages/panw_cortex_xdr/data_stream/incidents/agent/stream/httpjson.yml.hbs
+++ b/packages/panw_cortex_xdr/data_stream/incidents/agent/stream/httpjson.yml.hbs
@@ -18,10 +18,6 @@ request.timeout: {{request_timeout}}
 {{#if proxy_url }}
 request.proxy_url: {{proxy_url}}
 {{/if}}
-request.rate_limit:
-  limit: '[[.last_response.header.Get "X-Rate-Limit-Limit"]]'
-  remaining: '[[.last_response.header.Get "X-Rate-Limit-Remaining"]]'
-  reset: '[[(parseDate (.last_response.header.Get "X-Rate-Limit-Reset")).Unix]]'
 request.transforms:
 {{#if advanced_sec_level}}
 - set:

--- a/packages/panw_cortex_xdr/manifest.yml
+++ b/packages/panw_cortex_xdr/manifest.yml
@@ -1,6 +1,6 @@
 name: panw_cortex_xdr
 title: Palo Alto Cortex XDR
-version: "2.2.0"
+version: "2.3.0"
 description: Collect logs from Palo Alto Cortex XDR with Elastic Agent.
 type: integration
 format_version: "3.3.2"


### PR DESCRIPTION
## Proposed commit message

```
[panw_cortex_xdr] Improve rate limit configuration

- Remove HTTPJSON `request.rate_limit.*` configuration, since the API
  does not return `X-Rate-Limit-*` headers.
- Add CEL `resource.rate_limit` configuration to set a fixed limit of 4
  requests per second, which is just under half of the total limit.

The relevant API documentation[1] says:
> There is a limit of 10 API requests per second for each tenant. This
> includes all endpoints. Sending more than 10 requests per second can
> result in the following error: "Too many requests."

[1]: https://docs-cortex.paloaltonetworks.com/r/Cortex-XDR-REST-API/Get-Started-with-Cortex-XDR-APIs
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
