### PR TITLE
SSI Integration: Use terminate processor instead of fail

### DIFF
--- a/packages/abnormal_security/changelog.yml
+++ b/packages/abnormal_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.9.0"
   changes:
     - description: |

--- a/packages/abnormal_security/data_stream/ai_security_mailbox/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/abnormal_security/data_stream/ai_security_mailbox/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - rename:
       field: message
       tag: rename_message_to_event_original

--- a/packages/abnormal_security/data_stream/ai_security_mailbox_not_analyzed/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/abnormal_security/data_stream/ai_security_mailbox_not_analyzed/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - rename:
       tag: rename_message_to_event_original
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.

--- a/packages/abnormal_security/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/abnormal_security/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - rename:
       field: message
       tag: rename_message_to_event_original

--- a/packages/abnormal_security/data_stream/case/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/abnormal_security/data_stream/case/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - rename:
       field: message
       tag: rename_message_to_event_original

--- a/packages/abnormal_security/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/abnormal_security/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - rename:
       field: message
       tag: rename_message_to_event_original

--- a/packages/abnormal_security/data_stream/vendor_case/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/abnormal_security/data_stream/vendor_case/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - rename:
       field: message
       tag: rename_message_to_event_original

--- a/packages/abnormal_security/manifest.yml
+++ b/packages/abnormal_security/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.2.1
+format_version: 3.4.0
 name: abnormal_security
 title: Abnormal AI
-version: "1.9.0"
+version: "1.10.0"
 description: Collect logs from Abnormal AI with Elastic Agent.
 type: integration
 categories:

--- a/packages/beyondtrust_pra/changelog.yml
+++ b/packages/beyondtrust_pra/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.2.1"
   changes:
     - description: Add temporary processor to remove the fields added by the Agentless policy.

--- a/packages/beyondtrust_pra/data_stream/access_session/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/beyondtrust_pra/data_stream/access_session/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.17.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/beyondtrust_pra/manifest.yml
+++ b/packages/beyondtrust_pra/manifest.yml
@@ -1,9 +1,9 @@
 name: beyondtrust_pra
 title: "BeyondTrust PRA"
-version: 0.2.1
+version: 0.3.0
 description: "Collect logs from BeyondTrust PRA with Elastic Agent."
 type: integration
-format_version: 3.3.2
+format_version: 3.4.0
 categories:
   - security
 conditions:

--- a/packages/claroty_xdome/changelog.yml
+++ b/packages/claroty_xdome/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.1.1"
   changes:
     - description: Add temporary processor to remove the fields added by the Agentless policy.

--- a/packages/claroty_xdome/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/claroty_xdome/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.17.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/claroty_xdome/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/claroty_xdome/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.17.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/claroty_xdome/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/claroty_xdome/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.17.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/claroty_xdome/manifest.yml
+++ b/packages/claroty_xdome/manifest.yml
@@ -1,9 +1,9 @@
 name: claroty_xdome
 title: "Claroty xDome"
-version: 0.1.1
+version: 0.2.0
 description: "Collect logs from Claroty xDome with Elastic Agent."
 type: integration
-format_version: 3.3.2
+format_version: 3.4.0
 categories:
   - security
   - vulnerability_management

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.77.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.76.0"
   changes:
     - description: Extend info-level severity names to include "Informational".

--- a/packages/crowdstrike/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/crowdstrike/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -23,10 +23,10 @@ processors:
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field: message
       tag: remove_message

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,9 +1,9 @@
 name: crowdstrike
 title: CrowdStrike
-version: "1.76.0"
+version: "1.77.0"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
-format_version: "3.3.1"
+format_version: "3.4.0"
 categories: [security, edr_xdr]
 conditions:
   kibana:

--- a/packages/cyberark_epm/changelog.yml
+++ b/packages/cyberark_epm/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.1.0"
   changes:
     - description: Standardize user fields processing across integrations.

--- a/packages/cyberark_epm/data_stream/admin_audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyberark_epm/data_stream/admin_audit/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - drop:
       tag: drop_retry_events
       if: ctx.message != null && ctx.message == 'retry'

--- a/packages/cyberark_epm/data_stream/aggregated_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyberark_epm/data_stream/aggregated_event/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - drop:
       tag: drop_retry_events
       if: ctx.message != null && ctx.message == 'retry'

