### PR TITLE
[sentinel_one_cloud_funnel] Add Support for Azure Blob Storage Input

### DIFF
--- a/packages/sentinel_one_cloud_funnel/_dev/build/docs/README.md
+++ b/packages/sentinel_one_cloud_funnel/_dev/build/docs/README.md
@@ -124,7 +124,9 @@ A sample JSON Credentials file looks as follows:
 - Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options.For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
 - How to setup the `auth.oauth2` credentials can be found in the Azure documentation https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app[here]
 
-Note: The service principal must be granted the appropriate permissions to read blobs. Ensure that the necessary role assignments are in place for the service principal to access the storage resources. For more information, please refer to the [Azure Role-Based Access Control (RBAC) documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage).
+Note:
+- The service principal must be granted the appropriate permissions to read blobs. Ensure that the necessary role assignments are in place for the service principal to access the storage resources. For more information, please refer to the [Azure Role-Based Access Control (RBAC) documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage).
+- We recommend assigning either the Storage Blob Data Reader or BlobOwner role. The Storage Blob Data Reader role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The Storage Blob Data Owner role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
 
 ### Enabling the integration in Elastic:
 

--- a/packages/sentinel_one_cloud_funnel/_dev/build/docs/README.md
+++ b/packages/sentinel_one_cloud_funnel/_dev/build/docs/README.md
@@ -2,10 +2,11 @@
 
 This [SentinelOne Cloud Funnel](https://assets.sentinelone.com/training/sentinelone_cloud_fu#page=1) integration enables your security team to securely stream XDR data to Elastic Security, via Amazon S3. When integrated with Elastic Security, this valuable data can be leveraged within Elastic for threat protection, detection, and incident response.
 
-The SentinelOne Cloud Funnel integration can be used in three different modes to collect data:
+The SentinelOne Cloud Funnel integration can be used in four different modes to collect data:
 - AWS S3 polling mode: SentinelOne Cloud Funnel writes data to S3, and Elastic Agent polls the S3 bucket by listing its contents and reading new files.
 - AWS S3 SQS mode: SentinelOne Cloud Funnel writes data to S3, S3 sends a notification of a new object to SQS, the Elastic Agent receives the notification from SQS, and then reads the S3 object. Multiple agents can be used in this mode.
 - GCS polling mode: SentinelOne Cloud Funnel writes data to GCS bucket, and Elastic Agent polls the GCS bucket by listing its contents and reading new files.
+- Azure Blob Storage mode: SentinelOne Cloud Funnel writes data to Azure Blob containers, and Elastic Agent polls the data from containers by listing its contents and reading new files.
 
 ## Compatibility
 
@@ -83,7 +84,7 @@ If you are just starting out creating your GCS bucket, do the following:
 3) Make sure to download the JSON key file once prompted.
 4) Use this JSON key file either inline (JSON string object), or by specifying the path to the file on the host machine, where the agent is running.
 
-A sample JSON Credentials file looks as follows: 
+A sample JSON Credentials file looks as follows:
 ```json
 {
   "type": "dummy_service_account",
@@ -116,12 +117,21 @@ A sample JSON Credentials file looks as follows:
 3. Configure event notifications for an S3 bucket. Follow this [link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html).
    - While creating `event notification` select the event type as s3:ObjectCreated:*, destination type SQS Queue, and select the queue name created in Step 2.
 
+### To collect data from an Azure Blob Storage, follow the below steps:
+
+- Considering you already have an Blob Storage setup, to configure it with SentinelOne Cloud Funnel, follow the steps mentioned here: `[Your Login URL]/docs/en/how-to-configure-your-amazon-s3-bucket.html`.
+- Enable the Cloud Funnel Streaming as mentioned here: `[Your Login URL]/docs/en/how-to-enable-cloud-funnel-streaming.html#how-to-enable-cloud-funnel-streaming`.
+- Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options.For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
+- How to setup the `auth.oauth2` credentials can be found in the Azure documentation https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app[here]
+
+Note: The service principal must be granted the appropriate permissions to read blobs. Ensure that the necessary role assignments are in place for the service principal to access the storage resources. For more information, please refer to the [Azure Role-Based Access Control (RBAC) documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage).
+
 ### Enabling the integration in Elastic:
 
 1. In Kibana go to Management > Integrations
 2. In "Search for integrations" search bar, type SentinelOne Cloud Funnel
 3. Click on the "SentinelOne Cloud Funnel" integration from the search results.
