### PR TITLE
beyondinsight_password_safe: standardize user name processing

### DIFF
--- a/packages/beyondinsight_password_safe/changelog.yml
+++ b/packages/beyondinsight_password_safe/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Standardize user fields processing across integrations.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/14093
 - version: "0.4.0"
   changes:
     - description: Improve agent error reporting for failed API requests.

--- a/packages/beyondinsight_password_safe/changelog.yml
+++ b/packages/beyondinsight_password_safe/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.5.0"
+  changes:
+    - description: Standardize user fields processing across integrations.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "0.4.0"
   changes:
     - description: Improve agent error reporting for failed API requests.

--- a/packages/beyondinsight_password_safe/data_stream/useraudit/_dev/test/pipeline/test-useraudits.json-expected.json
+++ b/packages/beyondinsight_password_safe/data_stream/useraudit/_dev/test/pipeline/test-useraudits.json-expected.json
@@ -48,11 +48,14 @@
                     "216.160.83.56"
                 ],
                 "user": [
+                    "test_user",
                     "test_user@test.com"
                 ]
             },
             "user": {
-                "name": "test_user@test.com"
+                "domain": "test.com",
+                "email": "test_user@test.com",
+                "name": "test_user"
             }
         }
     ]

--- a/packages/beyondinsight_password_safe/data_stream/useraudit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/beyondinsight_password_safe/data_stream/useraudit/elasticsearch/ingest_pipeline/default.yml
@@ -114,11 +114,6 @@ processors:
       value: "{{{beyondinsight_password_safe.useraudit.user_name}}}"
       ignore_empty_value: true
 
-  - append:
-      field: related.user
-      value: "{{{beyondinsight_password_safe.useraudit.user_name}}}"  
-      allow_duplicates: false
-
  #################### Override host.ip ######################
   - gsub:
       field: "beyondinsight_password_safe.useraudit.ipaddress"
@@ -153,6 +148,34 @@ processors:
       field: "beyondinsight_password_safe.useraudit.user"
       target_field: "user.name"
       ignore_missing: true
+
+  - rename:
+      field: user.name
+      target_field: user.email
+      tag: rename_user_email
+      if: ctx.user?.name != null && ctx.user.name.contains("@")
+
+  - dissect:
+      field: user.email
+      pattern: '%{user.name}@%{user.domain}'
+      tag: dissect_user_email
+      ignore_missing: true
+      ignore_failure: true
+      if: ctx.user?.name == null
+
+  - append:
+      field: related.user
+      value: "{{{user.name}}}"
+      if: ctx.user?.name != null
+      allow_duplicates: false
+      ignore_failure: true
+
+  - append:
+      field: related.user
+      value: "{{{user.email}}}"
+      if: ctx.user?.email != null
+      allow_duplicates: false
+      ignore_failure: true
 
 on_failure:
   - append:

--- a/packages/beyondinsight_password_safe/data_stream/useraudit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/beyondinsight_password_safe/data_stream/useraudit/elasticsearch/ingest_pipeline/default.yml
@@ -153,7 +153,7 @@ processors:
       field: user.name
       target_field: user.email
       tag: rename_user_email
-      if: ctx.user?.name != null && ctx.user.name.contains("@")
+      if: ctx.user?.name != null && ctx.user.name.indexOf("@") > 0
 
   - dissect:
       field: user.email

--- a/packages/beyondinsight_password_safe/data_stream/useraudit/sample_event.json
+++ b/packages/beyondinsight_password_safe/data_stream/useraudit/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2025-01-22T18:19:25.637Z",
     "agent": {
-        "ephemeral_id": "f94c5e7a-6c1c-44dd-88a4-9745f5ee5af2",
-        "id": "fd188fac-3736-4ead-b591-2ffe3fedad55",
-        "name": "elastic-agent-49819",
+        "ephemeral_id": "7adefb3b-23df-4b35-99e4-713ba34299aa",
+        "id": "b48a19c9-614a-498a-9e6a-426f10a6a68a",
+        "name": "elastic-agent-62041",
         "type": "filebeat",
-        "version": "8.15.0"
+        "version": "8.18.1"
     },
     "beyondinsight_password_safe": {
         "useraudit": {
@@ -20,16 +20,16 @@
     },
     "data_stream": {
         "dataset": "beyondinsight_password_safe.useraudit",
-        "namespace": "83646",
+        "namespace": "50600",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "fd188fac-3736-4ead-b591-2ffe3fedad55",
+        "id": "b48a19c9-614a-498a-9e6a-426f10a6a68a",
         "snapshot": false,
-        "version": "8.15.0"
+        "version": "8.18.1"
     },
     "event": {
         "agent_id_status": "verified",
@@ -37,7 +37,7 @@
             "iam"
         ],
         "dataset": "beyondinsight_password_safe.useraudit",
-        "ingested": "2025-01-23T19:44:13Z",
+        "ingested": "2025-05-30T15:01:07Z",
         "kind": "event",
         "module": "beyondinsight_password_safe",
         "type": [

--- a/packages/beyondinsight_password_safe/docs/README.md
+++ b/packages/beyondinsight_password_safe/docs/README.md
@@ -53,11 +53,11 @@ An example event for `useraudit` looks as following:
 {
     "@timestamp": "2025-01-22T18:19:25.637Z",
     "agent": {
-        "ephemeral_id": "f94c5e7a-6c1c-44dd-88a4-9745f5ee5af2",
-        "id": "fd188fac-3736-4ead-b591-2ffe3fedad55",
-        "name": "elastic-agent-49819",
+        "ephemeral_id": "7adefb3b-23df-4b35-99e4-713ba34299aa",
+        "id": "b48a19c9-614a-498a-9e6a-426f10a6a68a",
+        "name": "elastic-agent-62041",
         "type": "filebeat",
-        "version": "8.15.0"
+        "version": "8.18.1"
     },
     "beyondinsight_password_safe": {
         "useraudit": {
@@ -72,16 +72,16 @@ An example event for `useraudit` looks as following:
     },
     "data_stream": {
         "dataset": "beyondinsight_password_safe.useraudit",
-        "namespace": "83646",
+        "namespace": "50600",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "fd188fac-3736-4ead-b591-2ffe3fedad55",
+        "id": "b48a19c9-614a-498a-9e6a-426f10a6a68a",
         "snapshot": false,
-        "version": "8.15.0"
+        "version": "8.18.1"
     },
     "event": {
         "agent_id_status": "verified",
@@ -89,7 +89,7 @@ An example event for `useraudit` looks as following:
             "iam"
         ],
         "dataset": "beyondinsight_password_safe.useraudit",
-        "ingested": "2025-01-23T19:44:13Z",
+        "ingested": "2025-05-30T15:01:07Z",
         "kind": "event",
         "module": "beyondinsight_password_safe",
         "type": [

--- a/packages/beyondinsight_password_safe/manifest.yml
+++ b/packages/beyondinsight_password_safe/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.0
 name: beyondinsight_password_safe
 title: BeyondInsight and Password Safe
-version: "0.4.0"
+version: "0.5.0"
 source:
   license: "Elastic-2.0"
 description: Ingest privileged access management (PAM) data from BeyondTrust's BeyondInsight PAM Reporting Platform and Password Safe, using Elastic Agent.


### PR DESCRIPTION
## Proposed commit message

Modified the processing of user name fields including email addresses to align with the rest of the integrations. Changes applied include the following:
- When the user name is an email, this field is dissected into `<user.name>@<user.domain>`.
- Also the `user.email` field is populated with the full email address.
- Append `user.name` and `user.email` to `related.user`.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/enhancements/issues/24531
