### PR TITLE
[CI] Update regex of files/folders to skip test packages

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -746,7 +746,7 @@ is_pr_affected() {
     # Example:
     # https://buildkite.com/elastic/integrations/builds/25606
     # https://github.com/elastic/integrations/pull/13810
-    if git diff --name-only "${commit_merge}" "${to}" | grep -E -v '^(packages/|\.github/(CODEOWNERS|ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)|README\.md|docs/|catalog-info\.yaml|\.buildkite/(pull-requests\.json|pipeline\.schedule-daily\.yml|pipeline\.schedule-weekly\.yml|pipeline\.backport\.yml))' > /dev/null; then
+    if git diff --name-only "${commit_merge}" "${to}" | grep -E -v '^(packages/|\.github/(CODEOWNERS|ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE|workflows/)|README\.md|docs/|catalog-info\.yaml|\.buildkite/(pull-requests\.json|pipeline\.schedule-daily\.yml|pipeline\.schedule-weekly\.yml|pipeline\.backport\.yml))' > /dev/null; then
         echo "[${package}] PR is affected: found non-package files"
         return 0
     fi


### PR DESCRIPTION
## Proposed commit message

Skip test all packages if files under `.github/workflows/` are updated, deleted or modified.

That folder is already skipped to trigger builds in Pull Requests:
https://github.com/elastic/integrations/blob/da0a9342630eb151a8b734818de0c37d853b67e4/.buildkite/pull-requests.json#L17


Example:
This build https://buildkite.com/elastic/integrations/builds/28159#0197e5e4-3986-41ba-8873-6edeef50ca87 was triggered due to this file was modified but all packages were tested:
`.github/workflows/bump-elastic-stack-version.yml` 

```
 $ git diff --name-only 951d4f041634a32de5e513a4d5eeff4073b03e22..7c48a2a906 
.github/workflows/bump-elastic-stack-version.yml
```

## How to test this PR locally

This has been tested locally by simulating the files obtained by `git diff` command:

```shell
 $ echo -e "packages/a\n.github/CODEOWNERS\ndocs/a.md\n.buildkite/pull-requests.json\n.buildkite/pipeline.schedule-daily.yml\n.buildkite/scripts/common.sh\n.github/other\n.github/workflows/bump-elastic-stack-version.yml" | grep -E -v '^(packages/|\.github/(CODEOWNERS|ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE|workflows/)|README\.md|docs/|catalog-info\.yaml|\.buildkite/(pull-requests\.json|pipeline\.schedule-daily\.yml|pipeline\.schedule-weekly\.yml|pipeline\.backport\.yml|scripts/common\.sh))'
.github/other
```