--- a/packages/cyberark_epm/data_stream/policyaudit_aggregated_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyberark_epm/data_stream/policyaudit_aggregated_event/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - drop:
       tag: drop_retry_events
       if: ctx.message != null && ctx.message == 'retry'

--- a/packages/cyberark_epm/data_stream/policyaudit_raw_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyberark_epm/data_stream/policyaudit_raw_event/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - drop:
       tag: drop_retry_events
       if: ctx.message != null && ctx.message == 'retry'

--- a/packages/cyberark_epm/data_stream/raw_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyberark_epm/data_stream/raw_event/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - drop:
       tag: drop_retry_events
       if: ctx.message != null && ctx.message == 'retry'

--- a/packages/cyberark_epm/manifest.yml
+++ b/packages/cyberark_epm/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.3.0
+format_version: 3.4.0
 name: cyberark_epm
 title: CyberArk EPM
-version: "1.1.0"
+version: "1.2.0"
 description: Collect logs from CyberArk EPM with Elastic Agent.
 type: integration
 categories:

--- a/packages/google_secops/changelog.yml
+++ b/packages/google_secops/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.1.1"
   changes:
     - description: Add temporary processor to remove the fields added by the Agentless policy.

--- a/packages/google_secops/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_secops/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.17.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/google_secops/manifest.yml
+++ b/packages/google_secops/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.3.1
+format_version: 3.4.0
 name: google_secops
 title: Google SecOps
-version: 1.1.1
+version: 1.2.0
 description: Collect alerts from Google SecOps with Elastic Agent.
 type: integration
 categories:

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.42.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.41.2"
   changes:
     - description: Handle failures in the convert and rename processors that occur when the organization.id field is already present.

--- a/packages/google_workspace/data_stream/calendar/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/calendar/elasticsearch/ingest_pipeline/default.yml
@@ -13,10 +13,10 @@ processors:
       field: observer.product
       tag: set_observer_product
       value: Calendar
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/google_workspace/data_stream/chat/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/chat/elasticsearch/ingest_pipeline/default.yml
@@ -13,10 +13,10 @@ processors:
       field: observer.product
       tag: set_observer_product
       value: Chat
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/google_workspace/data_stream/chrome/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/chrome/elasticsearch/ingest_pipeline/default.yml
@@ -13,10 +13,10 @@ processors:
       field: observer.product
       tag: set_observer_product
       value: Chrome
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/google_workspace/data_stream/data_studio/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/data_studio/elasticsearch/ingest_pipeline/default.yml
@@ -13,10 +13,10 @@ processors:
       field: observer.product
       tag: set_observer_product
       value: Data Studio
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/google_workspace/data_stream/keep/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/keep/elasticsearch/ingest_pipeline/default.yml
@@ -13,10 +13,10 @@ processors:
       field: observer.product
       tag: set_observer_product
       value: Keep
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/google_workspace/data_stream/meet/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/meet/elasticsearch/ingest_pipeline/default.yml
@@ -13,10 +13,10 @@ processors:
       field: observer.product
       tag: set_observer_product
       value: Meet
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/google_workspace/data_stream/vault/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/vault/elasticsearch/ingest_pipeline/default.yml
@@ -13,10 +13,10 @@ processors:
       field: observer.product
       tag: set_observer_product
       value: Vault
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,11 +1,11 @@
 name: google_workspace
 title: Google Workspace
-version: "2.41.2"
+version: "2.42.0"
 source:
   license: Elastic-2.0
 description: Collect logs from Google Workspace with Elastic Agent.
 type: integration
-format_version: "3.2.3"
+format_version: "3.4.0"
 categories:
   - security
   - productivity_security

--- a/packages/imperva_cloud_waf/changelog.yml
+++ b/packages/imperva_cloud_waf/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.12.2"
   changes:
     - description: Fix handling of API requests when the cursor state cannot be found in the log file index returned by Imperva.

--- a/packages/imperva_cloud_waf/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/imperva_cloud_waf/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - set:
       field: event.kind
       tag: set_event_kind_alert

--- a/packages/imperva_cloud_waf/manifest.yml
+++ b/packages/imperva_cloud_waf/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.0.3
+format_version: 3.4.0
 name: imperva_cloud_waf
 title: Imperva Cloud WAF
