### PR TITLE
Security Integrations: Add Deprecation Note in Readme

### DIFF
--- a/packages/bluecoat/_dev/build/docs/README.md
+++ b/packages/bluecoat/_dev/build/docs/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **IMPORTANT**
+>
+> This package is *deprecated* and is not supported for installation in Elastic Cloud Serverless.
+
 # Bluecoat integration
 
 This integration is for Bluecoat device's logs. It includes the following

--- a/packages/bluecoat/changelog.yml
+++ b/packages/bluecoat/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.18.0"
+  changes:
+    - description: Add deprecation note in readme.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.17.3"
   changes:
     - description: Use triple-brace Mustache templating when referencing variables in ingest pipelines.

--- a/packages/bluecoat/docs/README.md
+++ b/packages/bluecoat/docs/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **IMPORTANT**
+>
+> This package is *deprecated* and is not supported for installation in Elastic Cloud Serverless.
+
 # Bluecoat integration
 
 This integration is for Bluecoat device's logs. It includes the following

--- a/packages/bluecoat/manifest.yml
+++ b/packages/bluecoat/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: bluecoat
 title: Blue Coat Director Logs (Deprecated)
-version: "0.17.3"
+version: "0.18.0"
 description: Deprecated. Director is no longer supported.
 categories: ["network", "security", "proxy_security"]
 type: integration

--- a/packages/cloud_defend/changelog.yml
+++ b/packages/cloud_defend/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Deprecate package.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.2.8"
   changes:
     - description: Updated deprecation notice in Readme

--- a/packages/cloud_defend/docs/README.md
+++ b/packages/cloud_defend/docs/README.md
@@ -1,6 +1,6 @@
 > ⚠️ **IMPORTANT**
-> 
-> Defend for containers *BETA* is deprecated in Elastic Stack version 9.0.
+>
+> Defend for containers *BETA* is deprecated in Elastic Stack version 9.0 and also not supported for installation in Elastic Cloud Serverless.
 
 # How Container Workload Protection Works
 

--- a/packages/cloud_defend/manifest.yml
+++ b/packages/cloud_defend/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: cloud_defend
-title: "Defend for Containers"
-version: 1.2.8
+title: "Defend for Containers (Deprecated)"
+version: 1.3.0
 source:
   license: "Elastic-2.0"
 description: "Elastic Defend for Containers (BETA) provides cloud-native runtime protections for containerized environments."

