### PR TITLE
fix(cyberark_epm): propagate state variables on error

### DIFF
--- a/packages/cyberark_epm/changelog.yml
+++ b/packages/cyberark_epm/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: 'Enhanced error handling in the CEL program for API calls to prevent "no such key: version" errors by ensuring proper propagation of the `version` configuration during failures.'
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/14471
 - version: "1.2.0"
   changes:
     - description: Use `terminate` processor instead of `fail` processor to handle agent errors.

--- a/packages/cyberark_epm/data_stream/admin_audit/agent/stream/cel.yml.hbs
+++ b/packages/cyberark_epm/data_stream/admin_audit/agent/stream/cel.yml.hbs
@@ -29,7 +29,7 @@ redact:
     - password
     - access_token
 program: |
-  (
+  state.with(
     has(state.expiry) && timestamp(state.expiry) > now ?
       {
         "access_token": state.access_token,

--- a/packages/cyberark_epm/data_stream/aggregated_event/agent/stream/cel.yml.hbs
+++ b/packages/cyberark_epm/data_stream/aggregated_event/agent/stream/cel.yml.hbs
@@ -29,7 +29,7 @@ redact:
     - password
     - access_token
 program: |
-  (
+  state.with(
     has(state.expiry) && timestamp(state.expiry) > now ?
       {
         "access_token": state.access_token,

--- a/packages/cyberark_epm/data_stream/policyaudit_aggregated_event/agent/stream/cel.yml.hbs
+++ b/packages/cyberark_epm/data_stream/policyaudit_aggregated_event/agent/stream/cel.yml.hbs
@@ -29,7 +29,7 @@ redact:
     - password
     - access_token
 program: |
-  (
+  state.with(
     has(state.expiry) && timestamp(state.expiry) > now ?
       {
         "access_token": state.access_token,

--- a/packages/cyberark_epm/data_stream/policyaudit_raw_event/agent/stream/cel.yml.hbs
+++ b/packages/cyberark_epm/data_stream/policyaudit_raw_event/agent/stream/cel.yml.hbs
@@ -29,7 +29,7 @@ redact:
     - password
     - access_token
 program: |
-  (
+  state.with(
     has(state.expiry) && timestamp(state.expiry) > now ?
       {
         "access_token": state.access_token,

--- a/packages/cyberark_epm/data_stream/raw_event/agent/stream/cel.yml.hbs
+++ b/packages/cyberark_epm/data_stream/raw_event/agent/stream/cel.yml.hbs
@@ -29,7 +29,7 @@ redact:
     - password
     - access_token
 program: |
-  (
+  state.with(
     has(state.expiry) && timestamp(state.expiry) > now ?
       {
         "access_token": state.access_token,

--- a/packages/cyberark_epm/manifest.yml
+++ b/packages/cyberark_epm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: cyberark_epm
 title: CyberArk EPM
-version: "1.2.0"
+version: "1.2.1"
 description: Collect logs from CyberArk EPM with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Enhanced error handling in the CEL program to prevent "'no such key: version'" errors by ensuring proper propagation of the state data configuration during failures. This was accomplished by wrapping the programs with `state.with()`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

_Reproducing the problem before the fix by injecting HTTP 500 responses with p=0.8_

After go-retryablehttp exhausts its retries, the failure response is returned to the CEL problem. This results in the next iteration failing due to the missing `state.version`.

<img width="1336" alt="Screenshot 2025-07-09 at 15 31 31" src="https://github.com/user-attachments/assets/dff306de-bcbe-4c96-b0ba-fc64d1be3564" />


