### PR TITLE
[cloudflare_logpush] Fix audit data stream null handling

### DIFF
--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.39.1"
+  changes:
+    - description: Fix audit data stream null handling.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/14529
 - version: "1.39.0"
   changes:
     - description: Update the Cloudflare Logpush integration data streams introduction.

--- a/packages/cloudflare_logpush/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -59,9 +59,9 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ssZ
       timezone: UTC
       on_failure:
-      - append:
-          field: error.message
-          value: "{{{_ingest.on_failure_message}}}"
+        - append:
+            field: error.message
+            value: "{{{_ingest.on_failure_message}}}"
   - set:
       tag: set_cloudflare_logpush_audit_timestamp
       field: cloudflare_logpush.audit.timestamp
@@ -223,22 +223,23 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - script:
-        description: Drops null/empty values recursively.
-        lang: painless
-        source: |
-          boolean dropEmptyFields(Object object) {
-            if (object == null || object == "") {
-              return true;
-            } else if (object instanceof Map) {
-              ((Map) object).values().removeIf(value -> dropEmptyFields(value));
-              return (((Map) object).size() == 0);
-            } else if (object instanceof List) {
-              ((List) object).removeIf(value -> dropEmptyFields(value));
-              return (((List) object).length == 0);
-            }
-            return false;
+      tag: script_drops_null_empty_values_recursively
+      description: Drops null/empty values recursively.
+      lang: painless
+      source: |
+        boolean dropEmptyFields(Object object) {
+          if (object == null || object == "") {
+            return true;
+          } else if (object instanceof Map) {
+            ((Map) object).values().removeIf(value -> dropEmptyFields(value));
+            return (((Map) object).size() == 0);
+          } else if (object instanceof List) {
+            ((List) object).removeIf(value -> dropEmptyFields(value));
+            return (((List) object).length == 0);
           }
-          dropEmptyFields(ctx);
+          return false;
+        }
+        dropEmptyFields(ctx);
 on_failure:
   - append:
       tag: append_error_message

--- a/packages/cloudflare_logpush/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -85,12 +85,12 @@ processors:
       tag: set_cloudflare_logpush_audit_action_result
       field: cloudflare_logpush.audit.action.result
       value: success
-      if: ctx.json?.ActionResult
+      if: ctx.json?.ActionResult == true
   - set:
       tag: set_cloudflare_logpush_audit_action_result_2
       field: cloudflare_logpush.audit.action.result
       value: failure
-      if: '!ctx.json?.ActionResult'
+      if: ctx.json?.ActionResult != true
   - set:
       tag: set_event_outcome
       field: event.outcome

--- a/packages/cloudflare_logpush/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -2,24 +2,30 @@
 description: Pipeline for parsing Cloudflare Audit logs.
 processors:
   - set:
+      tag: set_ecs_version
       field: ecs.version
       value: '8.11.0'
   - rename:
+      tag: rename_message
       field: message
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
   - json:
+      tag: json_event_original
       field: event.original
       target_field: json
       ignore_failure: true
   - set:
+      tag: set_event_type
       field: event.type
       value: [info]
   - set:
+      tag: set_event_kind
       field: event.kind
       value: event
   - set:
+      tag: set_event_category
       field: event.category
       value: [authentication]
   - script:
@@ -44,6 +50,7 @@ processors:
         }
         catch (Exception e) {}
   - date:
+      tag: date_json_when
       field: json.When
       if: ctx.json?.When != null && ctx.json.When != ''
       formats:
@@ -56,49 +63,61 @@ processors:
           field: error.message
           value: "{{{_ingest.on_failure_message}}}"
   - set:
+      tag: set_cloudflare_logpush_audit_timestamp
       field: cloudflare_logpush.audit.timestamp
       copy_from: '@timestamp'
       ignore_failure: true
   - rename:
+      tag: rename_json_actiontype
       field: json.ActionType
       target_field: cloudflare_logpush.audit.action.type
       ignore_missing: true
   - set:
+      tag: set_event_action
       field: event.action
       copy_from: cloudflare_logpush.audit.action.type
       ignore_failure: true
   - lowercase:
+      tag: lowercase_event_action
       field: event.action
       ignore_missing: true
   - set:
+      tag: set_cloudflare_logpush_audit_action_result
       field: cloudflare_logpush.audit.action.result
       value: success
       if: ctx.json?.ActionResult
   - set:
+      tag: set_cloudflare_logpush_audit_action_result_2
       field: cloudflare_logpush.audit.action.result
       value: failure
       if: '!ctx.json?.ActionResult'
   - set:
