### PR TITLE
Allow ISO8601 datetime format

### DIFF
--- a/packages/keycloak/changelog.yml
+++ b/packages/keycloak/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.28.1"
+  changes:
+    - description: Allow ISO8601 datetime format.
+      type: enhancement
+      link: TODO
 - version: "1.28.0"
   changes:
     - description: Set the ECS field `event.outcome` based on the value of `keycloak.login.type`.

--- a/packages/keycloak/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/keycloak/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -26,6 +26,7 @@ processors:
       timezone: "{{{ event.timezone }}}"
       formats:
         - yyyy-MM-dd HH:mm:ss,SSS
+        - ISO8601
       if: ctx.event?.timezone != null
       tag: date_timestamp_timezone
   - date:
@@ -33,6 +34,7 @@ processors:
       target_field: '@timestamp'
       formats:
         - yyyy-MM-dd HH:mm:ss,SSS
+        - ISO8601
       if: ctx.event?.timezone == null
       tag: date_timestamp_no_timezone
   - pipeline:

--- a/packages/keycloak/manifest.yml
+++ b/packages/keycloak/manifest.yml
@@ -1,6 +1,6 @@
 name: keycloak
 title: Keycloak
-version: "1.28.0"
+version: "1.28.1"
 description: Collect logs from Keycloak with Elastic Agent.
 type: integration
 format_version: "3.0.3"


### PR DESCRIPTION
Please label as enhancement

The officially as-well supported ISO8601 timestamp shall be added to the date processor.


