### PR TITLE
[ti_threatconnect] Remove outdated version information

### DIFF
--- a/packages/ti_threatconnect/_dev/build/docs/README.md
+++ b/packages/ti_threatconnect/_dev/build/docs/README.md
@@ -13,10 +13,7 @@ Reference for [REST APIs](https://docs.threatconnect.com/en/latest/rest_api/rest
 ## Compatibility
 
 This module has been tested against the **ThreatConnect API Version v3**.
-The minimum **kibana.version** required is **8.11.0**.
-The minimum required versions for the Elastic Stack is **8.12.0**.
 The minimum required ThreatConnect Platform version is **7.3.1**.
-This integration module uses the ThreatConnect V3 API.
 
 ## Requirements
 

--- a/packages/ti_threatconnect/changelog.yml
+++ b/packages/ti_threatconnect/changelog.yml
@@ -1,5 +1,10 @@
 # newer versions go on top
 # WARNING: this version number needs to be kept up to date in the transform!
+- version: "1.10.2"
+  changes:
+    - description: Update README to remove outdated version information.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/14810
 - version: "1.10.1"
   changes:
     - description: Update `error.message` field mapping as per ECS inside transform destination indices.

--- a/packages/ti_threatconnect/docs/README.md
+++ b/packages/ti_threatconnect/docs/README.md
@@ -13,10 +13,7 @@ Reference for [REST APIs](https://docs.threatconnect.com/en/latest/rest_api/rest
 ## Compatibility
 
 This module has been tested against the **ThreatConnect API Version v3**.
-The minimum **kibana.version** required is **8.11.0**.
-The minimum required versions for the Elastic Stack is **8.12.0**.
 The minimum required ThreatConnect Platform version is **7.3.1**.
-This integration module uses the ThreatConnect V3 API.
 
 ## Requirements
 

--- a/packages/ti_threatconnect/elasticsearch/transform/latest/transform.yml
+++ b/packages/ti_threatconnect/elasticsearch/transform/latest/transform.yml
@@ -10,7 +10,7 @@ source:
 # time field type conflicts.
 dest:
   index: "logs-ti_threatconnect_latest.dest_indicator-8"
-  pipeline: "1.10.1-tactics_compatibility"
+  pipeline: "1.10.2-tactics_compatibility"
   aliases:
     - alias: "logs-ti_threatconnect_latest.indicator"
       move_on_creation: true

--- a/packages/ti_threatconnect/manifest.yml
+++ b/packages/ti_threatconnect/manifest.yml
@@ -2,7 +2,7 @@
 format_version: 3.0.3
 name: ti_threatconnect
 title: ThreatConnect
-version: "1.10.1"
+version: "1.10.2"
 description: Collects Indicators from ThreatConnect using the Elastic Agent and saves them as logs inside Elastic
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[ti_threatconnect] Remove outdated version information

The README included out of date advice about the required Kibana and
Elastic Stack version number.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 