### PR TITLE
[azure_blob_storage, azure_network_watcher_nsg, azure_network_watcher_vnet, symantec_enpoint_security] Add RBAC Based Auth for Azure Blob Storage Input

### DIFF
--- a/packages/azure_blob_storage/agent/input/abs.yml.hbs
+++ b/packages/azure_blob_storage/agent/input/abs.yml.hbs
@@ -6,6 +6,12 @@ pipeline: {{pipeline}}
 {{#if account_name}}
 account_name: {{account_name}}
 {{/if}}
+{{#if oauth2}}
+auth.oauth2:
+  client_id: {{client_id}}
+  client_secret: {{client_secret}}
+  tenant_id: {{tenant_id}}
+{{/if}}
 {{#if service_account_key}}
 auth.shared_credentials.account_key: {{service_account_key}}
 {{/if}}

--- a/packages/azure_blob_storage/changelog.yml
+++ b/packages/azure_blob_storage/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "2.3.0"
+  changes:
+    - description: Add RBAC based authentication for azure blob storage input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
+    - description: Update the Kibana Version to 8.16.0 to support RABC based authentication for azure blob storage input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.2.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/azure_blob_storage/changelog.yml
+++ b/packages/azure_blob_storage/changelog.yml
@@ -3,10 +3,10 @@
   changes:
     - description: Add RBAC based authentication for azure blob storage input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/14396
     - description: Update the Kibana Version to 8.16.0 to support RABC based authentication for azure blob storage input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/14396
 - version: "2.2.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/azure_blob_storage/manifest.yml
+++ b/packages/azure_blob_storage/manifest.yml
@@ -3,10 +3,10 @@ name: azure_blob_storage
 title: Custom Azure Blob Storage Input
 description: Collect log data from configured Azure Blob Storage Container with Elastic Agent.
 type: input
-version: "2.2.0"
+version: "2.3.0"
 conditions:
   kibana:
-    version: "^8.13.0 || ^9.0.0"
+    version: "^8.16.0 || ^9.0.0"
 categories:
   - azure
   - observability
@@ -20,12 +20,41 @@ policy_templates:
     template_path: abs.yml.hbs
     description: Collect log data from configured Azure Blob Storage Container with Elastic Agent.
     vars:
+      - name: oauth2
+        required: true
+        show_user: true
+        title: Collect logs using OAuth2 authentication
+        description: To collect logs using OAuth2 authentication enable the toggle switch. By default, it will collect logs using service account key or URI.
+        type: bool
+        multi: false
+        default: false
       - name: account_name
         type: text
         title: Account Name
         description: |
           This attribute is required for various internal operations with respect to authentication, creating service clients and blob clients which are used internally for various processing purposes.
         required: true
+        show_user: true
+      - name: client_id
+        type: text
+        title: Client ID (OAuth2)
+        description: Client ID of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.
+        required: false
+        show_user: true
+        secret: true
+      - name: client_secret
+        type: password
+        title: Client Secret (OAuth2)
+        description: Client Secret of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.
+        required: false
+        show_user: true
+        secret: true
+      - name: tenant_id
+        type: text
+        title: Tenant ID (OAuth2)
+        description: Tenant ID of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.
+        multi: false
+        required: false
         show_user: true
       - name: service_account_key
         type: password

--- a/packages/azure_network_watcher_nsg/_dev/build/docs/README.md
+++ b/packages/azure_network_watcher_nsg/_dev/build/docs/README.md
@@ -21,15 +21,15 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
 3. Click on **Show** keys to show your **access keys** and **connection strings** and to enable buttons to copy the values.
 4. Under key1, find the Key value. Click on the Copy button to copy the **account key**. Same way you can copy the **storage account name** shown above keys.
 5. Go to **Containers** under **Data storage** in your storage account to copy the **container name**.
-6. Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options.For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
+6. Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options. For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
 
-- How to setup the `auth.oauth2` credentials can be found in the Azure documentation https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app[here]
-- For more details about the Azure Blob Storage input settings, check the  [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).
+- How to setup the `auth.oauth2` credentials can be found in the Azure documentation [here](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app).
+- For more details about the Azure Blob Storage input settings, check the [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).
 
 Note:
 - Enable virtual network flow logs using the steps provided in [reference](https://learn.microsoft.com/en-us/azure/network-watcher/nsg-flow-logs-portal).
 - The service principal must be granted the appropriate permissions to read blobs. Ensure that the necessary role assignments are in place for the service principal to access the storage resources. For more information, please refer to the [Azure Role-Based Access Control (RBAC) documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage).
-- We recommend assigning either the Storage Blob Data Reader or BlobOwner role. The Storage Blob Data Reader role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The Storage Blob Data Owner role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
+- We recommend assigning either the **Storage Blob Data Reader** or **Storage Blob Data Owner** role. The **Storage Blob Data Reader** role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The **Storage Blob Data Owner** role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
 
 ### Enabling the integration in Elastic:
 

--- a/packages/azure_network_watcher_nsg/_dev/build/docs/README.md
+++ b/packages/azure_network_watcher_nsg/_dev/build/docs/README.md
@@ -21,8 +21,15 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
 3. Click on **Show** keys to show your **access keys** and **connection strings** and to enable buttons to copy the values.
 4. Under key1, find the Key value. Click on the Copy button to copy the **account key**. Same way you can copy the **storage account name** shown above keys.
 5. Go to **Containers** under **Data storage** in your storage account to copy the **container name**.
+6. Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options.For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
 
-**Note**:  Enable virtual network flow logs using the steps provided in [reference](https://learn.microsoft.com/en-us/azure/network-watcher/nsg-flow-logs-portal).
+- How to setup the `auth.oauth2` credentials can be found in the Azure documentation https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app[here]
+- For more details about the Azure Blob Storage input settings, check the  [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).
+
+Note:
+- Enable virtual network flow logs using the steps provided in [reference](https://learn.microsoft.com/en-us/azure/network-watcher/nsg-flow-logs-portal).
+- The service principal must be granted the appropriate permissions to read blobs. Ensure that the necessary role assignments are in place for the service principal to access the storage resources. For more information, please refer to the [Azure Role-Based Access Control (RBAC) documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage).
+- We recommend assigning either the Storage Blob Data Reader or BlobOwner role. The Storage Blob Data Reader role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The Storage Blob Data Owner role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
 
 ### Enabling the integration in Elastic:
 

--- a/packages/azure_network_watcher_nsg/_dev/build/docs/README.md
+++ b/packages/azure_network_watcher_nsg/_dev/build/docs/README.md
@@ -31,9 +31,18 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
 3. Select the "Azure Network Watcher NSG" integration from the search results.
 4. Select "Add Azure Network Watcher NSG" to add the integration.
 5. While adding the integration, to collect logs via Azure Blob Storage, keep **Collect NSG logs via Azure Blob Storage** toggle on and then configure following parameters:
-   - account name
-   - containers
-   - service account key/service account uri
+   For OAuth2 (Microsoft Entra ID RBAC):
+   - Toggle on **Collect logs using OAuth2 authentication**
+   - Account Name
+   - Client ID
+   - Client Secret
+   - Tenant ID
+   - Container Details.
+
+   For Service Account Credentials:
+   - Service Account Key or the URI
+   - Account Name
+   - Container Details
 6. Save the integration.
 
 ## Logs Reference

--- a/packages/azure_network_watcher_nsg/changelog.yml
+++ b/packages/azure_network_watcher_nsg/changelog.yml
@@ -3,10 +3,10 @@
   changes:
     - description: Add RBAC based authentication for azure blob storage input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/14396
     - description: Update the Kibana Version to 8.16.0 to support RABC based authentication for azure blob storage input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/14396
 - version: "1.4.0"
   changes:
     - description: Remove redundant installation instructions.

--- a/packages/azure_network_watcher_nsg/changelog.yml
+++ b/packages/azure_network_watcher_nsg/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Add RBAC based authentication for azure blob storage input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
+    - description: Update the Kibana Version to 8.16.0 to support RABC based authentication for azure blob storage input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.4.0"
   changes:
     - description: Remove redundant installation instructions.

--- a/packages/azure_network_watcher_nsg/data_stream/log/agent/stream/abs.yml.hbs
+++ b/packages/azure_network_watcher_nsg/data_stream/log/agent/stream/abs.yml.hbs
@@ -1,6 +1,12 @@
 {{#if account_name}}
 account_name: {{account_name}}
 {{/if}}
+{{#if oauth2}}
+auth.oauth2:
+  client_id: {{client_id}}
+  client_secret: {{client_secret}}
+  tenant_id: {{tenant_id}}
+{{/if}}
 {{#if service_account_key}}
 auth.shared_credentials.account_key: {{service_account_key}}
 {{/if}}

--- a/packages/azure_network_watcher_nsg/data_stream/log/manifest.yml
+++ b/packages/azure_network_watcher_nsg/data_stream/log/manifest.yml
@@ -13,6 +13,27 @@ streams:
           This attribute is required for various internal operations with respect to authentication, creating service clients and blob clients which are used internally for various processing purposes.
         required: true
         show_user: true
+      - name: client_id
+        type: text
+        title: Client ID (OAuth2)
+        description: Client ID of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.
+        required: false
+        show_user: true
+        secret: true
+      - name: client_secret
+        type: password
+        title: Client Secret (OAuth2)
+        description: Client Secret of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.
+        required: false
+        show_user: true
+        secret: true
+      - name: tenant_id
+        type: text
+        title: Tenant ID (OAuth2)
+        description: Tenant ID of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.
+        multi: false
+        required: false
+        show_user: true
       - name: service_account_key
         type: password
         title: Service Account Key

--- a/packages/azure_network_watcher_nsg/docs/README.md
+++ b/packages/azure_network_watcher_nsg/docs/README.md
@@ -21,15 +21,15 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
 3. Click on **Show** keys to show your **access keys** and **connection strings** and to enable buttons to copy the values.
 4. Under key1, find the Key value. Click on the Copy button to copy the **account key**. Same way you can copy the **storage account name** shown above keys.
 5. Go to **Containers** under **Data storage** in your storage account to copy the **container name**.
-6. Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options.For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
+6. Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options. For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
 
-- How to setup the `auth.oauth2` credentials can be found in the Azure documentation https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app[here]
-- For more details about the Azure Blob Storage input settings, check the  [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).
+- How to setup the `auth.oauth2` credentials can be found in the Azure documentation [here](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app).
+- For more details about the Azure Blob Storage input settings, check the [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).
 
 Note:
 - Enable virtual network flow logs using the steps provided in [reference](https://learn.microsoft.com/en-us/azure/network-watcher/nsg-flow-logs-portal).
 - The service principal must be granted the appropriate permissions to read blobs. Ensure that the necessary role assignments are in place for the service principal to access the storage resources. For more information, please refer to the [Azure Role-Based Access Control (RBAC) documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage).
-- We recommend assigning either the Storage Blob Data Reader or BlobOwner role. The Storage Blob Data Reader role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The Storage Blob Data Owner role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
+- We recommend assigning either the **Storage Blob Data Reader** or **Storage Blob Data Owner** role. The **Storage Blob Data Reader** role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The **Storage Blob Data Owner** role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
 
 ### Enabling the integration in Elastic:
 

--- a/packages/azure_network_watcher_nsg/docs/README.md
+++ b/packages/azure_network_watcher_nsg/docs/README.md
@@ -21,8 +21,15 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
 3. Click on **Show** keys to show your **access keys** and **connection strings** and to enable buttons to copy the values.
 4. Under key1, find the Key value. Click on the Copy button to copy the **account key**. Same way you can copy the **storage account name** shown above keys.
 5. Go to **Containers** under **Data storage** in your storage account to copy the **container name**.
+6. Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options.For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
 
-**Note**:  Enable virtual network flow logs using the steps provided in [reference](https://learn.microsoft.com/en-us/azure/network-watcher/nsg-flow-logs-portal).
+- How to setup the `auth.oauth2` credentials can be found in the Azure documentation https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app[here]
+- For more details about the Azure Blob Storage input settings, check the  [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).
+
+Note:
+- Enable virtual network flow logs using the steps provided in [reference](https://learn.microsoft.com/en-us/azure/network-watcher/nsg-flow-logs-portal).
+- The service principal must be granted the appropriate permissions to read blobs. Ensure that the necessary role assignments are in place for the service principal to access the storage resources. For more information, please refer to the [Azure Role-Based Access Control (RBAC) documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage).
+- We recommend assigning either the Storage Blob Data Reader or BlobOwner role. The Storage Blob Data Reader role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The Storage Blob Data Owner role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
 
 ### Enabling the integration in Elastic:
 

--- a/packages/azure_network_watcher_nsg/docs/README.md
+++ b/packages/azure_network_watcher_nsg/docs/README.md
@@ -31,9 +31,18 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
 3. Select the "Azure Network Watcher NSG" integration from the search results.
 4. Select "Add Azure Network Watcher NSG" to add the integration.
 5. While adding the integration, to collect logs via Azure Blob Storage, keep **Collect NSG logs via Azure Blob Storage** toggle on and then configure following parameters:
-   - account name
-   - containers
-   - service account key/service account uri
+   For OAuth2 (Microsoft Entra ID RBAC):
+   - Toggle on **Collect logs using OAuth2 authentication**
+   - Account Name
+   - Client ID
+   - Client Secret
+   - Tenant ID
+   - Container Details.
+
+   For Service Account Credentials:
+   - Service Account Key or the URI
+   - Account Name
+   - Container Details
 6. Save the integration.
 
 ## Logs Reference

--- a/packages/azure_network_watcher_nsg/manifest.yml
+++ b/packages/azure_network_watcher_nsg/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: azure_network_watcher_nsg
 title: Azure Network Watcher NSG
-version: "1.4.0"
+version: "1.5.0"
 description: Collect logs from Azure Network Watcher NSG with Elastic Agent.
 type: integration
 categories:
@@ -10,7 +10,7 @@ categories:
   - security
 conditions:
   kibana:
-    version: "^8.13.0 || ^9.0.0"
+    version: "^8.16.0 || ^9.0.0"
   elastic:
     subscription: basic
 screenshots:
@@ -31,6 +31,15 @@ policy_templates:
       - type: azure-blob-storage
         title: Collect Azure Network Watcher NSG logs via Azure Blob Storage Input
         description: Collecting Azure Network Watcher NSG logs via Azure Blob Storage Input.
+        vars:
+          - name: oauth2
+            required: true
+            show_user: true
+            title: Collect logs using OAuth2 authentication
+            description: To collect logs using OAuth2 authentication enable the toggle switch. By default, it will collect logs using service account key or URI.
+            type: bool
+            multi: false
+            default: false
 owner:
   github: elastic/security-service-integrations
   type: elastic

--- a/packages/azure_network_watcher_vnet/_dev/build/docs/README.md
+++ b/packages/azure_network_watcher_vnet/_dev/build/docs/README.md
@@ -21,15 +21,15 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
 3. Click **Show keys** to show your **access keys** and **connection strings** to enable buttons to copy the values.
 4. Under **key1**, find the key value. Click **Copy** to copy the **account key**. In the same way, copy the storage account name shown above the keys.
 5. In your storage account, go to **Data storage** > **Containers** to copy the container name.
-6. Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options.For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
+6. Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options. For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
 
-- How to setup the `auth.oauth2` credentials can be found in the Azure documentation https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app[here]
-- For more details about the Azure Blob Storage input settings, check the  [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).
+- How to setup the `auth.oauth2` credentials can be found in the Azure documentation [here](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app).
+- For more details about the Azure Blob Storage input settings, check the [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).
 
 Note:
 - Follow [these steps](https://learn.microsoft.com/en-us/azure/network-watcher/vnet-flow-logs-portal) to enable virtual network flow logs.
 - The service principal must be granted the appropriate permissions to read blobs. Ensure that the necessary role assignments are in place for the service principal to access the storage resources. For more information, please refer to the [Azure Role-Based Access Control (RBAC) documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage).
-- We recommend assigning either the Storage Blob Data Reader or BlobOwner role. The Storage Blob Data Reader role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The Storage Blob Data Owner role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
+- We recommend assigning either the **Storage Blob Data Reader** or **Storage Blob Data Owner** role. The **Storage Blob Data Reader** role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The **Storage Blob Data Owner** role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
 
 ### Enable the integration in Elastic
 

--- a/packages/azure_network_watcher_vnet/_dev/build/docs/README.md
+++ b/packages/azure_network_watcher_vnet/_dev/build/docs/README.md
@@ -30,9 +30,18 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
 2. In the search top bar, type **Azure Network Watcher VNet**.
 3. Select the **Azure Network Watcher VNet** integration and add it.
 5. To collect logs via Azure Blob Storage, select **Collect VNet logs via Azure Blob Storage** and configure the following parameters:
-   - account name
-   - containers
-   - service account key/service account uri
+   For OAuth2 (Microsoft Entra ID RBAC):
+   - Toggle on **Collect logs using OAuth2 authentication**
+   - Account Name
+   - Client ID
+   - Client Secret
+   - Tenant ID
+   - Container Details.
+
+   For Service Account Credentials:
+   - Service Account Key or the URI
+   - Account Name
+   - Container Details
 6. Save the integration.
 
 ## Limitations

--- a/packages/azure_network_watcher_vnet/_dev/build/docs/README.md
+++ b/packages/azure_network_watcher_vnet/_dev/build/docs/README.md
@@ -21,8 +21,15 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
 3. Click **Show keys** to show your **access keys** and **connection strings** to enable buttons to copy the values.
 4. Under **key1**, find the key value. Click **Copy** to copy the **account key**. In the same way, copy the storage account name shown above the keys.
 5. In your storage account, go to **Data storage** > **Containers** to copy the container name.
+6. Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options.For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
 
-**Note**: Follow [these steps](https://learn.microsoft.com/en-us/azure/network-watcher/vnet-flow-logs-portal) to enable virtual network flow logs.
+- How to setup the `auth.oauth2` credentials can be found in the Azure documentation https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app[here]
+- For more details about the Azure Blob Storage input settings, check the  [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).
+
+Note:
+- Follow [these steps](https://learn.microsoft.com/en-us/azure/network-watcher/vnet-flow-logs-portal) to enable virtual network flow logs.
+- The service principal must be granted the appropriate permissions to read blobs. Ensure that the necessary role assignments are in place for the service principal to access the storage resources. For more information, please refer to the [Azure Role-Based Access Control (RBAC) documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage).
+- We recommend assigning either the Storage Blob Data Reader or BlobOwner role. The Storage Blob Data Reader role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The Storage Blob Data Owner role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
 
 ### Enable the integration in Elastic
 

--- a/packages/azure_network_watcher_vnet/changelog.yml
+++ b/packages/azure_network_watcher_vnet/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "1.6.0"
+  changes:
+    - description: Add RBAC based authentication for azure blob storage input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
+    - description: Update the Kibana Version to 8.16.0 to support RABC based authentication for azure blob storage input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.5.0"
   changes:
     - description: Remove redundant installation instructions.

--- a/packages/azure_network_watcher_vnet/changelog.yml
+++ b/packages/azure_network_watcher_vnet/changelog.yml
@@ -3,10 +3,10 @@
   changes:
     - description: Add RBAC based authentication for azure blob storage input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/14396
     - description: Update the Kibana Version to 8.16.0 to support RABC based authentication for azure blob storage input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/14396
 - version: "1.5.0"
   changes:
     - description: Remove redundant installation instructions.

--- a/packages/azure_network_watcher_vnet/data_stream/log/agent/stream/abs.yml.hbs
+++ b/packages/azure_network_watcher_vnet/data_stream/log/agent/stream/abs.yml.hbs
@@ -1,6 +1,12 @@
 {{#if account_name}}
 account_name: {{account_name}}
 {{/if}}
+{{#if oauth2}}
+auth.oauth2:
+  client_id: {{client_id}}
+  client_secret: {{client_secret}}
+  tenant_id: {{tenant_id}}
+{{/if}}
 {{#if service_account_key}}
 auth.shared_credentials.account_key: {{service_account_key}}
 {{/if}}

--- a/packages/azure_network_watcher_vnet/data_stream/log/manifest.yml
+++ b/packages/azure_network_watcher_vnet/data_stream/log/manifest.yml
@@ -13,6 +13,27 @@ streams:
           This attribute is required for various internal operations with respect to authentication, creating service clients and blob clients which are used internally for various processing purposes.
         required: true
         show_user: true
+      - name: client_id
+        type: text
+        title: Client ID (OAuth2)
+        description: Client ID of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.
+        required: false
+        show_user: true
+        secret: true
+      - name: client_secret
+        type: password
+        title: Client Secret (OAuth2)
+        description: Client Secret of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.
+        required: false
+        show_user: true
+        secret: true
+      - name: tenant_id
+        type: text
+        title: Tenant ID (OAuth2)
+        description: Tenant ID of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.
+        multi: false
+        required: false
+        show_user: true
       - name: service_account_key
         type: password
         title: Service Account Key

--- a/packages/azure_network_watcher_vnet/docs/README.md
+++ b/packages/azure_network_watcher_vnet/docs/README.md
@@ -21,15 +21,15 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
 3. Click **Show keys** to show your **access keys** and **connection strings** to enable buttons to copy the values.
 4. Under **key1**, find the key value. Click **Copy** to copy the **account key**. In the same way, copy the storage account name shown above the keys.
 5. In your storage account, go to **Data storage** > **Containers** to copy the container name.
-6. Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options.For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
+6. Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options. For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
 
-- How to setup the `auth.oauth2` credentials can be found in the Azure documentation https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app[here]
-- For more details about the Azure Blob Storage input settings, check the  [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).
+- How to setup the `auth.oauth2` credentials can be found in the Azure documentation [here](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app).
+- For more details about the Azure Blob Storage input settings, check the [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).
 
 Note:
 - Follow [these steps](https://learn.microsoft.com/en-us/azure/network-watcher/vnet-flow-logs-portal) to enable virtual network flow logs.
 - The service principal must be granted the appropriate permissions to read blobs. Ensure that the necessary role assignments are in place for the service principal to access the storage resources. For more information, please refer to the [Azure Role-Based Access Control (RBAC) documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage).
-- We recommend assigning either the Storage Blob Data Reader or BlobOwner role. The Storage Blob Data Reader role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The Storage Blob Data Owner role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
+- We recommend assigning either the **Storage Blob Data Reader** or **Storage Blob Data Owner** role. The **Storage Blob Data Reader** role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The **Storage Blob Data Owner** role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
 
 ### Enable the integration in Elastic
 

--- a/packages/azure_network_watcher_vnet/docs/README.md
+++ b/packages/azure_network_watcher_vnet/docs/README.md
@@ -30,9 +30,18 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
 2. In the search top bar, type **Azure Network Watcher VNet**.
 3. Select the **Azure Network Watcher VNet** integration and add it.
 5. To collect logs via Azure Blob Storage, select **Collect VNet logs via Azure Blob Storage** and configure the following parameters:
-   - account name
-   - containers
-   - service account key/service account uri
+   For OAuth2 (Microsoft Entra ID RBAC):
+   - Toggle on **Collect logs using OAuth2 authentication**
+   - Account Name
+   - Client ID
+   - Client Secret
+   - Tenant ID
+   - Container Details.
+
+   For Service Account Credentials:
+   - Service Account Key or the URI
+   - Account Name
+   - Container Details
 6. Save the integration.
 
 ## Limitations

--- a/packages/azure_network_watcher_vnet/docs/README.md
+++ b/packages/azure_network_watcher_vnet/docs/README.md
@@ -21,8 +21,15 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
 3. Click **Show keys** to show your **access keys** and **connection strings** to enable buttons to copy the values.
 4. Under **key1**, find the key value. Click **Copy** to copy the **account key**. In the same way, copy the storage account name shown above the keys.
 5. In your storage account, go to **Data storage** > **Containers** to copy the container name.
+6. Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options.For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
 
-**Note**: Follow [these steps](https://learn.microsoft.com/en-us/azure/network-watcher/vnet-flow-logs-portal) to enable virtual network flow logs.
+- How to setup the `auth.oauth2` credentials can be found in the Azure documentation https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app[here]
+- For more details about the Azure Blob Storage input settings, check the  [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).
+
+Note:
+- Follow [these steps](https://learn.microsoft.com/en-us/azure/network-watcher/vnet-flow-logs-portal) to enable virtual network flow logs.
+- The service principal must be granted the appropriate permissions to read blobs. Ensure that the necessary role assignments are in place for the service principal to access the storage resources. For more information, please refer to the [Azure Role-Based Access Control (RBAC) documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage).
+- We recommend assigning either the Storage Blob Data Reader or BlobOwner role. The Storage Blob Data Reader role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The Storage Blob Data Owner role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
 
 ### Enable the integration in Elastic
 

--- a/packages/azure_network_watcher_vnet/manifest.yml
+++ b/packages/azure_network_watcher_vnet/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: azure_network_watcher_vnet
 title: Azure Network Watcher VNet
-version: "1.5.0"
+version: "1.6.0"
 description: Collect logs from Azure Network Watcher VNet with Elastic Agent.
 type: integration
 categories:
@@ -10,7 +10,7 @@ categories:
   - security
 conditions:
   kibana:
-    version: "^8.13.0 || ^9.0.0"
+    version: "^8.16.0 || ^9.0.0"
   elastic:
     subscription: basic
 screenshots:
@@ -31,6 +31,15 @@ policy_templates:
       - type: azure-blob-storage
         title: Collect Azure Network Watcher VNet logs via Azure Blob Storage Input
         description: Collecting Azure Network Watcher VNet logs via Azure Blob Storage Input.
+        vars:
+          - name: oauth2
+            required: true
+            show_user: true
+            title: Collect logs using OAuth2 authentication
+            description: To collect logs using OAuth2 authentication enable the toggle switch. By default, it will collect logs using service account key or URI.
+            type: bool
+            multi: false
+            default: false
 owner:
   github: elastic/security-service-integrations
   type: elastic

--- a/packages/symantec_endpoint_security/_dev/build/docs/README.md
+++ b/packages/symantec_endpoint_security/_dev/build/docs/README.md
@@ -93,14 +93,14 @@ Considering you already have an AWS S3 bucket setup, to configure it with Symant
 
 1. If you already have an Azure storage container setup, configure it with Symantec Endpoint Security.
 2. Enable the Symantec Endpoint Streaming by following [these instructions](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html).
-3. Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options.For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
+3. Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options. For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
 
-- How to setup the `auth.oauth2` credentials can be found in the Azure documentation https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app[here]
-- For more details about the Azure Blob Storage input settings, check the  [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).
+- How to setup the `auth.oauth2` credentials can be found in the Azure documentation [here]( https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app).
+- For more details about the Azure Blob Storage input settings, check the [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).
 
 Note:
 - The service principal must be granted the appropriate permissions to read blobs. Ensure that the necessary role assignments are in place for the service principal to access the storage resources. For more information, please refer to the [Azure Role-Based Access Control (RBAC) documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage).
-- We recommend assigning either the Storage Blob Data Reader or BlobOwner role. The Storage Blob Data Reader role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The Storage Blob Data Owner role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
+- We recommend assigning either the **Storage Blob Data Reader** or **Storage Blob Data Owner** role. The **Storage Blob Data Reader** role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The **Storage Blob Data Owner** role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
 
 ### Collect data from a GCS bucket
 

--- a/packages/symantec_endpoint_security/_dev/build/docs/README.md
+++ b/packages/symantec_endpoint_security/_dev/build/docs/README.md
@@ -191,7 +191,7 @@ For more details about the AWS-S3 input settings, check this [documentation](htt
    - URL
    - Token URL
 
-   or if you want to collect logs via Azure Blob    Storage, you'll need to provide the following    details:
+   or if you want to collect logs via Azure Blob Storage, you'll need to provide the following details:
    For OAuth2 (Microsoft Entra ID RBAC):
    - Account Name
    - Client ID

--- a/packages/symantec_endpoint_security/_dev/build/docs/README.md
+++ b/packages/symantec_endpoint_security/_dev/build/docs/README.md
@@ -4,10 +4,6 @@ Symantec Endpoint Security (SES), is fully cloud-managed version of the on-premi
 
 This SES Integration enables user to stream Events and EDR incidents data to Elastic, via Data Storage(AWS S3, AWS SQS or GCS) and API endpoint respectively.
 
-## Compatibility
-
-This module has been tested against **Symantec Integrated Cyber Defense Exchange 1.4.7** for events, and **Symantec Endpoint Security API Version v1** for EDR Incidents. 
-
 ## Data streams
 
 The Symantec Endpoint Security integration collects logs via Amazon S3 and SQS, and Google GCP for different events that The Integrated Cyber Defense Schema organizes into following categories:
@@ -81,41 +77,65 @@ The Symantec Endpoint Security integration can also retrieve **EDR incidents** v
 
 ## Requirements
 
-Elastic Agent must be installed. For more details, check the Elastic Agent [installation instructions](docs-content://reference/fleet/install-elastic-agents.md).  
+Elastic Agent must be installed. For more details and installation instructions, please refer to the [Elastic Agent Installation Guide](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
+
+### Installing and managing an Elastic Agent:
+
+There are several options for installing and managing Elastic Agent:
+
+### Install a Fleet-managed Elastic Agent (recommended):
+
+With this approach, you install Elastic Agent and use Fleet in Kibana to define, configure, and manage your agents in a central location. We recommend using Fleet management because it makes the management and upgrade of your agents considerably easier.
+
+### Install Elastic Agent in standalone mode (advanced users):
+
+With this approach, you install Elastic Agent and manually configure the agent locally on the system where it’s installed. You are responsible for managing and upgrading the agents. This approach is reserved for advanced users only.
+
+### Install Elastic Agent in a containerized environment:
+
+You can run Elastic Agent inside a container, either with Fleet Server or standalone. Docker images for all versions of Elastic Agent are available from the Elastic Docker registry, and we provide deployment manifests for running on Kubernetes.
+
+Please note, there are minimum requirements for running Elastic Agent. For more information, refer to the  [Elastic Agent Minimum Requirements](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html#elastic-agent-installation-minimum-requirements).
+
+This module has been tested against **Symantec Integrated Cyber Defense Exchange 1.4.7** for events, and **Symantec Endpoint Security API Version v1** for EDR Incidents.   
 
 ## Setup
 
-### Collect data from an AWS S3 bucket
+### To collect data from an AWS S3 bucket, follow the below steps:
 
-Considering you already have an AWS S3 bucket setup, to configure it with Symantec Endpoint Security, follow [these steps](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html) to enable the Symantec Endpoint Streaming.
+- Considering you already have an AWS S3 bucket setup, to configure it with Symantec Endpoint Security, follow the steps mentioned [here](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html) to enable the Symantec Endpoint Streaming.
 
-### Collect data from Azure Blob Storage
+### To collect data from Azure Blob Storage, follow the below steps:
 
-1. If you already have an Azure storage container setup, configure it with Symantec Endpoint Security.
-2. Enable the Symantec Endpoint Streaming by following [these instructions](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html).
-3. Configure the integration with your Azure Storage account name, Container name and Service Account Key/Service Account URI.
+- Considering you already have an Azure storage container setup, configure it with Symantec Endpoint Security.
+- Enable the Symantec Endpoint Streaming as mentioned [here](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html).
+- Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options.For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
+- How to setup the `auth.oauth2` credentials can be found in the Azure documentation https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app[here]
 
-For more details about the Azure Blob Storage input settings, check the  [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).
+Note:
+- The service principal must be granted the appropriate permissions to read blobs. Ensure that the necessary role assignments are in place for the service principal to access the storage resources. For more information, please refer to the [Azure Role-Based Access Control (RBAC) documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage).
+- We recommend assigning either the Storage Blob Data Reader or BlobOwner role. The Storage Blob Data Reader role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The Storage Blob Data Owner role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
 
-### Collect data from a GCS bucket
+**For more details about the Azure Blob Storage input settings please see the documentation [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).**
 
-1. If you already have a GCS bucket setup, configure it with Symantec Endpoint Security.
-2. Enable the Symantec Endpoint Streaming by following [these instructions](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html).
-3. Configure the integration with your GCS project ID, Bucket name and Service Account Key/Service Account Credentials File.
+### To collect data from a GCS bucket, follow the below steps:
 
-For more details about the GCS input settings, check the [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-gcs.html).
+- Considering you already have a GCS bucket setup, configure it with Symantec Endpoint Security.
+- Enable the Symantec Endpoint Streaming as mentioned [here](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html).
+- Configure the integration with your GCS project ID, Bucket name and Service Account Key/Service Account Credentials File.
+
+**For more details about the GCS input settings please see the documentation [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-gcs.html).**
 
 ### The GCS credentials key file:
-
 Once you have added a key to GCP service account, you will get a JSON key file that can only be downloaded once.
-If you're new to GCS bucket creation, follow these steps:
+If you're new to GCS bucket creation, follow the following steps:
 
-1. Make sure you have a service account available, if not follow the steps below:
+1) Make sure you have a service account available, if not follow the steps below:
    - Navigate to 'APIs & Services' > 'Credentials'
    - Click on 'Create credentials' > 'Service account'
-2. Once the service account is created, you can navigate to the 'Keys' section and attach/generate your service account key.
-3. Make sure to download the JSON key file once prompted.
-4. Use this JSON key file either inline (JSON string object), or by specifying the path to the file on the host machine, where the agent is running.
+2) Once the service account is created, you can navigate to the 'Keys' section and attach/generate your service account key.
+3) Make sure to download the JSON key file once prompted.
+4) Use this JSON key file either inline (JSON string object), or by specifying the path to the file on the host machine, where the agent is running.
 
 A sample JSON Credentials file looks as follows:
 ```json
@@ -135,20 +155,21 @@ A sample JSON Credentials file looks as follows:
 ```
 
 **NOTE**:
-You must have Symantec Account Credentials to configure event stream. Check [this documentation](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html) for more details.
+
+- You must have Symantec Account Credentials to configure event stream. Refer [here](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html) for more details.
 
 
-### Collect data from AWS SQS
+### To collect data from AWS SQS, follow the below steps:
 
-1. If you've already set up a connection to push data into the AWS bucket; if not, refer to the section above.
+1. Assuming you've already set up a connection to push data into the AWS bucket; if not, see the section above.
 2. To set up an SQS queue, follow "Step 1: Create an Amazon SQS Queue" mentioned in the [link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
    - While creating an access policy, use the bucket name configured to create a connection for AWS S3 in Symantec.
 3. Configure event notifications for an S3 bucket. Follow this [link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html).
    - While creating `event notification` select the event type as s3:ObjectCreated:*, destination type SQS Queue, and select the queue name created in Step 2.
 
-For more details about the AWS-S3 input settings, check this [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html).
+**For more details about the AWS-S3 input settings please see the documentation [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html).**
 
-### Steps to obtain Client ID and Client Secret to collect data from EDR Incident API
+### Steps to obtain Client ID and Client Secret to collect data from EDR Incident API:
 
 1. Login to your [Symantec EDR Cloud console](https://sep.securitycloud.symantec.com/v2/landing).
 2. Click Integration > Client Applications.
@@ -157,12 +178,13 @@ For more details about the AWS-S3 input settings, check this [documentation](htt
 5. Select Client Secret from the top.
 6. Copy the Client ID and Client Secret.
 
-### Enable the integration in Elastic
+### Enabling the integration in Elastic:
 
-1. In Kibana navigate to **Management** > **Integrations**.
-2. In the search top bar, type **Symantec Endpoint Security**.
-3. Select the **Symantec Endpoint Security** integration and add it.
-4. While adding the integration, if you want to collect logs via AWS S3, then you have to put the following details:
+1. In Kibana navigate to Management > Integrations
+2. In "Search for integrations" top bar, search for `Symantec Endpoint Security`.
+3. Select the "Symantec Endpoint Security" integration from the search results.
+4. Select "Add Symantec Endpoint Security Integration" to add the integration.
+5. While adding the integration, if you want to collect logs via AWS S3, then you have to put the following details:
    - Collect logs via S3 Bucket toggled on
    - Access Key ID
    - Secret Access Key
@@ -186,12 +208,26 @@ For more details about the AWS-S3 input settings, check this [documentation](htt
    - URL
    - Token URL
 
-5. Save the integration.
+   or if you want to collect logs via Azure Blob Storage, you'll need to provide the following details:
+   For OAuth2 (Microsoft Entra ID RBAC):
+   - Toggle on **Collect logs using OAuth2 authentication**
+   - Account Name
+   - Client ID
+   - Client Secret
+   - Tenant ID
+   - Container Details.
+
+   For Service Account Credentials:
+   - Service Account Key or the URI
+   - Account Name
+   - Container Details
+
+6. Save the integration.
 
 **NOTE**:
 
-1. There are other input combination options available for the AWS S3 and AWS SQS, check the [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html).
-2. There are other input combination options available for the GCS, check the [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-gcs.html).
+1. There are other input combination options available for the AWS S3 and AWS SQS, please check [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html).
+2. There are other input combination options available for the GCS, please check [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-gcs.html).
 
 ### Troubleshooting
 

--- a/packages/symantec_endpoint_security/_dev/build/docs/README.md
+++ b/packages/symantec_endpoint_security/_dev/build/docs/README.md
@@ -4,6 +4,10 @@ Symantec Endpoint Security (SES), is fully cloud-managed version of the on-premi
 
 This SES Integration enables user to stream Events and EDR incidents data to Elastic, via Data Storage(AWS S3, AWS SQS or GCS) and API endpoint respectively.
 
+## Compatibility
+
+This module has been tested against **Symantec Integrated Cyber Defense Exchange 1.4.7** for events, and **Symantec Endpoint Security API Version v1** for EDR Incidents. 
+
 ## Data streams
 
 The Symantec Endpoint Security integration collects logs via Amazon S3 and SQS, and Google GCP for different events that The Integrated Cyber Defense Schema organizes into following categories:
@@ -77,65 +81,46 @@ The Symantec Endpoint Security integration can also retrieve **EDR incidents** v
 
 ## Requirements
 
-Elastic Agent must be installed. For more details and installation instructions, please refer to the [Elastic Agent Installation Guide](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
-
-### Installing and managing an Elastic Agent:
-
-There are several options for installing and managing Elastic Agent:
-
-### Install a Fleet-managed Elastic Agent (recommended):
-
-With this approach, you install Elastic Agent and use Fleet in Kibana to define, configure, and manage your agents in a central location. We recommend using Fleet management because it makes the management and upgrade of your agents considerably easier.
-
-### Install Elastic Agent in standalone mode (advanced users):
-
-With this approach, you install Elastic Agent and manually configure the agent locally on the system where it’s installed. You are responsible for managing and upgrading the agents. This approach is reserved for advanced users only.
-
-### Install Elastic Agent in a containerized environment:
-
-You can run Elastic Agent inside a container, either with Fleet Server or standalone. Docker images for all versions of Elastic Agent are available from the Elastic Docker registry, and we provide deployment manifests for running on Kubernetes.
-
-Please note, there are minimum requirements for running Elastic Agent. For more information, refer to the  [Elastic Agent Minimum Requirements](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html#elastic-agent-installation-minimum-requirements).
-
-This module has been tested against **Symantec Integrated Cyber Defense Exchange 1.4.7** for events, and **Symantec Endpoint Security API Version v1** for EDR Incidents.   
+Elastic Agent must be installed. For more details, check the Elastic Agent [installation instructions](docs-content://reference/fleet/install-elastic-agents.md).  
 
 ## Setup
 
-### To collect data from an AWS S3 bucket, follow the below steps:
+### Collect data from an AWS S3 bucket
 
-- Considering you already have an AWS S3 bucket setup, to configure it with Symantec Endpoint Security, follow the steps mentioned [here](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html) to enable the Symantec Endpoint Streaming.
+Considering you already have an AWS S3 bucket setup, to configure it with Symantec Endpoint Security, follow [these steps](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html) to enable the Symantec Endpoint Streaming.
 
-### To collect data from Azure Blob Storage, follow the below steps:
+### Collect data from Azure Blob Storage
 
-- Considering you already have an Azure storage container setup, configure it with Symantec Endpoint Security.
-- Enable the Symantec Endpoint Streaming as mentioned [here](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html).
-- Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options.For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
+1. If you already have an Azure storage container setup, configure it with Symantec Endpoint Security.
+2. Enable the Symantec Endpoint Streaming by following [these instructions](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html).
+3. Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options.For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
+
 - How to setup the `auth.oauth2` credentials can be found in the Azure documentation https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app[here]
+- For more details about the Azure Blob Storage input settings, check the  [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).
 
 Note:
 - The service principal must be granted the appropriate permissions to read blobs. Ensure that the necessary role assignments are in place for the service principal to access the storage resources. For more information, please refer to the [Azure Role-Based Access Control (RBAC) documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage).
 - We recommend assigning either the Storage Blob Data Reader or BlobOwner role. The Storage Blob Data Reader role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The Storage Blob Data Owner role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
 
-**For more details about the Azure Blob Storage input settings please see the documentation [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).**
+### Collect data from a GCS bucket
 
-### To collect data from a GCS bucket, follow the below steps:
+1. If you already have a GCS bucket setup, configure it with Symantec Endpoint Security.
+2. Enable the Symantec Endpoint Streaming by following [these instructions](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html).
+3. Configure the integration with your GCS project ID, Bucket name and Service Account Key/Service Account Credentials File.
 
-- Considering you already have a GCS bucket setup, configure it with Symantec Endpoint Security.
-- Enable the Symantec Endpoint Streaming as mentioned [here](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html).
-- Configure the integration with your GCS project ID, Bucket name and Service Account Key/Service Account Credentials File.
-
-**For more details about the GCS input settings please see the documentation [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-gcs.html).**
+For more details about the GCS input settings, check the [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-gcs.html).
 
 ### The GCS credentials key file:
-Once you have added a key to GCP service account, you will get a JSON key file that can only be downloaded once.
-If you're new to GCS bucket creation, follow the following steps:
 
-1) Make sure you have a service account available, if not follow the steps below:
+Once you have added a key to GCP service account, you will get a JSON key file that can only be downloaded once.
+If you're new to GCS bucket creation, follow these steps:
+
+1. Make sure you have a service account available, if not follow the steps below:
    - Navigate to 'APIs & Services' > 'Credentials'
    - Click on 'Create credentials' > 'Service account'
-2) Once the service account is created, you can navigate to the 'Keys' section and attach/generate your service account key.
-3) Make sure to download the JSON key file once prompted.
-4) Use this JSON key file either inline (JSON string object), or by specifying the path to the file on the host machine, where the agent is running.
+2. Once the service account is created, you can navigate to the 'Keys' section and attach/generate your service account key.
+3. Make sure to download the JSON key file once prompted.
+4. Use this JSON key file either inline (JSON string object), or by specifying the path to the file on the host machine, where the agent is running.
 
 A sample JSON Credentials file looks as follows:
 ```json
@@ -155,21 +140,20 @@ A sample JSON Credentials file looks as follows:
 ```
 
 **NOTE**:
+You must have Symantec Account Credentials to configure event stream. Check [this documentation](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html) for more details.
 
-- You must have Symantec Account Credentials to configure event stream. Refer [here](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html) for more details.
 
+### Collect data from AWS SQS
 
-### To collect data from AWS SQS, follow the below steps:
-
-1. Assuming you've already set up a connection to push data into the AWS bucket; if not, see the section above.
+1. If you've already set up a connection to push data into the AWS bucket; if not, refer to the section above.
 2. To set up an SQS queue, follow "Step 1: Create an Amazon SQS Queue" mentioned in the [link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
    - While creating an access policy, use the bucket name configured to create a connection for AWS S3 in Symantec.
 3. Configure event notifications for an S3 bucket. Follow this [link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html).
    - While creating `event notification` select the event type as s3:ObjectCreated:*, destination type SQS Queue, and select the queue name created in Step 2.
 
-**For more details about the AWS-S3 input settings please see the documentation [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html).**
+For more details about the AWS-S3 input settings, check this [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html).
 
-### Steps to obtain Client ID and Client Secret to collect data from EDR Incident API:
+### Steps to obtain Client ID and Client Secret to collect data from EDR Incident API
 
 1. Login to your [Symantec EDR Cloud console](https://sep.securitycloud.symantec.com/v2/landing).
 2. Click Integration > Client Applications.
@@ -178,13 +162,12 @@ A sample JSON Credentials file looks as follows:
 5. Select Client Secret from the top.
 6. Copy the Client ID and Client Secret.
 
-### Enabling the integration in Elastic:
+### Enable the integration in Elastic
 
-1. In Kibana navigate to Management > Integrations
-2. In "Search for integrations" top bar, search for `Symantec Endpoint Security`.
-3. Select the "Symantec Endpoint Security" integration from the search results.
-4. Select "Add Symantec Endpoint Security Integration" to add the integration.
-5. While adding the integration, if you want to collect logs via AWS S3, then you have to put the following details:
+1. In Kibana navigate to **Management** > **Integrations**.
+2. In the search top bar, type **Symantec Endpoint Security**.
+3. Select the **Symantec Endpoint Security** integration and add it.
+4. While adding the integration, if you want to collect logs via AWS S3, then you have to put the following details:
    - Collect logs via S3 Bucket toggled on
    - Access Key ID
    - Secret Access Key
@@ -208,9 +191,8 @@ A sample JSON Credentials file looks as follows:
    - URL
    - Token URL
 
-   or if you want to collect logs via Azure Blob Storage, you'll need to provide the following details:
+   or if you want to collect logs via Azure Blob    Storage, you'll need to provide the following    details:
    For OAuth2 (Microsoft Entra ID RBAC):
-   - Toggle on **Collect logs using OAuth2 authentication**
    - Account Name
    - Client ID
    - Client Secret
@@ -222,12 +204,12 @@ A sample JSON Credentials file looks as follows:
    - Account Name
    - Container Details
 
-6. Save the integration.
+5. Save the integration.
 
 **NOTE**:
 
-1. There are other input combination options available for the AWS S3 and AWS SQS, please check [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html).
-2. There are other input combination options available for the GCS, please check [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-gcs.html).
+1. There are other input combination options available for the AWS S3 and AWS SQS, check the [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html).
+2. There are other input combination options available for the GCS, check the [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-gcs.html).
 
 ### Troubleshooting
 

--- a/packages/symantec_endpoint_security/changelog.yml
+++ b/packages/symantec_endpoint_security/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add RBAC based authentication for azure blob storage input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/14396
 - version: "1.12.1"
   changes:
     - description: Ignore failures on foreach processing of some missing subfields

--- a/packages/symantec_endpoint_security/changelog.yml
+++ b/packages/symantec_endpoint_security/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
-- version: "1.12.2"
+- version: "1.13.0"
   changes:
-    - description: Remove duplicated installation instructions from the documentation.
+    - description: Add RBAC based authentication for azure blob storage input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/14014
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.12.1"
   changes:
     - description: Ignore failures on foreach processing of some missing subfields

--- a/packages/symantec_endpoint_security/changelog.yml
+++ b/packages/symantec_endpoint_security/changelog.yml
@@ -4,6 +4,11 @@
     - description: Add RBAC based authentication for azure blob storage input.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/14396
+- version: "1.12.2"
+  changes:
+    - description: Remove duplicated installation instructions from the documentation.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/14014
 - version: "1.12.1"
   changes:
     - description: Ignore failures on foreach processing of some missing subfields

--- a/packages/symantec_endpoint_security/data_stream/event/agent/stream/abs.yml.hbs
+++ b/packages/symantec_endpoint_security/data_stream/event/agent/stream/abs.yml.hbs
@@ -1,6 +1,12 @@
 {{#if account_name}}
 account_name: {{account_name}}
 {{/if}}
+{{#if oauth2}}
+auth.oauth2:
+  client_id: {{client_id}}
+  client_secret: {{client_secret}}
+  tenant_id: {{tenant_id}}
+{{/if}}
 {{#if service_account_key}}
 auth.shared_credentials.account_key: {{service_account_key}}
 {{/if}}

--- a/packages/symantec_endpoint_security/data_stream/event/manifest.yml
+++ b/packages/symantec_endpoint_security/data_stream/event/manifest.yml
@@ -377,6 +377,27 @@ streams:
           This attribute is required for various internal operations with respect to authentication, creating service clients and blob clients which are used internally for various processing purposes.
         required: true
         show_user: true
+      - name: client_id
+        type: text
+        title: Client ID (OAuth2)
+        description: Client ID of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.
+        required: false
+        show_user: true
+        secret: true
+      - name: client_secret
+        type: password
+        title: Client Secret (OAuth2)
+        description: Client Secret of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.
+        required: false
+        show_user: true
+        secret: true
+      - name: tenant_id
+        type: text
+        title: Tenant ID (OAuth2)
+        description: Tenant ID of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.
+        multi: false
+        required: false
+        show_user: true
       - name: service_account_key
         type: password
         title: Service Account Key

--- a/packages/symantec_endpoint_security/docs/README.md
+++ b/packages/symantec_endpoint_security/docs/README.md
@@ -93,14 +93,14 @@ Considering you already have an AWS S3 bucket setup, to configure it with Symant
 
 1. If you already have an Azure storage container setup, configure it with Symantec Endpoint Security.
 2. Enable the Symantec Endpoint Streaming by following [these instructions](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html).
-3. Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options.For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
+3. Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options. For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
 
-- How to setup the `auth.oauth2` credentials can be found in the Azure documentation https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app[here]
-- For more details about the Azure Blob Storage input settings, check the  [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).
+- How to setup the `auth.oauth2` credentials can be found in the Azure documentation [here]( https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app).
+- For more details about the Azure Blob Storage input settings, check the [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).
 
 Note:
 - The service principal must be granted the appropriate permissions to read blobs. Ensure that the necessary role assignments are in place for the service principal to access the storage resources. For more information, please refer to the [Azure Role-Based Access Control (RBAC) documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage).
-- We recommend assigning either the Storage Blob Data Reader or BlobOwner role. The Storage Blob Data Reader role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The Storage Blob Data Owner role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
+- We recommend assigning either the **Storage Blob Data Reader** or **Storage Blob Data Owner** role. The **Storage Blob Data Reader** role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The **Storage Blob Data Owner** role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
 
 ### Collect data from a GCS bucket
 

--- a/packages/symantec_endpoint_security/docs/README.md
+++ b/packages/symantec_endpoint_security/docs/README.md
@@ -191,7 +191,7 @@ For more details about the AWS-S3 input settings, check this [documentation](htt
    - URL
    - Token URL
 
-   or if you want to collect logs via Azure Blob    Storage, you'll need to provide the following    details:
+   or if you want to collect logs via Azure Blob Storage, you'll need to provide the following details:
    For OAuth2 (Microsoft Entra ID RBAC):
    - Account Name
    - Client ID

--- a/packages/symantec_endpoint_security/docs/README.md
+++ b/packages/symantec_endpoint_security/docs/README.md
@@ -4,10 +4,6 @@ Symantec Endpoint Security (SES), is fully cloud-managed version of the on-premi
 
 This SES Integration enables user to stream Events and EDR incidents data to Elastic, via Data Storage(AWS S3, AWS SQS or GCS) and API endpoint respectively.
 
-## Compatibility
-
-This module has been tested against **Symantec Integrated Cyber Defense Exchange 1.4.7** for events, and **Symantec Endpoint Security API Version v1** for EDR Incidents. 
-
 ## Data streams
 
 The Symantec Endpoint Security integration collects logs via Amazon S3 and SQS, and Google GCP for different events that The Integrated Cyber Defense Schema organizes into following categories:
@@ -81,41 +77,65 @@ The Symantec Endpoint Security integration can also retrieve **EDR incidents** v
 
 ## Requirements
 
-Elastic Agent must be installed. For more details, check the Elastic Agent [installation instructions](docs-content://reference/fleet/install-elastic-agents.md).  
+Elastic Agent must be installed. For more details and installation instructions, please refer to the [Elastic Agent Installation Guide](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
+
+### Installing and managing an Elastic Agent:
+
+There are several options for installing and managing Elastic Agent:
+
+### Install a Fleet-managed Elastic Agent (recommended):
+
+With this approach, you install Elastic Agent and use Fleet in Kibana to define, configure, and manage your agents in a central location. We recommend using Fleet management because it makes the management and upgrade of your agents considerably easier.
+
+### Install Elastic Agent in standalone mode (advanced users):
+
+With this approach, you install Elastic Agent and manually configure the agent locally on the system where it’s installed. You are responsible for managing and upgrading the agents. This approach is reserved for advanced users only.
+
+### Install Elastic Agent in a containerized environment:
+
+You can run Elastic Agent inside a container, either with Fleet Server or standalone. Docker images for all versions of Elastic Agent are available from the Elastic Docker registry, and we provide deployment manifests for running on Kubernetes.
+
+Please note, there are minimum requirements for running Elastic Agent. For more information, refer to the  [Elastic Agent Minimum Requirements](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html#elastic-agent-installation-minimum-requirements).
+
+This module has been tested against **Symantec Integrated Cyber Defense Exchange 1.4.7** for events, and **Symantec Endpoint Security API Version v1** for EDR Incidents.   
 
 ## Setup
 
-### Collect data from an AWS S3 bucket
+### To collect data from an AWS S3 bucket, follow the below steps:
 
-Considering you already have an AWS S3 bucket setup, to configure it with Symantec Endpoint Security, follow [these steps](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html) to enable the Symantec Endpoint Streaming.
+- Considering you already have an AWS S3 bucket setup, to configure it with Symantec Endpoint Security, follow the steps mentioned [here](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html) to enable the Symantec Endpoint Streaming.
 
-### Collect data from Azure Blob Storage
+### To collect data from Azure Blob Storage, follow the below steps:
 
-1. If you already have an Azure storage container setup, configure it with Symantec Endpoint Security.
-2. Enable the Symantec Endpoint Streaming by following [these instructions](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html).
-3. Configure the integration with your Azure Storage account name, Container name and Service Account Key/Service Account URI.
+- Considering you already have an Azure storage container setup, configure it with Symantec Endpoint Security.
+- Enable the Symantec Endpoint Streaming as mentioned [here](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html).
+- Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options.For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
+- How to setup the `auth.oauth2` credentials can be found in the Azure documentation https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app[here]
 
-For more details about the Azure Blob Storage input settings, check the  [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).
+Note:
+- The service principal must be granted the appropriate permissions to read blobs. Ensure that the necessary role assignments are in place for the service principal to access the storage resources. For more information, please refer to the [Azure Role-Based Access Control (RBAC) documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage).
+- We recommend assigning either the Storage Blob Data Reader or BlobOwner role. The Storage Blob Data Reader role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The Storage Blob Data Owner role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
 
-### Collect data from a GCS bucket
+**For more details about the Azure Blob Storage input settings please see the documentation [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).**
 
-1. If you already have a GCS bucket setup, configure it with Symantec Endpoint Security.
-2. Enable the Symantec Endpoint Streaming by following [these instructions](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html).
-3. Configure the integration with your GCS project ID, Bucket name and Service Account Key/Service Account Credentials File.
+### To collect data from a GCS bucket, follow the below steps:
 
-For more details about the GCS input settings, check the [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-gcs.html).
+- Considering you already have a GCS bucket setup, configure it with Symantec Endpoint Security.
+- Enable the Symantec Endpoint Streaming as mentioned [here](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html).
+- Configure the integration with your GCS project ID, Bucket name and Service Account Key/Service Account Credentials File.
+
+**For more details about the GCS input settings please see the documentation [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-gcs.html).**
 
 ### The GCS credentials key file:
-
 Once you have added a key to GCP service account, you will get a JSON key file that can only be downloaded once.
-If you're new to GCS bucket creation, follow these steps:
+If you're new to GCS bucket creation, follow the following steps:
 
-1. Make sure you have a service account available, if not follow the steps below:
+1) Make sure you have a service account available, if not follow the steps below:
    - Navigate to 'APIs & Services' > 'Credentials'
    - Click on 'Create credentials' > 'Service account'
-2. Once the service account is created, you can navigate to the 'Keys' section and attach/generate your service account key.
-3. Make sure to download the JSON key file once prompted.
-4. Use this JSON key file either inline (JSON string object), or by specifying the path to the file on the host machine, where the agent is running.
+2) Once the service account is created, you can navigate to the 'Keys' section and attach/generate your service account key.
+3) Make sure to download the JSON key file once prompted.
+4) Use this JSON key file either inline (JSON string object), or by specifying the path to the file on the host machine, where the agent is running.
 
 A sample JSON Credentials file looks as follows:
 ```json
@@ -135,20 +155,21 @@ A sample JSON Credentials file looks as follows:
 ```
 
 **NOTE**:
-You must have Symantec Account Credentials to configure event stream. Check [this documentation](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html) for more details.
+
+- You must have Symantec Account Credentials to configure event stream. Refer [here](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html) for more details.
 
 
-### Collect data from AWS SQS
+### To collect data from AWS SQS, follow the below steps:
 
-1. If you've already set up a connection to push data into the AWS bucket; if not, refer to the section above.
+1. Assuming you've already set up a connection to push data into the AWS bucket; if not, see the section above.
 2. To set up an SQS queue, follow "Step 1: Create an Amazon SQS Queue" mentioned in the [link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
    - While creating an access policy, use the bucket name configured to create a connection for AWS S3 in Symantec.
 3. Configure event notifications for an S3 bucket. Follow this [link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html).
    - While creating `event notification` select the event type as s3:ObjectCreated:*, destination type SQS Queue, and select the queue name created in Step 2.
 
-For more details about the AWS-S3 input settings, check this [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html).
+**For more details about the AWS-S3 input settings please see the documentation [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html).**
 
-### Steps to obtain Client ID and Client Secret to collect data from EDR Incident API
+### Steps to obtain Client ID and Client Secret to collect data from EDR Incident API:
 
 1. Login to your [Symantec EDR Cloud console](https://sep.securitycloud.symantec.com/v2/landing).
 2. Click Integration > Client Applications.
@@ -157,12 +178,13 @@ For more details about the AWS-S3 input settings, check this [documentation](htt
 5. Select Client Secret from the top.
 6. Copy the Client ID and Client Secret.
 
-### Enable the integration in Elastic
+### Enabling the integration in Elastic:
 
-1. In Kibana navigate to **Management** > **Integrations**.
-2. In the search top bar, type **Symantec Endpoint Security**.
-3. Select the **Symantec Endpoint Security** integration and add it.
-4. While adding the integration, if you want to collect logs via AWS S3, then you have to put the following details:
+1. In Kibana navigate to Management > Integrations
+2. In "Search for integrations" top bar, search for `Symantec Endpoint Security`.
+3. Select the "Symantec Endpoint Security" integration from the search results.
+4. Select "Add Symantec Endpoint Security Integration" to add the integration.
+5. While adding the integration, if you want to collect logs via AWS S3, then you have to put the following details:
    - Collect logs via S3 Bucket toggled on
    - Access Key ID
    - Secret Access Key
@@ -186,12 +208,26 @@ For more details about the AWS-S3 input settings, check this [documentation](htt
    - URL
    - Token URL
 
-5. Save the integration.
+   or if you want to collect logs via Azure Blob Storage, you'll need to provide the following details:
+   For OAuth2 (Microsoft Entra ID RBAC):
+   - Toggle on **Collect logs using OAuth2 authentication**
+   - Account Name
+   - Client ID
+   - Client Secret
+   - Tenant ID
+   - Container Details.
+
+   For Service Account Credentials:
+   - Service Account Key or the URI
+   - Account Name
+   - Container Details
+
+6. Save the integration.
 
 **NOTE**:
 
-1. There are other input combination options available for the AWS S3 and AWS SQS, check the [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html).
-2. There are other input combination options available for the GCS, check the [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-gcs.html).
+1. There are other input combination options available for the AWS S3 and AWS SQS, please check [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html).
+2. There are other input combination options available for the GCS, please check [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-gcs.html).
 
 ### Troubleshooting
 

--- a/packages/symantec_endpoint_security/docs/README.md
+++ b/packages/symantec_endpoint_security/docs/README.md
@@ -4,6 +4,10 @@ Symantec Endpoint Security (SES), is fully cloud-managed version of the on-premi
 
 This SES Integration enables user to stream Events and EDR incidents data to Elastic, via Data Storage(AWS S3, AWS SQS or GCS) and API endpoint respectively.
 
+## Compatibility
+
+This module has been tested against **Symantec Integrated Cyber Defense Exchange 1.4.7** for events, and **Symantec Endpoint Security API Version v1** for EDR Incidents. 
+
 ## Data streams
 
 The Symantec Endpoint Security integration collects logs via Amazon S3 and SQS, and Google GCP for different events that The Integrated Cyber Defense Schema organizes into following categories:
@@ -77,65 +81,46 @@ The Symantec Endpoint Security integration can also retrieve **EDR incidents** v
 
 ## Requirements
 
-Elastic Agent must be installed. For more details and installation instructions, please refer to the [Elastic Agent Installation Guide](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
-
-### Installing and managing an Elastic Agent:
-
-There are several options for installing and managing Elastic Agent:
-
-### Install a Fleet-managed Elastic Agent (recommended):
-
-With this approach, you install Elastic Agent and use Fleet in Kibana to define, configure, and manage your agents in a central location. We recommend using Fleet management because it makes the management and upgrade of your agents considerably easier.
-
-### Install Elastic Agent in standalone mode (advanced users):
-
-With this approach, you install Elastic Agent and manually configure the agent locally on the system where it’s installed. You are responsible for managing and upgrading the agents. This approach is reserved for advanced users only.
-
-### Install Elastic Agent in a containerized environment:
-
-You can run Elastic Agent inside a container, either with Fleet Server or standalone. Docker images for all versions of Elastic Agent are available from the Elastic Docker registry, and we provide deployment manifests for running on Kubernetes.
-
-Please note, there are minimum requirements for running Elastic Agent. For more information, refer to the  [Elastic Agent Minimum Requirements](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html#elastic-agent-installation-minimum-requirements).
-
-This module has been tested against **Symantec Integrated Cyber Defense Exchange 1.4.7** for events, and **Symantec Endpoint Security API Version v1** for EDR Incidents.   
+Elastic Agent must be installed. For more details, check the Elastic Agent [installation instructions](docs-content://reference/fleet/install-elastic-agents.md).  
 
 ## Setup
 
-### To collect data from an AWS S3 bucket, follow the below steps:
+### Collect data from an AWS S3 bucket
 
-- Considering you already have an AWS S3 bucket setup, to configure it with Symantec Endpoint Security, follow the steps mentioned [here](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html) to enable the Symantec Endpoint Streaming.
+Considering you already have an AWS S3 bucket setup, to configure it with Symantec Endpoint Security, follow [these steps](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html) to enable the Symantec Endpoint Streaming.
 
-### To collect data from Azure Blob Storage, follow the below steps:
+### Collect data from Azure Blob Storage
 
-- Considering you already have an Azure storage container setup, configure it with Symantec Endpoint Security.
-- Enable the Symantec Endpoint Streaming as mentioned [here](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html).
-- Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options.For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
+1. If you already have an Azure storage container setup, configure it with Symantec Endpoint Security.
+2. Enable the Symantec Endpoint Streaming by following [these instructions](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html).
+3. Configure the integration using either Service Account Credentials or Microsoft Entra ID RBAC with OAuth2 options.For OAuth2 (Entra ID RBAC), you'll need the Client ID, Client Secret, and Tenant ID. For Service Account Credentials, you'll need either the Service Account Key or the URI to access the data.
+
 - How to setup the `auth.oauth2` credentials can be found in the Azure documentation https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app[here]
+- For more details about the Azure Blob Storage input settings, check the  [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).
 
 Note:
 - The service principal must be granted the appropriate permissions to read blobs. Ensure that the necessary role assignments are in place for the service principal to access the storage resources. For more information, please refer to the [Azure Role-Based Access Control (RBAC) documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage).
 - We recommend assigning either the Storage Blob Data Reader or BlobOwner role. The Storage Blob Data Reader role provides read-only access to blob data and is aligned with the principle of least privilege, making it suitable for most use cases. The Storage Blob Data Owner role grants full administrative access — including read, write, and delete permissions — and should be used only when such elevated access is explicitly required.
 
-**For more details about the Azure Blob Storage input settings please see the documentation [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html).**
+### Collect data from a GCS bucket
 
-### To collect data from a GCS bucket, follow the below steps:
+1. If you already have a GCS bucket setup, configure it with Symantec Endpoint Security.
+2. Enable the Symantec Endpoint Streaming by following [these instructions](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html).
+3. Configure the integration with your GCS project ID, Bucket name and Service Account Key/Service Account Credentials File.
 
-- Considering you already have a GCS bucket setup, configure it with Symantec Endpoint Security.
-- Enable the Symantec Endpoint Streaming as mentioned [here](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html).
-- Configure the integration with your GCS project ID, Bucket name and Service Account Key/Service Account Credentials File.
-
-**For more details about the GCS input settings please see the documentation [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-gcs.html).**
+For more details about the GCS input settings, check the [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-gcs.html).
 
 ### The GCS credentials key file:
-Once you have added a key to GCP service account, you will get a JSON key file that can only be downloaded once.
-If you're new to GCS bucket creation, follow the following steps:
 
-1) Make sure you have a service account available, if not follow the steps below:
+Once you have added a key to GCP service account, you will get a JSON key file that can only be downloaded once.
+If you're new to GCS bucket creation, follow these steps:
+
+1. Make sure you have a service account available, if not follow the steps below:
    - Navigate to 'APIs & Services' > 'Credentials'
    - Click on 'Create credentials' > 'Service account'
-2) Once the service account is created, you can navigate to the 'Keys' section and attach/generate your service account key.
-3) Make sure to download the JSON key file once prompted.
-4) Use this JSON key file either inline (JSON string object), or by specifying the path to the file on the host machine, where the agent is running.
+2. Once the service account is created, you can navigate to the 'Keys' section and attach/generate your service account key.
+3. Make sure to download the JSON key file once prompted.
+4. Use this JSON key file either inline (JSON string object), or by specifying the path to the file on the host machine, where the agent is running.
 
 A sample JSON Credentials file looks as follows:
 ```json
@@ -155,21 +140,20 @@ A sample JSON Credentials file looks as follows:
 ```
 
 **NOTE**:
+You must have Symantec Account Credentials to configure event stream. Check [this documentation](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html) for more details.
 
-- You must have Symantec Account Credentials to configure event stream. Refer [here](https://techdocs.broadcom.com/us/en/symantec-security-software/endpoint-security-and-management/endpoint-security/sescloud/Integrations/Event-streaming-using-EDR.html) for more details.
 
+### Collect data from AWS SQS
 
-### To collect data from AWS SQS, follow the below steps:
-
-1. Assuming you've already set up a connection to push data into the AWS bucket; if not, see the section above.
+1. If you've already set up a connection to push data into the AWS bucket; if not, refer to the section above.
 2. To set up an SQS queue, follow "Step 1: Create an Amazon SQS Queue" mentioned in the [link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
    - While creating an access policy, use the bucket name configured to create a connection for AWS S3 in Symantec.
 3. Configure event notifications for an S3 bucket. Follow this [link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html).
    - While creating `event notification` select the event type as s3:ObjectCreated:*, destination type SQS Queue, and select the queue name created in Step 2.
 
-**For more details about the AWS-S3 input settings please see the documentation [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html).**
+For more details about the AWS-S3 input settings, check this [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html).
 
-### Steps to obtain Client ID and Client Secret to collect data from EDR Incident API:
+### Steps to obtain Client ID and Client Secret to collect data from EDR Incident API
 
 1. Login to your [Symantec EDR Cloud console](https://sep.securitycloud.symantec.com/v2/landing).
 2. Click Integration > Client Applications.
@@ -178,13 +162,12 @@ A sample JSON Credentials file looks as follows:
 5. Select Client Secret from the top.
 6. Copy the Client ID and Client Secret.
 
-### Enabling the integration in Elastic:
+### Enable the integration in Elastic
 
-1. In Kibana navigate to Management > Integrations
-2. In "Search for integrations" top bar, search for `Symantec Endpoint Security`.
-3. Select the "Symantec Endpoint Security" integration from the search results.
-4. Select "Add Symantec Endpoint Security Integration" to add the integration.
-5. While adding the integration, if you want to collect logs via AWS S3, then you have to put the following details:
+1. In Kibana navigate to **Management** > **Integrations**.
+2. In the search top bar, type **Symantec Endpoint Security**.
+3. Select the **Symantec Endpoint Security** integration and add it.
+4. While adding the integration, if you want to collect logs via AWS S3, then you have to put the following details:
    - Collect logs via S3 Bucket toggled on
    - Access Key ID
    - Secret Access Key
@@ -208,9 +191,8 @@ A sample JSON Credentials file looks as follows:
    - URL
    - Token URL
 
-   or if you want to collect logs via Azure Blob Storage, you'll need to provide the following details:
+   or if you want to collect logs via Azure Blob    Storage, you'll need to provide the following    details:
    For OAuth2 (Microsoft Entra ID RBAC):
-   - Toggle on **Collect logs using OAuth2 authentication**
    - Account Name
    - Client ID
    - Client Secret
@@ -222,12 +204,12 @@ A sample JSON Credentials file looks as follows:
    - Account Name
    - Container Details
 
-6. Save the integration.
+5. Save the integration.
 
 **NOTE**:
 
-1. There are other input combination options available for the AWS S3 and AWS SQS, please check [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html).
-2. There are other input combination options available for the GCS, please check [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-gcs.html).
+1. There are other input combination options available for the AWS S3 and AWS SQS, check the [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html).
+2. There are other input combination options available for the GCS, check the [Filebeat documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-gcs.html).
 
 ### Troubleshooting
 

--- a/packages/symantec_endpoint_security/manifest.yml
+++ b/packages/symantec_endpoint_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: symantec_endpoint_security
 title: Symantec Endpoint Security
-version: "1.12.2"
+version: "1.13.0"
 description: Collect logs from Symantec Endpoint Security with Elastic Agent.
 type: integration
 categories:
@@ -130,6 +130,15 @@ policy_templates:
       - type: azure-blob-storage
         title: Collect Symantec Endpoint Security logs via Azure Blob Storage
         description: Collect JSON data from configured Azure Blob Storage Container with Elastic Agent.
+        vars:
+          - name: oauth2
+            required: true
+            show_user: true
+            title: Collect logs using OAuth2 authentication
+            description: To collect logs using OAuth2 authentication enable the toggle switch. By default, it will collect logs using service account key or URI.
+            type: bool
+            multi: false
+            default: false
 owner:
   github: elastic/security-service-integrations
   type: elastic


### PR DESCRIPTION
## Proposed commit message
```
azure_blob_storage,azure_network_watcher_nsg,azure_network_watcher_vnet,symantec_enpoint_security: add RBAC-based authentication for azure blob storage input

Implemented RBAC-based authentication support for the azure blob storage
input across the following packages: azure_blob_storage,
azure_network_watcher_nsg, azure_network_watcher_vnet, and
symantec_endpoint_security. This enhancement enables secure data
collection using azure active directory RBAC credentials instead of
access keys.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/<integration_name> directory.
- Run the following command to run tests.

> elastic-package test -v

NOTE: Replace the <integration_name> with the actual one.

## Related Issue

- Closes https://github.com/elastic/integrations/issues/14198
