### PR TITLE
[all] Use docker.elastic.co/observability/stream:v0.18.0

### DIFF
--- a/packages/1password/_dev/deploy/docker/docker-compose.yml
+++ b/packages/1password/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.0'
 services:
   1password_eventsapi_mock:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: 1password_eventsapi_mock
     ports:
       - 8080

--- a/packages/abnormal_security/_dev/deploy/docker/docker-compose.yml
+++ b/packages/abnormal_security/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   abnormal_security:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: abnormal_security
     ports:
       - 8090

--- a/packages/admin_by_request_epm/_dev/deploy/docker/docker-compose.yml
+++ b/packages/admin_by_request_epm/_dev/deploy/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   admin_by_request_epm:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: admin_by_request_epm
     ports:
       - 8080

--- a/packages/airflow/_dev/deploy/docker/docker-compose.yml
+++ b/packages/airflow/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   airflow:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:8125 -p=udp /sample_logs/test-airflow.log

--- a/packages/arista_ngfw/_dev/deploy/docker/docker-compose.yml
+++ b/packages/arista_ngfw/_dev/deploy/docker/docker-compose.yml
@@ -1,12 +1,12 @@
 version: "2.3"
 services:
   arista-ngfw-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/*.log
   arista-ngfw-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/*.log

--- a/packages/armis/_dev/deploy/docker/docker-compose.yml
+++ b/packages/armis/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.0'
 services:
   armis:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: armis
     ports:
       - 8090

--- a/packages/atlassian_bitbucket/_dev/deploy/docker/docker-compose.yml
+++ b/packages/atlassian_bitbucket/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/*.log /var/log/"
   bitbucket-api:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/atlassian_confluence/_dev/deploy/docker/docker-compose.yml
+++ b/packages/atlassian_confluence/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/*.log /var/log/"
   confluence-api:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/atlassian_jira/_dev/deploy/docker/docker-compose.yml
+++ b/packages/atlassian_jira/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/*.log /var/log/"
   jira-api:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/auth0/_dev/deploy/docker/docker-compose.yml
+++ b/packages/auth0/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   auth0-webhook-http:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -10,7 +10,7 @@ services:
       - STREAM_WEBHOOK_HEADER=Authorization=abc123
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/auth0-ndjson.log
   auth0-webhook-https:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -20,7 +20,7 @@ services:
       - STREAM_INSECURE=true
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/auth0-ndjson.log
   auth0-http-server:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: auth0
     ports:
       - 8090

--- a/packages/authentik/_dev/deploy/docker/docker-compose.yml
+++ b/packages/authentik/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   authentik:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: authentik
     ports:
       - 8090

--- a/packages/aws/data_stream/config/_dev/deploy/docker/docker-compose.yml
+++ b/packages/aws/data_stream/config/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   config:
-    image: docker.elastic.co/observability/stream:v0.17.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: config.xxxx.amazonaws.com
     ports:
       - 443

--- a/packages/aws/data_stream/guardduty/_dev/deploy/docker/docker-compose.yml
+++ b/packages/aws/data_stream/guardduty/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   guardduty:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: guardduty.xxxx.amazonaws.com
     ports:
       - 443

--- a/packages/aws/data_stream/inspector/_dev/deploy/docker/docker-compose.yml
+++ b/packages/aws/data_stream/inspector/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   inspector:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: inspector2.xxxx.amazonaws.com
     ports:
       - 443

--- a/packages/aws/data_stream/securityhub_findings/_dev/deploy/docker/docker-compose.yml
+++ b/packages/aws/data_stream/securityhub_findings/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   securityhub:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: securityhub.xxxx.amazonaws.cn
     ports:
       - 443

--- a/packages/aws/data_stream/securityhub_findings_full_posture/_dev/deploy/docker/docker-compose.yml
+++ b/packages/aws/data_stream/securityhub_findings_full_posture/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   securityhub_full_posture:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: securityhub.xxxx.amazonaws.cn
     ports:
       - 443

--- a/packages/aws/data_stream/securityhub_insights/_dev/deploy/docker/docker-compose.yml
+++ b/packages/aws/data_stream/securityhub_insights/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   securityhub:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: securityhub.xxxx.amazonaws.com
     ports:
       - 443

--- a/packages/azure_blob_storage/_dev/deploy/docker/docker-compose.yml
+++ b/packages/azure_blob_storage/_dev/deploy/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "10000/tcp"
   azure-blob-storage:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command:

--- a/packages/azure_network_watcher_nsg/_dev/deploy/docker/docker-compose.yml
+++ b/packages/azure_network_watcher_nsg/_dev/deploy/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "10000/tcp"
   azure-blob-storage:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command:

--- a/packages/azure_network_watcher_vnet/_dev/deploy/docker/docker-compose.yml
+++ b/packages/azure_network_watcher_vnet/_dev/deploy/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "10000/tcp"
   azure-blob-storage:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command:

--- a/packages/barracuda/_dev/deploy/docker/docker-compose.yml
+++ b/packages/barracuda/_dev/deploy/docker/docker-compose.yml
@@ -1,17 +1,17 @@
 version: "2.3"
 services:
   barracuda-waf-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9581 -p=tls --insecure /sample_logs/barracuda.log
   barracuda-waf-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9580 -p=tcp /sample_logs/barracuda.log
   barracuda-waf-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9580 -p=udp /sample_logs/barracuda.log

--- a/packages/barracuda_cloudgen_firewall/_dev/deploy/docker/docker-compose.yml
+++ b/packages/barracuda_cloudgen_firewall/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   barracuda-cloudgen-lumberjack:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/bbot/_dev/deploy/docker/docker-compose.yml
+++ b/packages/bbot/_dev/deploy/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp -v /sample_logs/bbot-v*-ndjson*.log /var/log/"
   bbot-all-http:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -15,7 +15,7 @@ services:
       - STREAM_WEBHOOK_HEADER=Authorization=abc123
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/bbot-v*-ndjson*.log
   bbot-all-https:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/beelzebub/_dev/deploy/docker/docker-compose.yml
+++ b/packages/beelzebub/_dev/deploy/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   test-http_endpoint:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/beyondinsight_password_safe/_dev/deploy/docker/docker-compose.yml
+++ b/packages/beyondinsight_password_safe/_dev/deploy/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   beyondinsight:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: beyondinsight
     ports:
       - 8080

--- a/packages/beyondtrust_pra/_dev/deploy/docker/docker-compose.yml
+++ b/packages/beyondtrust_pra/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   beyondtrust_pra-access_session:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: beyondtrust_pra-access_session
     ports:
       - 8090

--- a/packages/bitdefender/_dev/deploy/docker/docker-compose.yml
+++ b/packages/bitdefender/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   bitdefender-push-notification-qradar-http:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -10,7 +10,7 @@ services:
       - STREAM_WEBHOOK_HEADER=Authorization=abc123
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/qradar_format.log
   bitdefender-push-notification-jsonrpc-http:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -19,7 +19,7 @@ services:
       - STREAM_WEBHOOK_HEADER=Authorization=abc123
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/jsonrpc_format.log
   bitdefender-push-notification-jsonrpc-https:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -29,7 +29,7 @@ services:
       - STREAM_INSECURE=true
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/jsonrpc_format.log
   bitdefender-gravityzone-api-mock:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: bitdefender_gravityzone_api_mock
     ports:
       - 8585

--- a/packages/bitwarden/_dev/deploy/docker/docker-compose.yml
+++ b/packages/bitwarden/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   bitwarden:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: bitwarden
     ports:
       - 8090

--- a/packages/bluecoat/_dev/deploy/docker/docker-compose.yml
+++ b/packages/bluecoat/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   bluecoat-director-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9527 -p=udp /sample_logs/bluecoat-director-*.log
   bluecoat-director-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9527 -p=tcp /sample_logs/bluecoat-director-*.log

--- a/packages/box_events/_dev/deploy/docker/docker-compose.yml
+++ b/packages/box_events/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   box-http:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/carbon_black_cloud/_dev/deploy/docker/docker-compose.yml
+++ b/packages/carbon_black_cloud/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   carbon_black_cloud:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: carbon_black_cloud
     ports:
       - 8080

--- a/packages/carbonblack_edr/_dev/deploy/docker/docker-compose.yml
+++ b/packages/carbonblack_edr/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   carbonblack_edr-http:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -15,7 +15,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9080/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/cb_edr.ndjson.log
   carbonblack_edr-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -23,7 +23,7 @@ services:
       - STREAM_ADDR=elastic-agent:9081
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/cb_edr.ndjson.log
   carbonblack_edr-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/cef/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cef/_dev/deploy/docker/docker-compose.yml
@@ -14,12 +14,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /specific_test_logs/* /var/log/"
   cef-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/cef.log
   cef-log-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=udp /sample_logs/cef.log

--- a/packages/cel/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cel/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   cel:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/ceph/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ceph/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   ceph:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/checkpoint/_dev/deploy/docker/docker-compose.yml
+++ b/packages/checkpoint/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   checkpoint-firewall-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tls --insecure /sample_logs/test-checkpoint.log
   checkpoint-firewall-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/test-checkpoint.log
   checkpoint-firewall-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=udp /sample_logs/test-checkpoint.log

--- a/packages/checkpoint_email/_dev/deploy/docker/docker-compose.yml
+++ b/packages/checkpoint_email/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   checkpoint_email:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: checkpoint_email
     ports:
       - 8090

--- a/packages/checkpoint_harmony_endpoint/_dev/deploy/docker/docker-compose.yml
+++ b/packages/checkpoint_harmony_endpoint/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.0'
 services:
   harmony:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: harmony
     ports:
       - 8080

--- a/packages/cisa_kevs/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisa_kevs/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   cisakev:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/cisco_aironet/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_aironet/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   cisco-aironet-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9009 -p=tcp /sample_logs/cisco-aironet.log
   cisco-aironet-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9009 -p=udp /sample_logs/cisco-aironet.log

--- a/packages/cisco_asa/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_asa/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   cisco-asa-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tls --insecure /sample_logs/cisco-asa.log
   cisco-asa-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/cisco-asa.log
   cisco-asa-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/cisco-asa.log

--- a/packages/cisco_duo/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_duo/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   cisco_duo:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: cisco_duo
     ports:
       - 8080

--- a/packages/cisco_ftd/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_ftd/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   cisco-ftd-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tls --insecure /sample_logs/cisco-ftd.log
   cisco-ftd-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/cisco-ftd.log
   cisco-ftd-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/cisco-ftd.log

--- a/packages/cisco_ios/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_ios/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   cisco-ios-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tls --insecure /sample_logs/*.log
   cisco-ios-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/*.log
   cisco-ios-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/*.log

--- a/packages/cisco_ise/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_ise/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   cisco_ise-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9025 -p=tcp /sample_logs/log.log
   cisco_ise-log-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9026 -p=udp /sample_logs/log.log

--- a/packages/cisco_meraki/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_meraki/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   meraki-webhook-http:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_events:/sample_events:ro
     environment:
@@ -9,7 +9,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:8686/meraki/events
     command: log --start-signal=SIGHUP --delay=5s /sample_events/meraki-mx-ndjson.log
   meraki-webhook-https:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_events:/sample_events:ro
     environment:
@@ -24,12 +24,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   cisco_meraki-log-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:8685 -p=udp /sample_logs/cisco-meraki.log
   cisco_meraki-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:8685 -p=tcp /sample_logs/cisco-meraki.log

--- a/packages/cisco_nexus/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_nexus/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   cisco-nexus-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9506 -p=udp /sample_logs/test-nexus.log
   cisco-nexus-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9506 -p=tcp /sample_logs/test-nexus.log
   cisco-nexus-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9506 -p=tls --insecure /sample_logs/test-nexus.log

--- a/packages/cisco_secure_email_gateway/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_secure_email_gateway/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/*.s /var/log/"
   cisco_secure_email_gateway-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9519 -p=tcp /sample_logs/log.log
   cisco_secure_email_gateway-log-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9520 -p=udp /sample_logs/log.log

--- a/packages/cisco_secure_endpoint/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_secure_endpoint/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   cisco_secure_endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/citrix_adc/_dev/deploy/docker/docker-compose.yml
+++ b/packages/citrix_adc/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   citrix_adc:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: citrix_adc
     ports:
       - 8080
@@ -20,22 +20,22 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   citrix-adc-tls:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9561 -p=tls --insecure /sample_logs/citrix-adc.log
   citrix-adc-tcp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9560 -p=tcp /sample_logs/citrix-adc.log
   citrix-adc-udp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9560 -p=udp /sample_logs/citrix-adc.log
   citrix-adc-custom-date:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9560 -p=udp /sample_logs/citrix-adc-custom-date.log

--- a/packages/citrix_waf/_dev/deploy/docker/docker-compose.yml
+++ b/packages/citrix_waf/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   citrix-waf-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9561 -p=tls --insecure /sample_logs/citrix-waf.log
   citrix-waf-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9560 -p=tcp /sample_logs/citrix-waf.log
   citrix-waf-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9560 -p=udp /sample_logs/citrix-waf.log

--- a/packages/claroty_ctd/_dev/deploy/docker/docker-compose.yml
+++ b/packages/claroty_ctd/_dev/deploy/docker/docker-compose.yml
@@ -1,17 +1,17 @@
 version: '2.3'
 services:
   claroty-ctd-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9536 -p=udp /sample_logs/claroty_ctd_event.log
   claroty-ctd-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9537 -p=tcp /sample_logs/claroty_ctd_event.log
   claroty-ctd-cel:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: claroty_ctd
     ports:
       - 8090

--- a/packages/claroty_xdome/_dev/deploy/docker/docker-compose.yml
+++ b/packages/claroty_xdome/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.0'
 services:
   claroty_xdome:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: claroty_xdome
     ports:
       - 8090

--- a/packages/cloudflare/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cloudflare/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   cloudflare:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/cloudflare_logpush/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cloudflare_logpush/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   cloudflare-logpush-audit-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -9,7 +9,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/audit
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/audit.log
   cloudflare-logpush-dlp-forensic-copies-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -17,7 +17,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/dlp_forensic_copies
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/dlp_forensic_copies.log
   cloudflare-logpush-dns-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -25,7 +25,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/dns
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/dns.log
   cloudflare-logpush-email-security-alerts-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -33,7 +33,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/email_security_alerts
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/email_security_alerts.log
   cloudflare-logpush-firewall-event-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -41,7 +41,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/firewall_event
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/firewall_event.log
   cloudflare-logpush-http-request-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -49,7 +49,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/http_request
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/http_request.log
   cloudflare-logpush-nel-report-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -57,7 +57,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/nel_report
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/nel_report.log
   cloudflare-logpush-network-analytics-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -65,7 +65,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/network_analytics
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/network_analytics.log
   cloudflare-logpush-spectrum-event-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -73,7 +73,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/spectrum_event
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/spectrum_event.log
   cloudflare-logpush-gateway-dns-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -81,7 +81,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/gateway_dns
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/gateway_dns.log
   cloudflare-logpush-gateway-http-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -89,7 +89,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/gateway_http
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/gateway_http.log
   cloudflare-logpush-gateway-network-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -97,7 +97,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/gateway_network
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/gateway_network.log
   cloudflare-logpush-network-session-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -105,7 +105,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/network_session
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/network_session.log
   cloudflare-logpush-page-shield-events-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -113,7 +113,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/page_shield_events
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/page_shield_events.log
   cloudflare-logpush-casb-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -121,7 +121,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/casb
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/casb.log
   cloudflare-logpush-access-request-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -129,7 +129,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/access_request
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/access_request.log
   cloudflare-logpush-device-posture-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -137,7 +137,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/device_posture
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/device_posture.log
   cloudflare-logpush-workers-trace-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -145,7 +145,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/workers_trace
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/workers_trace.log
   cloudflare-logpush-magic-ids-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -153,7 +153,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/magic_ids
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/magic_ids.log
   cloudflare-logpush-sinkhole-http-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -161,7 +161,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/sinkhole_http
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/sinkhole_http.log
   cloudflare-logpush-dns-firewall-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/crowdstrike/_dev/deploy/docker/docker-compose.yml
+++ b/packages/crowdstrike/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   crowdstrike-alert:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: crowdstrike-alert
     ports:
       - 8090
@@ -14,7 +14,7 @@ services:
       - --addr=:8090
       - --config=/files/config-alert.yml
   crowdstrike-host:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: crowdstrike-host
     ports:
       - 8090
@@ -27,7 +27,7 @@ services:
       - --addr=:8090
       - --config=/files/config-host.yml
   crowdstrike-vulnerability:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: crowdstrike-vulnerability
     ports:
       - 8090

--- a/packages/crowdstrike/data_stream/falcon/_dev/deploy/docker/docker-compose.yml
+++ b/packages/crowdstrike/data_stream/falcon/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   crowdstrike-streaming:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/cyberark_epm/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cyberark_epm/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.0'
 services:
   cyberark_epm:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: cyberark_epm
     ports:
       - 8090

--- a/packages/cyberark_pta/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cyberark_pta/_dev/deploy/docker/docker-compose.yml
@@ -1,12 +1,12 @@
 version: "2.3"
 services:
   cyberark-pta-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/*.log
   cyberark-pta-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/*.log

--- a/packages/cyberarkpas/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cyberarkpas/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/audit/* /var/log/"
   cyberarkpas-audit-udp:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=udp /sample_logs/audit/*.log
   cyberarkpas-audit-tcp:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=tcp /sample_logs/audit/*.log
   cyberarkpas-audit-tls:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=tls --insecure /sample_logs/audit/*.log

--- a/packages/cylance/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cylance/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   cylance-protect-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9529 -p=udp /sample_logs/cylance-protect-*.log
   cylance-protect-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9529 -p=tcp /sample_logs/cylance-protect-*.log

--- a/packages/darktrace/_dev/deploy/docker/docker-compose.yml
+++ b/packages/darktrace/_dev/deploy/docker/docker-compose.yml
@@ -1,52 +1,52 @@
 version: '2.3'
 services:
   darktrace-ai_analyst_alert-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9571 -p=tls --insecure /sample_logs/ai_analyst_alert.log
   darktrace-ai_analyst_alert-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9571 -p=tcp /sample_logs/ai_analyst_alert.log
   darktrace-ai_analyst_alert-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9574 -p=udp /sample_logs/ai_analyst_alert.log
   darktrace-model_breach_alert-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9572 -p=tls --insecure /sample_logs/model_breach_alert.log
   darktrace-model_breach_alert-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9572 -p=tcp /sample_logs/model_breach_alert.log
   darktrace-model_breach_alert-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9575 -p=udp /sample_logs/model_breach_alert.log
   darktrace-system_status_alert-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9573 -p=tls --insecure /sample_logs/system_status_alert.log
   darktrace-system_status_alert-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9573 -p=tcp /sample_logs/system_status_alert.log
   darktrace-system_status_alert-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9576 -p=udp /sample_logs/system_status_alert.log
   darktrace:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: darktrace
     ports:
       - 8080

--- a/packages/digital_guardian/_dev/deploy/docker/docker-compose.yml
+++ b/packages/digital_guardian/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   dg-arc:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/endace/_dev/deploy/docker/docker-compose.yml
+++ b/packages/endace/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/pcaps
     command: /bin/sh -c "cp /sample_pcaps/* /pcaps/"
   netflow-log-netflow:
-    image: docker.elastic.co/observability/stream:v0.16.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: pcap --start-signal=SIGHUP --delay=5s --addr elastic-agent:2055 -p=udp /sample_logs/ipfix_cisco.pcap

--- a/packages/entityanalytics_entra_id/_dev/deploy/docker/docker-compose.yml
+++ b/packages/entityanalytics_entra_id/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.0'
 services:
   entra_id:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/entityanalytics_okta/_dev/deploy/docker/docker-compose.yml
+++ b/packages/entityanalytics_okta/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   entityanalytics_okta:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: trial-xxxxxxx-admin.okta.com
     ports:
       - 443

--- a/packages/envoyproxy/_dev/deploy/docker/docker-compose.yml
+++ b/packages/envoyproxy/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/envoy-logfile.log /var/log/envoy.log"
   envoyproxy-metrics:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:8125 -p=udp /sample_logs/envoy-stats.log

--- a/packages/eset_protect/_dev/deploy/docker/docker-compose.yml
+++ b/packages/eset_protect/_dev/deploy/docker/docker-compose.yml
@@ -1,12 +1,12 @@
 version: '3.7'
 services:
   eset_protect-event-tls:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9589 -p=tls --insecure /sample_logs/event.log
   eset_protect-detection:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: xx.incident-management.eset.systems
     ports:
       - 443
@@ -21,7 +21,7 @@ services:
       - --tls-cert=/files/detection-certificate.crt
       - --tls-key=/files/detection-private.key
   eset_protect-device_task:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: xx.automation.eset.systems
     ports:
       - 443
@@ -36,7 +36,7 @@ services:
       - --tls-cert=/files/device_task-certificate.crt
       - --tls-key=/files/device_task-private.key
   eset_protect-oauth:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: xx.business-account.iam.eset.systems
     networks:
       - elastic-package-stack_default

--- a/packages/f5_bigip/_dev/deploy/docker/docker-compose.yml
+++ b/packages/f5_bigip/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   f5-bigip-log-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/falco/_dev/deploy/docker/docker-compose.yml
+++ b/packages/falco/_dev/deploy/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   falco-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_syslog:/sample_logs:ro
       - ${SERVICE_LOGS_DIR}:/var/log

--- a/packages/fireeye/_dev/deploy/docker/docker-compose.yml
+++ b/packages/fireeye/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   fireeye-nx-log-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9523 -p=udp /sample_logs/fireeye-nx.log
   fireeye-nx-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9523 -p=tcp /sample_logs/fireeye-nx.log

--- a/packages/first_epss/_dev/deploy/docker/docker-compose.yml
+++ b/packages/first_epss/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   firstepss:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: first_epss
     ports:
       - 8090

--- a/packages/forgerock/_dev/deploy/docker/docker-compose.yml
+++ b/packages/forgerock/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.0'
 services:
   forgerock:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/fortinet_forticlient/_dev/deploy/docker/docker-compose.yml
+++ b/packages/fortinet_forticlient/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   fortinet-clientendpoint-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/fortinet-clientendpoint.log
   fortinet-clientendpoint-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=udp /sample_logs/fortinet-clientendpoint.log

--- a/packages/fortinet_fortiedr/_dev/deploy/docker/docker-compose.yml
+++ b/packages/fortinet_fortiedr/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   fortinet-edr-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/fortinet-edr.log
   fortinet-edr-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=udp /sample_logs/fortinet-edr.log

--- a/packages/fortinet_fortigate/_dev/deploy/docker/docker-compose.yml
+++ b/packages/fortinet_fortigate/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   fortinet-firewall-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tls --insecure /sample_logs/fortinet-firewall.log
   fortinet-firewall-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/fortinet-firewall.log
   fortinet-firewall-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=udp /sample_logs/fortinet-firewall.log

--- a/packages/fortinet_fortimail/_dev/deploy/docker/docker-compose.yml
+++ b/packages/fortinet_fortimail/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   fortinet-fortimail-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9024 -p=tcp /sample_logs/fortinet-fortimail.log
   fortinet-fortimail-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9024 -p=tls --insecure /sample_logs/fortinet-fortimail.log
   fortinet-fortimail-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9024 -p=udp /sample_logs/fortinet-fortimail.log

--- a/packages/fortinet_fortimanager/_dev/deploy/docker/docker-compose.yml
+++ b/packages/fortinet_fortimanager/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   fortinet-fortimanager-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9022 -p=tcp /sample_logs/fortinet-fortimanager.log
   fortinet-fortimanager-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9022 -p=tls --insecure /sample_logs/fortinet-fortimanager.log
   fortinet-fortimanager-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9022 -p=udp /sample_logs/fortinet-fortimanager.log

--- a/packages/fortinet_fortiproxy/_dev/deploy/docker/docker-compose.yml
+++ b/packages/fortinet_fortiproxy/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   fortinet-fortiproxy-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tls --insecure /sample_logs/fortinet-fortiproxy.log
   fortinet-fortiproxy-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/fortinet-fortiproxy.log
   fortinet-fortiproxy-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=udp /sample_logs/fortinet-fortiproxy.log

--- a/packages/gcp/_dev/deploy/docker/docker-compose.yml
+++ b/packages/gcp/_dev/deploy/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "8681/tcp"
   gcppubsub-audit:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command:
@@ -20,7 +20,7 @@ services:
     depends_on:
       - gcppubsub-emulator
   gcppubsub-dns:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command:
@@ -34,7 +34,7 @@ services:
     depends_on:
       - gcppubsub-emulator
   gcppubsub-firewall:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command:
@@ -48,7 +48,7 @@ services:
     depends_on:
       - gcppubsub-emulator
   gcppubsub-vpcflow:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command:
@@ -62,7 +62,7 @@ services:
     depends_on:
       - gcppubsub-emulator
   gcppubsub-load-balancer:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command:

--- a/packages/gcp_pubsub/_dev/deploy/docker/docker-compose.yml
+++ b/packages/gcp_pubsub/_dev/deploy/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "8681/tcp"
   gcppubsub-generic:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command:

--- a/packages/gigamon/_dev/deploy/docker/docker-compose.yml
+++ b/packages/gigamon/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   gigamon-ami-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/github/_dev/deploy/docker/docker-compose.yml
+++ b/packages/github/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   github:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/github/data_stream/security_advisories/_dev/deploy/docker/docker-compose.yml
+++ b/packages/github/data_stream/security_advisories/_dev/deploy/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   github:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/google_scc/_dev/deploy/docker/docker-compose.yml
+++ b/packages/google_scc/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   google_scc:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: google_scc
     ports:
       - 8090
@@ -19,7 +19,7 @@ services:
     ports:
       - "8681/tcp"
   gcppubsub-audit:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./files:/files:ro
     command:
@@ -33,7 +33,7 @@ services:
     depends_on:
       - gcppubsub-emulator
   gcppubsub-asset:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./files:/files:ro
     command:
@@ -47,7 +47,7 @@ services:
     depends_on:
       - gcppubsub-emulator
   gcppubsub-finding:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./files:/files:ro
     command:

--- a/packages/google_secops/_dev/deploy/docker/docker-compose.yml
+++ b/packages/google_secops/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.0'
 services:
   google_secops:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: google_secops
     ports:
       - 8090

--- a/packages/google_workspace/_dev/deploy/docker/docker-compose.yml
+++ b/packages/google_workspace/_dev/deploy/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         awk -v var="$$(sed -E ':a;N;$$!ba;s/\r{0,1}\n/\\\\n/g' pkcs8.key)" '{sub(/the-key/,var)}1' /credentials.json > /config/credentials.json;
         sleep 1000
   google_workspace:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: google_workspace
     ports:
       - 8080

--- a/packages/hashicorp_vault/_dev/deploy/docker/docker-compose.yml
+++ b/packages/hashicorp_vault/_dev/deploy/docker/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     depends_on:
       - hashicorp_vault
   hashicorp_vault-audit-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9007 -p=tcp /sample_logs/audit.ndjson

--- a/packages/hpe_aruba_cx/_dev/deploy/docker/docker-compose.yml
+++ b/packages/hpe_aruba_cx/_dev/deploy/docker/docker-compose.yml
@@ -6,17 +6,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   aruba-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tcp /sample_logs/*.log
   aruba-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tls --insecure /sample_logs/*.log 
   aruba-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=udp /sample_logs/*.log

--- a/packages/http_endpoint/_dev/deploy/docker/docker-compose.yml
+++ b/packages/http_endpoint/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   test-webhook-http:
-    image: docker.elastic.co/observability/stream:v0.16.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -14,7 +14,7 @@ services:
       - STREAM_DELAY=10s
     command: log /sample_logs/test-webhook.log
   test-webhook-http-ack:
-    image: docker.elastic.co/observability/stream:v0.16.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/httpjson/_dev/deploy/docker/docker-compose.yml
+++ b/packages/httpjson/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   httpjson:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/imperva/_dev/deploy/docker/docker-compose.yml
+++ b/packages/imperva/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   imperva-securesphere-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9507 -p=udp /sample_logs/test-imperva-securesphere.log
   imperva-securesphere-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9507 -p=tcp /sample_logs/test-imperva-securesphere.log
   imperva-securesphere-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9507 -p=tls --insecure /sample_logs/test-imperva-securesphere.log

--- a/packages/infoblox_bloxone_ddi/_dev/deploy/docker/docker-compose.yml
+++ b/packages/infoblox_bloxone_ddi/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   infoblox-bloxone-ddi:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: infoblox-bloxone-ddi
     ports:
       - 8080

--- a/packages/infoblox_nios/_dev/deploy/docker/docker-compose.yml
+++ b/packages/infoblox_nios/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   infoblox_nios-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9027 -p=tcp /sample_logs/log.log
   infoblox_nios-log-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9028 -p=udp /sample_logs/log.log

--- a/packages/iptables/_dev/deploy/docker/docker-compose.yml
+++ b/packages/iptables/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   iptables-log-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/iptables-syslog.log

--- a/packages/jamf_compliance_reporter/_dev/deploy/docker/docker-compose.yml
+++ b/packages/jamf_compliance_reporter/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   jamf-compliance-reporter-log-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -9,7 +9,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9551/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/log.log
   jamf-compliance-reporter-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9552 -p=tcp /sample_logs/log.log

--- a/packages/jamf_pro/_dev/deploy/docker/docker-compose.yml
+++ b/packages/jamf_pro/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   jamf_pro_events:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./events:/events:ro
     environment:
@@ -10,7 +10,7 @@ services:
       - STREAM_WEBHOOK_HEADER=Authorization=mysecrettoken
     command: log --start-signal=SIGHUP --delay=5s /events/computer_added.log
   jamf_pro_api_stub:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/jamf_protect/_dev/deploy/docker/docker-compose.yml
+++ b/packages/jamf_protect/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   jamf-protect-alerts-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -9,7 +9,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9551/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/alerts.log
   jamf-protect-telemetry-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -17,7 +17,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9550/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/telemetry.log
   jamf-protect-telemetry-legacy-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -25,7 +25,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9555/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/telemetry-legacy.log
   jamf-protect-webthreats-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -33,7 +33,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9552/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/webthreats.log
   jamf-protect-webtraffic-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/jumpcloud/_dev/deploy/docker/docker-compose.yml
+++ b/packages/jumpcloud/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   jumpcloud:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: jumpcloud
     ports:
       - 8090

--- a/packages/juniper_junos/_dev/deploy/docker/docker-compose.yml
+++ b/packages/juniper_junos/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   juniper-junos-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/juniper-junos.log
   juniper-junos-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/juniper-junos.log

--- a/packages/juniper_netscreen/_dev/deploy/docker/docker-compose.yml
+++ b/packages/juniper_netscreen/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   juniper-netscreen-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/juniper-netscreen.log
   juniper-netscreen-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/juniper-netscreen.log

--- a/packages/juniper_srx/_dev/deploy/docker/docker-compose.yml
+++ b/packages/juniper_srx/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   juniper-srx-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tls --insecure /sample_logs/juniper-srx.log
   juniper-srx-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/juniper-srx.log
   juniper-srx-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/juniper-srx.log

--- a/packages/kafka_log/_dev/deploy/docker/docker-compose.yml
+++ b/packages/kafka_log/_dev/deploy/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     ports:
       - 9094
   kafka-generic:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command:

--- a/packages/lastpass/_dev/deploy/docker/docker-compose.yml
+++ b/packages/lastpass/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   lastpass:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: lastpass
     ports:
       - 8090

--- a/packages/lumos/_dev/deploy/docker/docker-compose.yml
+++ b/packages/lumos/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.0'
 services:
   lumos:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: lumos
     ports:
       - 8080

--- a/packages/m365_defender/_dev/deploy/docker/docker-compose.yml
+++ b/packages/m365_defender/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   m365-defender-incident-http:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:
@@ -14,7 +14,7 @@ services:
       - --addr=:8080
       - --config=/config.yml
   m365-defender-alert-http:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:
@@ -27,7 +27,7 @@ services:
       - --addr=:8080
       - --config=/config.yml
   m365-defender-vulnerability-cel:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/menlo/_dev/deploy/docker/docker-compose.yml
+++ b/packages/menlo/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.0'
 services:
   menlo:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: menlosecurity
     ports:
       - 8080

--- a/packages/microsoft_defender_endpoint/_dev/deploy/docker/docker-compose.yml
+++ b/packages/microsoft_defender_endpoint/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   microsoft-defender-mock:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:
@@ -19,7 +19,7 @@ services:
       - --addr=:8080
       - --config=/config.yml
   microsoft-defender-endpoint-vulnerability-cel:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/microsoft_exchange_online_message_trace/_dev/deploy/docker/docker-compose.yml
+++ b/packages/microsoft_exchange_online_message_trace/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   exchange_online:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: exchange_online
     ports:
       - 8080

--- a/packages/microsoft_sentinel/_dev/deploy/docker/docker-compose.yml
+++ b/packages/microsoft_sentinel/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   microsoft_sentinel_incident:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: microsoft_sentinel_incident
     ports:
       - 8090
@@ -14,7 +14,7 @@ services:
       - --addr=:8090
       - --config=/files/incident-config.yml
   microsoft_sentinel_alert:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: microsoft_sentinel_alert
     ports:
       - 8090

--- a/packages/mimecast/_dev/deploy/docker/docker-compose.yml
+++ b/packages/mimecast/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   mimecast:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/miniflux/data_stream/feed_entry/_dev/deploy/docker/docker-compose.yml
+++ b/packages/miniflux/data_stream/feed_entry/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   miniflux:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: miniflux
     ports:
       - 8090

--- a/packages/nagios_xi/_dev/deploy/docker/docker-compose.yml
+++ b/packages/nagios_xi/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   nagios_xi:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: nagios_xi
     ports:
       - 8080

--- a/packages/netflow/_dev/deploy/docker/docker-compose.yml
+++ b/packages/netflow/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   netflow-log-netflow:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: pcap --start-signal=SIGHUP --delay=5s --addr elastic-agent:2055 -p=udp /sample_logs/ipfix_cisco.pcap

--- a/packages/netscout/_dev/deploy/docker/docker-compose.yml
+++ b/packages/netscout/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   netscout-sightline-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9524 -p=udp /sample_logs/netscout-sightline-*.log
   netscout-sightline-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9524 -p=tcp /sample_logs/netscout-sightline-*.log

--- a/packages/netskope/_dev/deploy/docker/docker-compose.yml
+++ b/packages/netskope/_dev/deploy/docker/docker-compose.yml
@@ -1,12 +1,12 @@
 version: "2.3"
 services:
   netskope-alerts-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9020 -p=tcp /sample_logs/alerts.log
   netskope-events-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9021 -p=tcp /sample_logs/events.log

--- a/packages/o365/_dev/deploy/docker/docker-compose.yml
+++ b/packages/o365/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   o365-cel:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     environment:

--- a/packages/o365_metrics/_dev/deploy/docker/docker-compose.yml
+++ b/packages/o365_metrics/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   o365_metrics:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: o365_metrics
     ports:
       - 8090

--- a/packages/okta/_dev/deploy/docker/docker-compose.yml
+++ b/packages/okta/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   okta:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:
@@ -13,7 +13,7 @@ services:
       - --addr=:8080
       - --config=/files/config.yml
   okta-oauth2:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/opencanary/_dev/deploy/docker/docker-compose.yml
+++ b/packages/opencanary/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   opencanary-log:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/*.log

--- a/packages/panw/_dev/deploy/docker/docker-compose.yml
+++ b/packages/panw/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   panw-panos-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./syslog_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tls --insecure /sample_logs/*.log
   panw-panos-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./syslog_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/*.log
   panw-panos-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./syslog_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/*.log

--- a/packages/panw_cortex_xdr/data_stream/alerts/_dev/deploy/docker/docker-compose.yml
+++ b/packages/panw_cortex_xdr/data_stream/alerts/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   panw-cortex-xdr-mock:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/panw_cortex_xdr/data_stream/incidents/_dev/deploy/docker/docker-compose.yml
+++ b/packages/panw_cortex_xdr/data_stream/incidents/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   panw-cortex-xdr-mock:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/pfsense/_dev/deploy/docker/docker-compose.yml
+++ b/packages/pfsense/_dev/deploy/docker/docker-compose.yml
@@ -1,17 +1,17 @@
 version: '2.3'
 services:
   pfsense-log-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=udp /sample_logs/*.log
   pfsense-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=tcp /sample_logs/*.log
   pfsense-log-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=tls --insecure /sample_logs/*.log

--- a/packages/ping_federate/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ping_federate/_dev/deploy/docker/docker-compose.yml
@@ -1,12 +1,12 @@
 version: '2.3'
 services:
   ping_federate-tcp-audit:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9598 -p=tcp /sample_logs/test-audit.log
   ping_federate-udp-audit:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9599 -p=udp /sample_logs/test-audit.log
@@ -17,7 +17,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   ping_federate-tls-audit:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9598 -p=tls --insecure /sample_logs/test-audit.log

--- a/packages/ping_one/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ping_one/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   ping-one-audit-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -9,7 +9,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9577/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/audit.log
   ping_one:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: ping_one
     ports:
       - 8080

--- a/packages/pps/_dev/deploy/docker/docker-compose.yml
+++ b/packages/pps/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   pps-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9037 -p=tcp /sample_logs/log.log
   pps-log-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9038 -p=udp /sample_logs/log.log

--- a/packages/prisma_access/_dev/deploy/docker/docker-compose.yml
+++ b/packages/prisma_access/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   prisma-access-event-tcp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9535 -p=tcp /sample_logs/prisma_access.log

--- a/packages/prisma_cloud/_dev/deploy/docker/docker-compose.yml
+++ b/packages/prisma_cloud/_dev/deploy/docker/docker-compose.yml
@@ -1,37 +1,37 @@
 version: '2.3'
 services:
   prisma_cloud-host-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9508 -p=tcp /sample_logs/host.log
   prisma_cloud-host-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9509 -p=udp /sample_logs/host.log
   prisma_cloud-host_profile-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9510 -p=tcp /sample_logs/host_profile.log
   prisma_cloud-host_profile-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9511 -p=udp /sample_logs/host_profile.log
   prisma_cloud-incident_audit-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9512 -p=tcp /sample_logs/incident_audit.log
   prisma_cloud-incident_audit-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9513 -p=udp /sample_logs/incident_audit.log
   prisma_cloud:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: prisma_cloud
     ports:
       - 8090

--- a/packages/proofpoint_itm/_dev/deploy/docker/docker-compose.yml
+++ b/packages/proofpoint_itm/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.0'
 services:
   proofpoint_itm:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: proofpoint_itm
     ports:
       - 8090

--- a/packages/proofpoint_tap/_dev/deploy/docker/docker-compose.yml
+++ b/packages/proofpoint_tap/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   proofpoint_tap:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: proofpoint_tap
     ports:
       - 8080

--- a/packages/proxysg/_dev/deploy/docker/docker-compose.yml
+++ b/packages/proxysg/_dev/deploy/docker/docker-compose.yml
@@ -6,17 +6,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   proxysg-log-udp:
-    image: docker.elastic.co/observability/stream:v0.16.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs/syslog:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:5144 -p=udp /sample_logs/proxysg.log
   proxysg-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.16.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs/syslog:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:6011 -p=tcp /sample_logs/proxysg.log
   proxysg-log-tls:
-    image: docker.elastic.co/observability/stream:v0.16.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs/syslog:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:6514 -p=tls --insecure /sample_logs/proxysg.log

--- a/packages/pulse_connect_secure/_dev/deploy/docker/docker-compose.yml
+++ b/packages/pulse_connect_secure/_dev/deploy/docker/docker-compose.yml
@@ -1,17 +1,17 @@
 version: '2.3'
 services:
   pulse_connect_secure-log-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/test-syslog.log
   pulse_connect_secure-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tcp /sample_logs/test-syslog.log
   pulse_connect_secure-log-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9516 -p=tls --insecure /sample_logs/test-syslog.log

--- a/packages/qnap_nas/_dev/deploy/docker/docker-compose.yml
+++ b/packages/qnap_nas/_dev/deploy/docker/docker-compose.yml
@@ -1,17 +1,17 @@
 version: '2.3'
 services:
   qnap-nas-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=udp /sample_logs/*.log
   qnap-nas-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=tcp /sample_logs/*.log
   qnap-nas-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=tls --insecure /sample_logs/*.log

--- a/packages/qualys_vmdr/_dev/deploy/docker/docker-compose.yml
+++ b/packages/qualys_vmdr/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   qualys_vmdr:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: qualys_vmdr
     ports:
       - '8090'

--- a/packages/radware/_dev/deploy/docker/docker-compose.yml
+++ b/packages/radware/_dev/deploy/docker/docker-compose.yml
@@ -7,13 +7,13 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   radware-defensepro-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     entrypoint: /bin/bash
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9535 -p=udp /sample_logs/radware-defensepro-*.log
   radware-defensepro-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     entrypoint: /bin/bash

--- a/packages/rapid7_insightvm/_dev/deploy/docker/docker-compose.yml
+++ b/packages/rapid7_insightvm/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   rapid7_insightvm:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: rapid7_insightvm
     ports:
       - 8080

--- a/packages/sailpoint_identity_sc/_dev/deploy/docker/docker-compose.yml
+++ b/packages/sailpoint_identity_sc/_dev/deploy/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   sailpoint:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: sailpoint
     ports:
       - 8080

--- a/packages/salesforce/_dev/deploy/docker/docker-compose.yml
+++ b/packages/salesforce/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   salesforce:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: salesforce
     ports:
       - 8010:8010

--- a/packages/sentinel_one/_dev/deploy/docker/docker-compose.yml
+++ b/packages/sentinel_one/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   sentinel_one:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: sentinel_one
     ports:
       - 8080

--- a/packages/servicenow/_dev/deploy/docker/docker-compose.yml
+++ b/packages/servicenow/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   servicenow:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: servicenow
     ports:
       - 8090

--- a/packages/slack/_dev/deploy/docker/docker-compose.yml
+++ b/packages/slack/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   slack:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/snort/_dev/deploy/docker/docker-compose.yml
+++ b/packages/snort/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/*.log /var/log/"
   snort-log-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/test-syslog.log

--- a/packages/snyk/_dev/deploy/docker/docker-compose.yml
+++ b/packages/snyk/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   snyk:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/sonicwall_firewall/_dev/deploy/docker/docker-compose.yml
+++ b/packages/sonicwall_firewall/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   sonicwall_firewall-syslog:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/log.log

--- a/packages/sophos/_dev/deploy/docker/docker-compose.yml
+++ b/packages/sophos/_dev/deploy/docker/docker-compose.yml
@@ -7,27 +7,27 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   sophos-utm-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9549 -p=udp /sample_logs/sophos-utm*.log
   sophos-utm-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9549 -p=tcp /sample_logs/sophos-utm*.log
   sophos-xg-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9549 -p=udp /sample_logs/sophos-xg*.log
   sophos-xg-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9549 -p=tcp /sample_logs/sophos-xg*.log
   sophos-xg-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9550 -p=tls --insecure /sample_logs/sophos-xg*.log

--- a/packages/sophos_central/_dev/deploy/docker/docker-compose.yml
+++ b/packages/sophos_central/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   sophos_central:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: sophos_central
     ports:
       - 8080

--- a/packages/splunk/_dev/deploy/docker/docker-compose.yml
+++ b/packages/splunk/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.0'
 services:
   splunk:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: splunk
     ports:
       - 8090

--- a/packages/spycloud/_dev/deploy/docker/docker-compose.yml
+++ b/packages/spycloud/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   spycloud:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: spycloud
     ports:
       - 8090

--- a/packages/squid/_dev/deploy/docker/docker-compose.yml
+++ b/packages/squid/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   squid-log-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9537 -p=udp /sample_logs/squid-log-*.log
   squid-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9537 -p=tcp /sample_logs/squid-log-*.log
   squid-log-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9538 -p=tls --insecure /sample_logs/squid-log-*.log

--- a/packages/statsd_input/_dev/deploy/docker/docker-compose.yml
+++ b/packages/statsd_input/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   statsd_input:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:8125 -p=udp /sample_logs/test-statsd.log

--- a/packages/stormshield/_dev/deploy/docker/docker-compose.yml
+++ b/packages/stormshield/_dev/deploy/docker/docker-compose.yml
@@ -1,17 +1,17 @@
 version: "2.3"
 services:
   stormshield-udp:
-    image: docker.elastic.co/observability/stream:v0.16.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:5144 -p=udp /sample_logs/stormshield.log
   stormshield-tcp:
-    image: docker.elastic.co/observability/stream:v0.16.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:6011 -p=tcp /sample_logs/stormshield.log
   stormshield-tls:
-    image: docker.elastic.co/observability/stream:v0.16.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:6514 -p=tls --insecure /sample_logs/stormshield.log

--- a/packages/sublime_security/data_stream/audit/_dev/deploy/docker/docker-compose.yml
+++ b/packages/sublime_security/data_stream/audit/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   sublime_security:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: sublime_security
     ports:
       - 8090

--- a/packages/sublime_security/data_stream/message_event/_dev/deploy/docker/docker-compose.yml
+++ b/packages/sublime_security/data_stream/message_event/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   sublime_security:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: sublime_security
     ports:
       - 8090

--- a/packages/symantec_endpoint/_dev/deploy/docker/docker-compose.yml
+++ b/packages/symantec_endpoint/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   symantec_endpoint-log-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/symantec_endpoint.log
   symantec_endpoint-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/symantec_endpoint.log

--- a/packages/symantec_endpoint_security/data_stream/incident/_dev/deploy/docker/docker-compose.yml
+++ b/packages/symantec_endpoint_security/data_stream/incident/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   ses-incident:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: ses-incident
     ports:
       - 8090

--- a/packages/sysdig/_dev/deploy/docker/docker-compose.yml
+++ b/packages/sysdig/_dev/deploy/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   sysdig-alerts-http:
-    image: docker.elastic.co/observability/stream:v0.16.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -8,7 +8,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9035/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/sysdig.log
   sysdig:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: sysdig
     ports:
       - 8090

--- a/packages/syslog_router/_dev/deploy/docker/docker-compose.yml
+++ b/packages/syslog_router/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   syslog-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=udp /sample_logs/test.log
   syslog-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tcp /sample_logs/test.log
   syslog-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9516 -p=tls --insecure /sample_logs/test.log

--- a/packages/tanium/_dev/deploy/docker/docker-compose.yml
+++ b/packages/tanium/_dev/deploy/docker/docker-compose.yml
@@ -1,37 +1,37 @@
 version: '2.3'
 services:
   tanium-tcp-action_history:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9081 -p=tcp /sample_logs/action_history.log
   tanium-tcp-client_status:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9082 -p=tcp /sample_logs/client_status.log
   tanium-tcp-discover:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9083 -p=tcp /sample_logs/discover.log
   tanium-tcp-endpoint_config:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9084 -p=tcp /sample_logs/endpoint_config.log
   tanium-tcp-reporting:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9085 -p=tcp /sample_logs/reporting.log
   tanium-tcp-threat_response:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9086 -p=tcp /sample_logs/threat_response.log
   tanium-action_history-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -39,7 +39,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9087/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/action_history.log
   tanium-client_status-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -47,7 +47,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9088/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/client_status.log
   tanium-discover-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -55,7 +55,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9089/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/discover.log
   tanium-endpoint_config-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -63,7 +63,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9090/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/endpoint_config.log
   tanium-reporting-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -71,7 +71,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9091/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/reporting.log
   tanium-threat_response-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/tcp/_dev/deploy/docker/docker-compose.yml
+++ b/packages/tcp/_dev/deploy/docker/docker-compose.yml
@@ -1,17 +1,17 @@
 version: '2.3'
 services:
   test-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tcp /sample_logs/test-tcp.log
   test-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9516 -p=tls --insecure /sample_logs/test-tcp.log
   test-syslog:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9517 -p=tcp /sample_logs/test-tcp.log

--- a/packages/tenable_io/_dev/deploy/docker/docker-compose.yml
+++ b/packages/tenable_io/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   tenable_io:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: tenable_io
     ports:
       - 8080

--- a/packages/tenable_ot_security/_dev/deploy/docker/docker-compose.yml
+++ b/packages/tenable_ot_security/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   assets:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:
@@ -13,7 +13,7 @@ services:
       - --addr=:8080
       - --config=/files/assets_config.yml
   events:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:
@@ -25,7 +25,7 @@ services:
       - --addr=:8080
       - --config=/files/events_config.yml
   system_log:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/tenable_sc/_dev/deploy/docker/docker-compose.yml
+++ b/packages/tenable_sc/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   tenable_sc:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: tenable_sc
     ports:
       - 8080

--- a/packages/thycotic_ss/_dev/deploy/docker/docker-compose.yml
+++ b/packages/thycotic_ss/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   thycotic-ss-log-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9571 -p=udp /sample_logs/thycotic-ss-*.log
   thycotic-ss-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9571 -p=tcp /sample_logs/thycotic-ss-*.log

--- a/packages/ti_abusech/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_abusech/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   abusech:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:
@@ -13,7 +13,7 @@ services:
       - --addr=:8080
       - --config=/files/config.yml
   abusech-threatfox:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8081
     volumes:

--- a/packages/ti_anomali/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_anomali/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   intelligence-api:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:
@@ -13,7 +13,7 @@ services:
       - --addr=:8080
       - --config=/files/intelligence-api-config.yml
   threatstream-webhook-http:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -21,7 +21,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9080/
     command: log --webhook-content-type application/x-ndjson --start-signal=SIGHUP --delay=5s /sample_logs/test-threatstream-ndjson.log
   threatstream-webhook-https:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/ti_cif3/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_cif3/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   cif3:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/ti_crowdstrike/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_crowdstrike/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   ti_crowdstrike:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: ti_crowdstrike
     ports:
       - 8090

--- a/packages/ti_custom/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_custom/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   stix-taxii:
-    image: docker.elastic.co/observability/stream:v0.16.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/ti_cybersixgill/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_cybersixgill/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   cybersixgill-http:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/ti_domaintools/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_domaintools/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   domaintools:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/ti_eclecticiq/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_eclecticiq/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   eiqtip:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     environment:

--- a/packages/ti_eset/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_eset/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   eti:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/ti_maltiverse/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_maltiverse/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   maltiverse:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     environment:

--- a/packages/ti_mandiant_advantage/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_mandiant_advantage/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   ti_mandiant_advantage:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/ti_misp/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_misp/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   misp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/ti_opencti/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_opencti/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   opencti_stub:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/ti_otx/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_otx/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   otx:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     environment:

--- a/packages/ti_rapid7_threat_command/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_rapid7_threat_command/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   ti_rapid7_threat_command:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: ti_rapid7_threat_command
     ports:
       - 8080

--- a/packages/ti_recordedfuture/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_recordedfuture/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   recordedfuture-api:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:
@@ -13,7 +13,7 @@ services:
       - --addr=:8080
       - --config=/files/config-api.yml
   recordedfuture-csv-download:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:
@@ -31,7 +31,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   recordedfuture-cel:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: recordedfuture
     ports:
       - 8090

--- a/packages/ti_threatconnect/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_threatconnect/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   threatconnect-indicator:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: threatconnect-indicator
     ports:
       - 8090

--- a/packages/ti_threatq/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_threatq/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   threatq:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/tines/_dev/deploy/docker/docker-compose.yml
+++ b/packages/tines/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.0'
 services:
   tines_api_mock:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: tines_api_mock
     ports:
       - 8080

--- a/packages/tomcat/_dev/deploy/docker/docker-compose.yml
+++ b/packages/tomcat/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   tomcat-log-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9523 -p=udp /sample_logs/tomcat-log-*.log
   tomcat-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9523 -p=tcp /sample_logs/tomcat-log-*.log

--- a/packages/trellix_epo_cloud/_dev/deploy/docker/docker-compose.yml
+++ b/packages/trellix_epo_cloud/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   trellix_epo_cloud:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: trellix_epo_cloud
     ports:
       - 8090

--- a/packages/trend_micro_vision_one/_dev/deploy/docker/docker-compose.yml
+++ b/packages/trend_micro_vision_one/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   trend_micro_vision_one:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: trend_micro_vision_one
     ports:
       - 8080

--- a/packages/trendmicro/_dev/deploy/docker/docker-compose.yml
+++ b/packages/trendmicro/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   trendmicro-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tls --insecure /sample_logs/trendmicro.log
   trendmicro-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/trendmicro.log
   trendmicro-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=udp /sample_logs/trendmicro.log

--- a/packages/udp/_dev/deploy/docker/docker-compose.yml
+++ b/packages/udp/_dev/deploy/docker/docker-compose.yml
@@ -1,12 +1,12 @@
 version: '2.3'
 services:
   test-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=udp /sample_logs/test-udp.log
   test-syslog:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9516 -p=udp /sample_logs/test-udp.log

--- a/packages/varonis/_dev/deploy/docker/docker-compose.yml
+++ b/packages/varonis/_dev/deploy/docker/docker-compose.yml
@@ -1,22 +1,22 @@
 version: '2.3'
 services:
   varonis-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=6s --addr elastic-agent:9030 -p=udp /sample_logs/varonis.log
   varonis-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=6s --addr elastic-agent:9031 -p=tcp /sample_logs/varonis.log
   varonis-udp-invalid-cef:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=6s --addr elastic-agent:9032 -p=udp /sample_logs/varonis_invalid_cef.log
   varonis-tcp-invalid-cef:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=6s --addr elastic-agent:9033 -p=tcp /sample_logs/varonis_invalid_cef.log

--- a/packages/vectra_detect/_dev/deploy/docker/docker-compose.yml
+++ b/packages/vectra_detect/_dev/deploy/docker/docker-compose.yml
@@ -1,17 +1,17 @@
 version: '2.3'
 services:
   vectra_detect-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9025 -p=tcp /sample_logs/vectra_detect.log
   vectra_detect-tls:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9025 -p=tls --insecure /sample_logs/vectra_detect.log
   vectra_detect-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9025 -p=udp /sample_logs/vectra_detect.log

--- a/packages/vectra_rux/_dev/deploy/docker/docker-compose.yml
+++ b/packages/vectra_rux/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.0'
 services:
   vectra_rux:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: vectra_rux
     ports:
       - 8090

--- a/packages/vsphere/_dev/deploy/docker/docker-compose.yml
+++ b/packages/vsphere/_dev/deploy/docker/docker-compose.yml
@@ -8,12 +8,12 @@ services:
     ports:
       - 8989
   vsphere-log-udp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/syslog.log
   vsphere-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tcp /sample_logs/syslog.log

--- a/packages/watchguard_firebox/_dev/deploy/docker/docker-compose.yml
+++ b/packages/watchguard_firebox/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   watchguard-firebox-log-udp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9528 -p=udp /sample_logs/watchguard_firebox.log

--- a/packages/wiz/_dev/deploy/docker/docker-compose.yml
+++ b/packages/wiz/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   wiz-audit:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: wiz-audit
     ports:
       - 8090
@@ -14,7 +14,7 @@ services:
       - --addr=:8090
       - --config=/files/config-audit.yml
   wiz-cloud_configuration_finding:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: wiz-cloud_configuration_finding
     ports:
       - 8090
@@ -27,7 +27,7 @@ services:
       - --addr=:8090
       - --config=/files/config-cloud_configuration_finding.yml
   wiz-cloud_configuration_finding_full_posture:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: wiz-cloud_configuration_finding_full_posture
     ports:
       - 8090
@@ -40,7 +40,7 @@ services:
       - --addr=:8090
       - --config=/files/config-cloud_configuration_finding_full_posture.yml
   wiz-issue:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: wiz-issue
     ports:
       - 8090
@@ -53,7 +53,7 @@ services:
       - --addr=:8090
       - --config=/files/config-issue.yml
   wiz-vulnerability:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: wiz-vulnerability
     ports:
       - 8090
@@ -66,7 +66,7 @@ services:
       - --addr=:8090
       - --config=/files/config-vulnerability.yml
   wiz-defend-no-auth:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -74,7 +74,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9588/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/defend.log
   wiz-defend-basic:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -84,7 +84,7 @@ services:
       - STREAM_PASSWORD=xxxx
     command: log --start-signal=SIGHUP  --webhook-username=testuser --webhook-password=xxxx --delay=5s /sample_logs/defend.log
   wiz-defend-token:
-    image: docker.elastic.co/observability/stream:v0.17.1
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/zerofox/_dev/deploy/docker/docker-compose.yml
+++ b/packages/zerofox/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   zerofox-http:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/zeronetworks/_dev/deploy/docker/docker-compose.yml
+++ b/packages/zeronetworks/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   zeronetworks:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     ports:
       - 8080
     volumes:

--- a/packages/zoom/_dev/deploy/docker/docker-compose.yml
+++ b/packages/zoom/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   zoom-webhook-http:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -10,7 +10,7 @@ services:
       - STREAM_WEBHOOK_HEADER=Authorization=abc123
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/account-ndjson.log
   zoom-webhook-https:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/zscaler_zia/_dev/deploy/docker/docker-compose.yml
+++ b/packages/zscaler_zia/_dev/deploy/docker/docker-compose.yml
@@ -1,42 +1,42 @@
 version: "2.3"
 services:
   zscaler-zia-alerts-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9010 -p=tcp /sample_logs/alerts.log
   zscaler-zia-audit-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9029 -p=tcp /sample_logs/audit.log
   zscaler-zia-dns-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9011 -p=tcp /sample_logs/dns.log
   zscaler-zia-endpoint-dlp-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9023 -p=tcp /sample_logs/endpoint_dlp.log
   zscaler-zia-firewall-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9012 -p=tcp /sample_logs/firewall.log
   zscaler-zia-tunnel-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9013 -p=tcp /sample_logs/tunnel.log
   zscaler-zia-web-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9014 -p=tcp /sample_logs/web.log
   zscaler-zia-audit-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -45,7 +45,7 @@ services:
       - STREAM_WEBHOOK_HEADER=Content-Type=application/ndjson
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/audit-http_endpoint.log
   zscaler-zia-dns-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -54,7 +54,7 @@ services:
       - STREAM_WEBHOOK_HEADER=Content-Type=application/ndjson
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/dns-http_endpoint.log
   zscaler-zia-endpoint-dlp-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -63,7 +63,7 @@ services:
       - STREAM_WEBHOOK_HEADER=Content-Type=application/ndjson
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/endpoint_dlp-http_endpoint.log
   zscaler-zia-firewall-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -72,7 +72,7 @@ services:
       - STREAM_WEBHOOK_HEADER=Content-Type=application/ndjson
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/firewall-http_endpoint.log
   zscaler-zia-tunnel-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -81,7 +81,7 @@ services:
       - STREAM_WEBHOOK_HEADER=Content-Type=application/ndjson
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/tunnel-http_endpoint.log
   zscaler-zia-web-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -90,7 +90,7 @@ services:
       - STREAM_WEBHOOK_HEADER=Content-Type=application/ndjson
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/web-http_endpoint.log
   sandbox-report:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     hostname: sandbox-report
     ports:
       - 8090

--- a/packages/zscaler_zpa/_dev/deploy/docker/docker-compose.yml
+++ b/packages/zscaler_zpa/_dev/deploy/docker/docker-compose.yml
@@ -1,27 +1,27 @@
 version: "2.3"
 services:
   zscaler-app-connector-status-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9015 -p=tcp /sample_logs/app_connector_status.log
   zscaler-zpa-audit-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9016 -p=tcp /sample_logs/audit.log
   zscaler-zpa-browser-access-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9017 -p=tcp /sample_logs/browser_access.log
   zscaler-zpa-user-activity-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9018 -p=tcp /sample_logs/user_activity.log
   zscaler-zpa-user-status-tcp:
-    image: docker.elastic.co/observability/stream:v0.15.0
+    image: docker.elastic.co/observability/stream:v0.18.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9019 -p=tcp /sample_logs/user_status.log


### PR DESCRIPTION
## Proposed commit message

Use https://github.com/elastic/stream/releases/tag/v0.18.0 across all system tests. This will help reduce data transfer costs because the image caching will be more effective.

There is no changelog because this is not a user facing change.

```
[git-generate]
find . -name 'docker-compose.yml' \
  -exec perl -p -i -e 's|docker.elastic.co/observability/stream:v\d+\.\d+\.\d+$|docker.elastic.co/observability/stream:v0.18.0|g' {} \;
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
