### PR TITLE
[system] fix CPU Usage on [Metrics System] Overview "hosts" tab

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix CPU Usage on [Metrics System] Overview "hosts" tab.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/13597
+      link: https://github.com/elastic/integrations/pull/14482
 - version: "2.3.2"
   changes:
     - description: Update documentation to mention the requirements for reading Journald logs.

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.3"
+  changes:
+    - description: Fix CPU Usage on [Metrics System] Overview "hosts" tab.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/13597
 - version: "2.3.2"
   changes:
     - description: Update documentation to mention the requirements for reading Journald logs.

--- a/packages/system/kibana/dashboard/system-Metrics-system-overview.json
+++ b/packages/system/kibana/dashboard/system-Metrics-system-overview.json
@@ -490,7 +490,7 @@
                                                     "dataType": "number",
                                                     "filter": {
                                                         "language": "kuery",
-                                                        "query": "\"system.process.cpu.total.norm.pct\": *"
+                                                        "query": "\"system.cpu.total.norm.pct\": *"
                                                     },
                                                     "isBucketed": false,
                                                     "label": "CPU usage",
@@ -503,7 +503,7 @@
                                                     },
                                                     "reducedTimeRange": "15m",
                                                     "scale": "ratio",
-                                                    "sourceField": "system.process.cpu.total.norm.pct"
+                                                    "sourceField": "system.cpu.total.norm.pct"
                                                 }
                                             },
                                             "ignoreGlobalFilters": false,
@@ -533,16 +533,16 @@
                                                 "meta": {
                                                     "alias": null,
                                                     "disabled": false,
-                                                    "field": "system.process.cpu.total.norm.pct",
+                                                    "field": "system.cpu.total.norm.pct",
                                                     "index": "metrics-*",
-                                                    "key": "system.process.cpu.total.norm.pct",
+                                                    "key": "system.cpu.total.norm.pct",
                                                     "negate": false,
                                                     "type": "exists",
                                                     "value": "exists"
                                                 },
                                                 "query": {
                                                     "exists": {
-                                                        "field": "system.process.cpu.total.norm.pct"
+                                                        "field": "system.cpu.total.norm.pct"
                                                     }
                                                 }
                                             },

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: system
 title: System
-version: "2.3.2"
+version: "2.3.3"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

For "CPU Usage" panels in `[Metrics System] Overview` and `[Metrics System] Host Overview`  the `system.cpu.total.norm.pct` metrics is used. However, in the `[Metrics System] Overview` dashboard, in the panel with "Host", "CPU Usage", "Memory Usage" (see screenshots) the `system.process.cpu.total.norm.pct` metric is used which is `0.00%` most of the time. This PR sets it to `system.cpu.total.norm.pct`.

## Proposed commit message

See title.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] ~I have verified that all data streams collect metrics or logs.~
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->

With the changes from this PR the CPU Usage is now the same, see screenshot of `[Metrics System] Overview` and `[Metrics System] Host Overview` (highlighted by red rounded rectangles):

<img width="1920" height="1200" alt="Screenshot 2025-07-10 at 13 40 52 (2)" src="https://github.com/user-attachments/assets/d1db23de-9cc0-4e01-9a17-c590dc279d78" />
