### PR TITLE
[Cisco Meraki] Add filter in grok parsing for port events

### DIFF
--- a/packages/cisco_meraki/changelog.yml
+++ b/packages/cisco_meraki/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.28.2"
+  changes:
+    - description: Limit Grok parsing for port events to logs with actionable phrases to prevent errors from benign messages.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.28.1"
   changes:
     - description: Extend the event pipeline with some ECS fields and a Grok pattern to improve DHCP event parsing.

--- a/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-events.log
+++ b/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-events.log
@@ -26,6 +26,7 @@
 <134>1 1694519069.912939179 TCP9001 events port 4 status changed from 100fdx to down
 <134>1 1694519040.863533579 TCP9001 events Port 1 changed STP role from disabled to designated
 <134>1 1694519040.862946339 TCP9001 events port 1 status changed from down to 100fdx
+<134>1 1748846458.463749218 TCP9001 events Port 17 is configured with guest VLAN 666
 <134>1 1694519007.104885873 TCP9001 events Auth failure resets to success
 <134>1 1700036621.820196636 AB_1234_Amsterdam_MX01 events carrier_change device port1 up true
 <134>1 1700036617.740693756 AB_1234_Amsterdam_MX01 events carrier_change device port1 up false

--- a/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-events.log-expected.json
+++ b/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-events.log-expected.json
@@ -1321,6 +1321,34 @@
             ]
         },
         {
+            "@timestamp": "2025-06-02T06:40:58.463Z",
+            "cisco_meraki": {
+                "event_subtype": "port",
+                "event_type": "events"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "port",
+                "category": [
+                    "network"
+                ],
+                "original": "<134>1 1748846458.463749218 TCP9001 events Port 17 is configured with guest VLAN 666",
+                "type": [
+                    "info"
+                ]
+            },
+            "message": "Port 17 is configured with guest VLAN 666",
+            "observer": {
+                "hostname": "TCP9001"
+            },
+            "tags": [
+                "forwarded",
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2023-09-12T11:43:27.104Z",
             "cisco_meraki": {
                 "event_subtype": "auth",

--- a/packages/cisco_meraki/data_stream/log/elasticsearch/ingest_pipeline/events.yml
+++ b/packages/cisco_meraki/data_stream/log/elasticsearch/ingest_pipeline/events.yml
@@ -155,7 +155,7 @@ processors:
       SYSLOGHDR: '%{SYSLOGPRI}%{SYSLOGVER}'
       WORDORHOST: '(?:%{WORD}|%{HOSTNAME})'
       PORTACTION: '(?:changed stp role|status changed)'
-    if: ctx.event.original.startsWith('<') && ctx.cisco_meraki?.event_subtype == "port"
+    if: ctx.event.original.startsWith('<') && ctx.cisco_meraki?.event_subtype == "port" && (ctx.event.original.toLowerCase().contains('status changed') || ctx.event.original.toLowerCase().contains('changed stp role'))
 - gsub:
     field: _temp.port_action
     pattern: ' '

--- a/packages/cisco_meraki/manifest.yml
+++ b/packages/cisco_meraki/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cisco_meraki
 title: Cisco Meraki
-version: "1.28.1"
+version: "1.28.2"
 description: Collect logs from Cisco Meraki with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
cisco_meraki: fix pipeline issue by adding a filter in grok parsing for port events

As the current Grok pattern in the ingest pipeline is designed to match log lines that indicate specific port actions, i.e. `status changes` or `STP role changes`, this PR adding a filter in grok parsing for port events to logs with actionable phrases to prevent errors from benign messages.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install the elastic package locally.
- Start the elastic stack using the elastic package.
- Move to integrations/packages/cisco_meraki directory.
- Run the following command to run tests.
> elastic-package test -v