### PR TITLE
aws: fix handling of last response body in guardduty data stream

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.13.1"
+  changes:
+    - description: Avoid updating fleet health status to degraded when Guardduty has no findings.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/14525
 - version: "3.13.0"
   changes:
     - description: Reduce unnecessary work done in cloudtrail data stream when flattened fields are not required.

--- a/packages/aws/data_stream/guardduty/agent/stream/httpjson.yml.hbs
+++ b/packages/aws/data_stream/guardduty/agent/stream/httpjson.yml.hbs
@@ -80,7 +80,8 @@ chain:
         target: body.findings
 cursor:
   last_execution_datetime:
-    value: '[[if (ne (len .last_response.body.findings) 50)]][[.last_event.updatedAt]][[end]]'
+    value: '[[with $f := (index .last_response.body "findings")]][[if (ne (len $f) 50)]][[.last_event.updatedAt]][[end]][[end]]'
+    ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: aws
 title: AWS
-version: 3.13.0
+version: 3.13.1
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
aws: fix handling of last response body in guardduty data stream

The previous code would access .last_response.body.findings and assess
its size. However, is the findings field is not present, which is
expected in the first part of the chain, the template fails with a map
look-up error. Instead, use the index helper to allow us to more gently
probe for the presence of the field, only preceeding if it is non-zero.
This does not fix the issue, but does allow us to handle it by logic
changes in the input.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #14491
- Ref elastic/beats#45361

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