-version: "1.12.2"
+version: "1.13.0"
 description: Collect logs from Imperva Cloud WAF with Elastic Agent.
 type: integration
 categories:

--- a/packages/m365_defender/changelog.yml
+++ b/packages/m365_defender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.12.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.11.0"
   changes:
     - description: |

--- a/packages/m365_defender/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/m365_defender/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.17.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - drop:
       if: ctx.message == 'retry'
       tag: drop_retry_events

--- a/packages/m365_defender/manifest.yml
+++ b/packages/m365_defender/manifest.yml
@@ -1,7 +1,7 @@
-format_version: "3.3.2"
+format_version: "3.4.0"
 name: m365_defender
 title: Microsoft Defender XDR
-version: "3.11.0"
+version: "3.12.0"
 description: Collect logs from Microsoft Defender XDR with Elastic Agent.
 categories:
   - "security"

--- a/packages/microsoft_defender_endpoint/changelog.yml
+++ b/packages/microsoft_defender_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.40.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.39.0"
   changes:
     - description: Standardize user fields processing across integrations.

--- a/packages/microsoft_defender_endpoint/data_stream/machine/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_defender_endpoint/data_stream/machine/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/microsoft_defender_endpoint/data_stream/machine_action/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_defender_endpoint/data_stream/machine_action/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/microsoft_defender_endpoint/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_defender_endpoint/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.17.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - drop:
       if: ctx.message == 'retry'
       tag: drop_retry_events

--- a/packages/microsoft_defender_endpoint/manifest.yml
+++ b/packages/microsoft_defender_endpoint/manifest.yml
@@ -1,7 +1,7 @@
-format_version: "3.3.2"
+format_version: "3.4.0"
 name: microsoft_defender_endpoint
 title: Microsoft Defender for Endpoint
-version: "2.39.0"
+version: "2.40.0"
 description: Collect logs from Microsoft Defender for Endpoint with Elastic Agent.
 categories:
   - "security"

--- a/packages/microsoft_sentinel/changelog.yml
+++ b/packages/microsoft_sentinel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.1.1"
   changes:
     - description: Add temporary processor to remove the fields added by the Agentless policy.

--- a/packages/microsoft_sentinel/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_sentinel/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
@@ -12,10 +12,10 @@ processors:
         - oberver.vendor
       ignore_missing: true
       description: Fields defined as constant_keyword are removed from _source for storage efficiency.
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - drop:
       if: ctx.message == "retry"
       tag: drop_retry_events

--- a/packages/microsoft_sentinel/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_sentinel/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/microsoft_sentinel/manifest.yml
+++ b/packages/microsoft_sentinel/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.2.3
+format_version: 3.4.0
 name: microsoft_sentinel
 title: Microsoft Sentinel
-version: "1.1.1"
+version: "1.2.0"
 description: Collect logs from Microsoft Sentinel with Elastic Agent.
 type: integration
 categories:

--- a/packages/miniflux/changelog.yml
+++ b/packages/miniflux/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.2.1"
   changes:
     - description: Fix minor spelling mistakes.

--- a/packages/miniflux/data_stream/feed_entry/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/miniflux/data_stream/feed_entry/elasticsearch/ingest_pipeline/default.yml
@@ -6,10 +6,10 @@ processors:
         tag: set_ecs_version
         value: 8.17.0
     
-    - fail:
-        tag: cel_failure
+    - terminate:
+        tag: data_collection_error
         if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-        message: error message set and no data to process
+        description: error message set and no data to process.
     - set:
         field: event.kind
         tag: set_event_kind_1

--- a/packages/miniflux/manifest.yml
+++ b/packages/miniflux/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.5
 name: miniflux
 title: "Miniflux RSS reader"
-version: 0.2.1
+version: 0.3.0
 source:
   license: "Elastic-2.0"
 description: Collect RSS feed content from the Miniflux API with Elastic Agent.

--- a/packages/nozomi_networks/changelog.yml
+++ b/packages/nozomi_networks/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.1.0"
   changes:
     - description: Initial release.