+      tag: set_event_outcome
       field: event.outcome
       copy_from: cloudflare_logpush.audit.action.result
       ignore_failure: true
   - rename:
+      tag: rename_json_actoremail
       field: json.ActorEmail
       target_field: cloudflare_logpush.audit.actor.email
       ignore_missing: true
   - set:
+      tag: set_user_email
       field: user.email
       copy_from: cloudflare_logpush.audit.actor.email
       ignore_empty_value: true
   - rename:
+      tag: rename_json_actorid
       field: json.ActorID
       target_field: cloudflare_logpush.audit.actor.id
       ignore_missing: true
   - set:
+      tag: set_user_id
       field: user.id
       copy_from: cloudflare_logpush.audit.actor.id
       ignore_empty_value: true
   - convert:
+      tag: convert_json_actorip
       field: json.ActorIP
       target_field: cloudflare_logpush.audit.actor.ip
       if: ctx.json?.ActorIP != ''
@@ -109,72 +128,88 @@ processors:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_source_ip
       field: source.ip
       copy_from: cloudflare_logpush.audit.actor.ip
       ignore_empty_value: true
   - rename:
+      tag: rename_json_actortype
       field: json.ActorType
       target_field: cloudflare_logpush.audit.actor.type
       ignore_missing: true
   - rename:
+      tag: rename_json_id
       field: json.ID
       target_field: cloudflare_logpush.audit.id
       ignore_missing: true
   - set:
+      tag: set_event_id
       field: event.id
       copy_from: cloudflare_logpush.audit.id
       ignore_empty_value: true
   - rename:
+      tag: rename_json_interface
       field: json.Interface
       target_field: cloudflare_logpush.audit.interface
       ignore_missing: true
       if: ctx.json?.interface != ''
   - set:
+      tag: set_event_provider
       field: event.provider
       copy_from: cloudflare_logpush.audit.interface
       ignore_empty_value: true
   - rename:
+      tag: rename_json_metadata
       field: json.Metadata
       target_field: cloudflare_logpush.audit.metadata
       ignore_missing: true
   - rename:
+      tag: rename_json_newvalue
       field: json.NewValue
       target_field: cloudflare_logpush.audit.new_value
       if: ctx.json?.NewValue != null
       ignore_missing: true
   - rename:
+      tag: rename_json_oldvalue
       field: json.OldValue
       target_field: cloudflare_logpush.audit.old_value
       if: ctx.json?.OldValue != null
       ignore_missing: true
   - rename:
+      tag: rename_json_ownerid
       field: json.OwnerID
       target_field: cloudflare_logpush.audit.owner.id
       ignore_missing: true
   - rename:
+      tag: rename_json_resourceid
       field: json.ResourceID
       target_field: cloudflare_logpush.audit.resource.id
       ignore_missing: true
   - rename:
+      tag: rename_json_resourcetype
       field: json.ResourceType
       target_field: cloudflare_logpush.audit.resource.type
       ignore_missing: true
   - append:
+      tag: append_related_user
       field: related.user
       value: '{{{user.id}}}'
       if: ctx.user?.id != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_ip
       field: related.ip
       value: '{{{source.ip}}}'
       if: ctx.source?.ip != null
       allow_duplicates: false
       ignore_failure: true
   - remove:
+      tag: remove_json
       field: json
       ignore_missing: true
   - remove:
+      tag: remove_others
       field:
         - cloudflare_logpush.audit.timestamp
         - cloudflare_logpush.audit.action.result
@@ -206,13 +241,19 @@ processors:
           dropEmptyFields(ctx);
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
-      value: |-
-        Processor "{{ _ingest.on_failure_processor_type }}" in pipeline "{{ _ingest.on_failure_pipeline }}" failed with message "{{ _ingest.on_failure_message }}"
+      value: >
+        Processor "{{{ _ingest.on_failure_processor_type }}}"
+        with tag "{{{ _ingest.on_failure_processor_tag }}}"
+        in pipeline "{{{ _ingest.on_failure_pipeline }}}"
+        failed with message "{{{ _ingest.on_failure_message }}}"
   - set:
+      tag: set_event_kind_2
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/cloudflare_logpush/manifest.yml
+++ b/packages/cloudflare_logpush/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cloudflare_logpush
 title: Cloudflare Logpush
-version: "1.39.0"
+version: "1.39.1"
 description: Collect and parse logs from Cloudflare API with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[cloudflare_logpush] Fix audit data stream null handling

Fix misuse of the Elvis operator that was causing the error:

    Cannot invoke "Object.getClass()" because "value" is null

Also add a tag to every processor in the audit data stream and include include
it in the on_failure message. Fix some indentation.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 