### PR TITLE
[FireEye] Add missing ECS fields

### DIFF
--- a/packages/fireeye/changelog.yml
+++ b/packages/fireeye/changelog.yml
@@ -1,6 +1,6 @@
 - version: "1.27.0"
   changes:
-    - description: Add support for `event.outcome`, `event.kind`, `destination.domain`, `file.hash.md5`, `file.path`, `observer.hostname` and `observer.ip` ECS fields.
+    - description: Add support for `event.kind`, `destination.domain`, `file.hash.md5`, `file.path`, `observer.hostname` and `observer.ip` ECS fields.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/14550
 - version: "1.26.0"

--- a/packages/fireeye/changelog.yml
+++ b/packages/fireeye/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.27.0"
+  changes:
+    - description: Add support for `event.outcome`, `event.kind`, `destination.domain`, `file.hash.md5`, `file.path`, `observer.hostname` and `observer.ip` ECS fields.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.26.0"
   changes:
     - description: Add Overview Dashboard.

--- a/packages/fireeye/changelog.yml
+++ b/packages/fireeye/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add support for `event.outcome`, `event.kind`, `destination.domain`, `file.hash.md5`, `file.path`, `observer.hostname` and `observer.ip` ECS fields.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/14550
 - version: "1.26.0"
   changes:
     - description: Add Overview Dashboard.

--- a/packages/fireeye/data_stream/nx/_dev/test/pipeline/test-nx.log-expected.json
+++ b/packages/fireeye/data_stream/nx/_dev/test/pipeline/test-nx.log-expected.json
@@ -16,7 +16,10 @@
                 "category": [
                     "network"
                 ],
+                "kind": "event",
                 "original": "{\"rawmsg\":\"{\\\"timestamp\\\":\\\"2020-09-22T08:34:44.991339+0000\\\",\\\"flow_id\\\":721570461162990,\\\"event_type\\\":\\\"flow\\\",\\\"src_ip\\\":\\\"fe80:0000:0000:0000:feec:daff:fe31:b706\\\",\\\"src_port\\\":45944,\\\"dest_ip\\\":\\\"ff02:0000:0000:0000:0000:0000:0000:0001\\\",\\\"dest_port\\\":10001,\\\"proto\\\":\\\"UDP\\\",\\\"proto_number\\\":17,\\\"ip_tc\\\":0,\\\"app_proto\\\":\\\"failed\\\",\\\"flow\\\":{\\\"pkts_toserver\\\":8,\\\"pkts_toclient\\\":0,\\\"bytes_toserver\\\":1680,\\\"bytes_toclient\\\":0,\\\"start\\\":\\\"2020-09-22T08:34:12.761326+0000\\\",\\\"end\\\":\\\"2020-09-22T08:34:12.761348+0000\\\",\\\"age\\\":0,\\\"state\\\":\\\"new\\\",\\\"reason\\\":\\\"timeout\\\",\\\"alerted\\\":false}}\\n\",\"meta_sip4\":\"192.168.1.99\",\"meta_oml\":520,\"deviceid\":\"860665216674\",\"meta_cbname\":\"fireeye-7e0de1\"}",
+                "outcome": "failure",
+                "reason": "timeout",
                 "type": [
                     "info"
                 ]
