### PR TITLE
cloudflare_logpush.gateway_http: Fix duplicate key `number_of_workers`

### DIFF
--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.38.3"
+  changes:
+    - description: Fix duplicate key `number_of_workers` inside gateway_http data stream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.38.2"
   changes:
     - description: Fix handling of TCP SACK block lists.

--- a/packages/cloudflare_logpush/data_stream/gateway_http/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/gateway_http/agent/stream/aws-s3.yml.hbs
@@ -9,9 +9,6 @@ When using an S3 bucket, you can specify only one of the following options:
 
 {{#if collect_s3_logs}}
 {{! shared S3 bucket polling options }}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
 
 {{#if bucket_list_prefix }}
 bucket_list_prefix: {{ bucket_list_prefix }}

--- a/packages/cloudflare_logpush/manifest.yml
+++ b/packages/cloudflare_logpush/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cloudflare_logpush
 title: Cloudflare Logpush
-version: "1.38.2"
+version: "1.38.3"
 description: Collect and parse logs from Cloudflare API with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
#13346 introduced a bug inside gateway_http data stream which allows 
input config to have a duplicate of number_of_workers.

Fix this by removing number_of_workers dependency on S3 bucket collection 
being enabled, similar to #13346.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->

**Before**
<img width="1187" alt="Screenshot 2025-06-19 at 9 42 49 PM" src="https://github.com/user-attachments/assets/e7fe694f-ee68-4789-8b8e-c9fc55611b48" />

**After**
<img width="1411" alt="Screenshot 2025-06-19 at 9 46 02 PM" src="https://github.com/user-attachments/assets/5c692f30-89dd-4481-821f-4b6159d51efa" />

