### PR TITLE
[o365] Stricter enforcement of maximum age limits

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.18.6"
+  changes:
+    - description: Stricter enforcement of maximum age limits.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/14567
 - version: "2.18.5"
   changes:
     - description: Ensure numeric Yammer IDs are not rendered with E-notation.

--- a/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
@@ -66,6 +66,7 @@ state:
     tenant_id: "{{azure_tenant_id}}"
     list_contents_start_time: "{{initial_interval}}"
     batch_interval: "{{batch_interval}}"
+    maximum_age: "{{maximum_age}}"
     content_types: "{{content_types}}"
 
 redact:
@@ -112,9 +113,8 @@ program: |-
   									content_type_state[0].content_created_at.as(content_type_state_created_at,
   										// if saved time inside state is more than 7 days old, then change it to 7 days.
   										max(
-  											// The 168h (7d) API age limit is expressed as 167h55m to prevent API call
-  											// delay from causing a call to fail.
-  											now() - duration("167h55m"),
+                        // Enforce the maximum age limit.
+  											now() - duration(state.base.maximum_age),
   											content_type_state_created_at.parse_time(time_layout.RFC3339)
   										).as(state_created_at_calc,
   											state.url.trim_right("/") + "/api/v1.0/" + state.base.tenant_id + "/activity/feed/subscriptions/content?" +
@@ -158,12 +158,12 @@ program: |-
   												{
   													"events_per_content_type": contents,
   													"content_type": content_type,
-  													// if 'contentCreated' is older than 167h55m, change it to 167h55m.
+  													// if 'contentCreated' is older than the maximum age, change it to the maximum age.
   													"content_created_at": {"temp": list_contents_resp_body}.collate("temp.contentCreated").max().as(temp_max,
-  														(temp_max.parse_time(time_layout.RFC3339) > now() - duration("167h55m")) ?
+  														(temp_max.parse_time(time_layout.RFC3339) > now() - duration(state.base.maximum_age)) ?
   															temp_max
   														:
-  															(now() - duration("167h55m")).format(time_layout.RFC3339)
+  															(now() - duration(state.base.maximum_age)).format(time_layout.RFC3339)
   													),
   													"next_page": (has(list_contents_resp.?Header.NextPageUri) && list_contents_resp.Header.NextPageUri.size() > 0) ?
   														(list_contents_resp.Header.NextPageUri[0])
@@ -185,10 +185,10 @@ program: |-
   												"events_per_content_type": [],
   												"content_type": content_type,
   												"content_created_at": {"temp": list_contents_resp_body}.collate("temp.contentCreated").max().as(temp_max,
-  													(temp_max.parse_time(time_layout.RFC3339) > now() - duration("167h55m")) ?
+  													(temp_max.parse_time(time_layout.RFC3339) > now() - duration(state.base.maximum_age)) ?
   														temp_max
   													:
-  														(now() - duration("167h55m")).format(time_layout.RFC3339)
+  														(now() - duration(state.base.maximum_age)).format(time_layout.RFC3339)
   												),
   												"next_page": (has(list_contents_resp.?Header.NextPageUri) && list_contents_resp.Header.NextPageUri.size() > 0) ?
   													(list_contents_resp.Header.NextPageUri[0])
@@ -203,10 +203,10 @@ program: |-
   										"events_per_content_type": [],
   										"content_type": content_type,
   										"content_created_at": {"temp": list_contents_resp_body}.collate("temp.contentCreated").max().as(temp_max,
-  											(temp_max.parse_time(time_layout.RFC3339) > now() - duration("167h55m")) ?
+  											(temp_max.parse_time(time_layout.RFC3339) > now() - duration(state.base.maximum_age)) ?
   												temp_max
   											:
-  												(now() - duration("167h55m")).format(time_layout.RFC3339)
+  												(now() - duration(state.base.maximum_age)).format(time_layout.RFC3339)
   										),
   										"next_page": (has(list_contents_resp.?Header.NextPageUri) && list_contents_resp.Header.NextPageUri.size() > 0) ?
   											(list_contents_resp.Header.NextPageUri[0])

--- a/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
@@ -114,15 +114,15 @@ program: |-
   										max(
   											// The 168h (7d) API age limit is expressed as 167h55m to prevent API call
   											// delay from causing a call to fail.
-  											now - duration("167h55m"),
+  											now() - duration("167h55m"),
   											content_type_state_created_at.parse_time(time_layout.RFC3339)
   										).as(state_created_at_calc,
   											state.url.trim_right("/") + "/api/v1.0/" + state.base.tenant_id + "/activity/feed/subscriptions/content?" +
   											{
   												"contentType": [content_type],
   												"PublisherIdentifier": [state.base.tenant_id],
-  												"startTime": [string(min(now - duration("1s"), state_created_at_calc + duration("1s")))],
-  												"endTime": [string(min(now, state_created_at_calc + batch_interval))],
+  												"startTime": [string(min(now() - duration("1s"), state_created_at_calc + duration("1s")))],
+  												"endTime": [string(min(now(), state_created_at_calc + batch_interval))],
   											}.format_query()
   										)
   									)
@@ -133,8 +133,8 @@ program: |-
   								{
   									"contentType": [content_type],
   									"PublisherIdentifier": [state.base.tenant_id],
-  									"startTime": [string(min(now - duration("1s"), now - duration(state.base.list_contents_start_time)))],
-  									"endTime": [string(min(now, now - duration(state.base.list_contents_start_time) + batch_interval))],
+  									"startTime": [string(min(now() - duration("1s"), now() - duration(state.base.list_contents_start_time)))],
+  									"endTime": [string(min(now(), now() - duration(state.base.list_contents_start_time) + batch_interval))],
   								}.format_query()
   						)
   					)
