### PR TITLE
auth0: standardize user name processing

### DIFF
--- a/packages/auth0/changelog.yml
+++ b/packages/auth0/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.0"
+  changes:
+    - description: Standardize user fields processing across integrations.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "1.21.2"
   changes:
     - description: Fix `event.type` and `event.category` classification of failed authentication events.

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-login-failure.json-expected.json
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-login-failure.json-expected.json
@@ -83,7 +83,7 @@
                 "os": {
                     "name": "Ubuntu"
                 },
-                "version": "93.0."
+                "version": "93.0"
             }
         },
         {
@@ -170,7 +170,7 @@
                 "os": {
                     "name": "Ubuntu"
                 },
-                "version": "93.0."
+                "version": "93.0"
             }
         },
         {
@@ -310,6 +310,12 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "neo",
+                    "neo@gmail.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -326,7 +332,9 @@
                 "ip": "81.2.69.143"
             },
             "user": {
-                "name": "neo@gmail.com"
+                "domain": "gmail.com",
+                "email": "neo@gmail.com",
+                "name": "neo"
             },
             "user_agent": {
                 "device": {
@@ -337,7 +345,7 @@
                 "os": {
                     "name": "Ubuntu"
                 },
-                "version": "93.0."
+                "version": "93.0"
             }
         },
         {
@@ -385,6 +393,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|61823277a44a21007221a59a",
+                    "new",
+                    "new@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -401,8 +416,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "new@test.com",
                 "id": "auth0|61823277a44a21007221a59a",
-                "name": "new@test.com"
+                "name": "new"
             },
             "user_agent": {
                 "device": {

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-login-success.json-expected.json
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-login-success.json-expected.json
@@ -84,6 +84,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618223a4e3f49e006948565c",
+                    "dev",
+                    "dev@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -100,8 +107,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "dev@test.com",
                 "id": "auth0|618223a4e3f49e006948565c",
-                "name": "dev@test.com"
+                "name": "dev"
             },
             "user_agent": {
                 "device": {
@@ -213,6 +222,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6182002f34f4dd006b05b5c7",
+                    "neo",
+                    "neo@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -229,8 +245,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "neo@test.com",
                 "id": "auth0|6182002f34f4dd006b05b5c7",
-                "name": "neo@test.com"
+                "name": "neo"
             },
             "user_agent": {
                 "device": {
@@ -241,7 +259,7 @@
                 "os": {
                     "name": "Ubuntu"
                 },
-                "version": "93.0."
+                "version": "93.0"
             }
         },
         {
@@ -289,6 +307,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6182002f34f4dd006b05b5c7",
+                    "neo",
+                    "neo@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -305,8 +330,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "neo@test.com",
                 "id": "auth0|6182002f34f4dd006b05b5c7",
-                "name": "neo@test.com"
+                "name": "neo"
             },
             "user_agent": {
                 "device": {
@@ -317,7 +344,7 @@
                 "os": {
                     "name": "Ubuntu"
                 },
-                "version": "93.0."
+                "version": "93.0"
             }
         },
         {
@@ -416,6 +443,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618223a4e3f49e006948565c",
+                    "dev",
+                    "dev@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -432,8 +466,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "dev@test.com",
                 "id": "auth0|618223a4e3f49e006948565c",
-                "name": "dev@test.com"
+                "name": "dev"
             },
             "user_agent": {
                 "device": {
@@ -444,7 +480,7 @@
                 "os": {
                     "name": "Ubuntu"
                 },
-                "version": "93.0."
+                "version": "93.0"
             }
         },
         {
@@ -543,6 +579,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618232c562bac1006935a7af",
+                    "neo",
+                    "neo@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -559,8 +602,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "neo@test.com",
                 "id": "auth0|618232c562bac1006935a7af",
-                "name": "neo@test.com"
+                "name": "neo"
             },
             "user_agent": {
                 "device": {
@@ -571,7 +616,7 @@
                 "os": {
                     "name": "Ubuntu"
                 },
-                "version": "93.0."
+                "version": "93.0"
             }
         },
         {
@@ -658,6 +703,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618223a4e3f49e006948565c",
+                    "dev",
+                    "dev@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -674,8 +726,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "dev@test.com",
                 "id": "auth0|618223a4e3f49e006948565c",
-                "name": "dev@test.com"
+                "name": "dev"
             },
             "user_agent": {
                 "device": {
@@ -686,7 +740,7 @@
                 "os": {
                     "name": "Ubuntu"
                 },
-                "version": "93.0."
+                "version": "93.0"
             }
         },
         {
@@ -773,6 +827,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618232c562bac1006935a7af",
+                    "neo",
+                    "neo@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -789,8 +850,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "neo@test.com",
                 "id": "auth0|618232c562bac1006935a7af",
-                "name": "neo@test.com"
+                "name": "neo"
             },
             "user_agent": {
                 "device": {
@@ -801,7 +864,7 @@
                 "os": {
                     "name": "Ubuntu"
                 },
-                "version": "93.0."
+                "version": "93.0"
             }
         },
         {
@@ -888,6 +951,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618232c562bac1006935a7af",
+                    "neo",
+                    "neo@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -904,8 +974,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "neo@test.com",
                 "id": "auth0|618232c562bac1006935a7af",
-                "name": "neo@test.com"
+                "name": "neo"
             },
             "user_agent": {
                 "device": {
@@ -966,6 +1038,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618232c562bac1006935a7af",
+                    "neo",
+                    "neo@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -982,8 +1061,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "neo@test.com",
                 "id": "auth0|618232c562bac1006935a7af",
-                "name": "neo@test.com"
+                "name": "neo"
             },
             "user_agent": {
                 "device": {
@@ -1083,6 +1164,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618223a4e3f49e006948565c",
+                    "dev",
+                    "dev@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -1099,8 +1187,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "dev@test.com",
                 "id": "auth0|618223a4e3f49e006948565c",
-                "name": "dev@test.com"
+                "name": "dev"
             },
             "user_agent": {
                 "device": {
@@ -1212,6 +1302,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|61823277a44a21007221a59a",
+                    "new",
+                    "new@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -1228,8 +1325,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "new@test.com",
                 "id": "auth0|61823277a44a21007221a59a",
-                "name": "new@test.com"
+                "name": "new"
             },
             "user_agent": {
                 "device": {
@@ -1329,6 +1428,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|61823277a44a21007221a59a",
+                    "new",
+                    "new@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -1345,8 +1451,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "new@test.com",
                 "id": "auth0|61823277a44a21007221a59a",
-                "name": "new@test.com"
+                "name": "new"
             },
             "user_agent": {
                 "device": {
@@ -1446,6 +1554,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|61823277a44a21007221a59a",
+                    "new",
+                    "new@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -1462,8 +1577,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "new@test.com",
                 "id": "auth0|61823277a44a21007221a59a",
-                "name": "new@test.com"
+                "name": "new"
             },
             "user_agent": {
                 "device": {
@@ -1563,6 +1680,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|61823277a44a21007221a59a",
+                    "new",
+                    "new@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -1579,8 +1703,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "new@test.com",
                 "id": "auth0|61823277a44a21007221a59a",
-                "name": "new@test.com"
+                "name": "new"
             },
             "user_agent": {
                 "device": {
@@ -1680,6 +1806,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6182002f34f4dd006b05b5c7",
+                    "neo",
+                    "neo@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -1696,8 +1829,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "neo@test.com",
                 "id": "auth0|6182002f34f4dd006b05b5c7",
-                "name": "neo@test.com"
+                "name": "neo"
             },
             "user_agent": {
                 "device": {
@@ -1797,6 +1932,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618232c562bac1006935a7af",
+                    "neo",
+                    "neo@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -1813,8 +1955,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "neo@test.com",
                 "id": "auth0|618232c562bac1006935a7af",
-                "name": "neo@test.com"
+                "name": "neo"
             },
             "user_agent": {
                 "device": {
@@ -1914,6 +2058,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|61823277a44a21007221a59a",
+                    "new",
+                    "new@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -1930,8 +2081,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "new@test.com",
                 "id": "auth0|61823277a44a21007221a59a",
-                "name": "new@test.com"
+                "name": "new"
             },
             "user_agent": {
                 "device": {
@@ -2031,6 +2184,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|61823277a44a21007221a59a",
+                    "new",
+                    "new@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -2047,8 +2207,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "new@test.com",
                 "id": "auth0|61823277a44a21007221a59a",
-                "name": "new@test.com"
+                "name": "new"
             },
             "user_agent": {
                 "device": {
@@ -2148,6 +2310,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618232c562bac1006935a7af",
+                    "neo",
+                    "neo@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -2164,8 +2333,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "neo@test.com",
                 "id": "auth0|618232c562bac1006935a7af",
-                "name": "neo@test.com"
+                "name": "neo"
             },
             "user_agent": {
                 "device": {
@@ -2265,6 +2436,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618223a4e3f49e006948565c",
+                    "dev",
+                    "dev@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -2281,8 +2459,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "dev@test.com",
                 "id": "auth0|618223a4e3f49e006948565c",
-                "name": "dev@test.com"
+                "name": "dev"
             },
             "user_agent": {
                 "device": {
@@ -2394,6 +2574,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6183285d6e5071006a61f319",
+                    "neo.theone",
+                    "neo.theone@gmail.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -2410,8 +2597,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "gmail.com",
+                "email": "neo.theone@gmail.com",
                 "id": "auth0|6183285d6e5071006a61f319",
-                "name": "neo.theone@gmail.com"
+                "name": "neo.theone"
             },
             "user_agent": {
                 "device": {
@@ -2523,6 +2712,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6183285d6e5071006a61f319",
+                    "neo.theone",
+                    "neo.theone@gmail.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -2539,8 +2735,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "gmail.com",
+                "email": "neo.theone@gmail.com",
                 "id": "auth0|6183285d6e5071006a61f319",
-                "name": "neo.theone@gmail.com"
+                "name": "neo.theone"
             },
             "user_agent": {
                 "device": {

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-logout-success.json-expected.json
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-logout-success.json-expected.json
@@ -47,6 +47,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6182002f34f4dd006b05b5c7",
+                    "morpheus",
+                    "morpheus@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -63,8 +70,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "morpheus@test.com",
                 "id": "auth0|6182002f34f4dd006b05b5c7",
-                "name": "morpheus@test.com"
+                "name": "morpheus"
             },
             "user_agent": {
                 "device": {
@@ -75,7 +84,7 @@
                 "os": {
                     "name": "Ubuntu"
                 },
-                "version": "93.0."
+                "version": "93.0"
             }
         },
         {
@@ -125,6 +134,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618223a4e3f49e006948565c",
+                    "dev",
+                    "dev@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -141,8 +157,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "dev@test.com",
                 "id": "auth0|618223a4e3f49e006948565c",
-                "name": "dev@test.com"
+                "name": "dev"
             },
             "user_agent": {
                 "device": {
@@ -153,7 +171,7 @@
                 "os": {
                     "name": "Ubuntu"
                 },
-                "version": "93.0."
+                "version": "93.0"
             }
         },
         {
@@ -203,6 +221,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618232c562bac1006935a7af",
+                    "neo",
+                    "neo@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -219,8 +244,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "neo@test.com",
                 "id": "auth0|618232c562bac1006935a7af",
-                "name": "neo@test.com"
+                "name": "neo"
             },
             "user_agent": {
                 "device": {
@@ -231,7 +258,7 @@
                 "os": {
                     "name": "Ubuntu"
                 },
-                "version": "93.0."
+                "version": "93.0"
             }
         }
     ]

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-mgmt-api-success.json-expected.json
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-mgmt-api-success.json-expected.json
@@ -79,6 +79,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
+            },
             "source": {
                 "as": {
                     "number": 29518,
@@ -194,6 +199,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
             },
             "source": {
                 "geo": {
@@ -335,6 +345,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
             },
             "source": {
                 "as": {
@@ -708,6 +723,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
+            },
             "source": {
                 "as": {
                     "number": 29518,
@@ -808,6 +828,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
             },
             "source": {
                 "geo": {
@@ -968,6 +993,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
             },
             "source": {
                 "geo": {
@@ -1209,6 +1239,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -1311,6 +1346,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
             },
             "source": {
                 "geo": {
@@ -1552,6 +1592,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
+            },
             "source": {
                 "as": {
                     "number": 29518,
@@ -1656,6 +1701,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
             },
             "source": {
                 "geo": {
@@ -1767,6 +1817,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
             },
             "source": {
                 "geo": {
@@ -2008,6 +2063,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -2248,6 +2308,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -2357,6 +2422,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
             },
             "source": {
                 "as": {
@@ -2474,6 +2544,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -2584,6 +2659,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -2686,6 +2766,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
             },
             "source": {
                 "as": {
@@ -2803,6 +2888,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -2913,6 +3003,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -3016,6 +3111,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -3109,6 +3209,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
             },
             "source": {
                 "geo": {
@@ -3221,6 +3326,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -3331,6 +3441,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -3424,6 +3539,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
             },
             "source": {
                 "geo": {
@@ -3536,6 +3656,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -3629,6 +3754,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
             },
             "source": {
                 "geo": {
@@ -3740,6 +3870,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
             },
             "source": {
                 "as": {
@@ -3857,6 +3992,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -3960,6 +4100,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
+            },
             "source": {
                 "as": {
                     "number": 29518,
@@ -4059,6 +4204,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
             },
             "source": {
                 "as": {
@@ -4176,6 +4326,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
             },
             "source": {
                 "geo": {
@@ -4417,6 +4572,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -4515,6 +4675,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
             },
             "source": {
                 "geo": {
@@ -4746,6 +4911,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -4972,6 +5142,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -5072,6 +5247,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
             },
             "source": {
                 "geo": {
@@ -5175,6 +5355,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
             },
             "source": {
                 "as": {
@@ -5285,6 +5470,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
+            },
             "source": {
                 "as": {
                     "number": 29518,
@@ -5394,6 +5584,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -5496,6 +5691,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
             },
             "source": {
                 "as": {
@@ -5601,6 +5801,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "auth0|6181ce2b0f293a006d158194"
+                ]
             },
             "source": {
                 "geo": {

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-pull-responses.json-expected.json
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-pull-responses.json-expected.json
@@ -70,6 +70,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "github|32487232"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -342,6 +347,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "github|32487232"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -471,6 +481,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "github|32487232"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -577,6 +592,11 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "github|32487232"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -671,6 +691,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "github|32487232"
+                ]
             },
             "source": {
                 "geo": {
@@ -869,6 +894,11 @@
             },
             "network": {
                 "type": "ipv4"
+            },
+            "related": {
+                "user": [
+                    "github|32487232"
+                ]
             },
             "source": {
                 "geo": {

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-signup-failure.json-expected.json
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-signup-failure.json-expected.json
@@ -96,6 +96,12 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "neo",
+                    "neo@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -112,7 +118,9 @@
                 "ip": "81.2.69.145"
             },
             "user": {
-                "name": "neo@test.com"
+                "domain": "test.com",
+                "email": "neo@test.com",
+                "name": "neo"
             },
             "user_agent": {
                 "device": {

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-signup-success.json-expected.json
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-signup-success.json-expected.json
@@ -48,6 +48,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6182002f34f4dd006b05b5c7",
+                    "neo",
+                    "neo@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -64,8 +71,10 @@
                 "ip": "81.2.69.144"
             },
             "user": {
+                "domain": "test.com",
+                "email": "neo@test.com",
                 "id": "auth0|6182002f34f4dd006b05b5c7",
-                "name": "neo@test.com"
+                "name": "neo"
             },
             "user_agent": {
                 "device": {
@@ -123,6 +132,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618223a4e3f49e006948565c",
+                    "dev",
+                    "dev@test.com"
+                ]
+            },
             "source": {
                 "as": {
                     "number": 29518,
@@ -145,8 +161,10 @@
                 "ip": "89.160.20.112"
             },
             "user": {
+                "domain": "test.com",
+                "email": "dev@test.com",
                 "id": "auth0|618223a4e3f49e006948565c",
-                "name": "dev@test.com"
+                "name": "dev"
             },
             "user_agent": {
                 "device": {
@@ -204,6 +222,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|61823277a44a21007221a59a",
+                    "new",
+                    "new@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -220,8 +245,10 @@
                 "ip": "81.2.69.145"
             },
             "user": {
+                "domain": "test.com",
+                "email": "new@test.com",
                 "id": "auth0|61823277a44a21007221a59a",
-                "name": "new@test.com"
+                "name": "new"
             },
             "user_agent": {
                 "device": {
@@ -279,6 +306,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618232c562bac1006935a7af",
+                    "neo",
+                    "neo@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -295,8 +329,10 @@
                 "ip": "81.2.69.145"
             },
             "user": {
+                "domain": "test.com",
+                "email": "neo@test.com",
                 "id": "auth0|618232c562bac1006935a7af",
-                "name": "neo@test.com"
+                "name": "neo"
             },
             "user_agent": {
                 "device": {
@@ -354,6 +390,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6183285d6e5071006a61f319",
+                    "neo.theone",
+                    "neo.theone@gmail.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -370,8 +413,10 @@
                 "ip": "81.2.69.144"
             },
             "user": {
+                "domain": "gmail.com",
+                "email": "neo.theone@gmail.com",
                 "id": "auth0|6183285d6e5071006a61f319",
-                "name": "neo.theone@gmail.com"
+                "name": "neo.theone"
             },
             "user_agent": {
                 "device": {

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-token-xchg-success.json-expected.json
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-token-xchg-success.json-expected.json
@@ -43,6 +43,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618223a4e3f49e006948565c",
+                    "dev",
+                    "dev@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -59,8 +66,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "dev@test.com",
                 "id": "auth0|618223a4e3f49e006948565c",
-                "name": "dev@test.com"
+                "name": "dev"
             },
             "user_agent": {
                 "device": {
@@ -114,6 +123,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6182002f34f4dd006b05b5c7",
+                    "neo",
+                    "neo@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -130,8 +146,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "neo@test.com",
                 "id": "auth0|6182002f34f4dd006b05b5c7",
-                "name": "neo@test.com"
+                "name": "neo"
             },
             "user_agent": {
                 "device": {
@@ -185,6 +203,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6182002f34f4dd006b05b5c7",
+                    "neo",
+                    "neo@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -201,8 +226,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "neo@test.com",
                 "id": "auth0|6182002f34f4dd006b05b5c7",
-                "name": "neo@test.com"
+                "name": "neo"
             },
             "user_agent": {
                 "device": {
@@ -256,6 +283,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618223a4e3f49e006948565c",
+                    "dev",
+                    "dev@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -272,8 +306,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "dev@test.com",
                 "id": "auth0|618223a4e3f49e006948565c",
-                "name": "dev@test.com"
+                "name": "dev"
             },
             "user_agent": {
                 "device": {
@@ -327,6 +363,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618232c562bac1006935a7af",
+                    "neo",
+                    "neo@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -343,8 +386,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "neo@test.com",
                 "id": "auth0|618232c562bac1006935a7af",
-                "name": "neo@test.com"
+                "name": "neo"
             },
             "user_agent": {
                 "device": {
@@ -398,6 +443,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618223a4e3f49e006948565c",
+                    "dev",
+                    "dev@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -414,8 +466,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "dev@test.com",
                 "id": "auth0|618223a4e3f49e006948565c",
-                "name": "dev@test.com"
+                "name": "dev"
             },
             "user_agent": {
                 "device": {
@@ -469,6 +523,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618232c562bac1006935a7af",
+                    "neo",
+                    "neo@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -485,8 +546,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "neo@test.com",
                 "id": "auth0|618232c562bac1006935a7af",
-                "name": "neo@test.com"
+                "name": "neo"
             },
             "user_agent": {
                 "device": {
@@ -540,6 +603,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618232c562bac1006935a7af",
+                    "neo",
+                    "neo@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -556,8 +626,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "neo@test.com",
                 "id": "auth0|618232c562bac1006935a7af",
-                "name": "neo@test.com"
+                "name": "neo"
             },
             "user_agent": {
                 "device": {
@@ -611,6 +683,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618223a4e3f49e006948565c",
+                    "dev",
+                    "dev@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -627,8 +706,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "dev@test.com",
                 "id": "auth0|618223a4e3f49e006948565c",
-                "name": "dev@test.com"
+                "name": "dev"
             },
             "user_agent": {
                 "device": {
@@ -682,6 +763,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|61823277a44a21007221a59a",
+                    "new",
+                    "new@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -698,8 +786,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "new@test.com",
                 "id": "auth0|61823277a44a21007221a59a",
-                "name": "new@test.com"
+                "name": "new"
             },
             "user_agent": {
                 "device": {
@@ -753,6 +843,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|61823277a44a21007221a59a",
+                    "new",
+                    "new@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -769,8 +866,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "new@test.com",
                 "id": "auth0|61823277a44a21007221a59a",
-                "name": "new@test.com"
+                "name": "new"
             },
             "user_agent": {
                 "device": {
@@ -824,6 +923,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|61823277a44a21007221a59a",
+                    "new",
+                    "new@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -840,8 +946,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "new@test.com",
                 "id": "auth0|61823277a44a21007221a59a",
-                "name": "new@test.com"
+                "name": "new"
             },
             "user_agent": {
                 "device": {
@@ -895,6 +1003,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|61823277a44a21007221a59a",
+                    "new",
+                    "new@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -911,8 +1026,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "new@test.com",
                 "id": "auth0|61823277a44a21007221a59a",
-                "name": "new@test.com"
+                "name": "new"
             },
             "user_agent": {
                 "device": {
@@ -966,6 +1083,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6182002f34f4dd006b05b5c7",
+                    "neo",
+                    "neo@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -982,8 +1106,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "neo@test.com",
                 "id": "auth0|6182002f34f4dd006b05b5c7",
-                "name": "neo@test.com"
+                "name": "neo"
             },
             "user_agent": {
                 "device": {
@@ -1037,6 +1163,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618232c562bac1006935a7af",
+                    "neo",
+                    "neo@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -1053,8 +1186,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "neo@test.com",
                 "id": "auth0|618232c562bac1006935a7af",
-                "name": "neo@test.com"
+                "name": "neo"
             },
             "user_agent": {
                 "device": {
@@ -1108,6 +1243,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|61823277a44a21007221a59a",
+                    "new",
+                    "new@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -1124,8 +1266,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "new@test.com",
                 "id": "auth0|61823277a44a21007221a59a",
-                "name": "new@test.com"
+                "name": "new"
             },
             "user_agent": {
                 "device": {
@@ -1179,6 +1323,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|61823277a44a21007221a59a",
+                    "new",
+                    "new@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -1195,8 +1346,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "new@test.com",
                 "id": "auth0|61823277a44a21007221a59a",
-                "name": "new@test.com"
+                "name": "new"
             },
             "user_agent": {
                 "device": {
@@ -1250,6 +1403,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618232c562bac1006935a7af",
+                    "neo",
+                    "neo@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -1266,8 +1426,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "neo@test.com",
                 "id": "auth0|618232c562bac1006935a7af",
-                "name": "neo@test.com"
+                "name": "neo"
             },
             "user_agent": {
                 "device": {
@@ -1321,6 +1483,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|618223a4e3f49e006948565c",
+                    "dev",
+                    "dev@test.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -1337,8 +1506,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "test.com",
+                "email": "dev@test.com",
                 "id": "auth0|618223a4e3f49e006948565c",
-                "name": "dev@test.com"
+                "name": "dev"
             },
             "user_agent": {
                 "device": {
@@ -1392,6 +1563,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6183285d6e5071006a61f319",
+                    "neo.theone",
+                    "neo.theone@gmail.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -1408,8 +1586,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "gmail.com",
+                "email": "neo.theone@gmail.com",
                 "id": "auth0|6183285d6e5071006a61f319",
-                "name": "neo.theone@gmail.com"
+                "name": "neo.theone"
             },
             "user_agent": {
                 "device": {
@@ -1463,6 +1643,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6183285d6e5071006a61f319",
+                    "neo.theone",
+                    "neo.theone@gmail.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -1479,8 +1666,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "gmail.com",
+                "email": "neo.theone@gmail.com",
                 "id": "auth0|6183285d6e5071006a61f319",
-                "name": "neo.theone@gmail.com"
+                "name": "neo.theone"
             },
             "user_agent": {
                 "device": {

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-user-behaviour-success.json-expected.json
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-user-behaviour-success.json-expected.json
@@ -58,6 +58,13 @@
             "network": {
                 "type": "ipv4"
             },
+            "related": {
+                "user": [
+                    "auth0|6183285d6e5071006a61f319",
+                    "monklinux5",
+                    "monklinux5@gmail.com"
+                ]
+            },
             "source": {
                 "geo": {
                     "city_name": "London",
@@ -74,8 +81,10 @@
                 "ip": "81.2.69.143"
             },
             "user": {
+                "domain": "gmail.com",
+                "email": "monklinux5@gmail.com",
                 "id": "auth0|6183285d6e5071006a61f319",
-                "name": "monklinux5@gmail.com"
+                "name": "monklinux5"
             },
             "user_agent": {
                 "device": {
@@ -88,7 +97,7 @@
                     "name": "Mac OS X",
                     "version": "10.15"
                 },
-                "version": "93.0."
+                "version": "93.0"
             }
         }
     ]

--- a/packages/auth0/data_stream/logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/auth0/data_stream/logs/elasticsearch/ingest_pipeline/default.yml
@@ -59,14 +59,40 @@ processors:
     field: network.type
     value: ipv4
     if: 'ctx.network?.type == null && ctx.source?.ip != null'
+- grok:
+    field: auth0.logs.data.user_name
+    patterns:
+      - '%{USERNAME:user.name}@%{HOSTNAME:user.domain}'
+      - '%{GREEDYDATA:user.name}'
+    ignore_missing: true
+    ignore_failure: true
 - set:
-    field: user.name
+    field: user.email
     copy_from: auth0.logs.data.user_name
-    if: 'ctx?.auth0?.logs?.data?.user_name != null'
+    tag: copy_user_email
+    if: ctx.auth0?.logs?.data?.user_name != null && ctx.auth0.logs.data.user_name.contains("@")
 - set:
     field: user.id
     copy_from: auth0.logs.data.user_id
     if: 'ctx?.auth0?.logs?.data?.user_id != null'
+- append:
+    field: related.user
+    value: '{{{user.id}}}'
+    allow_duplicates: false
+    tag: append_related_user_id
+    if: ctx.user?.id != null
+- append:
+    field: related.user
+    value: '{{{user.name}}}'
+    allow_duplicates: false
+    tag: append_related_user_name
+    if: ctx.user?.name != null
+- append:
+    field: related.user
+    value: '{{{user.email}}}'
+    allow_duplicates: false
+    tag: append_related_user_email
+    if: ctx.user?.email != null
 - user_agent:
     field: auth0.logs.data.user_agent
     ignore_missing: true

--- a/packages/auth0/data_stream/logs/sample_event.json
+++ b/packages/auth0/data_stream/logs/sample_event.json
@@ -1,155 +1,115 @@
 {
-    "@timestamp": "2025-03-15T18:08:04.365Z",
+    "@timestamp": "2021-11-03T03:06:05.696Z",
     "agent": {
-        "ephemeral_id": "e052c974-795f-41ed-802f-69f92e97d682",
-        "id": "fb7f48ab-5817-4c31-8e7b-0d943895ca0d",
-        "name": "elastic-agent-79075",
+        "ephemeral_id": "c332091a-27ef-4163-97f1-602c0c5722d2",
+        "id": "0f4499f8-3f89-4f53-945d-1f033cc2bf93",
+        "name": "elastic-agent-42968",
         "type": "filebeat",
-        "version": "8.17.3"
+        "version": "8.18.1"
     },
     "auth0": {
         "logs": {
             "data": {
-                "classification": "Login - Success",
-                "client_id": "A123v04ZMgorp521yX4lIyeI9nYIuwGP",
-                "client_name": "XYZ",
-                "connection": "example-users",
-                "connection_id": "con_Abc4hRDDmVrZWomi",
-                "date": "2025-03-15T18:08:04.365Z",
+                "classification": "Login - Failure",
+                "date": "2021-11-03T03:06:05.696Z",
+                "description": "Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs",
                 "details": {
-                    "actions": {
-                        "executions": [
-                            "ABCnLEtG3EJGfIJMP2UZms1pMjAyNTAzMja25rxa3ZNFXYDkKlwulvVB"
-                        ]
+                    "error": {
+                        "message": "Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs",
+                        "oauthError": "Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs. Please go to 'https://manage.auth0.com/#/applications/aI61p8I8aFjmYRliLWgvM9ev97kCCNDB/settings' and make sure you are sending the same callback url from your application.",
+                        "payload": {
+                            "attempt": "http://localhost:3000/callback",
+                            "client": {
+                                "clientID": "aI61p8I8aFjmYRliLWgvM9ev97kCCNDB"
+                            },
+                            "code": "unauthorized_client",
+                            "message": "Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs",
+                            "name": "CallbackMismatchError",
+                            "status": 403
+                        },
+                        "type": "callback-url-mismatch"
                     },
-                    "completedAt": 1743012484363,
-                    "elapsedTime": 63604,
-                    "initiatedAt": 1743012420759,
-                    "prompts": [
-                        {
-                            "completedAt": 1743012449133,
-                            "connection": "example-users",
-                            "connection_id": "con_Abc4hRDDmVrZWomi",
-                            "elapsedTime": 649,
-                            "identity": 12345,
-                            "initiatedAt": 1743012448484,
-                            "name": "lock-password-authenticate",
-                            "stats": {
-                                "loginsCount": 5
-                            },
-                            "strategy": "auth0"
-                        },
-                        {
-                            "completedAt": 1743012449137,
-                            "elapsedTime": 28376,
-                            "flow": "login",
-                            "initiatedAt": 1743012420761,
-                            "name": "login",
-                            "timers": {
-                                "rules": 626
-                            },
-                            "user_id": "auth0|12345",
-                            "user_name": "jdoe@example.com"
-                        },
-                        {
-                            "completedAt": 1743012484145,
-                            "elapsedTime": 34160,
-                            "flow": "mfa",
-                            "initiatedAt": 1743012449985,
-                            "name": "mfa",
-                            "performed_acr": [
-                                "http://schemas.openid.net/pape/policies/2007/06/multi-factor"
-                            ],
-                            "performed_amr": [
-                                "mfa"
-                            ],
-                            "provider": "guardian"
-                        }
-                    ],
-                    "session_id": "abcKFtsdFoVQqpf-a4gjQIXe1pMdM5kAH",
-                    "stats": {
-                        "loginsCount": 5
+                    "qs": {
+                        "client_id": "aI61p8I8aFjmYRliLWgvM9ev97kCCNDB",
+                        "redirect_uri": "http://localhost:3000/callback",
+                        "response_type": "code",
+                        "scope": "openid profile",
+                        "state": "Vz6G2zZf95/FCOQALrpvd4bS6jx5xvRos2pVldFAiw4="
                     }
                 },
-                "hostname": "auth.example.com",
-                "is_mobile": false,
-                "login": {
-                    "completedAt": "2025-03-26T18:08:04.363Z",
-                    "elapsedTime": 63604,
-                    "initiatedAt": "2025-03-26T18:07:00.759Z",
-                    "stats": {
-                        "loginsCount": 5
-                    }
-                },
-                "strategy": "auth0",
-                "strategy_type": "database",
-                "tenant_name": "example-apps",
-                "type": "Successful login",
-                "type_id": "s"
+                "hostname": "dev-yoj8axza.au.auth0.com",
+                "type": "Failed login",
+                "type_id": "f"
             }
         }
     },
     "data_stream": {
         "dataset": "auth0.logs",
-        "namespace": "61704",
+        "namespace": "49995",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "fb7f48ab-5817-4c31-8e7b-0d943895ca0d",
+        "id": "0f4499f8-3f89-4f53-945d-1f033cc2bf93",
         "snapshot": false,
-        "version": "8.17.3"
+        "version": "8.18.1"
     },
     "event": {
-        "action": "successful-login",
+        "action": "failed-login",
         "agent_id_status": "verified",
         "category": [
-            "authentication",
-            "session"
+            "authentication"
         ],
         "dataset": "auth0.logs",
-        "id": "90020250315180807266045000000000000001223372126167226037",
-        "ingested": "2025-04-01T10:59:14Z",
+        "id": "90020211103030609732115389415260839021644201259064885298",
+        "ingested": "2025-05-30T14:06:51Z",
         "kind": "event",
-        "outcome": "success",
+        "original": "{\"data\":{\"connection_id\":\"\",\"date\":\"2021-11-03T03:06:05.696Z\",\"description\":\"Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs\",\"details\":{\"body\":{},\"error\":{\"message\":\"Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs\",\"oauthError\":\"Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs. Please go to 'https://manage.auth0.com/#/applications/aI61p8I8aFjmYRliLWgvM9ev97kCCNDB/settings' and make sure you are sending the same callback url from your application.\",\"payload\":{\"attempt\":\"http://localhost:3000/callback\",\"authorized\":[],\"client\":{\"clientID\":\"aI61p8I8aFjmYRliLWgvM9ev97kCCNDB\"},\"code\":\"unauthorized_client\",\"message\":\"Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs\",\"name\":\"CallbackMismatchError\",\"status\":403},\"type\":\"callback-url-mismatch\"},\"qs\":{\"client_id\":\"aI61p8I8aFjmYRliLWgvM9ev97kCCNDB\",\"redirect_uri\":\"http://localhost:3000/callback\",\"response_type\":\"code\",\"scope\":\"openid profile\",\"state\":\"Vz6G2zZf95/FCOQALrpvd4bS6jx5xvRos2pVldFAiw4=\"}},\"hostname\":\"dev-yoj8axza.au.auth0.com\",\"ip\":\"81.2.69.143\",\"log_id\":\"90020211103030609732115389415260839021644201259064885298\",\"type\":\"f\",\"user_agent\":\"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0\"},\"log_id\":\"90020211103030609732115389415260839021644201259064885298\"}",
+        "outcome": "failure",
         "type": [
-            "info",
-            "start"
+            "info"
         ]
     },
     "input": {
-        "type": "cel"
+        "type": "http_endpoint"
     },
     "log": {
-        "level": "info"
+        "level": "error"
     },
     "network": {
         "type": "ipv4"
     },
     "source": {
-        "ip": "192.168.1.1"
+        "geo": {
+            "city_name": "London",
+            "continent_name": "Europe",
+            "country_iso_code": "GB",
+            "country_name": "United Kingdom",
+            "location": {
+                "lat": 51.5142,
+                "lon": -0.0931
+            },
+            "region_iso_code": "GB-ENG",
+            "region_name": "England"
+        },
+        "ip": "81.2.69.143"
     },
     "tags": [
         "preserve_original_event",
         "forwarded",
         "auth0-logstream"
     ],
-    "user": {
-        "id": "auth0|12345",
-        "name": "jdoe@example.com"
-    },
     "user_agent": {
         "device": {
             "name": "Other"
         },
-        "name": "Other",
-        "original": "Chrome 134.0.0 / Windows 10.0.0",
+        "name": "Firefox",
+        "original": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0",
         "os": {
-            "full": "Windows 10",
-            "name": "Windows",
-            "version": "10"
-        }
+            "name": "Ubuntu"
+        },
+        "version": "93.0"
     }
 }

--- a/packages/auth0/docs/README.md
+++ b/packages/auth0/docs/README.md
@@ -118,158 +118,118 @@ An example event for `logs` looks as following:
 
 ```json
 {
-    "@timestamp": "2025-03-15T18:08:04.365Z",
+    "@timestamp": "2021-11-03T03:06:05.696Z",
     "agent": {
-        "ephemeral_id": "e052c974-795f-41ed-802f-69f92e97d682",
-        "id": "fb7f48ab-5817-4c31-8e7b-0d943895ca0d",
-        "name": "elastic-agent-79075",
+        "ephemeral_id": "c332091a-27ef-4163-97f1-602c0c5722d2",
+        "id": "0f4499f8-3f89-4f53-945d-1f033cc2bf93",
+        "name": "elastic-agent-42968",
         "type": "filebeat",
-        "version": "8.17.3"
+        "version": "8.18.1"
     },
     "auth0": {
         "logs": {
             "data": {
-                "classification": "Login - Success",
-                "client_id": "A123v04ZMgorp521yX4lIyeI9nYIuwGP",
-                "client_name": "XYZ",
-                "connection": "example-users",
-                "connection_id": "con_Abc4hRDDmVrZWomi",
-                "date": "2025-03-15T18:08:04.365Z",
+                "classification": "Login - Failure",
+                "date": "2021-11-03T03:06:05.696Z",
+                "description": "Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs",
                 "details": {
-                    "actions": {
-                        "executions": [
-                            "ABCnLEtG3EJGfIJMP2UZms1pMjAyNTAzMja25rxa3ZNFXYDkKlwulvVB"
-                        ]
+                    "error": {
+                        "message": "Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs",
+                        "oauthError": "Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs. Please go to 'https://manage.auth0.com/#/applications/aI61p8I8aFjmYRliLWgvM9ev97kCCNDB/settings' and make sure you are sending the same callback url from your application.",
+                        "payload": {
+                            "attempt": "http://localhost:3000/callback",
+                            "client": {
+                                "clientID": "aI61p8I8aFjmYRliLWgvM9ev97kCCNDB"
+                            },
+                            "code": "unauthorized_client",
+                            "message": "Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs",
+                            "name": "CallbackMismatchError",
+                            "status": 403
+                        },
+                        "type": "callback-url-mismatch"
                     },
-                    "completedAt": 1743012484363,
-                    "elapsedTime": 63604,
-                    "initiatedAt": 1743012420759,
-                    "prompts": [
-                        {
-                            "completedAt": 1743012449133,
-                            "connection": "example-users",
-                            "connection_id": "con_Abc4hRDDmVrZWomi",
-                            "elapsedTime": 649,
-                            "identity": 12345,
-                            "initiatedAt": 1743012448484,
-                            "name": "lock-password-authenticate",
-                            "stats": {
-                                "loginsCount": 5
-                            },
-                            "strategy": "auth0"
-                        },
-                        {
-                            "completedAt": 1743012449137,
-                            "elapsedTime": 28376,
-                            "flow": "login",
-                            "initiatedAt": 1743012420761,
-                            "name": "login",
-                            "timers": {
-                                "rules": 626
-                            },
-                            "user_id": "auth0|12345",
-                            "user_name": "jdoe@example.com"
-                        },
-                        {
-                            "completedAt": 1743012484145,
-                            "elapsedTime": 34160,
-                            "flow": "mfa",
-                            "initiatedAt": 1743012449985,
-                            "name": "mfa",
-                            "performed_acr": [
-                                "http://schemas.openid.net/pape/policies/2007/06/multi-factor"
-                            ],
-                            "performed_amr": [
-                                "mfa"
-                            ],
-                            "provider": "guardian"
-                        }
-                    ],
-                    "session_id": "abcKFtsdFoVQqpf-a4gjQIXe1pMdM5kAH",
-                    "stats": {
-                        "loginsCount": 5
+                    "qs": {
+                        "client_id": "aI61p8I8aFjmYRliLWgvM9ev97kCCNDB",
+                        "redirect_uri": "http://localhost:3000/callback",
+                        "response_type": "code",
+                        "scope": "openid profile",
+                        "state": "Vz6G2zZf95/FCOQALrpvd4bS6jx5xvRos2pVldFAiw4="
                     }
                 },
-                "hostname": "auth.example.com",
-                "is_mobile": false,
-                "login": {
-                    "completedAt": "2025-03-26T18:08:04.363Z",
-                    "elapsedTime": 63604,
-                    "initiatedAt": "2025-03-26T18:07:00.759Z",
-                    "stats": {
-                        "loginsCount": 5
-                    }
-                },
-                "strategy": "auth0",
-                "strategy_type": "database",
-                "tenant_name": "example-apps",
-                "type": "Successful login",
-                "type_id": "s"
+                "hostname": "dev-yoj8axza.au.auth0.com",
+                "type": "Failed login",
+                "type_id": "f"
             }
         }
     },
     "data_stream": {
         "dataset": "auth0.logs",
-        "namespace": "61704",
+        "namespace": "49995",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "fb7f48ab-5817-4c31-8e7b-0d943895ca0d",
+        "id": "0f4499f8-3f89-4f53-945d-1f033cc2bf93",
         "snapshot": false,
-        "version": "8.17.3"
+        "version": "8.18.1"
     },
     "event": {
-        "action": "successful-login",
+        "action": "failed-login",
         "agent_id_status": "verified",
         "category": [
-            "authentication",
-            "session"
+            "authentication"
         ],
         "dataset": "auth0.logs",
-        "id": "90020250315180807266045000000000000001223372126167226037",
-        "ingested": "2025-04-01T10:59:14Z",
+        "id": "90020211103030609732115389415260839021644201259064885298",
+        "ingested": "2025-05-30T14:06:51Z",
         "kind": "event",
-        "outcome": "success",
+        "original": "{\"data\":{\"connection_id\":\"\",\"date\":\"2021-11-03T03:06:05.696Z\",\"description\":\"Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs\",\"details\":{\"body\":{},\"error\":{\"message\":\"Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs\",\"oauthError\":\"Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs. Please go to 'https://manage.auth0.com/#/applications/aI61p8I8aFjmYRliLWgvM9ev97kCCNDB/settings' and make sure you are sending the same callback url from your application.\",\"payload\":{\"attempt\":\"http://localhost:3000/callback\",\"authorized\":[],\"client\":{\"clientID\":\"aI61p8I8aFjmYRliLWgvM9ev97kCCNDB\"},\"code\":\"unauthorized_client\",\"message\":\"Callback URL mismatch. http://localhost:3000/callback is not in the list of allowed callback URLs\",\"name\":\"CallbackMismatchError\",\"status\":403},\"type\":\"callback-url-mismatch\"},\"qs\":{\"client_id\":\"aI61p8I8aFjmYRliLWgvM9ev97kCCNDB\",\"redirect_uri\":\"http://localhost:3000/callback\",\"response_type\":\"code\",\"scope\":\"openid profile\",\"state\":\"Vz6G2zZf95/FCOQALrpvd4bS6jx5xvRos2pVldFAiw4=\"}},\"hostname\":\"dev-yoj8axza.au.auth0.com\",\"ip\":\"81.2.69.143\",\"log_id\":\"90020211103030609732115389415260839021644201259064885298\",\"type\":\"f\",\"user_agent\":\"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0\"},\"log_id\":\"90020211103030609732115389415260839021644201259064885298\"}",
+        "outcome": "failure",
         "type": [
-            "info",
-            "start"
+            "info"
         ]
     },
     "input": {
-        "type": "cel"
+        "type": "http_endpoint"
     },
     "log": {
-        "level": "info"
+        "level": "error"
     },
     "network": {
         "type": "ipv4"
     },
     "source": {
-        "ip": "192.168.1.1"
+        "geo": {
+            "city_name": "London",
+            "continent_name": "Europe",
+            "country_iso_code": "GB",
+            "country_name": "United Kingdom",
+            "location": {
+                "lat": 51.5142,
+                "lon": -0.0931
+            },
+            "region_iso_code": "GB-ENG",
+            "region_name": "England"
+        },
+        "ip": "81.2.69.143"
     },
     "tags": [
         "preserve_original_event",
         "forwarded",
         "auth0-logstream"
     ],
-    "user": {
-        "id": "auth0|12345",
-        "name": "jdoe@example.com"
-    },
     "user_agent": {
         "device": {
             "name": "Other"
         },
-        "name": "Other",
-        "original": "Chrome 134.0.0 / Windows 10.0.0",
+        "name": "Firefox",
+        "original": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0",
         "os": {
-            "full": "Windows 10",
-            "name": "Windows",
-            "version": "10"
-        }
+            "name": "Ubuntu"
+        },
+        "version": "93.0"
     }
 }
 ```

--- a/packages/auth0/manifest.yml
+++ b/packages/auth0/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: auth0
 title: "Auth0"
-version: "1.21.2"
+version: "1.22.0"
 description: Collect logs from Auth0 with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Modified the processing of user name fields including email addresses to align with the rest of the integrations. Changes applied include the following:
- When the user name is an email, this field is dissected into `<user.name>@<user.domain>`.
- Also the `user.email` field is populated with the full email address.
- Append `user.name` and `user.email` to `related.user`.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/enhancements/issues/24531
