### PR TITLE
[cisco_ios] Add support for Kiwi format logs

### DIFF
--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.31.0"
+  changes:
+    - description: Add support for Kiwi format logs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/14294
 - version: "1.30.3"
   changes:
     - description: Add support for longer timezone formats

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-kiwi.log
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-kiwi.log
@@ -1,0 +1,1 @@
+<190>Original Address=192.168.0.1 1 2025-06-23T16:13:32.168Z syslog-host-1 Kiwi_SyslogNet_Server 3356 MSGOUT TEST-HOST-1: *Jun 23 15:52:38.534: %SYS-6-LOGOUT: User test-user has exited tty session 1(192.168.0.1)

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-kiwi.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-kiwi.log-expected.json
@@ -1,0 +1,67 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2025-06-23T15:52:38.534Z",
+            "cisco": {
+                "ios": {
+                    "action": "exited",
+                    "facility": "SYS",
+                    "session": {
+                        "number": "1",
+                        "type": "tty"
+                    }
+                }
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "LOGOUT",
+                "original": "<190>Original Address=192.168.0.1 1 2025-06-23T16:13:32.168Z syslog-host-1 Kiwi_SyslogNet_Server 3356 MSGOUT TEST-HOST-1: *Jun 23 15:52:38.534: %SYS-6-LOGOUT: User test-user has exited tty session 1(192.168.0.1)",
+                "provider": "firewall",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "TEST-HOST-1",
+                    "priority": 190
+                }
+            },
+            "message": "User test-user has exited tty session 1(192.168.0.1)",
+            "network": {
+                "type": "ipv4"
+            },
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "ip": [
+                    "192.168.0.1"
+                ],
+                "user": [
+                    "test-user"
+                ]
+            },
+            "source": {
+                "address": "192.168.0.1",
+                "ip": "192.168.0.1",
+                "user": {
+                    "name": "test-user"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -33,6 +33,18 @@ processors:
       ignore_missing: true
   - grok:
       field: event.original
+      tag: grok_kiwi_header
+      description: |- 
+        The Kiwi syslog header is expected to be in the following format:
+        <PRI>Original Address=IP [RFC 5424 header] [Cisco IOS log]
+        
+        This grok pattern currently only extracts the Cisco IOS log from
+        the event. It does not extract any Kiwi syslog header fields.
+      patterns:
+        - '^<%{NONNEGINT:log.syslog.priority:long}>Original Address=(?:%{DATA} ){7}%{GREEDYDATA:_temp_.message}$'
+        - '^%{GREEDYDATA:_temp_.message}$'
+  - grok:
+      field: _temp_.message
       tag: grok_header
       patterns:
         - '^%{CISCO_PRIORITY_MSGCOUNT}?%{TIMESTAMP_ISO8601:_temp_.cisco_timestamp} %{CISCO_HOSTNAME:log.syslog.hostname} %{GREEDYDATA:_temp_.message}$'

--- a/packages/cisco_ios/manifest.yml
+++ b/packages/cisco_ios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ios
 title: Cisco IOS
-version: "1.30.3"
+version: "1.31.0"
 description: Collect logs from Cisco IOS with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- Add support for Kiwi format logs. The Kiwi header is removed and the remaining log is parsed like a normal Cisco IOS log.

The Kiwi Syslog server alters the original Cisco IOS log by inserting a `Original Address=IP` at the beginning of the log, along with an RFC 5424 header.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~


## How to test this PR locally

```
cd packages/cisco_ios
elastic-package test
```

## Related issues

- Closes #14293 