--- a/packages/nozomi_networks/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
@@ -12,10 +12,10 @@ processors:
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/nozomi_networks/data_stream/asset/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/asset/elasticsearch/ingest_pipeline/default.yml
@@ -12,10 +12,10 @@ processors:
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/nozomi_networks/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.17.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/nozomi_networks/data_stream/health/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/health/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.17.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/nozomi_networks/data_stream/node/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/node/elasticsearch/ingest_pipeline/default.yml
@@ -12,10 +12,10 @@ processors:
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/nozomi_networks/data_stream/node_cve/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/node_cve/elasticsearch/ingest_pipeline/default.yml
@@ -12,10 +12,10 @@ processors:
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/nozomi_networks/data_stream/session/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/session/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.17.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/nozomi_networks/data_stream/variable/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/variable/elasticsearch/ingest_pipeline/default.yml
@@ -12,10 +12,10 @@ processors:
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/nozomi_networks/manifest.yml
+++ b/packages/nozomi_networks/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.3.2
+format_version: 3.4.0
 name: nozomi_networks
 title: Nozomi Networks
-version: 0.1.0
+version: 0.2.0
 description: Collect logs from Nozomi Networks with Elastic Agent.
 type: integration
 categories:

--- a/packages/panw_cortex_xdr/changelog.yml
+++ b/packages/panw_cortex_xdr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.3.1"
   changes:
     - description: Add temporary processor to remove the fields added by the Agentless policy.

--- a/packages/panw_cortex_xdr/data_stream/alerts/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/panw_cortex_xdr/data_stream/alerts/elasticsearch/ingest_pipeline/default.yml
@@ -4,10 +4,10 @@ processors:
   - set:
       field: ecs.version
       value: '8.11.0'
-  - fail:
-      tag: cel_failure
+  - terminate:
+      tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/panw_cortex_xdr/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/panw_cortex_xdr/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/panw_cortex_xdr/manifest.yml
+++ b/packages/panw_cortex_xdr/manifest.yml
@@ -1,9 +1,9 @@
 name: panw_cortex_xdr
 title: Palo Alto Cortex XDR
-version: "2.3.1"
+version: "2.4.0"
 description: Collect logs from Palo Alto Cortex XDR with Elastic Agent.
 type: integration
-format_version: "3.3.2"
+format_version: "3.4.0"
 categories:
   - security
   - edr_xdr

--- a/packages/proofpoint_itm/changelog.yml
+++ b/packages/proofpoint_itm/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.2.0"
   changes:
     - description: Remove duplicated installation instructions from the documentation

--- a/packages/proofpoint_itm/data_stream/report/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/proofpoint_itm/data_stream/report/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.17.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/proofpoint_itm/manifest.yml
+++ b/packages/proofpoint_itm/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.3.1
+format_version: 3.4.0
 name: proofpoint_itm
 title: Proofpoint ITM
-version: "0.2.0"
+version: "0.3.0"
 description: Collect logs from Proofpoint ITM using Elastic Agent.
 type: integration
 categories:

--- a/packages/qualys_vmdr/changelog.yml
+++ b/packages/qualys_vmdr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "6.8.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "6.7.3"
   changes:
     - description: Remove duplicated installation instructions from the documentation.

--- a/packages/qualys_vmdr/data_stream/asset_host_detection/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/qualys_vmdr/data_stream/asset_host_detection/elasticsearch/ingest_pipeline/default.yml
@@ -57,10 +57,10 @@ processors:
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - fail:
-      tag: cel_failure
+  - terminate:
+      tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process
+      description: error message set and no data to process.
   - set:
       field: event.kind
       tag: set_event_kind_1

--- a/packages/qualys_vmdr/data_stream/knowledge_base/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/qualys_vmdr/data_stream/knowledge_base/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
-      tag: cel_failure
+  - terminate:
+      tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/qualys_vmdr/data_stream/user_activity/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/qualys_vmdr/data_stream/user_activity/elasticsearch/ingest_pipeline/default.yml
@@ -4,10 +4,10 @@ processors:
   - set:
       field: ecs.version
       value: 8.11.0
-  - fail:
-      tag: cel_failure
+  - terminate:
+      tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/qualys_vmdr/manifest.yml
+++ b/packages/qualys_vmdr/manifest.yml
@@ -1,7 +1,7 @@
-format_version: "3.2.3"
+format_version: "3.4.0"
 name: qualys_vmdr
 title: Qualys VMDR
-version: "6.7.3"
+version: "6.8.0"
 description: Collect data from Qualys VMDR platform with Elastic Agent.
 type: integration
 categories:

