### PR TITLE
crowdstrike: add support for multi-resource streams

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,7 +1,12 @@
 # newer versions go on top
+- version: "1.75.1"
+  changes:
+    - description: Add support for multi-resource falcon hose streams.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/14212
 - version: "1.75.0"
   changes:
-    - description: Add additional parsed fields in alert datastream
+    - description: Add additional parsed fields in alert datastream.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/14143
 - version: "1.74.0"

--- a/packages/crowdstrike/data_stream/falcon/agent/stream/streaming.yml.hbs
+++ b/packages/crowdstrike/data_stream/falcon/agent/stream/streaming.yml.hbs
@@ -8,8 +8,19 @@ crowdstrike_app_id: {{app_id}}
 redact:
   fields: ~
 program: |
-  state.response.decode_json().as(body,{
-    ?"cursor": body.?metadata.optMap(m, {"offset": m.offset}),
+  state.response.decode_json().as(body, {
+    // Handle both old agent behaviour and new multi-resource cursors.
+    ?"cursor": !has(state.feed) ?
+      // Old behaviour: no feed key.
+      body.?metadata.optMap(m, {"offset": m.offset})
+    : has(body.metadata) ?
+      // New behaviour with a cursor from the event.
+      optional.of(state.?cursor.orValue({}).with({
+        ?state.feed: body.?metadata.optMap(m, {"offset": m.offset}),
+      }))
+    :
+      // New behaviour with no cursor; pass through.
+      state.?cursor,
     "events": [{
           "message":  body.encode_json(),
     }],

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "1.75.0"
+version: "1.75.1"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: "3.3.1"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
crowdstrike: add support for multi-resource streams

elastic/beats#44548 added support for multi-resource stream. This
updates the CEL program that processes the events provided by the stream
so that it is able to handle the new cursor structure. It is able to
distinguish old agents from the new multi-resource aware agents by the
presence of the feed field in state.

When the agent is upgraded from the old state form to the new form, it is
expected that the integration will recollect the existing data since the
cursors are not compatible with each other.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #13953
- Relates elastic/beats#44548

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