-4. Click on the Add SentinelOne Cloud Funnel Integration button to add the integration.
+4. Click on the Add SentinelOne Cloud Funnel Integration button to add the integration. Here you will have three options to collect data.
 5. While adding the integration, if you want to collect logs via AWS S3, then you have to put the following details:
    - access key id
    - secret access key
@@ -133,6 +143,21 @@ A sample JSON Credentials file looks as follows:
    - secret access key
    - queue url
    - collect logs via S3 Bucket toggled off
+6. To collect logs from Azure Blob Storage, you'll need to provide the following details:
+   For OAuth2 (Microsoft Entra ID RBAC):
+   - Account Name
+   - Client ID
+   - Client Secret
+   - Tenant ID
+   - Container Details.
+
+   For Service Account Credentials:
+   - Service Account Key or the URI
+   - Account Name
+   - Container Details
+7. To collect logs from Google Cloud Storage, you'll need to provide the following details:
+   - Project ID
+   - Either the JSON credential key or the path to the JSON credential file
 
 **NOTE**: There are other input combination options available, please check [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html).
 

--- a/packages/sentinel_one_cloud_funnel/changelog.yml
+++ b/packages/sentinel_one_cloud_funnel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add support for Azure Blob Storage Input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/14124
 - version: "1.12.1"
   changes:
     - description: Fix handling of command script and indicator events without `process.parent` fields.