--- a/packages/qualys_was/changelog.yml
+++ b/packages/qualys_was/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.2.0"
   changes:
     - description: |

--- a/packages/qualys_was/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/qualys_was/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -28,10 +28,10 @@ processors:
   - set:
       field: ecs.version
       value: '8.16.0'
-  - fail:
-      tag: cel_failure
+  - terminate:
+      tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process
+      description: error message set and no data to process.
   - set:
       field: event.kind
       tag: set_event_kind_1

--- a/packages/qualys_was/manifest.yml
+++ b/packages/qualys_was/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: qualys_was
 title: Qualys Web Application Scanning (WAS)
-version: "0.2.0"
+version: "0.3.0"
 description: Collect data from Qualys Web Application Scanning platform with Elastic Agent or Agentless
 type: integration
 categories:

--- a/packages/rapid7_insightvm/changelog.yml
+++ b/packages/rapid7_insightvm/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.1.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.0.0"
   changes:
     - description: |

--- a/packages/rapid7_insightvm/data_stream/asset_vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/rapid7_insightvm/data_stream/asset_vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/rapid7_insightvm/manifest.yml
+++ b/packages/rapid7_insightvm/manifest.yml
@@ -1,7 +1,7 @@
-format_version: "3.3.5"
+format_version: "3.4.0"
 name: rapid7_insightvm
 title: Rapid7 InsightVM
-version: "2.0.0"
+version: "2.1.0"
 source:
   license: "Elastic-2.0"
 description: Collect logs from Rapid7 InsightVM with Elastic Agent.

--- a/packages/servicenow/changelog.yml
+++ b/packages/servicenow/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.0.2"
   changes:
     - description: |

--- a/packages/servicenow/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/servicenow/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -8,10 +8,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.17.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - rename:
       field: message
       tag: rename_message_to_event_original

--- a/packages/servicenow/manifest.yml
+++ b/packages/servicenow/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.3.2
+format_version: 3.4.0
 name: servicenow
 title: "ServiceNow"
-version: "1.0.2"
+version: "1.1.0"
 description: "Collect logs from ServiceNow with Elastic Agent."
 type: integration
 categories:

--- a/packages/splunk/changelog.yml
+++ b/packages/splunk/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.4.0"
   changes:
     - description: Remove duplicated installation instructions from the documentation

--- a/packages/splunk/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/splunk/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
@@ -8,10 +8,10 @@ processors:
   - drop:
       description: Ignore want_more placeholder message.
       if: ctx.message == "want_more"
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/splunk/manifest.yml
+++ b/packages/splunk/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.3.2
+format_version: 3.4.0
 name: splunk
 title: Splunk
-version: "0.4.0"
+version: "0.5.0"
 source:
   license: "Elastic-2.0"
 description: Collect logs from Splunk with Elastic Agent.

--- a/packages/sublime_security/changelog.yml
+++ b/packages/sublime_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.10.0"
   changes:
     - description: Remove duplicated installation instructions from the documentation

--- a/packages/sublime_security/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sublime_security/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/sublime_security/data_stream/message_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sublime_security/data_stream/message_event/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/sublime_security/manifest.yml
+++ b/packages/sublime_security/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.2.3
+format_version: 3.4.0
 name: sublime_security
 title: Sublime Security
-version: "1.10.0"
+version: "1.11.0"
 description: Collect logs from Sublime Security with Elastic Agent.
 type: integration
 categories:

--- a/packages/symantec_endpoint_security/changelog.yml
+++ b/packages/symantec_endpoint_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.12.2"
   changes:
     - description: Remove duplicated installation instructions from the documentation.

--- a/packages/symantec_endpoint_security/data_stream/incident/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/symantec_endpoint_security/data_stream/incident/elasticsearch/ingest_pipeline/default.yml
@@ -5,15 +5,22 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
+  - terminate:
+      tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process
+      description: error message set and no data to process.
   - rename:
       field: message
       target_field: event.original
       tag: rename_message
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      tag: remove_message
+      ignore_missing: true
+      description: The `message` field is no longer required if the document has an `event.original` field.
+      if: ctx.event?.original != null
   - json:
       field: event.original
       tag: json_decoding

