### PR TITLE
fix(aws/securityhub_findings): event.kind as keyword

### DIFF
--- a/packages/aws/data_stream/securityhub_findings/fields/agent.yml
+++ b/packages/aws/data_stream/securityhub_findings/fields/agent.yml
@@ -1,19 +1,11 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
   type: group
   fields:
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
 - name: host
-  title: Host
-  group: 2
-  description: 'A host is defined as a general computing instance.
 
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
   type: group
   fields:
     - name: containerized

--- a/packages/aws/data_stream/securityhub_findings/fields/ecs.yml
+++ b/packages/aws/data_stream/securityhub_findings/fields/ecs.yml
@@ -1,7 +1,9 @@
 # Define ECS constant fields as constant_keyword
 - name: cloud.provider
   type: constant_keyword
+  external: ecs
 - name: event.kind
-  type: keyword
+  external: ecs
 - name: observer.vendor
   type: constant_keyword
+  external: ecs

--- a/packages/aws/data_stream/securityhub_findings/fields/ecs.yml
+++ b/packages/aws/data_stream/securityhub_findings/fields/ecs.yml
@@ -2,6 +2,6 @@
 - name: cloud.provider
   type: constant_keyword
 - name: event.kind
-  type: constant_keyword
+  type: keyword
 - name: observer.vendor
   type: constant_keyword


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Change event.kind to keyword instead of constant_keyword.
When a pipeline error occurs, event.kind was being set to
'pipeline_error' and this break ingestion because event.kind
was already assigned a value of 'state'.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