--- a/packages/sentinel_one_cloud_funnel/changelog.yml
+++ b/packages/sentinel_one_cloud_funnel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.0"
+  changes:
+    - description: Add support for Azure Blob Storage Input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.12.1"
   changes:
     - description: Fix handling of command script and indicator events without `process.parent` fields.

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/agent/stream/abs.yml.hbs
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/agent/stream/abs.yml.hbs
@@ -1,6 +1,12 @@
 {{#if account_name}}
 account_name: {{account_name}}
 {{/if}}
+{{#if oauth2}}
+auth.oauth2:
+  client_id: {{client_id}}
+  client_secret: {{client_secret}}
+  tenant_id: {{tenant_id}}
+{{/if}}
 {{#if service_account_key}}
 auth.shared_credentials.account_key: {{service_account_key}}
 {{/if}}

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/agent/stream/abs.yml.hbs
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/agent/stream/abs.yml.hbs
@@ -1,0 +1,89 @@
+{{#if account_name}}
+account_name: {{account_name}}
+{{/if}}
+{{#if service_account_key}}
+auth.shared_credentials.account_key: {{service_account_key}}
+{{/if}}
+{{#if service_account_uri}}
+auth.connection_string.uri: {{service_account_uri}}
+{{/if}}
+{{#if storage_url}}
+storage_url: {{storage_url}}
+{{/if}}
+{{#if number_of_workers}}
+max_workers: {{number_of_workers}}
+{{/if}}
+{{#if poll}}
+poll: {{poll}}
+{{/if}}
+{{#if poll_interval}}
+poll_interval: {{poll_interval}}
+{{/if}}
+{{#if containers}}
+containers:
+{{containers}}
+{{/if}}
+{{#if file_selectors}}
+file_selectors:
+{{file_selectors}}
+{{/if}}
+{{#if timestamp_epoch}}
+timestamp_epoch: {{timestamp_epoch}}
+{{/if}}
+tags:
+{{#if preserve_original_event}}
+  - preserve_original_event
+{{/if}}
+{{#each tags as |tag|}}
+  - {{tag}}
+{{/each}}
+{{#contains "forwarded" tags}}
+publisher_pipeline.disable_host: true
+{{/contains}}
+fields_under_root: true
+fields:
+  _conf:
+    reroute:
+{{#if reroute_command_script}}
+      - command_script
+{{/if}}
+{{#if reroute_cross_process}}
+      - cross_process
+{{/if}}
+{{#if reroute_dns}}
+      - dns
+{{/if}}
+{{#if reroute_file}}
+      - file
+{{/if}}
+{{#if reroute_indicators}}
+      - indicators
+{{/if}}
+{{#if reroute_logins}}
+      - logins
+{{/if}}
+{{#if reroute_module}}
+      - module
+{{/if}}
+{{#if reroute_ip}}
+      - ip
+{{/if}}
+{{#if reroute_process}}
+      - process
+{{/if}}
+{{#if reroute_registry}}
+      - registry
+{{/if}}
+{{#if reroute_scheduled_task}}
+      - scheduled_task
+{{/if}}
+{{#if reroute_threat_intelligence_indicators}}
+      - threat_intelligence_indicators
+{{/if}}
+{{#if reroute_url}}
+      - url
+{{/if}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/manifest.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/manifest.yml
@@ -215,3 +215,119 @@ streams:
         type: bool
         multi: false
         default: false
+  - input: azure-blob-storage
+    description: Collect Event Logs from Sentinel One Cloud Funnel via Azure Blob Storage.
+    title: Event Logs
+    template_path: abs.yml.hbs
+    vars:
+      - name: account_name
+        type: text
+        title: Account Name
+        description: |
+          This attribute is required for various internal operations with respect to authentication, creating service clients and blob clients which are used internally for various processing purposes.
+        required: true
+        show_user: true
+      - name: service_account_key
+        type: password
+        title: Service Account Key
+        description: |
+          This attribute contains the access key, found under the Access keys section on Azure Cloud, under the respective storage account. A single storage account can contain multiple containers, and they will all use this common access key.
+        required: false
+        show_user: true
+        secret: true
+      - name: service_account_uri
+        type: text
+        title: Service Account URI
+        description: |
+          This attribute contains the connection string, found under the Access keys section on Azure Cloud, under the respective storage account. A single storage account can contain multiple containers, and they will all use this common connection string.
+        required: false
+        show_user: false
+      - name: storage_url
+        type: text
+        title: Storage URL
+        description: |
+          Use this attribute to specify a custom storage URL if required. By default it points to azure cloud storage. Only use this if there is a specific need to connect to a different environment where blob storage is available.
+          URL format : {{protocol}}://{{account_name}}.{{storage_uri}}.
+        required: false
+        show_user: false
+      - name: number_of_workers
+        type: integer
+        title: Maximum number of workers
+        multi: false
+        required: false
+        show_user: true
+        default: 3
+        description: Determines how many workers are spawned per container. Maximum allowed value is 5000.
+      - name: poll
+        type: bool
+        title: Polling
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: Determines if the container will be continuously polled for new documents.
+      - name: poll_interval
+        type: text
+        title: Polling interval
+        multi: false
+        required: false
+        show_user: true
+        default: 15s
+        description: Determines the time interval between polling operations.
+      - name: containers
+        type: yaml
+        title: Containers
+        description: "This attribute contains the details about a specific container like, name, number_of_workers, poll, poll_interval etc. \nThe attribute 'name' is specific to a container as it describes the container name, while the fields number_of_workers, poll, poll_interval can exist both at the container level and at the global level. \nIf you have already defined the attributes globally, then you can only specify the container name in this yaml config. \nIf you want to override any specific attribute for a container, then, you can define it here. \nAny attribute defined in the yaml will override the global definitions. Please see the relevant [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html#attrib-containers) for further information.\n"
+        required: true
+        show_user: true
+        default: |
+          #- name: azure-container1
+          #   max_workers: 3
+          #   poll: true
+          #   poll_interval: 15s
+          #- name: azure-container2
+          #  max_workers: 3
+          #  poll: true
+          #  poll_interval: 10s
+      - name: file_selectors
+        type: yaml
+        title: File Selectors
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          # - regex: "event/"
+        description: "If the container will have events that correspond to files that this integration shouldn’t process, file_selectors can be used to limit the files that are downloaded. This is a list of selectors which is made up of regex patters. \nThe regex should match the container filepath. Regexes use [RE2 syntax](https://pkg.go.dev/regexp/syntax). Files that don’t match one of the regexes will not be processed.\n"
+      - name: timestamp_epoch
+        type: integer
+        title: Timestamp Epoch
+        multi: false
+        required: false
+        description: "This attribute can be used to filter out files/blobs which have a timestamp older than the specified value. The value of this attribute should be in unix epoch (seconds) format."
+        show_user: false
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`.
+        type: bool
+        multi: false
+        default: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: |
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: tags
+        type: text
+        title: Tags
+        description: Tags to include in the published event.
+        required: true
+        default:
+          - forwarded
+          - sentinel_one_cloud_funnel-event
+        multi: true
+        show_user: false

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/manifest.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/manifest.yml
@@ -235,6 +235,27 @@ streams:
         required: false
         show_user: true
         secret: true
+      - name: client_id
+        type: text
+        title: Client ID
+        description: Client ID of Azure Account.
+        required: false
+        show_user: true
+        secret: true
+      - name: client_secret
+        type: password
+        title: Client Secret
+        description: Client Secret of Azure Account.
+        required: false
+        show_user: true
+        secret: true
+      - name: tenant_id
+        type: text
+        title: Tenant ID
+        description: Tenant ID of Azure Account.
+        multi: false
+        required: false
+        show_user: true
       - name: service_account_uri
         type: text
         title: Service Account URI

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/manifest.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/manifest.yml
@@ -237,22 +237,22 @@ streams:
         secret: true
       - name: client_id
         type: text
-        title: Client ID
-        description: Client ID of Azure Account.
+        title: Client ID (OAuth2)
+        description: Client ID of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.
         required: false
         show_user: true
         secret: true
       - name: client_secret
         type: password
-        title: Client Secret
-        description: Client Secret of Azure Account.
+        title: Client Secret (OAuth2)
+        description: Client Secret of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.
         required: false
         show_user: true
         secret: true
       - name: tenant_id
         type: text
-        title: Tenant ID
-        description: Tenant ID of Azure Account.
+        title: Tenant ID (OAuth2)
+        description: Tenant ID of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.
         multi: false
         required: false
         show_user: true

--- a/packages/sentinel_one_cloud_funnel/docs/README.md
+++ b/packages/sentinel_one_cloud_funnel/docs/README.md
@@ -124,7 +124,9 @@ A sample JSON Credentials file looks as follows:
 - Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options.For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
 - How to setup the `auth.oauth2` credentials can be found in the Azure documentation https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app[here]
 
-Note: The service principal must be granted the appropriate permissions to read blobs. Ensure that the necessary role assignments are in place for the service principal to access the storage resources. For more information, please refer to the [Azure Role-Based Access Control (RBAC) documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage).
+Note:
+- The service principal must be granted the appropriate permissions to read blobs. Ensure that the necessary role assignments are in place for the service principal to access the storage resources. For more information, please refer to the [Azure Role-Based Access Control (RBAC) documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage).
+- We recommend assigning either the Storage Blob Data Reader or BlobOwner role. The Storage Blob Data Reader role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The Storage Blob Data Owner role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
 
 ### Enabling the integration in Elastic:
 

--- a/packages/sentinel_one_cloud_funnel/docs/README.md
+++ b/packages/sentinel_one_cloud_funnel/docs/README.md
@@ -2,10 +2,11 @@
 
 This [SentinelOne Cloud Funnel](https://assets.sentinelone.com/training/sentinelone_cloud_fu#page=1) integration enables your security team to securely stream XDR data to Elastic Security, via Amazon S3. When integrated with Elastic Security, this valuable data can be leveraged within Elastic for threat protection, detection, and incident response.
 
-The SentinelOne Cloud Funnel integration can be used in three different modes to collect data:
+The SentinelOne Cloud Funnel integration can be used in four different modes to collect data:
 - AWS S3 polling mode: SentinelOne Cloud Funnel writes data to S3, and Elastic Agent polls the S3 bucket by listing its contents and reading new files.
 - AWS S3 SQS mode: SentinelOne Cloud Funnel writes data to S3, S3 sends a notification of a new object to SQS, the Elastic Agent receives the notification from SQS, and then reads the S3 object. Multiple agents can be used in this mode.
 - GCS polling mode: SentinelOne Cloud Funnel writes data to GCS bucket, and Elastic Agent polls the GCS bucket by listing its contents and reading new files.
+- Azure Blob Storage mode: SentinelOne Cloud Funnel writes data to Azure Blob containers, and Elastic Agent polls the data from containers by listing its contents and reading new files.
 
 ## Compatibility
 
@@ -83,7 +84,7 @@ If you are just starting out creating your GCS bucket, do the following:
 3) Make sure to download the JSON key file once prompted.
 4) Use this JSON key file either inline (JSON string object), or by specifying the path to the file on the host machine, where the agent is running.
 
-A sample JSON Credentials file looks as follows: 
+A sample JSON Credentials file looks as follows:
 ```json
 {
   "type": "dummy_service_account",
@@ -116,12 +117,21 @@ A sample JSON Credentials file looks as follows:
 3. Configure event notifications for an S3 bucket. Follow this [link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html).
    - While creating `event notification` select the event type as s3:ObjectCreated:*, destination type SQS Queue, and select the queue name created in Step 2.
 
+### To collect data from an Azure Blob Storage, follow the below steps:
+
+- Considering you already have an Blob Storage setup, to configure it with SentinelOne Cloud Funnel, follow the steps mentioned here: `[Your Login URL]/docs/en/how-to-configure-your-amazon-s3-bucket.html`.
+- Enable the Cloud Funnel Streaming as mentioned here: `[Your Login URL]/docs/en/how-to-enable-cloud-funnel-streaming.html#how-to-enable-cloud-funnel-streaming`.
+- Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options.For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
+- How to setup the `auth.oauth2` credentials can be found in the Azure documentation https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app[here]
+
+Note: The service principal must be granted the appropriate permissions to read blobs. Ensure that the necessary role assignments are in place for the service principal to access the storage resources. For more information, please refer to the [Azure Role-Based Access Control (RBAC) documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage).
+
 ### Enabling the integration in Elastic:
 
 1. In Kibana go to Management > Integrations
 2. In "Search for integrations" search bar, type SentinelOne Cloud Funnel
 3. Click on the "SentinelOne Cloud Funnel" integration from the search results.
-4. Click on the Add SentinelOne Cloud Funnel Integration button to add the integration.
+4. Click on the Add SentinelOne Cloud Funnel Integration button to add the integration. Here you will have three options to collect data.
 5. While adding the integration, if you want to collect logs via AWS S3, then you have to put the following details:
    - access key id
    - secret access key
@@ -133,6 +143,21 @@ A sample JSON Credentials file looks as follows:
    - secret access key
    - queue url
    - collect logs via S3 Bucket toggled off
+6. To collect logs from Azure Blob Storage, you'll need to provide the following details:
+   For OAuth2 (Microsoft Entra ID RBAC):
+   - Account Name
+   - Client ID
+   - Client Secret
+   - Tenant ID
+   - Container Details.
+
+   For Service Account Credentials:
+   - Service Account Key or the URI
+   - Account Name
+   - Container Details
+7. To collect logs from Google Cloud Storage, you'll need to provide the following details:
+   - Project ID
+   - Either the JSON credential key or the path to the JSON credential file
 
 **NOTE**: There are other input combination options available, please check [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html).
 

--- a/packages/sentinel_one_cloud_funnel/manifest.yml
+++ b/packages/sentinel_one_cloud_funnel/manifest.yml
@@ -408,6 +408,14 @@ policy_templates:
         title: Collect Sentinel One Cloud Funnel logs via Azure Blob Storage Input
         description: Collecting Sentinel One Cloud Funnel logs via Azure Blob Storage Input.
         vars:
+          - name: oauth2
+            required: true
+            show_user: true
+            title: Collect logs using OAuth2 authentication
+            description: To collect logs using OAuth2 authentication enable the toggle switch. By default, it will collect logs using service account key or URI.
+            type: bool
+            multi: false
+            default: false
           # Rerouting options
           - name: reroute_command_script
             type: bool

--- a/packages/sentinel_one_cloud_funnel/manifest.yml
+++ b/packages/sentinel_one_cloud_funnel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: sentinel_one_cloud_funnel
 title: SentinelOne Cloud Funnel
-version: "1.12.1"
+version: "1.13.0"
 description: Collect logs from SentinelOne Cloud Funnel with Elastic Agent.
 type: integration
 categories: ["security", "edr_xdr"]
@@ -299,6 +299,115 @@ policy_templates:
             multi: false
             required: false
             show_user: false
+          # Rerouting options
+          - name: reroute_command_script
+            type: bool
+            title: Reroute Command Script events to `sentinel_one_cloud_funnel.command_script`
+            default: false
+            multi: false
+            required: false
+            show_user: false
+            description: Enabling this option reroutes command_script events to `sentinel_one_cloud_funnel.command_script` from `sentinel_one_cloud_funnel.event`.
+          - name: reroute_cross_process
+            type: bool
+            title: Reroute Coss Process events to `sentinel_one_cloud_funnel.cross_process`
+            default: false
+            multi: false
+            required: false
+            show_user: false
+            description: Enabling this option reroutes cross_process events to `sentinel_one_cloud_funnel.cross_process` from `sentinel_one_cloud_funnel.event`.
+          - name: reroute_dns
+            type: bool
+            title: Reroute DNS events to `sentinel_one_cloud_funnel.dns`
+            default: false
+            multi: false
+            required: false
+            show_user: false
+            description: Enabling this option reroutes dns events to `sentinel_one_cloud_funnel.dns` from `sentinel_one_cloud_funnel.event`.
+          - name: reroute_file
+            type: bool
+            title: Reroute File events to `sentinel_one_cloud_funnel.file`
+            default: false
+            multi: false
+            required: false
+            show_user: false
+            description: Enabling this option reroutes file events to `sentinel_one_cloud_funnel.file` from `sentinel_one_cloud_funnel.event`.
+          - name: reroute_indicators
+            type: bool
+            title: Reroute Indicator events to `sentinel_one_cloud_funnel.indicators`
+            default: false
+            multi: false
+            required: false
+            show_user: false
+            description: Enabling this option reroutes indicators events to `sentinel_one_cloud_funnel.indicators` from `sentinel_one_cloud_funnel.event`.
+          - name: reroute_logins
+            type: bool
+            title: Reroute Login events to `sentinel_one_cloud_funnel.logins`
+            default: false
+            multi: false
+            required: false
+            show_user: false
+            description: Enabling this option reroutes logins events to `sentinel_one_cloud_funnel.logins` from `sentinel_one_cloud_funnel.event`.
+          - name: reroute_module
+            type: bool
+            title: Reroute Module events to `sentinel_one_cloud_funnel.module`
+            default: false
+            multi: false
+            required: false
+            show_user: false
+            description: Enabling this option reroutes module events to `sentinel_one_cloud_funnel.module` from `sentinel_one_cloud_funnel.event`.
+          - name: reroute_ip
+            type: bool
+            title: Reroute IP events to `sentinel_one_cloud_funnel.ip`
+            default: false
+            multi: false
+            required: false
+            show_user: false
+            description: Enabling this option reroutes ip events to `sentinel_one_cloud_funnel.ip` from `sentinel_one_cloud_funnel.event`.
+          - name: reroute_process
+            type: bool
+            title: Reroute Process events to `sentinel_one_cloud_funnel.process`
+            default: false
+            multi: false
+            required: false
+            show_user: false
+            description: Enabling this option reroutes process events to `sentinel_one_cloud_funnel.process` from `sentinel_one_cloud_funnel.event`.
+          - name: reroute_registry
+            type: bool
+            title: Reroute registry events to `sentinel_one_cloud_funnel.registry`
+            default: false
+            multi: false
+            required: false
+            show_user: false
+            description: Enabling this option reroutes registry events to `sentinel_one_cloud_funnel.registry` from `sentinel_one_cloud_funnel.event`.
+          - name: reroute_scheduled_task
+            type: bool
+            title: Reroute Scheduled Task events to `sentinel_one_cloud_funnel.scheduled_task`
+            default: false
+            multi: false
+            required: false
+            show_user: false
+            description: Enabling this option reroutes scheduled_task events to `sentinel_one_cloud_funnel.scheduled_task` from `sentinel_one_cloud_funnel.event`.
+          - name: reroute_threat_intelligence_indicators
+            type: bool
+            title: Reroute Threat Intelligence Indicator events to `sentinel_one_cloud_funnel.threat_intelligence_indicators`
+            default: false
+            multi: false
+            required: false
+            show_user: false
+            description: Enabling this option reroutes threat_intelligence_indicators events to `sentinel_one_cloud_funnel.threat_intelligence_indicators` from `sentinel_one_cloud_funnel.event`.
+          - name: reroute_url
+            type: bool
+            title: Reroute URL events to `sentinel_one_cloud_funnel.url`
+            default: false
+            multi: false
+            required: false
+            show_user: false
+            description: Enabling this option reroutes url events to `sentinel_one_cloud_funnel.url` from `sentinel_one_cloud_funnel.event`.
+      - type: azure-blob-storage
+        title: Collect Sentinel One Cloud Funnel logs via Azure Blob Storage Input
+        description: Collecting Sentinel One Cloud Funnel logs via Azure Blob Storage Input.
+        vars:
           # Rerouting options
           - name: reroute_command_script
             type: bool


### PR DESCRIPTION
## Proposed Commit Message

```
sentinel_one_cloud_funnel: add support for azure blob storage input.

Previously, azure blob storage input was not supported in the sentinel_one_cloud_funnel event data stream. 
This update adds support for azure blob storage input.

Testing has been performed using log samples available in the test folder, which were accessed via an
azure blob storage container to validate the input functionality.

```


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

### To test sentinel_one_cloud_funnel integration
Clone integrations repo.
Install the elastic package locally.
Start the elastic stack using the elastic package.
Move to integrations/packages/sentinel_one_cloud_funnel directory.
Run the following command to run tests.
`elastic-package test -v`

## Related issues

- Closes https://github.com/elastic/integrations/issues/13945