--- a/packages/symantec_endpoint_security/manifest.yml
+++ b/packages/symantec_endpoint_security/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.0.3
+format_version: 3.4.0
 name: symantec_endpoint_security
 title: Symantec Endpoint Security
-version: "1.12.2"
+version: "1.13.0"
 description: Collect logs from Symantec Endpoint Security with Elastic Agent.
 type: integration
 categories:

--- a/packages/tenable_io/changelog.yml
+++ b/packages/tenable_io/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.2.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "4.1.1"
   changes:
     - description: Remove duplicated installation instructions from the documentation

--- a/packages/tenable_io/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/tenable_io/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -4,10 +4,10 @@ processors:
   - set:
       field: ecs.version
       value: '8.11.0'
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/tenable_io/data_stream/plugin/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/tenable_io/data_stream/plugin/elasticsearch/ingest_pipeline/default.yml
@@ -37,10 +37,10 @@ processors:
   - json:
       field: event.original
       target_field: json
-  - fail:
-      tag: cel_failure
+  - terminate:
+      tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process
+      description: error message set and no data to process.
   - drop:
       if: ctx.json?.data?.plugin_details != null && ctx.json.data.plugin_details.isEmpty()
   - fingerprint:

--- a/packages/tenable_io/manifest.yml
+++ b/packages/tenable_io/manifest.yml
@@ -1,7 +1,7 @@
-format_version: "3.2.3"
+format_version: "3.4.0"
 name: tenable_io
 title: Tenable Vulnerability Management
-version: "4.1.1"
+version: "4.2.0"
 description: Collect logs from Tenable Vulnerability Management with Elastic Agent.
 type: integration
 categories:

--- a/packages/ti_google_threat_intelligence/changelog.yml
+++ b/packages/ti_google_threat_intelligence/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: 0.1.0
   changes:
     - description: Google Threat Intelligence integration package with "cryptominer", "first_stage_delivery_vectors", "infostealer" and "iot" data streams.

--- a/packages/ti_google_threat_intelligence/data_stream/cryptominer/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/cryptominer/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.17.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - drop:
       if: ctx.message == 'retry'
       tag: drop_retry_events

--- a/packages/ti_google_threat_intelligence/data_stream/first_stage_delivery_vectors/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/first_stage_delivery_vectors/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.17.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - drop:
       if: ctx.message == 'retry'
       tag: drop_retry_events

--- a/packages/ti_google_threat_intelligence/data_stream/infostealer/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/infostealer/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.17.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - drop:
       if: ctx.message == 'retry'
       tag: drop_retry_events

--- a/packages/ti_google_threat_intelligence/data_stream/iot/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/iot/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.17.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - drop:
       if: ctx.message == 'retry'
       tag: drop_retry_events

--- a/packages/ti_google_threat_intelligence/manifest.yml
+++ b/packages/ti_google_threat_intelligence/manifest.yml
@@ -1,9 +1,9 @@
-format_version: 3.3.1
+format_version: 3.4.0
 name: ti_google_threat_intelligence
 title: Google Threat Intelligence
 # This version must match the User-Agent version used in CEL code.
 # Remember to update the User-Agent in CEL code when changing this version.
-version: 0.1.0
+version: 0.2.0
 description: Collect Threat Intelligence Events from Google Threat Intelligence using Elastic Agent, and perform enrichment on Elasticsearch by correlating Indicators of Compromise (IOCs).
 type: integration
 categories:

--- a/packages/ti_greynoise/changelog.yml
+++ b/packages/ti_greynoise/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: 0.1.0
   changes:
     - description: GreyNoise integration package with "ip" data stream.

--- a/packages/ti_greynoise/data_stream/ip/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_greynoise/data_stream/ip/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.17.0
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - drop:
       if: ctx.message == 'retry'
       tag: drop_retry_events

--- a/packages/ti_greynoise/manifest.yml
+++ b/packages/ti_greynoise/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.3.1
+format_version: 3.4.0
 name: ti_greynoise
 title: GreyNoise
-version: 0.1.0
+version: 0.2.0
 description: Collect Threat Intelligence Indicators from GreyNoise using Elastic Agent, and perform enrichment on Elasticsearch by correlating Indicators of Compromise (IOCs).
 type: integration
 categories:

--- a/packages/ti_recordedfuture/changelog.yml
+++ b/packages/ti_recordedfuture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.1.0"
   changes:
     - description: Handle IP address entities that are CIDR blocks.