@@ -147,7 +147,7 @@ program: |-
   						) ?
   							// contents exist to consume
   							list_contents_resp_body.map(l1,
-  								(has(l1.contentExpiration) && l1.contentExpiration.parse_time(time_layout.RFC3339) >= now) ?
+  								(has(l1.contentExpiration) && l1.contentExpiration.parse_time(time_layout.RFC3339) >= now()) ?
   									request("GET", l1.contentUri).do_request().as(content_resp,
   										(has(content_resp.StatusCode) && content_resp.StatusCode == 200 && size(content_resp.Body) > 0) ?
   											content_resp.Body.decode_json().map(content_resp_body,
@@ -160,10 +160,10 @@ program: |-
   													"content_type": content_type,
   													// if 'contentCreated' is older than 167h55m, change it to 167h55m.
   													"content_created_at": {"temp": list_contents_resp_body}.collate("temp.contentCreated").max().as(temp_max,
-  														(temp_max.parse_time(time_layout.RFC3339) > now - duration("167h55m")) ?
+  														(temp_max.parse_time(time_layout.RFC3339) > now() - duration("167h55m")) ?
   															temp_max
   														:
-  															(now - duration("167h55m")).format(time_layout.RFC3339)
+  															(now() - duration("167h55m")).format(time_layout.RFC3339)
   													),
   													"next_page": (has(list_contents_resp.?Header.NextPageUri) && list_contents_resp.Header.NextPageUri.size() > 0) ?
   														(list_contents_resp.Header.NextPageUri[0])
@@ -177,7 +177,7 @@ program: |-
   														has(list_contents_resp.Header.NextPageUri) && list_contents_resp.Header.NextPageUri.size() > 0 ||
   														has(list_contents_resp.Header.Nextpageuri) && list_contents_resp.Header.Nextpageuri.size() > 0
   													) || {"temp": list_contents_resp_body}.collate("temp.contentCreated").max().split("T").as(t, t.size() > 1 &&
-  													t[0] != now.format("2006-01-02")),
+  													t[0] != now().format("2006-01-02")),
   												}
   											)
   										:
