### PR TITLE
Okta: populate user.email when user name is an email address

### DIFF
--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Populate `user.email` from `user.name` when contains an email address to align with EntityAnalytics Okta and the other integrations.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/14148
 - version: "3.9.0"
   changes:
     - description: Parse `transaction.detail.rootApiTokenId` and `authenticationContext.rootSessionId` fields in pipeline.

--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.10.0"
+  changes:
+    - description: Populate `user.email` from `user.name` when contains an email address to align with EntityAnalytics Okta and the other integrations.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "3.9.0"
   changes:
     - description: Parse `transaction.detail.rootApiTokenId` and `authenticationContext.rootSessionId` fields in pipeline.

--- a/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-events.json-expected.json
+++ b/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-events.json-expected.json
@@ -14,6 +14,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "username@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "username@elastic.co"
@@ -129,12 +130,14 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "username@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "username@elastic.co"
                 }
             },
             "user": {
+                "email": "username@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "username@elastic.co"
             },

--- a/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-events.log-expected.json
+++ b/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-events.log-expected.json
@@ -14,6 +14,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "username@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "username@elastic.co"
@@ -126,6 +127,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "username@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "username@elastic.co"
@@ -135,6 +137,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "username@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "username@elastic.co"
             },
@@ -166,6 +169,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -279,6 +283,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -288,6 +293,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -319,6 +325,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -445,6 +452,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -454,6 +462,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -485,6 +494,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "someusername@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "someusername@elastic.co"
@@ -597,6 +607,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "someusername@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "someusername@elastic.co"
@@ -606,6 +617,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "someusername@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "someusername@elastic.co"
             },
@@ -637,6 +649,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -750,6 +763,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -759,6 +773,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -790,6 +805,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -916,6 +932,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -925,6 +942,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -956,6 +974,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1068,6 +1087,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1077,6 +1097,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -1108,6 +1129,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1221,6 +1243,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1230,6 +1253,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -1261,6 +1285,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1387,6 +1412,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1396,6 +1422,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -1426,6 +1453,7 @@
                     "region_name": "California"
                 },
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1521,6 +1549,7 @@
             },
             "source": {
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1530,6 +1559,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -1560,6 +1590,7 @@
                     "region_name": "California"
                 },
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1656,6 +1687,7 @@
             },
             "source": {
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1665,6 +1697,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -1695,6 +1728,7 @@
                     "region_name": "California"
                 },
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1804,6 +1838,7 @@
             },
             "source": {
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1813,6 +1848,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -1850,6 +1886,7 @@
                 },
                 "ip": "81.2.69.144",
                 "user": {
+                    "email": "test@test.com",
                     "full_name": "test@test.com",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "test@test.com"
@@ -2001,6 +2038,7 @@
                 },
                 "ip": "81.2.69.144",
                 "user": {
+                    "email": "test@test.com",
                     "full_name": "test@test.com",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "test@test.com"
@@ -2010,6 +2048,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "test@test.com",
                 "full_name": "test@test.com",
                 "name": "test@test.com"
             },
@@ -2041,6 +2080,7 @@
                 },
                 "ip": "67.43.156.14",
                 "user": {
+                    "email": "test1@test.com",
                     "full_name": "None",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "test1@test.com"
@@ -2171,6 +2211,7 @@
                 },
                 "ip": "67.43.156.14",
                 "user": {
+                    "email": "test1@test.com",
                     "full_name": "None",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "test1@test.com"
@@ -2180,6 +2221,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "test1@test.com",
                 "full_name": "None",
                 "name": "test1@test.com"
             },
@@ -2216,6 +2258,7 @@
                 },
                 "ip": "81.2.69.144",
                 "user": {
+                    "email": "Snipped_User@domain.com",
                     "full_name": "Last_name, First_Name",
                     "id": "user_id",
                     "name": "Snipped_User@domain.com"
@@ -2357,6 +2400,7 @@
                 },
                 "ip": "81.2.69.144",
                 "user": {
+                    "email": "Snipped_User@domain.com",
                     "full_name": "Last_name, First_Name",
                     "id": "user_id",
                     "name": "Snipped_User@domain.com"
@@ -2366,6 +2410,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "Snipped_User@domain.com",
                 "full_name": "Last_name, First_Name",
                 "name": "Snipped_User@domain.com"
             },
