### PR TITLE
Update System Core Metrics description

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.1"
+  changes:
+    - description: Enchanced description around System Core Metrics
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/14125
 - version: "2.2.0"
   changes:
     - description: Add support for ignore_types for fsstat.

--- a/packages/system/data_stream/core/manifest.yml
+++ b/packages/system/data_stream/core/manifest.yml
@@ -46,5 +46,5 @@ streams:
         default: false
         description: >-
           This option enables the use of performance counters to collect data. You should use this option if running agent on Windows machines with more than 64 cores
-    title: System core metrics
-    description: Collect System core metrics
+    title: System CPU core metrics
+    description: Collect usage statistics for each CPU core

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: system
 title: System
-version: "2.2.0"
+version: "2.2.1"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION


## Proposed commit message
It seems that the System integration collects` system core metrics` and `system cpu metric`s. However, `core metrics` here is actually referring CPU cores, not core as in basic metrics. I would not have picked this up from the GUI. If I look at the docs (https://www.elastic.co/docs/reference/integrations/system/#core), it's actually explained quite well. I suggest we update the description a bit more so it's more clear what the integration is actually collecting.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist


- [ ] Double check if I made the change in the right place.

## How to test this PR locally

N/A

## Related issues

N/A

## Screenshots

N/A

cc @ishleenk17 