@@ -37,15 +40,19 @@
             "network": {
                 "community_id": "1:McNAQcsUcKZYOHHZYm0sD8JiBLc=",
                 "iana_number": "17",
-                "protocol": "failed",
                 "transport": "udp"
             },
             "observer": {
+                "hostname": "fireeye-7e0de1",
+                "ip": [
+                    "192.168.1.99"
+                ],
                 "product": "NX",
                 "vendor": "Fireeye"
             },
             "related": {
                 "ip": [
+                    "192.168.1.99",
                     "fe80:0000:0000:0000:feec:daff:fe31:b706",
                     "ff02:0000:0000:0000:0000:0000:0000:0001"
                 ]
@@ -89,7 +96,10 @@
                 "category": [
                     "network"
                 ],
+                "kind": "event",
                 "original": "{\"rawmsg\":\"{\\\"timestamp\\\":\\\"2020-09-22T08:34:44.993228+0000\\\",\\\"flow_id\\\":175370876476591,\\\"event_type\\\":\\\"flow\\\",\\\"src_ip\\\":\\\"192.168.1.15\\\",\\\"src_port\\\":39808,\\\"dest_ip\\\":\\\"67.43.156.14\\\",\\\"dest_port\\\":123,\\\"proto\\\":\\\"UDP\\\",\\\"proto_number\\\":17,\\\"ip_tos\\\":0,\\\"app_proto\\\":\\\"failed\\\",\\\"flow\\\":{\\\"pkts_toserver\\\":1,\\\"pkts_toclient\\\":1,\\\"bytes_toserver\\\":90,\\\"bytes_toclient\\\":90,\\\"start\\\":\\\"2020-09-22T08:33:15.122031+0000\\\",\\\"end\\\":\\\"2020-09-22T08:33:15.193693+0000\\\",\\\"age\\\":0,\\\"state\\\":\\\"established\\\",\\\"reason\\\":\\\"shutdown\\\",\\\"alerted\\\":false}}\\n\",\"meta_sip4\":\"192.168.1.99\",\"meta_oml\":475,\"deviceid\":\"860665216674\",\"meta_cbname\":\"fireeye-7e0de1\"}",
+                "outcome": "failure",
+                "reason": "shutdown",
                 "type": [
                     "info"
                 ]
@@ -110,15 +120,19 @@
             "network": {
                 "community_id": "1:RXq9OIqNb6ISMqP+R+uVnsOCMAc=",
                 "iana_number": "17",
-                "protocol": "failed",
                 "transport": "udp"
             },
             "observer": {
+                "hostname": "fireeye-7e0de1",
+                "ip": [
+                    "192.168.1.99"
+                ],
                 "product": "NX",
                 "vendor": "Fireeye"
             },
             "related": {
                 "ip": [
+                    "192.168.1.99",
                     "192.168.1.15",
                     "67.43.156.14"
                 ]
@@ -150,7 +164,10 @@
                 "category": [
                     "network"
                 ],
+                "kind": "event",
                 "original": "{\"rawmsg\":\"{\\\"timestamp\\\":\\\"2020-09-22T08:34:44.993227+0000\\\",\\\"flow_id\\\":1285126005631046,\\\"event_type\\\":\\\"flow\\\",\\\"src_ip\\\":\\\"fe80:0000:0000:0000:feec:daff:fe31:b706\\\",\\\"src_port\\\":44535,\\\"dest_ip\\\":\\\"ff02:0000:0000:0000:0000:0000:0000:0001\\\",\\\"dest_port\\\":10001,\\\"proto\\\":\\\"UDP\\\",\\\"proto_number\\\":17,\\\"ip_tc\\\":0,\\\"app_proto\\\":\\\"failed\\\",\\\"flow\\\":{\\\"pkts_toserver\\\":8,\\\"pkts_toclient\\\":0,\\\"bytes_toserver\\\":1680,\\\"bytes_toclient\\\":0,\\\"start\\\":\\\"2020-09-22T08:34:22.763974+0000\\\",\\\"end\\\":\\\"2020-09-22T08:34:22.764073+0000\\\",\\\"age\\\":0,\\\"state\\\":\\\"new\\\",\\\"reason\\\":\\\"shutdown\\\",\\\"alerted\\\":false}}\\n\",\"meta_sip4\":\"192.168.1.99\",\"meta_oml\":522,\"deviceid\":\"860665216674\",\"meta_cbname\":\"fireeye-7e0de1\"}",
+                "outcome": "failure",
+                "reason": "shutdown",
                 "type": [
                     "info"
                 ]
@@ -171,15 +188,19 @@
             "network": {
                 "community_id": "1:99eFhjuGzHgOvXPRAgULIELViPs=",
                 "iana_number": "17",
-                "protocol": "failed",
                 "transport": "udp"
             },
             "observer": {
+                "hostname": "fireeye-7e0de1",
+                "ip": [
+                    "192.168.1.99"
+                ],
                 "product": "NX",
                 "vendor": "Fireeye"
             },
             "related": {
                 "ip": [
+                    "192.168.1.99",
                     "fe80:0000:0000:0000:feec:daff:fe31:b706",
                     "ff02:0000:0000:0000:0000:0000:0000:0001"
                 ]
@@ -223,7 +244,10 @@
                 "category": [
                     "network"
                 ],
+                "kind": "event",
                 "original": "{\"rawmsg\":\"{\\\"timestamp\\\":\\\"2020-09-22T08:34:44.993286+0000\\\",\\\"flow_id\\\":222460015300681,\\\"event_type\\\":\\\"flow\\\",\\\"src_ip\\\":\\\"192.168.1.150\\\",\\\"src_port\\\":51082,\\\"dest_ip\\\":\\\"67.43.156.15\\\",\\\"dest_port\\\":5938,\\\"proto\\\":\\\"TCP\\\",\\\"proto_number\\\":6,\\\"ip_tos\\\":0,\\\"app_proto\\\":\\\"failed\\\",\\\"flow\\\":{\\\"pkts_toserver\\\":799,\\\"pkts_toclient\\\":544,\\\"bytes_toserver\\\":69825,\\\"bytes_toclient\\\":59808,\\\"start\\\":\\\"2020-09-22T04:48:48.282697+0000\\\",\\\"end\\\":\\\"2020-09-22T08:34:36.067255+0000\\\",\\\"age\\\":13548,\\\"state\\\":\\\"established\\\",\\\"reason\\\":\\\"shutdown\\\",\\\"alerted\\\":false},\\\"tcp\\\":{\\\"tcp_flags\\\":\\\"1a\\\",\\\"tcp_flags_ts\\\":\\\"1a\\\",\\\"tcp_flags_tc\\\":\\\"1a\\\",\\\"syn\\\":true,\\\"psh\\\":true,\\\"ack\\\":true,\\\"state\\\":\\\"established\\\"}}\\n\",\"meta_sip4\":\"192.168.1.99\",\"meta_oml\":611,\"deviceid\":\"860665216674\",\"meta_cbname\":\"fireeye-7e0de1\"}",
+                "outcome": "failure",
+                "reason": "shutdown",
                 "type": [
                     "info"
                 ]
@@ -253,15 +277,19 @@
             "network": {
                 "community_id": "1:45/AGSM9JqMdS9WIK3bAZqim3A4=",
                 "iana_number": "6",
-                "protocol": "failed",
                 "transport": "tcp"
             },
             "observer": {
+                "hostname": "fireeye-7e0de1",
+                "ip": [
+                    "192.168.1.99"
+                ],
                 "product": "NX",
                 "vendor": "Fireeye"
             },
             "related": {
                 "ip": [
+                    "192.168.1.99",
                     "192.168.1.150",
                     "67.43.156.15"
                 ]
@@ -305,7 +333,10 @@
                 "category": [
                     "network"
                 ],
+                "kind": "event",
                 "original": "{\"rawmsg\":\"{\\\"timestamp\\\":\\\"2020-09-22T08:34:44.993501+0000\\\",\\\"flow_id\\\":1463569002949603,\\\"event_type\\\":\\\"flow\\\",\\\"src_ip\\\":\\\"192.168.1.15\\\",\\\"src_port\\\":52147,\\\"dest_ip\\\":\\\"67.43.156.14\\\",\\\"dest_port\\\":123,\\\"proto\\\":\\\"UDP\\\",\\\"proto_number\\\":17,\\\"ip_tos\\\":0,\\\"app_proto\\\":\\\"failed\\\",\\\"flow\\\":{\\\"pkts_toserver\\\":1,\\\"pkts_toclient\\\":1,\\\"bytes_toserver\\\":90,\\\"bytes_toclient\\\":90,\\\"start\\\":\\\"2020-09-22T08:32:06.355299+0000\\\",\\\"end\\\":\\\"2020-09-22T08:32:06.439495+0000\\\",\\\"age\\\":0,\\\"state\\\":\\\"established\\\",\\\"reason\\\":\\\"shutdown\\\",\\\"alerted\\\":false}}\\n\",\"meta_sip4\":\"192.168.1.99\",\"meta_oml\":476,\"deviceid\":\"860665216674\",\"meta_cbname\":\"fireeye-7e0de1\"}",
+                "outcome": "failure",
+                "reason": "shutdown",
                 "type": [
                     "info"
                 ]
@@ -326,15 +357,19 @@
             "network": {
                 "community_id": "1:lPFhChZNfHDZ1i2YD0w8DBTTAf0=",
                 "iana_number": "17",
-                "protocol": "failed",
                 "transport": "udp"
             },
             "observer": {
+                "hostname": "fireeye-7e0de1",
+                "ip": [
+                    "192.168.1.99"
+                ],
                 "product": "NX",
                 "vendor": "Fireeye"
             },
             "related": {
                 "ip": [
+                    "192.168.1.99",
                     "192.168.1.15",
                     "67.43.156.14"
                 ]
@@ -357,6 +392,7 @@
                 "as": {
                     "number": 35908
                 },
+                "domain": "cloud.fireeye.com",
                 "geo": {
                     "continent_name": "Asia",
                     "country_iso_code": "BT",
@@ -376,7 +412,9 @@
                 "category": [
                     "network"
                 ],
+                "kind": "event",
                 "original": "{\"rawmsg\":\"{\\\"timestamp\\\":\\\"2020-09-23T05:02:01.175635+0000\\\",\\\"flow_id\\\":1136872856843530,\\\"iface\\\":\\\"pether3\\\",\\\"event_type\\\":\\\"tls\\\",\\\"src_ip\\\":\\\"192.168.1.99\\\",\\\"src_port\\\":53918,\\\"dest_ip\\\":\\\"67.43.156.13\\\",\\\"dest_port\\\":443,\\\"proto\\\":\\\"TCP\\\",\\\"tls\\\":{\\\"subject\\\":\\\"C=US, ST=CA, L=San Francisco, O=Cloudflare, Inc., CN=fireeye.com\\\",\\\"issuerdn\\\":\\\"C=US, O=Cloudflare, Inc., CN=Cloudflare Inc ECC CA-3\\\",\\\"ja3\\\":{\\\"hash\\\":\\\"21536525fbf9e289f79e0f98af64bb59\\\",\\\"string\\\":\\\"771,49199-49195-49200-49196-158-159-49191-49187-49192-49188-103-107-49171-49161-49172-49162-51-57-156-157-60-61-47-53-255,0-11-10-13-15-13172,25-24-23,0-1-2\\\"},\\\"ja3s\\\":{\\\"hash\\\":\\\"9873b112313d7c4e5e8ef6207e6c6f0d\\\",\\\"string\\\":\\\"771,49195,0-65281-11-13172\\\"},\\\"fingerprint\\\":\\\"2a:6a:46:d2:05:4d:7b:22:1b:68:02:f2:ee:f0:09:c6:ff:15:e9:58\\\",\\\"sni\\\":\\\"cloud.fireeye.com\\\",\\\"version\\\":\\\"TLS 1.2\\\",\\\"notbefore\\\":\\\"2020-07-01T00:00:00.000000+0000\\\",\\\"notafter\\\":\\\"2021-07-01T12:00:00.000000+0000\\\",\\\"client_ciphersuites\\\":[49199,49195,49200,49196,158,159,49191,49187,49192,49188,103,107,49171,49161,49172,49162,51,57,156,157,60,61,47,53,255],\\\"client_tls_exts\\\":[0,11,10,13,15,13172],\\\"server_ciphersuite\\\":49195,\\\"server_tls_exts\\\":[0,65281,11,13172],\\\"pubkeylength\\\":65}}\\n\",\"meta_sip4\":\"192.168.1.99\",\"meta_oml\":1146,\"deviceid\":\"860665216674\",\"meta_cbname\":\"fireeye-7e0de1\"}",
+                "outcome": "unknown",
                 "type": [
                     "info"
                 ]
@@ -392,11 +430,15 @@
                 "transport": "tcp"
             },
             "observer": {
+                "hostname": "fireeye-7e0de1",
                 "ingress": {
                     "interface": {
                         "name": "pether3"
                     }
                 },
+                "ip": [
+                    "192.168.1.99"
+                ],
                 "product": "NX",
                 "vendor": "Fireeye"
             },
@@ -404,6 +446,9 @@
                 "hash": [
                     "9873b112313d7c4e5e8ef6207e6c6f0d",
                     "21536525fbf9e289f79e0f98af64bb59"
+                ],
+                "hosts": [
+                    "cloud.fireeye.com"
                 ],
                 "ip": [
                     "192.168.1.99",
@@ -494,10 +539,19 @@
                     "file",
                     "network"
                 ],
+                "kind": "event",
                 "original": "{\"rawmsg\":\"{\\\"timestamp\\\":\\\"2020-09-23T05:02:19.906154+0000\\\",\\\"flow_id\\\":1444203537876422,\\\"iface\\\":\\\"pether3\\\",\\\"event_type\\\":\\\"fileinfo\\\",\\\"src_ip\\\":\\\"192.168.1.222\\\",\\\"src_port\\\":47220,\\\"dest_ip\\\":\\\"192.168.100.31\\\",\\\"dest_port\\\":5601,\\\"proto\\\":\\\"TCP\\\",\\\"http\\\":{\\\"hostname\\\":\\\"192.168.100.31\\\",\\\"url\\\":\\\"\\\\/internal\\\\/search\\\\/es\\\",\\\"http_user_agent\\\":\\\"Mozilla\\\\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\\\\/537.36 (KHTML, like Gecko) Chrome\\\\/85.0.4183.102 Safari\\\\/537.36\\\",\\\"http_refer\\\":\\\"http:\\\\/\\\\/192.168.100.31:5601\\\\/app\\\\/kibana\\\",\\\"http_method\\\":\\\"POST\\\",\\\"protocol\\\":\\\"HTTP\\\\/1.1\\\",\\\"length\\\":0},\\\"app_proto\\\":\\\"http\\\",\\\"fileinfo\\\":{\\\"filename\\\":\\\"\\\\/internal\\\\/search\\\\/es\\\",\\\"magic\\\":\\\"ASCII text, with very long lines, with no line terminators\\\",\\\"state\\\":\\\"CLOSED\\\",\\\"md5\\\":\\\"548d03d3e11c009da833e6e59c4adfee\\\",\\\"stored\\\":false,\\\"size\\\":6394,\\\"tx_id\\\":0}}\\n\",\"meta_sip4\":\"192.168.1.99\",\"meta_oml\":769,\"deviceid\":\"860665216674\",\"meta_cbname\":\"fireeye-7e0de1\"}",
+                "outcome": "unknown",
                 "type": [
                     "info"
                 ]
+            },
+            "file": {
+                "hash": {
+                    "md5": "548d03d3e11c009da833e6e59c4adfee"
+                },
+                "path": "/internal/search/es",
+                "size": 6394
             },
             "fireeye": {
                 "nx": {
@@ -529,16 +583,24 @@
                 "transport": "tcp"
             },
             "observer": {
+                "hostname": "fireeye-7e0de1",
                 "ingress": {
                     "interface": {
                         "name": "pether3"
                     }
                 },
+                "ip": [
+                    "192.168.1.99"
+                ],
                 "product": "NX",
                 "vendor": "Fireeye"
             },
             "related": {
+                "hosts": [
+                    "192.168.100.31"
+                ],
                 "ip": [
+                    "192.168.1.99",
                     "192.168.1.222",
                     "192.168.100.31"
                 ]
@@ -603,7 +665,9 @@
                 "category": [
                     "network"
                 ],
+                "kind": "event",
                 "original": "{\"rawmsg\":\"{\\\"timestamp\\\":\\\"2020-09-23T05:02:41.077232+0000\\\",\\\"flow_id\\\":206535698492848,\\\"iface\\\":\\\"pether3\\\",\\\"event_type\\\":\\\"dns\\\",\\\"src_ip\\\":\\\"192.168.1.176\\\",\\\"src_port\\\":60269,\\\"dest_ip\\\":\\\"67.43.156.15\\\",\\\"dest_port\\\":53,\\\"proto\\\":\\\"UDP\\\",\\\"dns\\\":{\\\"type\\\":\\\"query\\\",\\\"id\\\":28224,\\\"rrname\\\":\\\"time-ios.apple.com\\\",\\\"rrtype\\\":\\\"A\\\",\\\"tx_id\\\":0}}\\n\",\"meta_sip4\":\"192.168.1.99\",\"meta_oml\":289,\"deviceid\":\"860665216674\",\"meta_cbname\":\"fireeye-7e0de1\"}",
+                "outcome": "unknown",
                 "type": [
                     "info"
                 ]
@@ -619,16 +683,21 @@
                 "transport": "udp"
             },
             "observer": {
+                "hostname": "fireeye-7e0de1",
                 "ingress": {
                     "interface": {
                         "name": "pether3"
                     }
                 },
+                "ip": [
+                    "192.168.1.99"
+                ],
                 "product": "NX",
                 "vendor": "Fireeye"
             },
             "related": {
                 "ip": [
+                    "192.168.1.99",
                     "192.168.1.176",
                     "67.43.156.15"
                 ]

--- a/packages/fireeye/data_stream/nx/_dev/test/pipeline/test-nx.log-expected.json
+++ b/packages/fireeye/data_stream/nx/_dev/test/pipeline/test-nx.log-expected.json
@@ -18,7 +18,6 @@
                 ],
                 "kind": "event",
                 "original": "{\"rawmsg\":\"{\\\"timestamp\\\":\\\"2020-09-22T08:34:44.991339+0000\\\",\\\"flow_id\\\":721570461162990,\\\"event_type\\\":\\\"flow\\\",\\\"src_ip\\\":\\\"fe80:0000:0000:0000:feec:daff:fe31:b706\\\",\\\"src_port\\\":45944,\\\"dest_ip\\\":\\\"ff02:0000:0000:0000:0000:0000:0000:0001\\\",\\\"dest_port\\\":10001,\\\"proto\\\":\\\"UDP\\\",\\\"proto_number\\\":17,\\\"ip_tc\\\":0,\\\"app_proto\\\":\\\"failed\\\",\\\"flow\\\":{\\\"pkts_toserver\\\":8,\\\"pkts_toclient\\\":0,\\\"bytes_toserver\\\":1680,\\\"bytes_toclient\\\":0,\\\"start\\\":\\\"2020-09-22T08:34:12.761326+0000\\\",\\\"end\\\":\\\"2020-09-22T08:34:12.761348+0000\\\",\\\"age\\\":0,\\\"state\\\":\\\"new\\\",\\\"reason\\\":\\\"timeout\\\",\\\"alerted\\\":false}}\\n\",\"meta_sip4\":\"192.168.1.99\",\"meta_oml\":520,\"deviceid\":\"860665216674\",\"meta_cbname\":\"fireeye-7e0de1\"}",
-                "outcome": "failure",
                 "reason": "timeout",
                 "type": [
                     "info"
@@ -40,6 +39,7 @@
             "network": {
                 "community_id": "1:McNAQcsUcKZYOHHZYm0sD8JiBLc=",
                 "iana_number": "17",
+                "protocol": "failed",
                 "transport": "udp"
             },
             "observer": {
@@ -98,7 +98,6 @@
                 ],
                 "kind": "event",
                 "original": "{\"rawmsg\":\"{\\\"timestamp\\\":\\\"2020-09-22T08:34:44.993228+0000\\\",\\\"flow_id\\\":175370876476591,\\\"event_type\\\":\\\"flow\\\",\\\"src_ip\\\":\\\"192.168.1.15\\\",\\\"src_port\\\":39808,\\\"dest_ip\\\":\\\"67.43.156.14\\\",\\\"dest_port\\\":123,\\\"proto\\\":\\\"UDP\\\",\\\"proto_number\\\":17,\\\"ip_tos\\\":0,\\\"app_proto\\\":\\\"failed\\\",\\\"flow\\\":{\\\"pkts_toserver\\\":1,\\\"pkts_toclient\\\":1,\\\"bytes_toserver\\\":90,\\\"bytes_toclient\\\":90,\\\"start\\\":\\\"2020-09-22T08:33:15.122031+0000\\\",\\\"end\\\":\\\"2020-09-22T08:33:15.193693+0000\\\",\\\"age\\\":0,\\\"state\\\":\\\"established\\\",\\\"reason\\\":\\\"shutdown\\\",\\\"alerted\\\":false}}\\n\",\"meta_sip4\":\"192.168.1.99\",\"meta_oml\":475,\"deviceid\":\"860665216674\",\"meta_cbname\":\"fireeye-7e0de1\"}",
-                "outcome": "failure",
                 "reason": "shutdown",
                 "type": [
                     "info"
@@ -120,6 +119,7 @@
             "network": {
                 "community_id": "1:RXq9OIqNb6ISMqP+R+uVnsOCMAc=",
                 "iana_number": "17",
+                "protocol": "failed",
                 "transport": "udp"
             },
             "observer": {
@@ -166,7 +166,6 @@
                 ],
                 "kind": "event",
                 "original": "{\"rawmsg\":\"{\\\"timestamp\\\":\\\"2020-09-22T08:34:44.993227+0000\\\",\\\"flow_id\\\":1285126005631046,\\\"event_type\\\":\\\"flow\\\",\\\"src_ip\\\":\\\"fe80:0000:0000:0000:feec:daff:fe31:b706\\\",\\\"src_port\\\":44535,\\\"dest_ip\\\":\\\"ff02:0000:0000:0000:0000:0000:0000:0001\\\",\\\"dest_port\\\":10001,\\\"proto\\\":\\\"UDP\\\",\\\"proto_number\\\":17,\\\"ip_tc\\\":0,\\\"app_proto\\\":\\\"failed\\\",\\\"flow\\\":{\\\"pkts_toserver\\\":8,\\\"pkts_toclient\\\":0,\\\"bytes_toserver\\\":1680,\\\"bytes_toclient\\\":0,\\\"start\\\":\\\"2020-09-22T08:34:22.763974+0000\\\",\\\"end\\\":\\\"2020-09-22T08:34:22.764073+0000\\\",\\\"age\\\":0,\\\"state\\\":\\\"new\\\",\\\"reason\\\":\\\"shutdown\\\",\\\"alerted\\\":false}}\\n\",\"meta_sip4\":\"192.168.1.99\",\"meta_oml\":522,\"deviceid\":\"860665216674\",\"meta_cbname\":\"fireeye-7e0de1\"}",
-                "outcome": "failure",
                 "reason": "shutdown",
                 "type": [
                     "info"
@@ -188,6 +187,7 @@
             "network": {
                 "community_id": "1:99eFhjuGzHgOvXPRAgULIELViPs=",
                 "iana_number": "17",
+                "protocol": "failed",
                 "transport": "udp"
             },
             "observer": {
@@ -246,7 +246,6 @@
                 ],
                 "kind": "event",
                 "original": "{\"rawmsg\":\"{\\\"timestamp\\\":\\\"2020-09-22T08:34:44.993286+0000\\\",\\\"flow_id\\\":222460015300681,\\\"event_type\\\":\\\"flow\\\",\\\"src_ip\\\":\\\"192.168.1.150\\\",\\\"src_port\\\":51082,\\\"dest_ip\\\":\\\"67.43.156.15\\\",\\\"dest_port\\\":5938,\\\"proto\\\":\\\"TCP\\\",\\\"proto_number\\\":6,\\\"ip_tos\\\":0,\\\"app_proto\\\":\\\"failed\\\",\\\"flow\\\":{\\\"pkts_toserver\\\":799,\\\"pkts_toclient\\\":544,\\\"bytes_toserver\\\":69825,\\\"bytes_toclient\\\":59808,\\\"start\\\":\\\"2020-09-22T04:48:48.282697+0000\\\",\\\"end\\\":\\\"2020-09-22T08:34:36.067255+0000\\\",\\\"age\\\":13548,\\\"state\\\":\\\"established\\\",\\\"reason\\\":\\\"shutdown\\\",\\\"alerted\\\":false},\\\"tcp\\\":{\\\"tcp_flags\\\":\\\"1a\\\",\\\"tcp_flags_ts\\\":\\\"1a\\\",\\\"tcp_flags_tc\\\":\\\"1a\\\",\\\"syn\\\":true,\\\"psh\\\":true,\\\"ack\\\":true,\\\"state\\\":\\\"established\\\"}}\\n\",\"meta_sip4\":\"192.168.1.99\",\"meta_oml\":611,\"deviceid\":\"860665216674\",\"meta_cbname\":\"fireeye-7e0de1\"}",
-                "outcome": "failure",
                 "reason": "shutdown",
                 "type": [
                     "info"
@@ -277,6 +276,7 @@
             "network": {
                 "community_id": "1:45/AGSM9JqMdS9WIK3bAZqim3A4=",
                 "iana_number": "6",
+                "protocol": "failed",
                 "transport": "tcp"
             },
             "observer": {
@@ -335,7 +335,6 @@
                 ],
                 "kind": "event",
                 "original": "{\"rawmsg\":\"{\\\"timestamp\\\":\\\"2020-09-22T08:34:44.993501+0000\\\",\\\"flow_id\\\":1463569002949603,\\\"event_type\\\":\\\"flow\\\",\\\"src_ip\\\":\\\"192.168.1.15\\\",\\\"src_port\\\":52147,\\\"dest_ip\\\":\\\"67.43.156.14\\\",\\\"dest_port\\\":123,\\\"proto\\\":\\\"UDP\\\",\\\"proto_number\\\":17,\\\"ip_tos\\\":0,\\\"app_proto\\\":\\\"failed\\\",\\\"flow\\\":{\\\"pkts_toserver\\\":1,\\\"pkts_toclient\\\":1,\\\"bytes_toserver\\\":90,\\\"bytes_toclient\\\":90,\\\"start\\\":\\\"2020-09-22T08:32:06.355299+0000\\\",\\\"end\\\":\\\"2020-09-22T08:32:06.439495+0000\\\",\\\"age\\\":0,\\\"state\\\":\\\"established\\\",\\\"reason\\\":\\\"shutdown\\\",\\\"alerted\\\":false}}\\n\",\"meta_sip4\":\"192.168.1.99\",\"meta_oml\":476,\"deviceid\":\"860665216674\",\"meta_cbname\":\"fireeye-7e0de1\"}",
-                "outcome": "failure",
                 "reason": "shutdown",
                 "type": [
                     "info"
@@ -357,6 +356,7 @@
             "network": {
                 "community_id": "1:lPFhChZNfHDZ1i2YD0w8DBTTAf0=",
                 "iana_number": "17",
+                "protocol": "failed",
                 "transport": "udp"
             },
             "observer": {
@@ -414,7 +414,6 @@
                 ],
                 "kind": "event",
                 "original": "{\"rawmsg\":\"{\\\"timestamp\\\":\\\"2020-09-23T05:02:01.175635+0000\\\",\\\"flow_id\\\":1136872856843530,\\\"iface\\\":\\\"pether3\\\",\\\"event_type\\\":\\\"tls\\\",\\\"src_ip\\\":\\\"192.168.1.99\\\",\\\"src_port\\\":53918,\\\"dest_ip\\\":\\\"67.43.156.13\\\",\\\"dest_port\\\":443,\\\"proto\\\":\\\"TCP\\\",\\\"tls\\\":{\\\"subject\\\":\\\"C=US, ST=CA, L=San Francisco, O=Cloudflare, Inc., CN=fireeye.com\\\",\\\"issuerdn\\\":\\\"C=US, O=Cloudflare, Inc., CN=Cloudflare Inc ECC CA-3\\\",\\\"ja3\\\":{\\\"hash\\\":\\\"21536525fbf9e289f79e0f98af64bb59\\\",\\\"string\\\":\\\"771,49199-49195-49200-49196-158-159-49191-49187-49192-49188-103-107-49171-49161-49172-49162-51-57-156-157-60-61-47-53-255,0-11-10-13-15-13172,25-24-23,0-1-2\\\"},\\\"ja3s\\\":{\\\"hash\\\":\\\"9873b112313d7c4e5e8ef6207e6c6f0d\\\",\\\"string\\\":\\\"771,49195,0-65281-11-13172\\\"},\\\"fingerprint\\\":\\\"2a:6a:46:d2:05:4d:7b:22:1b:68:02:f2:ee:f0:09:c6:ff:15:e9:58\\\",\\\"sni\\\":\\\"cloud.fireeye.com\\\",\\\"version\\\":\\\"TLS 1.2\\\",\\\"notbefore\\\":\\\"2020-07-01T00:00:00.000000+0000\\\",\\\"notafter\\\":\\\"2021-07-01T12:00:00.000000+0000\\\",\\\"client_ciphersuites\\\":[49199,49195,49200,49196,158,159,49191,49187,49192,49188,103,107,49171,49161,49172,49162,51,57,156,157,60,61,47,53,255],\\\"client_tls_exts\\\":[0,11,10,13,15,13172],\\\"server_ciphersuite\\\":49195,\\\"server_tls_exts\\\":[0,65281,11,13172],\\\"pubkeylength\\\":65}}\\n\",\"meta_sip4\":\"192.168.1.99\",\"meta_oml\":1146,\"deviceid\":\"860665216674\",\"meta_cbname\":\"fireeye-7e0de1\"}",
-                "outcome": "unknown",
                 "type": [
                     "info"
                 ]
@@ -541,7 +540,6 @@
                 ],
                 "kind": "event",
                 "original": "{\"rawmsg\":\"{\\\"timestamp\\\":\\\"2020-09-23T05:02:19.906154+0000\\\",\\\"flow_id\\\":1444203537876422,\\\"iface\\\":\\\"pether3\\\",\\\"event_type\\\":\\\"fileinfo\\\",\\\"src_ip\\\":\\\"192.168.1.222\\\",\\\"src_port\\\":47220,\\\"dest_ip\\\":\\\"192.168.100.31\\\",\\\"dest_port\\\":5601,\\\"proto\\\":\\\"TCP\\\",\\\"http\\\":{\\\"hostname\\\":\\\"192.168.100.31\\\",\\\"url\\\":\\\"\\\\/internal\\\\/search\\\\/es\\\",\\\"http_user_agent\\\":\\\"Mozilla\\\\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\\\\/537.36 (KHTML, like Gecko) Chrome\\\\/85.0.4183.102 Safari\\\\/537.36\\\",\\\"http_refer\\\":\\\"http:\\\\/\\\\/192.168.100.31:5601\\\\/app\\\\/kibana\\\",\\\"http_method\\\":\\\"POST\\\",\\\"protocol\\\":\\\"HTTP\\\\/1.1\\\",\\\"length\\\":0},\\\"app_proto\\\":\\\"http\\\",\\\"fileinfo\\\":{\\\"filename\\\":\\\"\\\\/internal\\\\/search\\\\/es\\\",\\\"magic\\\":\\\"ASCII text, with very long lines, with no line terminators\\\",\\\"state\\\":\\\"CLOSED\\\",\\\"md5\\\":\\\"548d03d3e11c009da833e6e59c4adfee\\\",\\\"stored\\\":false,\\\"size\\\":6394,\\\"tx_id\\\":0}}\\n\",\"meta_sip4\":\"192.168.1.99\",\"meta_oml\":769,\"deviceid\":\"860665216674\",\"meta_cbname\":\"fireeye-7e0de1\"}",
-                "outcome": "unknown",
                 "type": [
                     "info"
                 ]
@@ -667,7 +665,6 @@
                 ],
                 "kind": "event",
                 "original": "{\"rawmsg\":\"{\\\"timestamp\\\":\\\"2020-09-23T05:02:41.077232+0000\\\",\\\"flow_id\\\":206535698492848,\\\"iface\\\":\\\"pether3\\\",\\\"event_type\\\":\\\"dns\\\",\\\"src_ip\\\":\\\"192.168.1.176\\\",\\\"src_port\\\":60269,\\\"dest_ip\\\":\\\"67.43.156.15\\\",\\\"dest_port\\\":53,\\\"proto\\\":\\\"UDP\\\",\\\"dns\\\":{\\\"type\\\":\\\"query\\\",\\\"id\\\":28224,\\\"rrname\\\":\\\"time-ios.apple.com\\\",\\\"rrtype\\\":\\\"A\\\",\\\"tx_id\\\":0}}\\n\",\"meta_sip4\":\"192.168.1.99\",\"meta_oml\":289,\"deviceid\":\"860665216674\",\"meta_cbname\":\"fireeye-7e0de1\"}",
-                "outcome": "unknown",
                 "type": [
                     "info"
                 ]

--- a/packages/fireeye/data_stream/nx/_dev/test/pipeline/test-nx.log-expected.json
+++ b/packages/fireeye/data_stream/nx/_dev/test/pipeline/test-nx.log-expected.json
@@ -25,6 +25,8 @@
             },
             "fireeye": {
                 "nx": {
+                    "device_oml": 520,
+                    "deviceid": "860665216674",
                     "flow": {
                         "age": 0,
                         "alerted": false,
@@ -33,7 +35,8 @@
                         "starttime": "2020-09-22T08:34:12.761326+0000",
                         "state": "new"
                     },
-                    "flow_id": 721570461162990
+                    "flow_id": 721570461162990,
+                    "hostname": "fireeye-7e0de1"
                 }
             },
             "network": {
@@ -105,6 +108,8 @@
             },
             "fireeye": {
                 "nx": {
+                    "device_oml": 475,
+                    "deviceid": "860665216674",
                     "flow": {
                         "age": 0,
                         "alerted": false,
@@ -113,7 +118,8 @@
                         "starttime": "2020-09-22T08:33:15.122031+0000",
                         "state": "established"
                     },
-                    "flow_id": 175370876476591
+                    "flow_id": 175370876476591,
+                    "hostname": "fireeye-7e0de1"
                 }
             },
             "network": {
@@ -173,6 +179,8 @@
             },
             "fireeye": {
                 "nx": {
+                    "device_oml": 522,
+                    "deviceid": "860665216674",
                     "flow": {
                         "age": 0,
                         "alerted": false,
@@ -181,7 +189,8 @@
                         "starttime": "2020-09-22T08:34:22.763974+0000",
                         "state": "new"
                     },
-                    "flow_id": 1285126005631046
+                    "flow_id": 1285126005631046,
+                    "hostname": "fireeye-7e0de1"
                 }
             },
             "network": {
@@ -253,6 +262,8 @@
             },
             "fireeye": {
                 "nx": {
+                    "device_oml": 611,
+                    "deviceid": "860665216674",
                     "flow": {
                         "age": 13548,
                         "alerted": false,
@@ -262,6 +273,7 @@
                         "state": "established"
                     },
                     "flow_id": 222460015300681,
+                    "hostname": "fireeye-7e0de1",
                     "tcp": {
                         "ack": true,
                         "psh": true,
@@ -342,6 +354,8 @@
             },
             "fireeye": {
                 "nx": {
+                    "device_oml": 476,
+                    "deviceid": "860665216674",
                     "flow": {
                         "age": 0,
                         "alerted": false,
@@ -350,7 +364,8 @@
                         "starttime": "2020-09-22T08:32:06.355299+0000",
                         "state": "established"
                     },
-                    "flow_id": 1463569002949603
+                    "flow_id": 1463569002949603,
+                    "hostname": "fireeye-7e0de1"
                 }
             },
             "network": {
@@ -420,7 +435,10 @@
             },
             "fireeye": {
                 "nx": {
-                    "flow_id": 1136872856843530
+                    "device_oml": 1146,
+                    "deviceid": "860665216674",
+                    "flow_id": 1136872856843530,
+                    "hostname": "fireeye-7e0de1"
                 }
             },
             "network": {
@@ -548,11 +566,13 @@
                 "hash": {
                     "md5": "548d03d3e11c009da833e6e59c4adfee"
                 },
-                "path": "/internal/search/es",
+                "name": "/internal/search/es",
                 "size": 6394
             },
             "fireeye": {
                 "nx": {
+                    "device_oml": 769,
+                    "deviceid": "860665216674",
                     "fileinfo": {
                         "filename": "/internal/search/es",
                         "magic": "ASCII text, with very long lines, with no line terminators",
@@ -561,7 +581,8 @@
                         "state": "CLOSED",
                         "stored": false
                     },
-                    "flow_id": 1444203537876422
+                    "flow_id": 1444203537876422,
+                    "hostname": "fireeye-7e0de1"
                 }
             },
             "http": {
@@ -671,7 +692,10 @@
             },
             "fireeye": {
                 "nx": {
-                    "flow_id": 206535698492848
+                    "device_oml": 289,
+                    "deviceid": "860665216674",
+                    "flow_id": 206535698492848,
+                    "hostname": "fireeye-7e0de1"
                 }
             },
             "network": {

--- a/packages/fireeye/data_stream/nx/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fireeye/data_stream/nx/elasticsearch/ingest_pipeline/default.yml
@@ -5,6 +5,10 @@ processors:
       field: ecs.version
       value: '8.11.0'
   - set:
+      field: event.kind
+      tag: set_event_kind_to_event
+      value: event
+  - set:
       field: observer.vendor
       value: "Fireeye"
   - set:

--- a/packages/fireeye/data_stream/nx/elasticsearch/ingest_pipeline/renaming-raws.yml
+++ b/packages/fireeye/data_stream/nx/elasticsearch/ingest_pipeline/renaming-raws.yml
@@ -12,7 +12,10 @@ processors:
   - rename:
       field: rawmsg.app_proto
       target_field: network.protocol
-      if: ctx.rawmsg.app_proto != null && !['failed','succeded'].contains(ctx.rawmsg.app_proto.toLowerCase())
+      if: >-
+        ctx.rawmsg?.app_proto != null
+        && ctx.rawmsg.app_proto.toLowerCase() != 'failed'
+        && ctx.rawmsg.app_proto.toLowerCase() != 'succeeded'
       ignore_missing: true
   - set:
       field: event.outcome
@@ -21,7 +24,7 @@ processors:
   - set:
       field: event.outcome
       value: success
-      if: ctx.rawmsg?.app_proto != null && ['succeded'].contains(ctx.rawmsg.app_proto.toLowerCase())
+      if: ctx.rawmsg?.app_proto?.equalsIgnoreCase('succeeded') == true
   - set:
       field: event.outcome
       value: unknown

--- a/packages/fireeye/data_stream/nx/elasticsearch/ingest_pipeline/renaming-raws.yml
+++ b/packages/fireeye/data_stream/nx/elasticsearch/ingest_pipeline/renaming-raws.yml
@@ -12,23 +12,7 @@ processors:
   - rename:
       field: rawmsg.app_proto
       target_field: network.protocol
-      if: >-
-        ctx.rawmsg?.app_proto != null
-        && ctx.rawmsg.app_proto.equalsIgnoreCase('failed') == false
-        && ctx.rawmsg.app_proto.equalsIgnoreCase('succeeded') == false
       ignore_missing: true
-  - set:
-      field: event.outcome
-      value: failure
-      if: ctx.rawmsg?.app_proto?.equalsIgnoreCase('failed') == true
-  - set:
-      field: event.outcome
-      value: success
-      if: ctx.rawmsg?.app_proto?.equalsIgnoreCase('succeeded') == true
-  - set:
-      field: event.outcome
-      value: unknown
-      if: ctx.event?.outcome == null
   - rename:
       field: rawmsg.flow_id
       target_field: fireeye.nx.flow_id

--- a/packages/fireeye/data_stream/nx/elasticsearch/ingest_pipeline/renaming-raws.yml
+++ b/packages/fireeye/data_stream/nx/elasticsearch/ingest_pipeline/renaming-raws.yml
@@ -14,8 +14,8 @@ processors:
       target_field: network.protocol
       if: >-
         ctx.rawmsg?.app_proto != null
-        && ctx.rawmsg.app_proto.toLowerCase() != 'failed'
-        && ctx.rawmsg.app_proto.toLowerCase() != 'succeeded'
+        && ctx.rawmsg.app_proto.equalsIgnoreCase('failed') == false
+        && ctx.rawmsg.app_proto.equalsIgnoreCase('succeeded') == false
       ignore_missing: true
   - set:
       field: event.outcome

--- a/packages/fireeye/data_stream/nx/elasticsearch/ingest_pipeline/renaming-raws.yml
+++ b/packages/fireeye/data_stream/nx/elasticsearch/ingest_pipeline/renaming-raws.yml
@@ -17,7 +17,7 @@ processors:
   - set:
       field: event.outcome
       value: failure
-      if: ctx.rawmsg?.app_proto != null && ['failed'].contains(ctx.rawmsg.app_proto.toLowerCase())
+      if: ctx.rawmsg?.app_proto?.equalsIgnoreCase('failed') == true
   - set:
       field: event.outcome
       value: success

--- a/packages/fireeye/data_stream/nx/elasticsearch/ingest_pipeline/renaming-raws.yml
+++ b/packages/fireeye/data_stream/nx/elasticsearch/ingest_pipeline/renaming-raws.yml
@@ -12,7 +12,20 @@ processors:
   - rename:
       field: rawmsg.app_proto
       target_field: network.protocol
+      if: ctx.rawmsg.app_proto != null && !['failed','succeded'].contains(ctx.rawmsg.app_proto.toLowerCase())
       ignore_missing: true
+  - set:
+      field: event.outcome
+      value: failure
+      if: ctx.rawmsg?.app_proto != null && ['failed'].contains(ctx.rawmsg.app_proto.toLowerCase())
+  - set:
+      field: event.outcome
+      value: success
+      if: ctx.rawmsg?.app_proto != null && ['succeded'].contains(ctx.rawmsg.app_proto.toLowerCase())
+  - set:
+      field: event.outcome
+      value: unknown
+      if: ctx.event?.outcome == null
   - rename:
       field: rawmsg.flow_id
       target_field: fireeye.nx.flow_id
@@ -45,10 +58,18 @@ processors:
       field: rawmsg.dest_port
       target_field: destination.port
       ignore_missing: true
-  - rename:
-      field: meta_sip4
-      target_field: fireeye.nx.device_ip
-      ignore_missing: true
+  - append:
+      field: observer.ip
+      tag: append_observer_ip_from_meta_sip4
+      value: "{{{json.meta_sip4}}}"
+      allow_duplicates: false
+      if: ctx.json?.meta_sip4 != null
+  - append:
+      field: related.ip
+      tag: append_related_ip_from_meta_sip4
+      value: "{{{json.meta_sip4}}}"
+      allow_duplicates: false
+      if: ctx.json?.meta_sip4 != null
   - rename:
       field: meta_oml
       target_field: fireeye.nx.device_oml
@@ -58,9 +79,15 @@ processors:
       target_field: fireeye.nx.deviceid
       ignore_missing: true
   - rename:
-      field: meta_cbname
-      target_field: fireeye.nx.hostname
+      field: json.meta_cbname
+      target_field: observer.hostname
       ignore_missing: true
+  - append:
+      field: related.hosts
+      tag: append_related_hosts_from_observer_hostname
+      value: "{{{observer.hostname}}}"
+      allow_duplicates: false
+      if: ctx.url?.domain != null
   # flow event type fields
   - rename:
       field: rawmsg.proto_number
@@ -112,6 +139,11 @@ processors:
       target_field: fireeye.nx.flow.reason
       if: ctx?.event?.type == 'flow'
       ignore_missing: true
+  - set:
+      field: event.reason
+      tag: set_event_reason_from_flow_reason
+      copy_from: fireeye.nx.flow.reason
+      ignore_empty_value: true
   - rename:
       field: rawmsg.flow.alerted
       target_field: fireeye.nx.flow.alerted
@@ -148,6 +180,11 @@ processors:
       target_field: fireeye.nx.fileinfo.filename
       if: ctx?.event?.type == 'fileinfo'
       ignore_missing: true
+  - set:
+      field: file.path
+      tag: set_file_path_from_fileinfo_filename
+      copy_from: fireeye.nx.fileinfo.filename
+      ignore_empty_value: true
   - rename:
       field: rawmsg.fileinfo.magic
       target_field: fireeye.nx.fileinfo.magic
@@ -158,11 +195,21 @@ processors:
       target_field: fireeye.nx.fileinfo.md5
       if: ctx?.event?.type == 'fileinfo'
       ignore_missing: true
+  - set:
+      field: file.hash.md5
+      tag: set_file_hash_md5_from_hostname
+      copy_from: fireeye.nx.fileinfo.md5
+      ignore_empty_value: true
   - rename:
       field: rawmsg.fileinfo.size
       target_field: fireeye.nx.fileinfo.size
       if: ctx?.event?.type == 'fileinfo'
       ignore_missing: true
+  - set:
+      field: file.size
+      tag: set_file_size_from_fileinfo_size
+      copy_from: fireeye.nx.fileinfo.size
+      ignore_empty_value: true
   - rename:
       field: rawmsg.fileinfo.state
       target_field: fireeye.nx.fileinfo.state
@@ -280,6 +327,12 @@ processors:
       target_field: url.domain
       if: ctx?.event?.type == 'http'
       ignore_missing: true
+  - append:
+      field: related.hosts
+      tag: append_related_hosts_from_url_domain
+      value: "{{{url.domain}}}"
+      allow_duplicates: false
+      if: ctx.url?.domain != null
   - rename:
       field: rawmsg.http.http_content_type
       target_field: http.request.mime_type
@@ -438,6 +491,17 @@ processors:
       target_field: tls.client.server_name
       if: ctx?.event?.type == 'tls'
       ignore_missing: true
+  - set:
+      field: destination.domain
+      tag: set_destination_domain_from_server_name
+      copy_from: tls.client.server_name
+      ignore_empty_value: true
+  - append:
+      field: related.hosts
+      tag: append_related_hosts_from_destination_domain
+      value: "{{{destination.domain}}}"
+      allow_duplicates: false
+      if: ctx.destination?.domain != null
   - rename:
       field: rawmsg.tls.subject
       target_field: tls.client.subject

--- a/packages/fireeye/data_stream/nx/elasticsearch/ingest_pipeline/renaming-raws.yml
+++ b/packages/fireeye/data_stream/nx/elasticsearch/ingest_pipeline/renaming-raws.yml
@@ -58,17 +58,21 @@ processors:
       allow_duplicates: false
       if: ctx.json?.meta_sip4 != null
   - rename:
-      field: meta_oml
+      field: json.meta_oml
       target_field: fireeye.nx.device_oml
       ignore_missing: true
   - rename:
-      field: deviceid
+      field: json.deviceid
       target_field: fireeye.nx.deviceid
       ignore_missing: true
   - rename:
       field: json.meta_cbname
-      target_field: observer.hostname
+      target_field: fireeye.nx.hostname
       ignore_missing: true
+  - set:
+      field: observer.hostname
+      copy_from: fireeye.nx.hostname
+      ignore_empty_value: true
   - append:
       field: related.hosts
       tag: append_related_hosts_from_observer_hostname
@@ -168,7 +172,7 @@ processors:
       if: ctx?.event?.type == 'fileinfo'
       ignore_missing: true
   - set:
-      field: file.path
+      field: file.name
       tag: set_file_path_from_fileinfo_filename
       copy_from: fireeye.nx.fileinfo.filename
       ignore_empty_value: true

--- a/packages/fireeye/data_stream/nx/fields/fields.yml
+++ b/packages/fireeye/data_stream/nx/fields/fields.yml
@@ -70,6 +70,15 @@
         - name: stored
           type: boolean
           description: File stored or not.
+    - name: device_oml
+      type: long
+      description: Device OML (Object Management Layer) identifier.
+    - name: deviceid
+      type: keyword
+      description: Device ID of the event.
+    - name: hostname
+      type: keyword
+      description: Hostname of the event.
 - name: tls
   type: group
   fields:

--- a/packages/fireeye/data_stream/nx/sample_event.json
+++ b/packages/fireeye/data_stream/nx/sample_event.json
@@ -1,15 +1,15 @@
 {
     "@timestamp": "2020-09-22T08:34:44.991Z",
     "agent": {
-        "ephemeral_id": "dff6c436-37c3-4536-bdf9-08aed3ed94bd",
-        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
-        "name": "docker-fleet-agent",
+        "ephemeral_id": "96bd6f72-99f6-4840-818f-5d1be61e78f7",
+        "id": "4f744ee0-88a4-454c-9b91-7d471e019662",
+        "name": "elastic-agent-23482",
         "type": "filebeat",
-        "version": "8.10.1"
+        "version": "8.13.0"
     },
     "data_stream": {
         "dataset": "fireeye.nx",
-        "namespace": "ep",
+        "namespace": "55889",
         "type": "logs"
     },
     "destination": {
@@ -23,9 +23,9 @@
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
+        "id": "4f744ee0-88a4-454c-9b91-7d471e019662",
         "snapshot": false,
-        "version": "8.10.1"
+        "version": "8.13.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -33,8 +33,10 @@
             "network"
         ],
         "dataset": "fireeye.nx",
-        "ingested": "2023-09-25T20:05:32Z",
-        "original": "{\"rawmsg\":\"{\\\"timestamp\\\":\\\"2020-09-22T08:34:44.991339+0000\\\",\\\"flow_id\\\":721570461162990,\\\"event_type\\\":\\\"flow\\\",\\\"src_ip\\\":\\\"fe80:0000:0000:0000:feec:daff:fe31:b706\\\",\\\"src_port\\\":45944,\\\"dest_ip\\\":\\\"ff02:0000:0000:0000:0000:0000:0000:0001\\\",\\\"dest_port\\\":10001,\\\"proto\\\":\\\"UDP\\\",\\\"proto_number\\\":17,\\\"ip_tc\\\":0,\\\"app_proto\\\":\\\"failed\\\",\\\"flow\\\":{\\\"pkts_toserver\\\":8,\\\"pkts_toclient\\\":0,\\\"bytes_toserver\\\":1680,\\\"bytes_toclient\\\":0,\\\"start\\\":\\\"2020-09-22T08:34:12.761326+0000\\\",\\\"end\\\":\\\"2020-09-22T08:34:12.761348+0000\\\",\\\"age\\\":0,\\\"state\\\":\\\"new\\\",\\\"reason\\\":\\\"timeout\\\",\\\"alerted\\\":false}}\\n\",\"meta_sip4\":\"192.168.1.99\",\"meta_oml\":520,\"deviceid\":\"860665216674\",\"meta_cbname\":\"fireeye-7e0de1\"}",
+        "ingested": "2025-07-03T10:48:44Z",
+        "kind": "event",
+        "outcome": "failure",
+        "reason": "timeout",
         "timezone": "+00:00",
         "type": [
             "info"
@@ -53,49 +55,30 @@
             "flow_id": 721570461162990
         }
     },
-    "host": {
-        "architecture": "x86_64",
-        "containerized": false,
-        "hostname": "docker-fleet-agent",
-        "id": "28da52b32df94b50aff67dfb8f1be3d6",
-        "ip": [
-            "192.168.80.5"
-        ],
-        "mac": [
-            "02-42-C0-A8-50-05"
-        ],
-        "name": "docker-fleet-agent",
-        "os": {
-            "codename": "focal",
-            "family": "debian",
-            "kernel": "5.10.104-linuxkit",
-            "name": "Ubuntu",
-            "platform": "ubuntu",
-            "type": "linux",
-            "version": "20.04.6 LTS (Focal Fossa)"
-        }
-    },
     "input": {
-        "type": "log"
+        "type": "udp"
     },
     "log": {
-        "file": {
-            "path": "/tmp/service_logs/fireeye-nx.log"
-        },
-        "offset": 0
+        "source": {
+            "address": "192.168.249.3:42005"
+        }
     },
     "network": {
         "community_id": "1:McNAQcsUcKZYOHHZYm0sD8JiBLc=",
         "iana_number": "17",
-        "protocol": "failed",
         "transport": "udp"
     },
     "observer": {
+        "hostname": "fireeye-7e0de1",
+        "ip": [
+            "192.168.1.99"
+        ],
         "product": "NX",
         "vendor": "Fireeye"
     },
     "related": {
         "ip": [
+            "192.168.1.99",
             "fe80:0000:0000:0000:feec:daff:fe31:b706",
             "ff02:0000:0000:0000:0000:0000:0000:0001"
         ]
@@ -108,6 +91,7 @@
         "port": 45944
     },
     "tags": [
-        "fireeye-nx"
+        "fireeye-nx",
+        "forwarded"
     ]
 }

--- a/packages/fireeye/data_stream/nx/sample_event.json
+++ b/packages/fireeye/data_stream/nx/sample_event.json
@@ -1,15 +1,15 @@
 {
     "@timestamp": "2020-09-22T08:34:44.991Z",
     "agent": {
-        "ephemeral_id": "96bd6f72-99f6-4840-818f-5d1be61e78f7",
-        "id": "4f744ee0-88a4-454c-9b91-7d471e019662",
-        "name": "elastic-agent-23482",
+        "ephemeral_id": "29a00621-9074-4b14-bcbb-db252f6203c3",
+        "id": "7740d13f-75db-41df-89ee-b1cb3b873df4",
+        "name": "elastic-agent-93841",
         "type": "filebeat",
         "version": "8.13.0"
     },
     "data_stream": {
         "dataset": "fireeye.nx",
-        "namespace": "55889",
+        "namespace": "68601",
         "type": "logs"
     },
     "destination": {
@@ -23,7 +23,7 @@
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "4f744ee0-88a4-454c-9b91-7d471e019662",
+        "id": "7740d13f-75db-41df-89ee-b1cb3b873df4",
         "snapshot": false,
         "version": "8.13.0"
     },
@@ -33,9 +33,8 @@
             "network"
         ],
         "dataset": "fireeye.nx",
-        "ingested": "2025-07-03T10:48:44Z",
+        "ingested": "2025-07-23T06:50:57Z",
         "kind": "event",
-        "outcome": "failure",
         "reason": "timeout",
         "timezone": "+00:00",
         "type": [
@@ -60,12 +59,13 @@
     },
     "log": {
         "source": {
-            "address": "192.168.249.3:42005"
+            "address": "192.168.245.3:36580"
         }
     },
     "network": {
         "community_id": "1:McNAQcsUcKZYOHHZYm0sD8JiBLc=",
         "iana_number": "17",
+        "protocol": "failed",
         "transport": "udp"
     },
     "observer": {

--- a/packages/fireeye/docs/README.md
+++ b/packages/fireeye/docs/README.md
@@ -23,6 +23,8 @@ The `nx` integration ingests network security logs from FireEye NX through TCP/U
 | data_stream.type | Data stream type. | constant_keyword |
 | event.dataset | Event dataset | constant_keyword |
 | event.module | Event module | constant_keyword |
+| fireeye.nx.device_oml | Device OML (Object Management Layer) identifier. | long |
+| fireeye.nx.deviceid | Device ID of the event. | keyword |
 | fireeye.nx.fileinfo.filename | File name. | keyword |
 | fireeye.nx.fileinfo.magic | Fileinfo magic. | keyword |
 | fireeye.nx.fileinfo.md5 | File hash. | keyword |
@@ -36,6 +38,7 @@ The `nx` integration ingests network security logs from FireEye NX through TCP/U
 | fireeye.nx.flow.starttime | Flow start time. | date |
 | fireeye.nx.flow.state | Flow state. | keyword |
 | fireeye.nx.flow_id | Flow ID of the event. | long |
+| fireeye.nx.hostname | Hostname of the event. | keyword |
 | fireeye.nx.tcp.ack | TCP acknowledgement. | boolean |
 | fireeye.nx.tcp.psh | TCP PSH. | boolean |
 | fireeye.nx.tcp.state | TCP connectin state. | keyword |

--- a/packages/fireeye/docs/README.md
+++ b/packages/fireeye/docs/README.md
@@ -65,15 +65,15 @@ An example event for `nx` looks as following:
 {
     "@timestamp": "2020-09-22T08:34:44.991Z",
     "agent": {
-        "ephemeral_id": "96bd6f72-99f6-4840-818f-5d1be61e78f7",
-        "id": "4f744ee0-88a4-454c-9b91-7d471e019662",
-        "name": "elastic-agent-23482",
+        "ephemeral_id": "29a00621-9074-4b14-bcbb-db252f6203c3",
+        "id": "7740d13f-75db-41df-89ee-b1cb3b873df4",
+        "name": "elastic-agent-93841",
         "type": "filebeat",
         "version": "8.13.0"
     },
     "data_stream": {
         "dataset": "fireeye.nx",
-        "namespace": "55889",
+        "namespace": "68601",
         "type": "logs"
     },
     "destination": {
@@ -87,7 +87,7 @@ An example event for `nx` looks as following:
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "4f744ee0-88a4-454c-9b91-7d471e019662",
+        "id": "7740d13f-75db-41df-89ee-b1cb3b873df4",
         "snapshot": false,
         "version": "8.13.0"
     },
@@ -97,9 +97,8 @@ An example event for `nx` looks as following:
             "network"
         ],
         "dataset": "fireeye.nx",
-        "ingested": "2025-07-03T10:48:44Z",
+        "ingested": "2025-07-23T06:50:57Z",
         "kind": "event",
-        "outcome": "failure",
         "reason": "timeout",
         "timezone": "+00:00",
         "type": [
@@ -124,12 +123,13 @@ An example event for `nx` looks as following:
     },
     "log": {
         "source": {
-            "address": "192.168.249.3:42005"
+            "address": "192.168.245.3:36580"
         }
     },
     "network": {
         "community_id": "1:McNAQcsUcKZYOHHZYm0sD8JiBLc=",
         "iana_number": "17",
+        "protocol": "failed",
         "transport": "udp"
     },
     "observer": {

--- a/packages/fireeye/docs/README.md
+++ b/packages/fireeye/docs/README.md
@@ -65,15 +65,15 @@ An example event for `nx` looks as following:
 {
     "@timestamp": "2020-09-22T08:34:44.991Z",
     "agent": {
-        "ephemeral_id": "dff6c436-37c3-4536-bdf9-08aed3ed94bd",
-        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
-        "name": "docker-fleet-agent",
+        "ephemeral_id": "96bd6f72-99f6-4840-818f-5d1be61e78f7",
+        "id": "4f744ee0-88a4-454c-9b91-7d471e019662",
+        "name": "elastic-agent-23482",
         "type": "filebeat",
-        "version": "8.10.1"
+        "version": "8.13.0"
     },
     "data_stream": {
         "dataset": "fireeye.nx",
-        "namespace": "ep",
+        "namespace": "55889",
         "type": "logs"
     },
     "destination": {
@@ -87,9 +87,9 @@ An example event for `nx` looks as following:
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
+        "id": "4f744ee0-88a4-454c-9b91-7d471e019662",
         "snapshot": false,
-        "version": "8.10.1"
+        "version": "8.13.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -97,8 +97,10 @@ An example event for `nx` looks as following:
             "network"
         ],
         "dataset": "fireeye.nx",
-        "ingested": "2023-09-25T20:05:32Z",
-        "original": "{\"rawmsg\":\"{\\\"timestamp\\\":\\\"2020-09-22T08:34:44.991339+0000\\\",\\\"flow_id\\\":721570461162990,\\\"event_type\\\":\\\"flow\\\",\\\"src_ip\\\":\\\"fe80:0000:0000:0000:feec:daff:fe31:b706\\\",\\\"src_port\\\":45944,\\\"dest_ip\\\":\\\"ff02:0000:0000:0000:0000:0000:0000:0001\\\",\\\"dest_port\\\":10001,\\\"proto\\\":\\\"UDP\\\",\\\"proto_number\\\":17,\\\"ip_tc\\\":0,\\\"app_proto\\\":\\\"failed\\\",\\\"flow\\\":{\\\"pkts_toserver\\\":8,\\\"pkts_toclient\\\":0,\\\"bytes_toserver\\\":1680,\\\"bytes_toclient\\\":0,\\\"start\\\":\\\"2020-09-22T08:34:12.761326+0000\\\",\\\"end\\\":\\\"2020-09-22T08:34:12.761348+0000\\\",\\\"age\\\":0,\\\"state\\\":\\\"new\\\",\\\"reason\\\":\\\"timeout\\\",\\\"alerted\\\":false}}\\n\",\"meta_sip4\":\"192.168.1.99\",\"meta_oml\":520,\"deviceid\":\"860665216674\",\"meta_cbname\":\"fireeye-7e0de1\"}",
+        "ingested": "2025-07-03T10:48:44Z",
+        "kind": "event",
+        "outcome": "failure",
+        "reason": "timeout",
         "timezone": "+00:00",
         "type": [
             "info"
@@ -117,49 +119,30 @@ An example event for `nx` looks as following:
             "flow_id": 721570461162990
         }
     },
-    "host": {
-        "architecture": "x86_64",
-        "containerized": false,
-        "hostname": "docker-fleet-agent",
-        "id": "28da52b32df94b50aff67dfb8f1be3d6",
-        "ip": [
-            "192.168.80.5"
-        ],
-        "mac": [
-            "02-42-C0-A8-50-05"
-        ],
-        "name": "docker-fleet-agent",
-        "os": {
-            "codename": "focal",
-            "family": "debian",
-            "kernel": "5.10.104-linuxkit",
-            "name": "Ubuntu",
-            "platform": "ubuntu",
-            "type": "linux",
-            "version": "20.04.6 LTS (Focal Fossa)"
-        }
-    },
     "input": {
-        "type": "log"
+        "type": "udp"
     },
     "log": {
-        "file": {
-            "path": "/tmp/service_logs/fireeye-nx.log"
-        },
-        "offset": 0
+        "source": {
+            "address": "192.168.249.3:42005"
+        }
     },
     "network": {
         "community_id": "1:McNAQcsUcKZYOHHZYm0sD8JiBLc=",
         "iana_number": "17",
-        "protocol": "failed",
         "transport": "udp"
     },
     "observer": {
+        "hostname": "fireeye-7e0de1",
+        "ip": [
+            "192.168.1.99"
+        ],
         "product": "NX",
         "vendor": "Fireeye"
     },
     "related": {
         "ip": [
+            "192.168.1.99",
             "fe80:0000:0000:0000:feec:daff:fe31:b706",
             "ff02:0000:0000:0000:0000:0000:0000:0001"
         ]
@@ -172,7 +155,8 @@ An example event for `nx` looks as following:
         "port": 45944
     },
     "tags": [
-        "fireeye-nx"
+        "fireeye-nx",
+        "forwarded"
     ]
 }
 ```

--- a/packages/fireeye/manifest.yml
+++ b/packages/fireeye/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: fireeye
 title: "FireEye Network Security"
-version: "1.26.0"
+version: "1.27.0"
 description: Collect logs from FireEye NX with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
fireeye: add missing ECS fields

This PR has added the missing ECS fields like event, file, IP related fields, etc.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/fireeye directory.
- Run the following command to run tests.

> elastic-package test -v

## Related issues

- Closes #13756