--- a/packages/ti_recordedfuture/data_stream/playbook_alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_recordedfuture/data_stream/playbook_alert/elasticsearch/ingest_pipeline/default.yml
@@ -9,10 +9,10 @@ processors:
       field: event.kind
       tag: set_alert_to_event_kind
       value: alert
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/ti_recordedfuture/data_stream/triggered_alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_recordedfuture/data_stream/triggered_alert/elasticsearch/ingest_pipeline/default.yml
@@ -9,10 +9,10 @@ processors:
       field: event.kind
       tag: set_alert_to_event_kind
       value: alert
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/ti_recordedfuture/manifest.yml
+++ b/packages/ti_recordedfuture/manifest.yml
@@ -1,9 +1,9 @@
 name: ti_recordedfuture
 title: Recorded Future
-version: "2.1.0"
+version: "2.2.0"
 description: Ingest threat intelligence and alert data from Recorded Future with Elastic Agent.
 type: integration
-format_version: 3.2.3
+format_version: 3.4.0
 categories: ["security", "threat_intel"]
 conditions:
   kibana:

--- a/packages/vectra_rux/changelog.yml
+++ b/packages/vectra_rux/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.2.0"
   changes:
     - description: Standardize user fields processing across integrations.

--- a/packages/vectra_rux/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/vectra_rux/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -12,10 +12,10 @@ processors:
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/vectra_rux/data_stream/health/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/vectra_rux/data_stream/health/elasticsearch/ingest_pipeline/default.yml
@@ -20,10 +20,10 @@ processors:
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
-  - fail:
+  - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/vectra_rux/manifest.yml
+++ b/packages/vectra_rux/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.3.2
+format_version: 3.4.0
 name: vectra_rux
 title: "Vectra RUX"
-version: 0.2.0
+version: 0.3.0
 description: "Collect logs from Vectra RUX with Elastic Agent."
 type: integration
 categories:

--- a/packages/wiz/changelog.yml
+++ b/packages/wiz/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.5.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.4.0"
   changes:
     - description: Add maximum executions configuration option for API-based data streams.

--- a/packages/wiz/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/wiz/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: '8.11.0'
-  - fail:
-      tag: cel_failure
+  - terminate:
+      tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/wiz/data_stream/issue/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/wiz/data_stream/issue/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: '8.11.0'
-  - fail:
-      tag: cel_failure
+  - terminate:
+      tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/wiz/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/wiz/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -5,10 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
-      tag: cel_failure
+  - terminate:
+      tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/wiz/manifest.yml
+++ b/packages/wiz/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.2.3
+format_version: 3.4.0
 name: wiz
 title: Wiz
-version: "3.4.0"
+version: "3.5.0"
 description: Collect logs from Wiz with Elastic Agent.
 type: integration
 categories:

--- a/packages/zscaler_zia/changelog.yml
+++ b/packages/zscaler_zia/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.14.0"
+  changes:
+    - description: Use `terminate` processor instead of `fail`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.13.0"
   changes:
     - description: Remove duplicated installation instructions from the documentation

--- a/packages/zscaler_zia/data_stream/sandbox_report/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zscaler_zia/data_stream/sandbox_report/elasticsearch/ingest_pipeline/default.yml
@@ -5,9 +5,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.11.0
-  - fail:
+  - terminate:
+      tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-      message: error message set and no data to process.
+      description: error message set and no data to process.
   - remove:
       field:
         - organization

--- a/packages/zscaler_zia/manifest.yml
+++ b/packages/zscaler_zia/manifest.yml
@@ -1,10 +1,10 @@
-format_version: "3.2.3"
+format_version: "3.4.0"
 name: zscaler_zia
 title: Zscaler Internet Access
 # When updating version, make sure the pkg_version parameter in
 # the check_template_version script in ingest pipelines is
 # updated to match.
-version: "3.13.0"
+version: "3.14.0"
 description: Collect logs from Zscaler Internet Access (ZIA) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
SSI Integration: Use terminate processor instead of fail

This will utilize the `terminate` processor instead of the `fail` processor, as the `fail` processor
introduces an unwanted side effect by creating an additional `error.message` value.
Upgrade the `format_version` to latest 8.4.0
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## Related issues

- Closes #14382 
- Relates #12083 