--- a/packages/cylance/_dev/build/docs/README.md
+++ b/packages/cylance/_dev/build/docs/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **IMPORTANT**
+>
+> This package is *deprecated* and is not supported for installation in Elastic Cloud Serverless.
+
 # Cylance integration
 
 This integration is for [Cylance](https://www.blackberry.com/us/en/products/unified-endpoint-security/blackberry-protect) logs. It includes the following datasets for receiving logs over syslog or read from a file:

--- a/packages/cylance/changelog.yml
+++ b/packages/cylance/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.24.0"
+  changes:
+    - description: Deprecate package.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.23.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/cylance/docs/README.md
+++ b/packages/cylance/docs/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **IMPORTANT**
+>
+> This package is *deprecated* and is not supported for installation in Elastic Cloud Serverless.
+
 # Cylance integration
 
 This integration is for [Cylance](https://www.blackberry.com/us/en/products/unified-endpoint-security/blackberry-protect) logs. It includes the following datasets for receiving logs over syslog or read from a file:

--- a/packages/cylance/manifest.yml
+++ b/packages/cylance/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: cylance
-title: CylanceProtect Logs
-version: "0.23.0"
+title: CylanceProtect Logs (Deprecated)
+version: "0.24.0"
 description: Collect logs from CylanceProtect devices with Elastic Agent.
 categories: ["security", "edr_xdr"]
 type: integration

--- a/packages/fortinet_forticlient/_dev/build/docs/README.md
+++ b/packages/fortinet_forticlient/_dev/build/docs/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **IMPORTANT**
+>
+> This package is *deprecated* and is not supported for installation in Elastic Cloud Serverless.
+
 # Fortinet FortiClient Integration
 
 This integration is for Fortinet FortiClient logs sent in the syslog format.

--- a/packages/fortinet_forticlient/changelog.yml
+++ b/packages/fortinet_forticlient/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Add deprecation note in readme.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.11.0"
   changes:
     - description: Deprecate package.

--- a/packages/fortinet_forticlient/docs/README.md
+++ b/packages/fortinet_forticlient/docs/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **IMPORTANT**
+>
+> This package is *deprecated* and is not supported for installation in Elastic Cloud Serverless.
+
 # Fortinet FortiClient Integration
 
 This integration is for Fortinet FortiClient logs sent in the syslog format.

--- a/packages/fortinet_forticlient/manifest.yml
+++ b/packages/fortinet_forticlient/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_forticlient
 title: Fortinet FortiClient Logs (Deprecated)
-version: "1.11.0"
+version: "1.12.0"
 description: Deprecated. Fortinet FortiClient Logs is no longer supported.
 type: integration
 format_version: 2.7.0

--- a/packages/juniper_junos/_dev/build/docs/README.md
+++ b/packages/juniper_junos/_dev/build/docs/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **IMPORTANT**
+>
+> This package is *deprecated* and is not supported for installation in Elastic Cloud Serverless.
+
 # Juniper JunOS integration
 
 This is an integration for ingesting logs from [Juniper JunOS](https://www.juniper.net/documentation/product/us/en/junos-os).  For more information on sending syslog messages from JunOS to a remote destination such as a file / syslog host, see: [Directing System Log Messages to a Remote Machine or the Other Routing Engine](https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/directing-system-log-messages-to-a-remote-destination.html).

--- a/packages/juniper_junos/changelog.yml
+++ b/packages/juniper_junos/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.11.0"
+  changes:
+    - description: Add deprecation note in readme.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.10.3"
   changes:
     - description: Use triple-brace Mustache templating when referencing variables in ingest pipelines.

--- a/packages/juniper_junos/docs/README.md
+++ b/packages/juniper_junos/docs/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **IMPORTANT**
+>
+> This package is *deprecated* and is not supported for installation in Elastic Cloud Serverless.
+
 # Juniper JunOS integration
 
 This is an integration for ingesting logs from [Juniper JunOS](https://www.juniper.net/documentation/product/us/en/junos-os).  For more information on sending syslog messages from JunOS to a remote destination such as a file / syslog host, see: [Directing System Log Messages to a Remote Machine or the Other Routing Engine](https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/directing-system-log-messages-to-a-remote-destination.html).

--- a/packages/juniper_junos/manifest.yml
+++ b/packages/juniper_junos/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: juniper_junos
 title: Juniper JunOS (Deprecated)
-version: "0.10.3"
+version: "0.11.0"
 description: Deprecated. Use the Juniper SRX package instead.
 categories: ["network", "security"]
 release: experimental

--- a/packages/juniper_netscreen/_dev/build/docs/README.md
+++ b/packages/juniper_netscreen/_dev/build/docs/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **IMPORTANT**
+>
+> This package is *deprecated* and is not supported for installation in Elastic Cloud Serverless.
+
 # Juniper integration
 
 This is an integration for ingesting logs from [Juniper NetScreen](https://www.juniper.net/documentation/en_US/release-independent/screenos/information-products/pathway-pages/netscreen-series/product/).

--- a/packages/juniper_netscreen/changelog.yml
+++ b/packages/juniper_netscreen/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.11.0"
+  changes:
+    - description: Add deprecation note in readme.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.10.3"
   changes:
     - description: Use triple-brace Mustache templating when referencing variables in ingest pipelines.

--- a/packages/juniper_netscreen/docs/README.md
+++ b/packages/juniper_netscreen/docs/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **IMPORTANT**
+>
+> This package is *deprecated* and is not supported for installation in Elastic Cloud Serverless.
+
 # Juniper integration
 
 This is an integration for ingesting logs from [Juniper NetScreen](https://www.juniper.net/documentation/en_US/release-independent/screenos/information-products/pathway-pages/netscreen-series/product/).

--- a/packages/juniper_netscreen/manifest.yml
+++ b/packages/juniper_netscreen/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: juniper_netscreen
 title: Juniper NetScreen (Deprecated)
-version: "0.10.3"
+version: "0.11.0"
 description: Deprecated. Juniper NetScreen is no longer supported.
 categories: ["network", "security", "firewall_security"]
 release: experimental

--- a/packages/netscout/_dev/build/docs/README.md
+++ b/packages/netscout/_dev/build/docs/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **IMPORTANT**
+>
+> This package is *deprecated* and is not supported for installation in Elastic Cloud Serverless.
+
 # Netscout integration
 
 This integration is for [Netscout](https://www.netscout.com/product/arbor-sightline) device's logs. It includes the following

--- a/packages/netscout/changelog.yml
+++ b/packages/netscout/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.21.0"
+  changes:
+    - description: Add deprecation note in readme.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.20.1"
   changes:
     - description: Use triple-brace Mustache templating when referencing variables in ingest pipelines.

--- a/packages/netscout/docs/README.md
+++ b/packages/netscout/docs/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **IMPORTANT**
+>
+> This package is *deprecated* and is not supported for installation in Elastic Cloud Serverless.
+
 # Netscout integration
 
 This integration is for [Netscout](https://www.netscout.com/product/arbor-sightline) device's logs. It includes the following

--- a/packages/netscout/manifest.yml
+++ b/packages/netscout/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: netscout
 title: Arbor Peakflow SP Logs (Deprecated)
-version: "0.20.1"
+version: "0.21.0"
 description: Deprecated. Netscout Arbor Peakflow SP is no longer supported.
 categories: ["security", "network"]
 type: integration

--- a/packages/radware/_dev/build/docs/README.md
+++ b/packages/radware/_dev/build/docs/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **IMPORTANT**
+>
+> This package is *deprecated* and is not supported for installation in Elastic Cloud Serverless.
+
 # Radware integration
 
 This integration is for Radware device's logs. It includes the following

--- a/packages/radware/changelog.yml
+++ b/packages/radware/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.20.0"
+  changes:
+    - description: Add deprecation note in readme.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.19.1"
   changes:
     - description: Use triple-brace Mustache templating when referencing variables in ingest pipelines.

--- a/packages/radware/docs/README.md
+++ b/packages/radware/docs/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **IMPORTANT**
+>
+> This package is *deprecated* and is not supported for installation in Elastic Cloud Serverless.
+
 # Radware integration
 
 This integration is for Radware device's logs. It includes the following

--- a/packages/radware/manifest.yml
+++ b/packages/radware/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: radware
 title: Radware DefensePro Logs (Deprecated)
-version: "0.19.1"
+version: "0.20.0"
 description: Deprecated. Radware DefensePro Logs is no longer supported.
 categories: ["security"]
 type: integration

--- a/packages/tomcat/_dev/build/docs/README.md
+++ b/packages/tomcat/_dev/build/docs/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **IMPORTANT**
+>
+> This package is *deprecated* and is not supported for installation in Elastic Cloud Serverless.
+
 # Tomcat NetWitness Logs integration (To be deprecated soon)
 
 This integration is for [Tomcat device's](https://tomcat.apache.org/tomcat-10.0-doc/logging.html) logs. It includes the following

--- a/packages/tomcat/changelog.yml
+++ b/packages/tomcat/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.0"
+  changes:
+    - description: Deprecate package.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.12.0"
   changes:
     - description: Add support for Kibana `9.0.0`.

--- a/packages/tomcat/docs/README.md
+++ b/packages/tomcat/docs/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **IMPORTANT**
+>
+> This package is *deprecated* and is not supported for installation in Elastic Cloud Serverless.
+
 # Tomcat NetWitness Logs integration (To be deprecated soon)
 
 This integration is for [Tomcat device's](https://tomcat.apache.org/tomcat-10.0-doc/logging.html) logs. It includes the following

--- a/packages/tomcat/manifest.yml
+++ b/packages/tomcat/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: tomcat
-title: Tomcat NetWitness Logs
-version: "1.12.0"
+title: Tomcat NetWitness Logs (Deprecated)
+version: "1.13.0"
 description: Collect and parse logs from Apache Tomcat servers with Elastic Agent.
 categories: ["web", "observability"]
 type: integration


### PR DESCRIPTION
## Proposed Commit Message

```
bluecoat, cloud_defend, cylance, fortinet_forticlient, juniper_junos, juniper_netscreen, netscout, 
radware, tomcat: deprecate package and add deprecation note in readme

* cloud_defend, cylance, tomcat: deprecate the package and add note in readme that the package is not
supported for installation in Elastic Cloud Serverless.
* bluecoat, fortinet_forticlient, juniper_junos, juniper_netscreen, netscout, 
radware : Add deprecation note in readme that the package is not supported for installation in
Elastic Cloud Serverless.

```

## Checklist

- [] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally
Clone integrations repo.
Install the elastic package locally.
Start the elastic stack using the elastic package.
Move to integrations/packages/<integration_name> directory.
Run the following command to run tests.
`elastic-package test -v`

Replace the <integration_name> with the actual integration name.

## Related issues

- Closes https://github.com/elastic/integrations/issues/13536