@@ -185,10 +185,10 @@ program: |-
   												"events_per_content_type": [],
   												"content_type": content_type,
   												"content_created_at": {"temp": list_contents_resp_body}.collate("temp.contentCreated").max().as(temp_max,
-  													(temp_max.parse_time(time_layout.RFC3339) > now - duration("167h55m")) ?
+  													(temp_max.parse_time(time_layout.RFC3339) > now() - duration("167h55m")) ?
   														temp_max
   													:
-  														(now - duration("167h55m")).format(time_layout.RFC3339)
+  														(now() - duration("167h55m")).format(time_layout.RFC3339)
   												),
   												"next_page": (has(list_contents_resp.?Header.NextPageUri) && list_contents_resp.Header.NextPageUri.size() > 0) ?
   													(list_contents_resp.Header.NextPageUri[0])
@@ -203,10 +203,10 @@ program: |-
   										"events_per_content_type": [],
   										"content_type": content_type,
   										"content_created_at": {"temp": list_contents_resp_body}.collate("temp.contentCreated").max().as(temp_max,
-  											(temp_max.parse_time(time_layout.RFC3339) > now - duration("167h55m")) ?
+  											(temp_max.parse_time(time_layout.RFC3339) > now() - duration("167h55m")) ?
   												temp_max
   											:
-  												(now - duration("167h55m")).format(time_layout.RFC3339)
+  												(now() - duration("167h55m")).format(time_layout.RFC3339)
   										),
   										"next_page": (has(list_contents_resp.?Header.NextPageUri) && list_contents_resp.Header.NextPageUri.size() > 0) ?
   											(list_contents_resp.Header.NextPageUri[0])
@@ -239,13 +239,13 @@ program: |-
   												e.content_type == content_type
   											)[0].content_created_at
   										:
-  											string(now - duration(state.base.list_contents_start_time)),
+  											string(now() - duration(state.base.list_contents_start_time)),
   										"next_page": "",
   										"want_more_content": (
   											has(list_contents_resp.StatusCode) && has(reqQuery.endTime) &&
   											list_contents_resp.StatusCode == 200 && reqQuery.endTime.size() > 0 &&
   											reqQuery.endTime[0].split("T").as(t, t.size() > 0 &&
-  											t[0] != now.format("2006-01-02"))
+  											t[0] != now().format("2006-01-02"))
   										),
   									},
   								]
@@ -261,7 +261,7 @@ program: |-
   						"content_created_at": (has(state.cursor) && has(state.cursor.content_types_state_as_list)) ?
   							state.cursor.content_types_state_as_list.filter(e, e.content_type == content_type)[0].content_created_at
   						:
-  							string(now - duration(state.base.list_contents_start_time)),
+  							string(now() - duration(state.base.list_contents_start_time)),
   						"next_page": "",
   						"want_more_content": false,
   					},

--- a/packages/o365/data_stream/audit/manifest.yml
+++ b/packages/o365/data_stream/audit/manifest.yml
@@ -69,7 +69,7 @@ streams:
       - name: initial_interval
         type: text
         title: Initial Interval
-        description: Initial interval for the first API call. Default starts fetching events from 167h55m, i.e., 7 days ago, and can not go further back than that. Supports following suffixes - "h" (hour), "m" (minute), "s" (second), "ms" (millisecond), "us" (microsecond), and "ns" (nanosecond)
+        description: Initial interval for the first API call. Default starts fetching events from 167h55m, i.e., 7 days ago, and must not go further back than that. Supports following suffixes - "h" (hour), "m" (minute), "s" (second), "ms" (millisecond), "us" (microsecond), and "ns" (nanosecond)
         show_user: true
         required: true
         default: 167h55m

--- a/packages/o365/data_stream/audit/manifest.yml
+++ b/packages/o365/data_stream/audit/manifest.yml
@@ -83,7 +83,7 @@ streams:
       - name: maximum_age
         type: text
         title: Maximum Age
