### PR TITLE
[microsoft_defender_endpoint] Add Initial Interval in Config Options

### DIFF
--- a/packages/microsoft_defender_endpoint/changelog.yml
+++ b/packages/microsoft_defender_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.40.0"
+  changes:
+    - description: Added support for `Initial Interval` in Config Options.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.39.0"
   changes:
     - description: Standardize user fields processing across integrations.

--- a/packages/microsoft_defender_endpoint/changelog.yml
+++ b/packages/microsoft_defender_endpoint/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Added support for `Initial Interval` in Config Options.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/14331
 - version: "2.39.0"
   changes:
     - description: Standardize user fields processing across integrations.

--- a/packages/microsoft_defender_endpoint/changelog.yml
+++ b/packages/microsoft_defender_endpoint/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.40.0"
   changes:
-    - description: Added support for `Initial Interval` in Config Options.
+    - description: Added support for Initial Interval in Config Options.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/14331
 - version: "2.39.0"

--- a/packages/microsoft_defender_endpoint/data_stream/log/agent/stream/httpjson.yml.hbs
+++ b/packages/microsoft_defender_endpoint/data_stream/log/agent/stream/httpjson.yml.hbs
@@ -31,7 +31,7 @@ request.transforms:
   - set:
       target: "url.params.$filter"
       value: 'lastUpdateTime gt [[formatDate .cursor.lastUpdateTime "2006-01-02T15:04:05.9999999Z"]]'
-      default: 'lastUpdateTime gt [[formatDate (now (parseDuration "-5m")) "2006-01-02T15:04:05.9999999Z"]]'
+      default: 'lastUpdateTime gt [[formatDate (now (parseDuration "-{{initial_interval}}")) "2006-01-02T15:04:05.9999999Z"]]'
 response.split:
   target: body.value
   ignore_empty_value: true

--- a/packages/microsoft_defender_endpoint/data_stream/log/manifest.yml
+++ b/packages/microsoft_defender_endpoint/data_stream/log/manifest.yml
@@ -41,6 +41,14 @@ streams:
         multi: false
         required: true
         show_user: true
+      - name: initial_interval
+        type: text
+        title: Initial Interval
+        multi: false
+        required: true
+        show_user: true
+        default: 5m
+        description: How far back to pull the logs from Microsoft Defender Endpoint API. Supported units for this parameter are h/m/s.
       - name: interval
         type: text
         title: Interval

--- a/packages/microsoft_defender_endpoint/data_stream/log/sample_event.json
+++ b/packages/microsoft_defender_endpoint/data_stream/log/sample_event.json
@@ -1,9 +1,9 @@
 {
-    "@timestamp": "2025-05-27T10:31:25.333Z",
+    "@timestamp": "2025-06-26T07:39:37.683Z",
     "agent": {
-        "ephemeral_id": "f481d28b-2b00-4bf2-b5b2-b1a40c1f3aaf",
-        "id": "69a70946-8492-4834-baf6-1db2cc9db17c",
-        "name": "elastic-agent-16526",
+        "ephemeral_id": "1eb5c026-8daf-479c-8685-e69263ac5497",
+        "id": "0ebaf690-12f1-40a6-bf6a-cc1468818f04",
+        "name": "elastic-agent-77058",
         "type": "filebeat",
         "version": "8.18.0"
     },
@@ -18,14 +18,14 @@
     },
     "data_stream": {
         "dataset": "microsoft_defender_endpoint.log",
-        "namespace": "48129",
+        "namespace": "81472",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "69a70946-8492-4834-baf6-1db2cc9db17c",
+        "id": "0ebaf690-12f1-40a6-bf6a-cc1468818f04",
         "snapshot": false,
         "version": "8.18.0"
     },
@@ -41,7 +41,7 @@
         "duration": 0,
         "end": "2020-06-30T10:07:44.333733Z",
         "id": "da637291085411733957_-1043898914",
-        "ingested": "2025-05-27T10:31:28Z",
+        "ingested": "2025-06-26T07:39:40Z",
         "kind": "alert",
         "provider": "defender_endpoint",
         "severity": 21,

--- a/packages/microsoft_defender_endpoint/docs/README.md
+++ b/packages/microsoft_defender_endpoint/docs/README.md
@@ -111,11 +111,11 @@ An example event for `log` looks as following:
 
 ```json
 {
-    "@timestamp": "2025-05-27T10:31:25.333Z",
+    "@timestamp": "2025-06-26T07:39:37.683Z",
     "agent": {
-        "ephemeral_id": "f481d28b-2b00-4bf2-b5b2-b1a40c1f3aaf",
-        "id": "69a70946-8492-4834-baf6-1db2cc9db17c",
-        "name": "elastic-agent-16526",
+        "ephemeral_id": "1eb5c026-8daf-479c-8685-e69263ac5497",
+        "id": "0ebaf690-12f1-40a6-bf6a-cc1468818f04",
+        "name": "elastic-agent-77058",
         "type": "filebeat",
         "version": "8.18.0"
     },
@@ -130,14 +130,14 @@ An example event for `log` looks as following:
     },
     "data_stream": {
         "dataset": "microsoft_defender_endpoint.log",
-        "namespace": "48129",
+        "namespace": "81472",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "69a70946-8492-4834-baf6-1db2cc9db17c",
+        "id": "0ebaf690-12f1-40a6-bf6a-cc1468818f04",
         "snapshot": false,
         "version": "8.18.0"
     },
@@ -153,7 +153,7 @@ An example event for `log` looks as following:
         "duration": 0,
         "end": "2020-06-30T10:07:44.333733Z",
         "id": "da637291085411733957_-1043898914",
-        "ingested": "2025-05-27T10:31:28Z",
+        "ingested": "2025-06-26T07:39:40Z",
         "kind": "alert",
         "provider": "defender_endpoint",
         "severity": 21,

--- a/packages/microsoft_defender_endpoint/manifest.yml
+++ b/packages/microsoft_defender_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: microsoft_defender_endpoint
 title: Microsoft Defender for Endpoint
-version: "2.39.0"
+version: "2.40.0"
 description: Collect logs from Microsoft Defender for Endpoint with Elastic Agent.
 categories:
   - "security"


### PR DESCRIPTION
## Proposed Commit Message

```
microsoft_defender_endpoint: add configurable initial interval to the log data stream.

Previously, the initial interval was hardcoded to "5m" and not exposed
in the configuration options in log data stream. This update adds it as
a configurable option, with a default value of "5m". It allows users to
define how far back they want to pull data from the API.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

Clone integrations repo.
Install the elastic package locally.
Start the elastic stack using the elastic package.
Move to integrations/packages/microsoft_defender_endpoint directory.
Run the following command to run tests.
`elastic-package test -v`

## Related issues

- Closes https://github.com/elastic/integrations/issues/12912

