### PR TITLE
[cisco_ios] Add support for longer time zone formats

### DIFF
--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -1,4 +1,10 @@
 # newer versions go on top
+- version: "1.30.3"
+  changes:
+    - description: Add support for longer timezone formats
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/999999
+
 - version: "1.30.2"
   changes:
     - description: Fix parsing of hostnames that start with a digit

--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -3,8 +3,7 @@
   changes:
     - description: Add support for longer timezone formats
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/999999
-
+      link: https://github.com/elastic/integrations/pull/14250
 - version: "1.30.2"
   changes:
     - description: Fix parsing of hostnames that start with a digit

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format-tzoffset.log
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format-tzoffset.log
@@ -1,3 +1,4 @@
 <190>2361044: sw01: Jan 16 2022 22:11:43: %FOO-6-BAR: Test date format.
 <190>2361044: sw01: Jan 16 2022 22:11:43 AEST: %FOO-6-BAR: Test date format.
 <190>2361044: sw01: Jan 16 2022 22:11:43 CST: %FOO-6-BAR: Test date format.
+<190>2361044: sw01: Jan 16 2022 22:11:43 METDST: %FOO-6-BAR: Test date format.

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format-tzoffset.log-config.yml
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format-tzoffset.log-config.yml
@@ -7,3 +7,5 @@ fields:
     tz_map:
       - tz_short: AEST
         tz_long: Australia/Sydney
+      - tz_short: METDST
+        tz_long: Europe/Berlin

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format-tzoffset.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format-tzoffset.log-expected.json
@@ -123,6 +123,47 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2022-01-16T22:11:43.000+01:00",
+            "cisco": {
+                "ios": {
+                    "facility": "FOO",
+                    "message_count": 2361044
+                }
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "BAR",
+                "original": "<190>2361044: sw01: Jan 16 2022 22:11:43 METDST: %FOO-6-BAR: Test date format.",
+                "provider": "firewall",
+                "sequence": 2361044,
+                "severity": 6,
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "sw01",
+                    "priority": 190
+                }
+            },
+            "message": "Test date format.",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -50,7 +50,7 @@ processors:
         CISCOTIMESTAMP_EX: '(%{CISCOTIMESTAMP})|(%{YEAR} %{MONTH} %{MONTHDAY} %{TIME})'
         CISCO_UPTIME: '(?:\d{1,4}:\d{2}:\d{2}|(?:(\d+)y)?(?:(\d+)w)?(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?)'
         CISCO_HOSTNAME: '[0-9a-zA-Z][.0-9a-zA-Z_-]{0,253}[0-9a-zA-Z]?'
-        CISCO_TZ: '[a-zA-Z]{1,4}([+-]\d{1,2}|[+-]\d{2}:\d{2})?'
+        CISCO_TZ: '[a-zA-Z]{1,7}([+-]\d{1,2}|[+-]\d{2}:\d{2})?'
   - grok:
       field: _temp_.message
       tag: grok_message

--- a/packages/cisco_ios/manifest.yml
+++ b/packages/cisco_ios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ios
 title: Cisco IOS
-version: "1.30.2"
+version: "1.30.3"
 description: Collect logs from Cisco IOS with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Cisco IOS logs can have time zone formats up to 7 characters long. This adds matching support for 7-character time zones in the ingest pipeline.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Cisco IOS logs can have time zone formats up to 7 characters long.
This adds matching support for 7-character time zones in the ingest
pipeline.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- ~~[ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