@@ -2397,6 +2442,7 @@
                 },
                 "ip": "127.0.0.1",
                 "user": {
+                    "email": "user@domain.com",
                     "full_name": "first last",
                     "id": "id",
                     "name": "user@domain.com"
@@ -2526,6 +2572,7 @@
                 "domain": "swisscom.ch",
                 "ip": "127.0.0.1",
                 "user": {
+                    "email": "user@domain.com",
                     "full_name": "first last",
                     "id": "id",
                     "name": "user@domain.com"
@@ -2535,6 +2582,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "user@domain.com",
                 "full_name": "first last",
                 "name": "user@domain.com",
                 "target": {
@@ -2575,6 +2623,7 @@
                 },
                 "ip": "127.0.0.1",
                 "user": {
+                    "email": "name@domain.com",
                     "full_name": "first last",
                     "id": "id",
                     "name": "name@domain.com"
@@ -2713,6 +2762,7 @@
                 "domain": "german-local.net",
                 "ip": "127.0.0.1",
                 "user": {
+                    "email": "name@domain.com",
                     "full_name": "first last",
                     "id": "id",
                     "name": "name@domain.com"
@@ -2722,6 +2772,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "name@domain.com",
                 "full_name": "first last",
                 "name": "name@domain.com",
                 "target": {
@@ -2761,6 +2812,7 @@
                 },
                 "ip": "127.0.0.1",
                 "user": {
+                    "email": "name@domain.com",
                     "full_name": "first last",
                     "id": "id",
                     "name": "name@domain.com"
@@ -2906,6 +2958,7 @@
                 "domain": "german-local.net",
                 "ip": "127.0.0.1",
                 "user": {
+                    "email": "name@domain.com",
                     "full_name": "first last",
                     "id": "id",
                     "name": "name@domain.com"
@@ -2915,6 +2968,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "name@domain.com",
                 "full_name": "first last",
                 "name": "name@domain.com",
                 "target": {
@@ -2958,6 +3012,7 @@
                 },
                 "ip": "192.168.7.19",
                 "user": {
+                    "email": "actor.user@test.com",
                     "full_name": "Test Actor User",
                     "id": "randomidhere",
                     "name": "actor.user@test.com"
@@ -3083,6 +3138,7 @@
                 "domain": "thisisadomain.com",
                 "ip": "192.168.7.19",
                 "user": {
+                    "email": "actor.user@test.com",
                     "full_name": "Test Actor User",
                     "id": "randomidhere",
                     "name": "actor.user@test.com"
@@ -3092,6 +3148,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "actor.user@test.com",
                 "full_name": "Test Actor User",
                 "name": "actor.user@test.com",
                 "target": {
@@ -3121,6 +3178,7 @@
             "@timestamp": "2023-04-27T00:56:17.750Z",
             "client": {
                 "user": {
+                    "email": "system@okta.com",
                     "full_name": "Okta System",
                     "id": "spr294puarJOdUsWD1t7",
                     "name": "system@okta.com"
@@ -3193,6 +3251,7 @@
             },
             "source": {
                 "user": {
+                    "email": "system@okta.com",
                     "full_name": "Okta System",
                     "id": "spr294puarJOdUsWD1t7",
                     "name": "system@okta.com"
@@ -3202,6 +3261,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "system@okta.com",
                 "full_name": "Okta System",
                 "name": "system@okta.com",
                 "target": {
@@ -3220,6 +3280,7 @@
                 },
                 "domain": "sbcglobal.net",
                 "user": {
+                    "email": "test.user@test.com",
                     "full_name": "Test User",
                     "id": "00uk123456abct7",
                     "name": "test.user@test.com"
@@ -3326,6 +3387,7 @@
             "source": {
                 "domain": "sbcglobal.net",
                 "user": {
+                    "email": "test.user@test.com",
                     "full_name": "Test User",
                     "id": "00uk123456abct7",
                     "name": "test.user@test.com"
@@ -3335,6 +3397,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "test.user@test.com",
                 "full_name": "Test User",
                 "name": "test.user@test.com"
             }
@@ -3349,6 +3412,7 @@
                 },
                 "domain": "sbcglobal.net",
                 "user": {
+                    "email": "test.user@test.com",
                     "full_name": "Test User",
                     "id": "00uk123456abct7",
                     "name": "test.user@test.com"
@@ -3459,6 +3523,7 @@
             "source": {
                 "domain": "sbcglobal.net",
                 "user": {
+                    "email": "test.user@test.com",
                     "full_name": "Test User",
                     "id": "00uk123456abct7",
                     "name": "test.user@test.com"
@@ -3468,6 +3533,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "test.user@test.com",
                 "full_name": "Test User",
                 "name": "test.user@test.com"
             }
@@ -3492,6 +3558,7 @@
                 },
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "test.user@domain.com",
                     "full_name": "Test User",
                     "id": "00ua123456abcat7",
                     "name": "test.user@domain.com"
@@ -3617,6 +3684,7 @@
                 "domain": "voenergies.net",
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "test.user@domain.com",
                     "full_name": "Test User",
                     "id": "00ua123456abcat7",
                     "name": "test.user@domain.com"
@@ -3626,6 +3694,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "test.user@domain.com",
                 "full_name": "Test User",
                 "name": "test.user@domain.com",
                 "target": {
@@ -3661,6 +3730,7 @@
                 },
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "john.doe@elastic.co",
                     "full_name": "John Doe",
                     "id": "00aabbccddeeffaaaaaa",
                     "name": "john.doe@elastic.co"
@@ -3773,6 +3843,7 @@
                 "domain": "verizon.net",
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "john.doe@elastic.co",
                     "full_name": "John Doe",
                     "id": "00aabbccddeeffaaaaaa",
                     "name": "john.doe@elastic.co"
@@ -3782,6 +3853,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "john.doe@elastic.co",
                 "full_name": "John Doe",
                 "name": "john.doe@elastic.co"
             },
@@ -3813,6 +3885,7 @@
                 },
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "john.doe@elastic.co",
                     "full_name": "John Doe",
                     "id": "00aabbccddeeffaaaaaa",
                     "name": "john.doe@elastic.co"
@@ -3927,6 +4000,7 @@
                 "domain": "verizon.net",
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "john.doe@elastic.co",
                     "full_name": "John Doe",
                     "id": "00aabbccddeeffaaaaaa",
                     "name": "john.doe@elastic.co"
@@ -3936,6 +4010,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "john.doe@elastic.co",
                 "full_name": "John Doe",
                 "name": "john.doe@elastic.co"
             },

--- a/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-no-flattened-events.log-expected.json
+++ b/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-no-flattened-events.log-expected.json
@@ -14,6 +14,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "username@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "username@elastic.co"
@@ -120,6 +121,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "username@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "username@elastic.co"
@@ -129,6 +131,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "username@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "username@elastic.co"
             },
@@ -160,6 +163,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -266,6 +270,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -275,6 +280,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -306,6 +312,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -425,6 +432,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -434,6 +442,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -465,6 +474,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "someusername@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "someusername@elastic.co"
@@ -571,6 +581,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "someusername@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "someusername@elastic.co"
@@ -580,6 +591,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "someusername@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "someusername@elastic.co"
             },
@@ -611,6 +623,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -717,6 +730,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -726,6 +740,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -757,6 +772,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -876,6 +892,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -885,6 +902,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -916,6 +934,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1022,6 +1041,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1031,6 +1051,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -1062,6 +1083,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1168,6 +1190,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1177,6 +1200,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -1208,6 +1232,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1327,6 +1352,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1336,6 +1362,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -1366,6 +1393,7 @@
                     "region_name": "California"
                 },
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1455,6 +1483,7 @@
             },
             "source": {
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1464,6 +1493,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -1494,6 +1524,7 @@
                     "region_name": "California"
                 },
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1583,6 +1614,7 @@
             },
             "source": {
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1592,6 +1624,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -1622,6 +1655,7 @@
                     "region_name": "California"
                 },
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1724,6 +1758,7 @@
             },
             "source": {
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1733,6 +1768,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -1770,6 +1806,7 @@
                 },
                 "ip": "81.2.69.144",
                 "user": {
+                    "email": "test@test.com",
                     "full_name": "test@test.com",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "test@test.com"
@@ -1915,6 +1952,7 @@
                 },
                 "ip": "81.2.69.144",
                 "user": {
+                    "email": "test@test.com",
                     "full_name": "test@test.com",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "test@test.com"
@@ -1924,6 +1962,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "test@test.com",
                 "full_name": "test@test.com",
                 "name": "test@test.com"
             },
@@ -1955,6 +1994,7 @@
                 },
                 "ip": "67.43.156.14",
                 "user": {
+                    "email": "test1@test.com",
                     "full_name": "None",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "test1@test.com"
@@ -2078,6 +2118,7 @@
                 },
                 "ip": "67.43.156.14",
                 "user": {
+                    "email": "test1@test.com",
                     "full_name": "None",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "test1@test.com"
@@ -2087,6 +2128,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "test1@test.com",
                 "full_name": "None",
                 "name": "test1@test.com"
             },
@@ -2123,6 +2165,7 @@
                 },
                 "ip": "81.2.69.144",
                 "user": {
+                    "email": "Snipped_User@domain.com",
                     "full_name": "Last_name, First_Name",
                     "id": "user_id",
                     "name": "Snipped_User@domain.com"
@@ -2257,6 +2300,7 @@
                 },
                 "ip": "81.2.69.144",
                 "user": {
+                    "email": "Snipped_User@domain.com",
                     "full_name": "Last_name, First_Name",
                     "id": "user_id",
                     "name": "Snipped_User@domain.com"
@@ -2266,6 +2310,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "Snipped_User@domain.com",
                 "full_name": "Last_name, First_Name",
                 "name": "Snipped_User@domain.com"
             },
@@ -2297,6 +2342,7 @@
                 },
                 "ip": "127.0.0.1",
                 "user": {
+                    "email": "user@domain.com",
                     "full_name": "first last",
                     "id": "id",
                     "name": "user@domain.com"
@@ -2419,6 +2465,7 @@
                 "domain": "swisscom.ch",
                 "ip": "127.0.0.1",
                 "user": {
+                    "email": "user@domain.com",
                     "full_name": "first last",
                     "id": "id",
                     "name": "user@domain.com"
@@ -2428,6 +2475,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "user@domain.com",
                 "full_name": "first last",
                 "name": "user@domain.com",
                 "target": {
@@ -2468,6 +2516,7 @@
                 },
                 "ip": "127.0.0.1",
                 "user": {
+                    "email": "name@domain.com",
                     "full_name": "first last",
                     "id": "id",
                     "name": "name@domain.com"
@@ -2597,6 +2646,7 @@
                 "domain": "german-local.net",
                 "ip": "127.0.0.1",
                 "user": {
+                    "email": "name@domain.com",
                     "full_name": "first last",
                     "id": "id",
                     "name": "name@domain.com"
@@ -2606,6 +2656,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "name@domain.com",
                 "full_name": "first last",
                 "name": "name@domain.com",
                 "target": {
@@ -2645,6 +2696,7 @@
                 },
                 "ip": "127.0.0.1",
                 "user": {
+                    "email": "name@domain.com",
                     "full_name": "first last",
                     "id": "id",
                     "name": "name@domain.com"
@@ -2781,6 +2833,7 @@
                 "domain": "german-local.net",
                 "ip": "127.0.0.1",
                 "user": {
+                    "email": "name@domain.com",
                     "full_name": "first last",
                     "id": "id",
                     "name": "name@domain.com"
@@ -2790,6 +2843,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "name@domain.com",
                 "full_name": "first last",
                 "name": "name@domain.com",
                 "target": {
@@ -2833,6 +2887,7 @@
                 },
                 "ip": "192.168.7.19",
                 "user": {
+                    "email": "actor.user@test.com",
                     "full_name": "Test Actor User",
                     "id": "randomidhere",
                     "name": "actor.user@test.com"
@@ -2952,6 +3007,7 @@
                 "domain": "thisisadomain.com",
                 "ip": "192.168.7.19",
                 "user": {
+                    "email": "actor.user@test.com",
                     "full_name": "Test Actor User",
                     "id": "randomidhere",
                     "name": "actor.user@test.com"
@@ -2961,6 +3017,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "actor.user@test.com",
                 "full_name": "Test Actor User",
                 "name": "actor.user@test.com",
                 "target": {
@@ -2990,6 +3047,7 @@
             "@timestamp": "2023-04-27T00:56:17.750Z",
             "client": {
                 "user": {
+                    "email": "system@okta.com",
                     "full_name": "Okta System",
                     "id": "spr294puarJOdUsWD1t7",
                     "name": "system@okta.com"
@@ -3062,6 +3120,7 @@
             },
             "source": {
                 "user": {
+                    "email": "system@okta.com",
                     "full_name": "Okta System",
                     "id": "spr294puarJOdUsWD1t7",
                     "name": "system@okta.com"
@@ -3071,6 +3130,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "system@okta.com",
                 "full_name": "Okta System",
                 "name": "system@okta.com",
                 "target": {
@@ -3089,6 +3149,7 @@
                 },
                 "domain": "sbcglobal.net",
                 "user": {
+                    "email": "test.user@test.com",
                     "full_name": "Test User",
                     "id": "00uk123456abct7",
                     "name": "test.user@test.com"
@@ -3195,6 +3256,7 @@
             "source": {
                 "domain": "sbcglobal.net",
                 "user": {
+                    "email": "test.user@test.com",
                     "full_name": "Test User",
                     "id": "00uk123456abct7",
                     "name": "test.user@test.com"
@@ -3204,6 +3266,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "test.user@test.com",
                 "full_name": "Test User",
                 "name": "test.user@test.com"
             }
@@ -3218,6 +3281,7 @@
                 },
                 "domain": "sbcglobal.net",
                 "user": {
+                    "email": "test.user@test.com",
                     "full_name": "Test User",
                     "id": "00uk123456abct7",
                     "name": "test.user@test.com"
@@ -3328,6 +3392,7 @@
             "source": {
                 "domain": "sbcglobal.net",
                 "user": {
+                    "email": "test.user@test.com",
                     "full_name": "Test User",
                     "id": "00uk123456abct7",
                     "name": "test.user@test.com"
@@ -3337,6 +3402,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "test.user@test.com",
                 "full_name": "Test User",
                 "name": "test.user@test.com"
             }
@@ -3361,6 +3427,7 @@
                 },
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "test.user@domain.com",
                     "full_name": "Test User",
                     "id": "00ua123456abcat7",
                     "name": "test.user@domain.com"
@@ -3479,6 +3546,7 @@
                 "domain": "voenergies.net",
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "test.user@domain.com",
                     "full_name": "Test User",
                     "id": "00ua123456abcat7",
                     "name": "test.user@domain.com"
@@ -3488,6 +3556,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "test.user@domain.com",
                 "full_name": "Test User",
                 "name": "test.user@domain.com",
                 "target": {
@@ -3523,6 +3592,7 @@
                 },
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "john.doe@elastic.co",
                     "full_name": "John Doe",
                     "id": "00aabbccddeeffaaaaaa",
                     "name": "john.doe@elastic.co"
@@ -3630,6 +3700,7 @@
                 "domain": "verizon.net",
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "john.doe@elastic.co",
                     "full_name": "John Doe",
                     "id": "00aabbccddeeffaaaaaa",
                     "name": "john.doe@elastic.co"
@@ -3639,6 +3710,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "john.doe@elastic.co",
                 "full_name": "John Doe",
                 "name": "john.doe@elastic.co"
             },
@@ -3670,6 +3742,7 @@
                 },
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "john.doe@elastic.co",
                     "full_name": "John Doe",
                     "id": "00aabbccddeeffaaaaaa",
                     "name": "john.doe@elastic.co"
@@ -3785,6 +3858,7 @@
                 "domain": "verizon.net",
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "john.doe@elastic.co",
                     "full_name": "John Doe",
                     "id": "00aabbccddeeffaaaaaa",
                     "name": "john.doe@elastic.co"
@@ -3794,6 +3868,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "john.doe@elastic.co",
                 "full_name": "John Doe",
                 "name": "john.doe@elastic.co"
             },
@@ -3825,6 +3900,7 @@
                 },
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "john.doe@elastic.co",
                     "full_name": "John Doe",
                     "id": "00aabbccddeeffaaaaaa",
                     "name": "john.doe@elastic.co"
@@ -3947,6 +4023,7 @@
                 "domain": "verizon.net",
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "john.doe@elastic.co",
                     "full_name": "John Doe",
                     "id": "00aabbccddeeffaaaaaa",
                     "name": "john.doe@elastic.co"
@@ -3956,6 +4033,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "john.doe@elastic.co",
                 "full_name": "John Doe",
                 "name": "john.doe@elastic.co"
             },

--- a/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-yes-flattened-events.log-expected.json
+++ b/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-yes-flattened-events.log-expected.json
@@ -14,6 +14,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "username@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "username@elastic.co"
@@ -126,6 +127,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "username@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "username@elastic.co"
@@ -135,6 +137,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "username@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "username@elastic.co"
             },
@@ -166,6 +169,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -279,6 +283,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -288,6 +293,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -319,6 +325,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -445,6 +452,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -454,6 +462,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -485,6 +494,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "someusername@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "someusername@elastic.co"
@@ -597,6 +607,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "someusername@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "someusername@elastic.co"
@@ -606,6 +617,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "someusername@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "someusername@elastic.co"
             },
@@ -637,6 +649,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -750,6 +763,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -759,6 +773,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -790,6 +805,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -916,6 +932,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -925,6 +942,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -956,6 +974,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1068,6 +1087,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1077,6 +1097,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -1108,6 +1129,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1221,6 +1243,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1230,6 +1253,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -1261,6 +1285,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1387,6 +1412,7 @@
                 },
                 "ip": "175.16.199.1",
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1396,6 +1422,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -1426,6 +1453,7 @@
                     "region_name": "California"
                 },
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1521,6 +1549,7 @@
             },
             "source": {
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1530,6 +1559,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -1560,6 +1590,7 @@
                     "region_name": "California"
                 },
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1656,6 +1687,7 @@
             },
             "source": {
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1665,6 +1697,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -1695,6 +1728,7 @@
                     "region_name": "California"
                 },
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1804,6 +1838,7 @@
             },
             "source": {
                 "user": {
+                    "email": "xxxxxx@elastic.co",
                     "full_name": "xxxxxx",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "xxxxxx@elastic.co"
@@ -1813,6 +1848,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "xxxxxx@elastic.co",
                 "full_name": "xxxxxx",
                 "name": "xxxxxx@elastic.co"
             },
@@ -1850,6 +1886,7 @@
                 },
                 "ip": "81.2.69.144",
                 "user": {
+                    "email": "test@test.com",
                     "full_name": "test@test.com",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "test@test.com"
@@ -2001,6 +2038,7 @@
                 },
                 "ip": "81.2.69.144",
                 "user": {
+                    "email": "test@test.com",
                     "full_name": "test@test.com",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "test@test.com"
@@ -2010,6 +2048,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "test@test.com",
                 "full_name": "test@test.com",
                 "name": "test@test.com"
             },
@@ -2041,6 +2080,7 @@
                 },
                 "ip": "67.43.156.14",
                 "user": {
+                    "email": "test1@test.com",
                     "full_name": "None",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "test1@test.com"
@@ -2171,6 +2211,7 @@
                 },
                 "ip": "67.43.156.14",
                 "user": {
+                    "email": "test1@test.com",
                     "full_name": "None",
                     "id": "00u1abvz4pYqdM8ms4x6",
                     "name": "test1@test.com"
@@ -2180,6 +2221,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "test1@test.com",
                 "full_name": "None",
                 "name": "test1@test.com"
             },
@@ -2216,6 +2258,7 @@
                 },
                 "ip": "81.2.69.144",
                 "user": {
+                    "email": "Snipped_User@domain.com",
                     "full_name": "Last_name, First_Name",
                     "id": "user_id",
                     "name": "Snipped_User@domain.com"
@@ -2357,6 +2400,7 @@
                 },
                 "ip": "81.2.69.144",
                 "user": {
+                    "email": "Snipped_User@domain.com",
                     "full_name": "Last_name, First_Name",
                     "id": "user_id",
                     "name": "Snipped_User@domain.com"
@@ -2366,6 +2410,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "Snipped_User@domain.com",
                 "full_name": "Last_name, First_Name",
                 "name": "Snipped_User@domain.com"
             },
@@ -2397,6 +2442,7 @@
                 },
                 "ip": "127.0.0.1",
                 "user": {
+                    "email": "user@domain.com",
                     "full_name": "first last",
                     "id": "id",
                     "name": "user@domain.com"
@@ -2526,6 +2572,7 @@
                 "domain": "swisscom.ch",
                 "ip": "127.0.0.1",
                 "user": {
+                    "email": "user@domain.com",
                     "full_name": "first last",
                     "id": "id",
                     "name": "user@domain.com"
@@ -2535,6 +2582,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "user@domain.com",
                 "full_name": "first last",
                 "name": "user@domain.com",
                 "target": {
@@ -2575,6 +2623,7 @@
                 },
                 "ip": "127.0.0.1",
                 "user": {
+                    "email": "name@domain.com",
                     "full_name": "first last",
                     "id": "id",
                     "name": "name@domain.com"
@@ -2713,6 +2762,7 @@
                 "domain": "german-local.net",
                 "ip": "127.0.0.1",
                 "user": {
+                    "email": "name@domain.com",
                     "full_name": "first last",
                     "id": "id",
                     "name": "name@domain.com"
@@ -2722,6 +2772,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "name@domain.com",
                 "full_name": "first last",
                 "name": "name@domain.com",
                 "target": {
@@ -2761,6 +2812,7 @@
                 },
                 "ip": "127.0.0.1",
                 "user": {
+                    "email": "name@domain.com",
                     "full_name": "first last",
                     "id": "id",
                     "name": "name@domain.com"
@@ -2906,6 +2958,7 @@
                 "domain": "german-local.net",
                 "ip": "127.0.0.1",
                 "user": {
+                    "email": "name@domain.com",
                     "full_name": "first last",
                     "id": "id",
                     "name": "name@domain.com"
@@ -2915,6 +2968,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "name@domain.com",
                 "full_name": "first last",
                 "name": "name@domain.com",
                 "target": {
@@ -2958,6 +3012,7 @@
                 },
                 "ip": "192.168.7.19",
                 "user": {
+                    "email": "actor.user@test.com",
                     "full_name": "Test Actor User",
                     "id": "randomidhere",
                     "name": "actor.user@test.com"
@@ -3083,6 +3138,7 @@
                 "domain": "thisisadomain.com",
                 "ip": "192.168.7.19",
                 "user": {
+                    "email": "actor.user@test.com",
                     "full_name": "Test Actor User",
                     "id": "randomidhere",
                     "name": "actor.user@test.com"
@@ -3092,6 +3148,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "actor.user@test.com",
                 "full_name": "Test Actor User",
                 "name": "actor.user@test.com",
                 "target": {
@@ -3121,6 +3178,7 @@
             "@timestamp": "2023-04-27T00:56:17.750Z",
             "client": {
                 "user": {
+                    "email": "system@okta.com",
                     "full_name": "Okta System",
                     "id": "spr294puarJOdUsWD1t7",
                     "name": "system@okta.com"
@@ -3193,6 +3251,7 @@
             },
             "source": {
                 "user": {
+                    "email": "system@okta.com",
                     "full_name": "Okta System",
                     "id": "spr294puarJOdUsWD1t7",
                     "name": "system@okta.com"
@@ -3202,6 +3261,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "system@okta.com",
                 "full_name": "Okta System",
                 "name": "system@okta.com",
                 "target": {
@@ -3220,6 +3280,7 @@
                 },
                 "domain": "sbcglobal.net",
                 "user": {
+                    "email": "test.user@test.com",
                     "full_name": "Test User",
                     "id": "00uk123456abct7",
                     "name": "test.user@test.com"
@@ -3326,6 +3387,7 @@
             "source": {
                 "domain": "sbcglobal.net",
                 "user": {
+                    "email": "test.user@test.com",
                     "full_name": "Test User",
                     "id": "00uk123456abct7",
                     "name": "test.user@test.com"
@@ -3335,6 +3397,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "test.user@test.com",
                 "full_name": "Test User",
                 "name": "test.user@test.com"
             }
@@ -3349,6 +3412,7 @@
                 },
                 "domain": "sbcglobal.net",
                 "user": {
+                    "email": "test.user@test.com",
                     "full_name": "Test User",
                     "id": "00uk123456abct7",
                     "name": "test.user@test.com"
@@ -3459,6 +3523,7 @@
             "source": {
                 "domain": "sbcglobal.net",
                 "user": {
+                    "email": "test.user@test.com",
                     "full_name": "Test User",
                     "id": "00uk123456abct7",
                     "name": "test.user@test.com"
@@ -3468,6 +3533,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "test.user@test.com",
                 "full_name": "Test User",
                 "name": "test.user@test.com"
             }
@@ -3492,6 +3558,7 @@
                 },
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "test.user@domain.com",
                     "full_name": "Test User",
                     "id": "00ua123456abcat7",
                     "name": "test.user@domain.com"
@@ -3617,6 +3684,7 @@
                 "domain": "voenergies.net",
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "test.user@domain.com",
                     "full_name": "Test User",
                     "id": "00ua123456abcat7",
                     "name": "test.user@domain.com"
@@ -3626,6 +3694,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "test.user@domain.com",
                 "full_name": "Test User",
                 "name": "test.user@domain.com",
                 "target": {
@@ -3661,6 +3730,7 @@
                 },
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "john.doe@elastic.co",
                     "full_name": "John Doe",
                     "id": "00aabbccddeeffaaaaaa",
                     "name": "john.doe@elastic.co"
@@ -3773,6 +3843,7 @@
                 "domain": "verizon.net",
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "john.doe@elastic.co",
                     "full_name": "John Doe",
                     "id": "00aabbccddeeffaaaaaa",
                     "name": "john.doe@elastic.co"
@@ -3782,6 +3853,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "john.doe@elastic.co",
                 "full_name": "John Doe",
                 "name": "john.doe@elastic.co"
             },
@@ -3813,6 +3885,7 @@
                 },
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "john.doe@elastic.co",
                     "full_name": "John Doe",
                     "id": "00aabbccddeeffaaaaaa",
                     "name": "john.doe@elastic.co"
@@ -3939,6 +4012,7 @@
                 "domain": "verizon.net",
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "john.doe@elastic.co",
                     "full_name": "John Doe",
                     "id": "00aabbccddeeffaaaaaa",
                     "name": "john.doe@elastic.co"
@@ -3948,6 +4022,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "john.doe@elastic.co",
                 "full_name": "John Doe",
                 "name": "john.doe@elastic.co"
             },
@@ -3979,6 +4054,7 @@
                 },
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "john.doe@elastic.co",
                     "full_name": "John Doe",
                     "id": "00aabbccddeeffaaaaaa",
                     "name": "john.doe@elastic.co"
@@ -4112,6 +4188,7 @@
                 "domain": "verizon.net",
                 "ip": "192.168.1.10",
                 "user": {
+                    "email": "john.doe@elastic.co",
                     "full_name": "John Doe",
                     "id": "00aabbccddeeffaaaaaa",
                     "name": "john.doe@elastic.co"
@@ -4121,6 +4198,7 @@
                 "preserve_original_event"
             ],
             "user": {
+                "email": "john.doe@elastic.co",
                 "full_name": "John Doe",
                 "name": "john.doe@elastic.co"
             },

--- a/packages/okta/data_stream/system/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/okta/data_stream/system/elasticsearch/ingest_pipeline/default.yml
@@ -181,13 +181,26 @@ processors:
       copy_from: okta.actor.alternate_id
       ignore_empty_value: true
   - set:
+      field: user.email
+      copy_from: user.name
+      ignore_empty_value: true
+      if: ctx.user?.name != null && ctx.user.name.indexOf("@") > 0
+  - set:
       field: source.user.name
       copy_from: user.name
       ignore_empty_value: true
   - set:
+      field: source.user.email
+      copy_from: source.user.name
+      if: ctx.source?.user?.name != null && ctx.source.user.name.indexOf("@") > 0
+  - set:
       field: client.user.name
       copy_from: user.name
       ignore_empty_value: true
+  - set:
+      field: client.user.email
+      copy_from: client.user.name
+      if: ctx.client?.user?.name != null && ctx.client.user.name.indexOf("@") > 0
   - rename:
       field: json.actor.displayName
       target_field: okta.actor.display_name

--- a/packages/okta/data_stream/system/sample_event.json
+++ b/packages/okta/data_stream/system/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2020-02-14T20:18:57.718Z",
     "agent": {
-        "ephemeral_id": "eeed25bf-dc6f-48ab-b30f-a9c7fa45d6c4",
-        "id": "f466dfde-d7b7-4c3a-a3e1-9c0175d94132",
-        "name": "elastic-agent-20611",
+        "ephemeral_id": "f0fa8393-26a1-453e-96fe-212743206a30",
+        "id": "da1b4fd1-cf45-42bc-8036-09da5b16e085",
+        "name": "elastic-agent-91674",
         "type": "filebeat",
-        "version": "8.18.0"
+        "version": "8.18.1"
     },
     "client": {
         "geo": {
@@ -19,6 +19,7 @@
         },
         "ip": "108.255.197.247",
         "user": {
+            "email": "xxxxxx@elastic.co",
             "full_name": "xxxxxx",
             "id": "00u1abvz4pYqdM8ms4x6",
             "name": "xxxxxx@elastic.co"
@@ -26,16 +27,16 @@
     },
     "data_stream": {
         "dataset": "okta.system",
-        "namespace": "92902",
+        "namespace": "58099",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "f466dfde-d7b7-4c3a-a3e1-9c0175d94132",
+        "id": "da1b4fd1-cf45-42bc-8036-09da5b16e085",
         "snapshot": false,
-        "version": "8.18.0"
+        "version": "8.18.1"
     },
     "event": {
         "action": "user.session.start",
@@ -44,10 +45,10 @@
             "authentication",
             "session"
         ],
-        "created": "2025-04-30T01:38:47.331Z",
+        "created": "2025-06-04T15:16:49.436Z",
         "dataset": "okta.system",
         "id": "3aeede38-4f67-11ea-abd3-1f5d113f2546",
-        "ingested": "2025-04-30T01:38:48Z",
+        "ingested": "2025-06-04T15:16:50Z",
         "kind": "event",
         "original": "{\"actor\":{\"alternateId\":\"xxxxxx@elastic.co\",\"detailEntry\":null,\"displayName\":\"xxxxxx\",\"id\":\"00u1abvz4pYqdM8ms4x6\",\"type\":\"User\"},\"authenticationContext\":{\"authenticationProvider\":null,\"authenticationStep\":0,\"credentialProvider\":null,\"credentialType\":null,\"externalSessionId\":\"102bZDNFfWaQSyEZQuDgWt-uQ\",\"interface\":null,\"issuer\":null},\"client\":{\"device\":\"Computer\",\"geographicalContext\":{\"city\":\"Dublin\",\"country\":\"United States\",\"geolocation\":{\"lat\":37.7201,\"lon\":-121.919},\"postalCode\":\"94568\",\"state\":\"California\"},\"id\":null,\"ipAddress\":\"108.255.197.247\",\"userAgent\":{\"browser\":\"FIREFOX\",\"os\":\"Mac OS X\",\"rawUserAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:72.0) Gecko/20100101 Firefox/72.0\"},\"zone\":\"null\"},\"debugContext\":{\"debugData\":{\"deviceFingerprint\":\"541daf91d15bef64a7e08c946fd9a9d0\",\"requestId\":\"XkcAsWb8WjwDP76xh@1v8wAABp0\",\"requestUri\":\"/api/v1/authn\",\"threatSuspected\":\"false\",\"url\":\"/api/v1/authn?\"}},\"displayMessage\":\"User login to Okta\",\"eventType\":\"user.session.start\",\"legacyEventType\":\"core.user_auth.login_success\",\"outcome\":{\"reason\":null,\"result\":\"SUCCESS\"},\"published\":\"2020-02-14T20:18:57.718Z\",\"request\":{\"ipChain\":[{\"geographicalContext\":{\"city\":\"Dublin\",\"country\":\"United States\",\"geolocation\":{\"lat\":37.7201,\"lon\":-121.919},\"postalCode\":\"94568\",\"state\":\"California\"},\"ip\":\"108.255.197.247\",\"source\":null,\"version\":\"V4\"}]},\"securityContext\":{\"asNumber\":null,\"asOrg\":null,\"domain\":null,\"isProxy\":null,\"isp\":null},\"severity\":\"INFO\",\"target\":null,\"transaction\":{\"detail\":{},\"id\":\"XkcAsWb8WjwDP76xh@1v8wAABp0\",\"type\":\"WEB\"},\"uuid\":\"3aeede38-4f67-11ea-abd3-1f5d113f2546\",\"version\":\"0\"}",
         "outcome": "success",
@@ -140,6 +141,7 @@
     "source": {
         "ip": "108.255.197.247",
         "user": {
+            "email": "xxxxxx@elastic.co",
             "full_name": "xxxxxx",
             "id": "00u1abvz4pYqdM8ms4x6",
             "name": "xxxxxx@elastic.co"
@@ -151,6 +153,7 @@
         "okta-system"
     ],
     "user": {
+        "email": "xxxxxx@elastic.co",
         "full_name": "xxxxxx",
         "name": "xxxxxx@elastic.co"
     },

--- a/packages/okta/docs/README.md
+++ b/packages/okta/docs/README.md
@@ -58,11 +58,11 @@ An example event for `system` looks as following:
 {
     "@timestamp": "2020-02-14T20:18:57.718Z",
     "agent": {
-        "ephemeral_id": "eeed25bf-dc6f-48ab-b30f-a9c7fa45d6c4",
-        "id": "f466dfde-d7b7-4c3a-a3e1-9c0175d94132",
-        "name": "elastic-agent-20611",
+        "ephemeral_id": "f0fa8393-26a1-453e-96fe-212743206a30",
+        "id": "da1b4fd1-cf45-42bc-8036-09da5b16e085",
+        "name": "elastic-agent-91674",
         "type": "filebeat",
-        "version": "8.18.0"
+        "version": "8.18.1"
     },
     "client": {
         "geo": {
@@ -76,6 +76,7 @@ An example event for `system` looks as following:
         },
         "ip": "108.255.197.247",
         "user": {
+            "email": "xxxxxx@elastic.co",
             "full_name": "xxxxxx",
             "id": "00u1abvz4pYqdM8ms4x6",
             "name": "xxxxxx@elastic.co"
@@ -83,16 +84,16 @@ An example event for `system` looks as following:
     },
     "data_stream": {
         "dataset": "okta.system",
-        "namespace": "92902",
+        "namespace": "58099",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "f466dfde-d7b7-4c3a-a3e1-9c0175d94132",
+        "id": "da1b4fd1-cf45-42bc-8036-09da5b16e085",
         "snapshot": false,
-        "version": "8.18.0"
+        "version": "8.18.1"
     },
     "event": {
         "action": "user.session.start",
@@ -101,10 +102,10 @@ An example event for `system` looks as following:
             "authentication",
             "session"
         ],
-        "created": "2025-04-30T01:38:47.331Z",
+        "created": "2025-06-04T15:16:49.436Z",
         "dataset": "okta.system",
         "id": "3aeede38-4f67-11ea-abd3-1f5d113f2546",
-        "ingested": "2025-04-30T01:38:48Z",
+        "ingested": "2025-06-04T15:16:50Z",
         "kind": "event",
         "original": "{\"actor\":{\"alternateId\":\"xxxxxx@elastic.co\",\"detailEntry\":null,\"displayName\":\"xxxxxx\",\"id\":\"00u1abvz4pYqdM8ms4x6\",\"type\":\"User\"},\"authenticationContext\":{\"authenticationProvider\":null,\"authenticationStep\":0,\"credentialProvider\":null,\"credentialType\":null,\"externalSessionId\":\"102bZDNFfWaQSyEZQuDgWt-uQ\",\"interface\":null,\"issuer\":null},\"client\":{\"device\":\"Computer\",\"geographicalContext\":{\"city\":\"Dublin\",\"country\":\"United States\",\"geolocation\":{\"lat\":37.7201,\"lon\":-121.919},\"postalCode\":\"94568\",\"state\":\"California\"},\"id\":null,\"ipAddress\":\"108.255.197.247\",\"userAgent\":{\"browser\":\"FIREFOX\",\"os\":\"Mac OS X\",\"rawUserAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:72.0) Gecko/20100101 Firefox/72.0\"},\"zone\":\"null\"},\"debugContext\":{\"debugData\":{\"deviceFingerprint\":\"541daf91d15bef64a7e08c946fd9a9d0\",\"requestId\":\"XkcAsWb8WjwDP76xh@1v8wAABp0\",\"requestUri\":\"/api/v1/authn\",\"threatSuspected\":\"false\",\"url\":\"/api/v1/authn?\"}},\"displayMessage\":\"User login to Okta\",\"eventType\":\"user.session.start\",\"legacyEventType\":\"core.user_auth.login_success\",\"outcome\":{\"reason\":null,\"result\":\"SUCCESS\"},\"published\":\"2020-02-14T20:18:57.718Z\",\"request\":{\"ipChain\":[{\"geographicalContext\":{\"city\":\"Dublin\",\"country\":\"United States\",\"geolocation\":{\"lat\":37.7201,\"lon\":-121.919},\"postalCode\":\"94568\",\"state\":\"California\"},\"ip\":\"108.255.197.247\",\"source\":null,\"version\":\"V4\"}]},\"securityContext\":{\"asNumber\":null,\"asOrg\":null,\"domain\":null,\"isProxy\":null,\"isp\":null},\"severity\":\"INFO\",\"target\":null,\"transaction\":{\"detail\":{},\"id\":\"XkcAsWb8WjwDP76xh@1v8wAABp0\",\"type\":\"WEB\"},\"uuid\":\"3aeede38-4f67-11ea-abd3-1f5d113f2546\",\"version\":\"0\"}",
         "outcome": "success",
@@ -197,6 +198,7 @@ An example event for `system` looks as following:
     "source": {
         "ip": "108.255.197.247",
         "user": {
+            "email": "xxxxxx@elastic.co",
             "full_name": "xxxxxx",
             "id": "00u1abvz4pYqdM8ms4x6",
             "name": "xxxxxx@elastic.co"
@@ -208,6 +210,7 @@ An example event for `system` looks as following:
         "okta-system"
     ],
     "user": {
+        "email": "xxxxxx@elastic.co",
         "full_name": "xxxxxx",
         "name": "xxxxxx@elastic.co"
     },

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -1,6 +1,6 @@
 name: okta
 title: Okta
-version: "3.9.0"
+version: "3.10.0"
 description: Collect and parse event logs from Okta API with Elastic Agent.
 type: integration
 format_version: "3.2.3"


### PR DESCRIPTION
## Proposed commit message

```
According to ECS documentation about user fields usage[1]:

- When a system uses an email address as the main identifier, populate
  both user.id and user.email with it.

This change copies the `user.name` field into the `user.email` field to align
with all other integrations where the main user identifier is an email address,
including Entity Analytics Okta.

This should help to who wants to correlate email addresses between integrations.

In this case, the user email is not dissected into `user.name@user.domail` as
for the Okta ecosystem, the user part of the email doesn't make sense by itself. 

[1] https://www.elastic.co/docs/reference/ecs/ecs-user-usage#ecs-user-identifiers
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/enhancements/issues/24531
