### PR TITLE
[o365] No delays until up-to-date

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.18.7"
+  changes:
+    - description: No delays until up-to-date.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/14609
 - version: "2.18.6"
   changes:
     - description: Stricter enforcement of maximum age limits.

--- a/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
@@ -171,13 +171,17 @@ program: |-
   														(list_contents_resp.Header.Nextpageuri[0])
   													:
   														"",
-  													// keep fetching more if (nextpageuri exists) or (max time returned date != today's date)
+  													// keep fetching more if (nextpageuri exists) or (the request time range ends within one batch duration of now)
   													"want_more_content": has(list_contents_resp.Header) &&
   													(
   														has(list_contents_resp.Header.NextPageUri) && list_contents_resp.Header.NextPageUri.size() > 0 ||
-  														has(list_contents_resp.Header.Nextpageuri) && list_contents_resp.Header.Nextpageuri.size() > 0
-  													) || {"temp": list_contents_resp_body}.collate("temp.contentCreated").max().split("T").as(t, t.size() > 1 &&
-  													t[0] != now().format("2006-01-02")),
+  														has(list_contents_resp.Header.Nextpageuri) && list_contents_resp.Header.Nextpageuri.size() > 0 ||
+  														list_contents_resp.Request.URL.parse_url().RawQuery.parse_query().as(reqQuery,
+  														  reqQuery.?endTime[?0].optMap(endTime,
+  														    (now() - endTime.parse_time(time_layout.RFC3339)) >= duration(state.base.batch_interval)
+  														  ).orValue(false)
+  														)
+  													)
   												}
   											)
   										:
@@ -244,8 +248,9 @@ program: |-
   										"want_more_content": (
   											has(list_contents_resp.StatusCode) && has(reqQuery.endTime) &&
   											list_contents_resp.StatusCode == 200 && reqQuery.endTime.size() > 0 &&
-  											reqQuery.endTime[0].split("T").as(t, t.size() > 0 &&
-  											t[0] != now().format("2006-01-02"))
+  											reqQuery.endTime[0].parse_time(time_layout.RFC3339).as(endTime,
+  											  (now() - endTime) >= duration(state.base.batch_interval)
+  											)
   										),
   									},
   								]

--- a/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
@@ -171,16 +171,15 @@ program: |-
   														(list_contents_resp.Header.Nextpageuri[0])
   													:
   														"",
-  													// keep fetching more if (nextpageuri exists) or (the request time range ends within one batch duration of now)
+  													// keep fetching more if (nextpageuri exists) or
+  													// (the end of the request range is one batch interval or longer before the current time)
   													"want_more_content": has(list_contents_resp.Header) &&
   													(
   														has(list_contents_resp.Header.NextPageUri) && list_contents_resp.Header.NextPageUri.size() > 0 ||
   														has(list_contents_resp.Header.Nextpageuri) && list_contents_resp.Header.Nextpageuri.size() > 0 ||
-  														list_contents_resp.Request.URL.parse_url().RawQuery.parse_query().as(reqQuery,
-  														  reqQuery.?endTime[?0].optMap(endTime,
-  														    (now() - endTime.parse_time(time_layout.RFC3339)) >= duration(state.base.batch_interval)
-  														  ).orValue(false)
-  														)
+  														list_contents_resp.Request.URL.parse_url().RawQuery.parse_query().?endTime[0].optMap(endTime,
+  														  (now() - endTime.parse_time(time_layout.RFC3339)) >= duration(state.base.batch_interval)
+  														).orValue(false)
   													)
   												}
   											)

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft Office 365
-version: "2.18.6"
+version: "2.18.7"
 description: Collect logs from Microsoft Office 365 with Elastic Agent.
 type: integration
 format_version: "3.2.3"


### PR DESCRIPTION
## Proposed commit message

```
[o365] No delays until up-to-date

Instead of fetching history continuously until reaching the current day
then waiting the interval time between requests, keep fetching until
within one batch length of the current time.

With the default settings, waiting 3 minutes between requests for one
hour batches would significantly extend the time required to get
up-to-date. For example, it's 45 minutes of waiting to cover 15 hours.
It's particularly disruptive to the user experience if there is no
historical data and new data has such a delay.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 