### PR TITLE
imperva_cloud_waf: handle case where cursor state cannot be found in …

### DIFF
--- a/packages/imperva_cloud_waf/changelog.yml
+++ b/packages/imperva_cloud_waf/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.2"
+  changes:
+    - description: Fix handling of API requests when the cursor state cannot be found in the log file index returned by Imperva.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/14298
 - version: "1.12.1"
   changes:
     - description: Fix ingest pipeline to handle whitespace in request URL.

--- a/packages/imperva_cloud_waf/data_stream/event/agent/stream/cel.yml.hbs
+++ b/packages/imperva_cloud_waf/data_stream/event/agent/stream/cel.yml.hbs
@@ -31,13 +31,20 @@ program: |
           "Authorization": ["Basic "+string(base64(state.user+":"+state.password))],
         }
       }).do_request().as(resp, resp.StatusCode == 200 ?
-        bytes(resp.Body).as(body, {
+        resp.Body.as(body, {
           "worklist": (
-            has(state.cursor) && has(state.cursor.log_file) && state.cursor.log_file != null
-            ?
-              string(body).split(state.cursor.log_file)[1].split("\n").filter(x,x!="").map(x,{"filename":x})
+            has(state.?cursor.log_file) && state.cursor.log_file != null ?
+              string(body).split(state.cursor.log_file)[?1].optMap(f,
+                f.split("\n").map(x, x != "",
+                  {"filename":x}
+                )
+              ).orValue(string(body).split("\n").map(x,
+                {"filename":x}
+              ))
             :
-              string(body).split("\n").map(x,{"filename":x})
+              string(body).split("\n").map(x,
+                {"filename":x}
+              )
           ),
           "next": 0,
         })
@@ -71,7 +78,7 @@ program: |
           "Authorization": ["Basic "+string(base64(state.user + ":" + state.password))],
         }
       }).do_request().as(resp, resp.StatusCode == 200 ?
-        bytes(resp.Body).as(body, {
+        resp.Body.as(body, {
           "events": try(string(body), "error").as(body, type(body) == type("") ?
             dyn((body+"|==|").split("|==|")[1].split("\n").filter(x,x!="").map(x,{"message":x}))
           :
@@ -90,8 +97,7 @@ program: |
           ),
           "cursor": {
             "log_file": (
-              has(state.cursor) && has(state.cursor.log_file) && state.cursor.log_file != null
-              ?
+              has(state.?cursor.log_file) && state.cursor.log_file != null ?
                 (
                   (v.worklist[v.next].filename).split(".")[0] != (state.cursor.log_file).split(".")[0] ?
                     v.worklist[v.next].filename

--- a/packages/imperva_cloud_waf/manifest.yml
+++ b/packages/imperva_cloud_waf/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: imperva_cloud_waf
 title: Imperva Cloud WAF
-version: "1.12.1"
+version: "1.12.2"
 description: Collect logs from Imperva Cloud WAF with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
imperva_cloud_waf: handle case where cursor state cannot be found in log file index

The previous code assumes that it is possible to determine the remainder
of work to be done by splitting on the last log file that was collected.
This fails when the last log file collected is not in the log files that
the index returns for whatever reason.

In that case, use the complete index to start again on the basis that
the cursor log file state has gone stale relative to the index returned
by the API.
```
> [!NOTE]
> Due to testing infrastructure limitations, the change here is not testable in CI.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
