### PR TITLE
{ti_eclectiqiq,ti_opencti,ti_threatconnect}: Update error.message field mapping as per ECS inside Threat Intel destination indices.

### DIFF
--- a/packages/ti_eclecticiq/changelog.yml
+++ b/packages/ti_eclecticiq/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update error.message field mapping as per ECS inside transform destination indices.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/14290
 - version: "1.4.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/ti_eclecticiq/changelog.yml
+++ b/packages/ti_eclecticiq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.1"
+  changes:
+    - description: Update error.message field mapping as per ECS inside transform destination indices.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.4.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/ti_eclecticiq/changelog.yml
+++ b/packages/ti_eclecticiq/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.4.1"
   changes:
-    - description: Update error.message field mapping as per ECS inside transform destination indices.
+    - description: Update `error.message` field mapping as per ECS inside transform destination indices.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/14290
 - version: "1.4.0"

--- a/packages/ti_eclecticiq/elasticsearch/transform/latest_ioc/fields/ecs.yml
+++ b/packages/ti_eclecticiq/elasticsearch/transform/latest_ioc/fields/ecs.yml
@@ -5,6 +5,8 @@
 - external: ecs
   name: tags
 - external: ecs
+  name: error.message
+- external: ecs
   name: event.url
 - external: ecs
   name: event.created

--- a/packages/ti_eclecticiq/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_eclecticiq/elasticsearch/transform/latest_ioc/transform.yml
@@ -8,7 +8,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_eclecticiq_latest.threat-3"
+  index: "logs-ti_eclecticiq_latest.threat-4"
 latest:
   unique_key:
     - event.dataset
@@ -28,4 +28,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.3.0
+  fleet_transform_version: 0.4.0

--- a/packages/ti_eclecticiq/manifest.yml
+++ b/packages/ti_eclecticiq/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_eclecticiq
 title: EclecticIQ
-version: "1.4.0"
+version: "1.4.1"
 description: Ingest threat intelligence from EclecticIQ with Elastic Agent
 type: integration
 categories:

--- a/packages/ti_opencti/changelog.yml
+++ b/packages/ti_opencti/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.6.1"
   changes:
-    - description: Update error.message field mapping as per ECS inside transform destination indices.
+    - description: Update `error.message` field mapping as per ECS inside transform destination indices.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/14290
 - version: "2.6.0"

--- a/packages/ti_opencti/changelog.yml
+++ b/packages/ti_opencti/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.6.1"
+  changes:
+    - description: Update error.message field mapping as per ECS inside transform destination indices.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.6.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/ti_opencti/changelog.yml
+++ b/packages/ti_opencti/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update error.message field mapping as per ECS inside transform destination indices.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/14290
 - version: "2.6.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/ti_opencti/elasticsearch/transform/latest_ioc/fields/ecs.yml
+++ b/packages/ti_opencti/elasticsearch/transform/latest_ioc/fields/ecs.yml
@@ -50,6 +50,8 @@
 - external: ecs
   name: ecs.version
 - external: ecs
+  name: error.message
+- external: ecs
   name: event.agent_id_status
 - external: ecs
   name: event.category

--- a/packages/ti_opencti/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_opencti/elasticsearch/transform/latest_ioc/transform.yml
@@ -10,7 +10,7 @@ source:
 # that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_opencti_latest.dest_indicator-3"
+  index: "logs-ti_opencti_latest.dest_indicator-4"
   aliases:
     - alias: "logs-ti_opencti_latest.indicator"
       move_on_creation: true
@@ -34,4 +34,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during
   # package installation.
-  fleet_transform_version: 0.3.0
+  fleet_transform_version: 0.4.0

--- a/packages/ti_opencti/manifest.yml
+++ b/packages/ti_opencti/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: ti_opencti
 title: OpenCTI
-version: "2.6.0"
+version: "2.6.1"
 description: "Ingest threat intelligence indicators from OpenCTI with Elastic Agent."
 type: integration
 source:

--- a/packages/ti_threatconnect/changelog.yml
+++ b/packages/ti_threatconnect/changelog.yml
@@ -4,7 +4,7 @@
   changes:
     - description: Update error.message field mapping as per ECS inside transform destination indices.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/14290
 - version: "1.10.0"
   changes:
     - description: Remove duplicated installation instructions from the documentation

--- a/packages/ti_threatconnect/changelog.yml
+++ b/packages/ti_threatconnect/changelog.yml
@@ -2,7 +2,7 @@
 # WARNING: this version number needs to be kept up to date in the transform!
 - version: "1.10.1"
   changes:
-    - description: Update error.message field mapping as per ECS inside transform destination indices.
+    - description: Update `error.message` field mapping as per ECS inside transform destination indices.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/14290
 - version: "1.10.0"

--- a/packages/ti_threatconnect/changelog.yml
+++ b/packages/ti_threatconnect/changelog.yml
@@ -1,5 +1,10 @@
 # newer versions go on top
 # WARNING: this version number needs to be kept up to date in the transform!
+- version: "1.10.1"
+  changes:
+    - description: Update error.message field mapping as per ECS inside transform destination indices.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.10.0"
   changes:
     - description: Remove duplicated installation instructions from the documentation

--- a/packages/ti_threatconnect/elasticsearch/transform/latest/fields/ecs.yml
+++ b/packages/ti_threatconnect/elasticsearch/transform/latest/fields/ecs.yml
@@ -4,6 +4,8 @@
   type: keyword
 - name: email.to.address
   type: keyword
+- name: error.message
+  external: ecs
 - name: event.category
   type: keyword
 - name: event.id

--- a/packages/ti_threatconnect/elasticsearch/transform/latest/transform.yml
+++ b/packages/ti_threatconnect/elasticsearch/transform/latest/transform.yml
@@ -9,7 +9,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_threatconnect_latest.dest_indicator-7"
+  index: "logs-ti_threatconnect_latest.dest_indicator-8"
   pipeline: "1.10.0-tactics_compatibility"
   aliases:
     - alias: "logs-ti_threatconnect_latest.indicator"
@@ -33,4 +33,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.7.0
+  fleet_transform_version: 0.8.0

--- a/packages/ti_threatconnect/elasticsearch/transform/latest/transform.yml
+++ b/packages/ti_threatconnect/elasticsearch/transform/latest/transform.yml
@@ -10,7 +10,7 @@ source:
 # time field type conflicts.
 dest:
   index: "logs-ti_threatconnect_latest.dest_indicator-8"
-  pipeline: "1.10.0-tactics_compatibility"
+  pipeline: "1.10.1-tactics_compatibility"
   aliases:
     - alias: "logs-ti_threatconnect_latest.indicator"
       move_on_creation: true

--- a/packages/ti_threatconnect/manifest.yml
+++ b/packages/ti_threatconnect/manifest.yml
@@ -2,7 +2,7 @@
 format_version: 3.0.3
 name: ti_threatconnect
 title: ThreatConnect
-version: "1.10.0"
+version: "1.10.1"
 description: Collects Indicators from ThreatConnect using the Elastic Agent and saves them as logs inside Elastic
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
error.message is undefined in some Threat Intel integrations.
If the field is undefined, the default keyword mapping is applied.
This causes issues when searching on data and also impacts 
custom rules. 

Update error.message field mapping as per ECS inside 
Threat Intel destination indices. The change impacts following 
integrations:
- ti_eclectiqiq
- ti_opencti
- ti_threatconnect

Since the mapping needs to be applied to destination indices, 
the index version suffix is also incremented along with upgrading 
transform's fleet version, only when the transform is updated.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