-        description: A hard maximum age limit for data that can be requested. It defaults to 5 mins less than the API's documented limit but can be shortened as a workaround for errors related to expired data. Supports following suffixes - "h" (hour), "m" (minute), "s" (second), "ms" (millisecond), "us" (microsecond), and "ns" (nanosecond)
+        description: A hard maximum age limit for data that can be requested. It defaults to 5 mins less than the API's documented limit but may be shortened as a workaround for errors related to expired data. Supports following suffixes - "h" (hour), "m" (minute), "s" (second), "ms" (millisecond), "us" (microsecond), and "ns" (nanosecond)
         show_user: false
         required: true
         default: 167h55m

--- a/packages/o365/data_stream/audit/manifest.yml
+++ b/packages/o365/data_stream/audit/manifest.yml
@@ -69,7 +69,7 @@ streams:
       - name: initial_interval
         type: text
         title: Initial Interval
-        description: Initial interval for the first API call. Default starts fetching events from 167h55m, i.e., 7 days ago. This value should not be more than this and will be cut to 167h55m if it is. Supports following suffixes - "h" (hour), "m" (minute), "s" (second), "ms" (millisecond), "us" (microsecond), and "ns" (nanosecond)
+        description: Initial interval for the first API call. Default starts fetching events from 167h55m, i.e., 7 days ago, and can not go further back than that. Supports following suffixes - "h" (hour), "m" (minute), "s" (second), "ms" (millisecond), "us" (microsecond), and "ns" (nanosecond)
         show_user: true
         required: true
         default: 167h55m
@@ -80,6 +80,13 @@ streams:
         show_user: true
         required: true
         default: 1h
+      - name: maximum_age
+        type: text
+        title: Maximum Age
+        description: A hard maximum age for data that can be requested. It defaults to 5 mins less than the API's documented limit but can be shortened as a workaround for errors related to expired data. Supports following suffixes - "h" (hour), "m" (minute), "s" (second), "ms" (millisecond), "us" (microsecond), and "ns" (nanosecond)
+        show_user: false
+        required: true
+        default: 167h55m
       - name: resource_ssl
         type: yaml
         title: Resource SSL Configuration

--- a/packages/o365/data_stream/audit/manifest.yml
+++ b/packages/o365/data_stream/audit/manifest.yml
@@ -83,7 +83,7 @@ streams:
       - name: maximum_age
         type: text
         title: Maximum Age
-        description: A hard maximum age for data that can be requested. It defaults to 5 mins less than the API's documented limit but can be shortened as a workaround for errors related to expired data. Supports following suffixes - "h" (hour), "m" (minute), "s" (second), "ms" (millisecond), "us" (microsecond), and "ns" (nanosecond)
+        description: A hard maximum age limit for data that can be requested. It defaults to 5 mins less than the API's documented limit but can be shortened as a workaround for errors related to expired data. Supports following suffixes - "h" (hour), "m" (minute), "s" (second), "ms" (millisecond), "us" (microsecond), and "ns" (nanosecond)
         show_user: false
         required: true
         default: 167h55m

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft Office 365
-version: "2.18.5"
+version: "2.18.6"
 description: Collect logs from Microsoft Office 365 with Elastic Agent.
 type: integration
 format_version: "3.2.3"


### PR DESCRIPTION
## Proposed commit message

```
[o365] Stricter enforcement of maximum age limits

In order to avoid requesting data more than 7 days old:

- When calculating the start of the allowed time range, use `now()` (a
  function that returns the current time) rather than `now` (which is
  the time the current CEL evaluation began), as the latter will become
  too old if a singe CEL evaluation runs for more than a few minutes.

- Make the `167h55m`  limit used throughout the CEL expression
  configurable, in the advanced settings, so that it can be shortened if
  necessary.

This integration's CEL expression is one that may run for a long time.
For each of a list of content types it will register a subscription,
list data and fetch data, and this has been observed to take many
minutes.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 