### PR TITLE
[Kafka] Add raft dataset to kafka integration

### DIFF
--- a/packages/kafka/_dev/build/docs/README.md
+++ b/packages/kafka/_dev/build/docs/README.md
@@ -55,3 +55,23 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 Please refer to the following [document](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) for detailed information on ECS fields.
 
 {{fields "partition"}}
+
+### raft
+
+The `raft` dataset collects metrics related to Kafka's Raft consensus algorithm implementation (KRaft), which is used for metadata management in Kafka without requiring ZooKeeper. KRaft mode is available in Kafka 3.0.0 and later versions.
+
+This dataset includes metrics such as:
+- Append and fetch records rates
+- Commit latency (average and maximum)
+- Current epoch, leader, and vote information
+- High watermark and log offset metrics
+- Node state and voter information
+- Poll idle ratio
+
+{{event "raft"}}
+
+**ECS Field Reference**
+
+Please refer to the following [document](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) for detailed information on ECS fields.
+
+{{fields "raft"}}

--- a/packages/kafka/changelog.yml
+++ b/packages/kafka/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.0"
+  changes:
+    - description: Add raft data stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.18.4"
   changes:
     - description: Update supported kafka versions in README.

--- a/packages/kafka/changelog.yml
+++ b/packages/kafka/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add raft data stream.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/14612
 - version: "1.18.4"
   changes:
     - description: Update supported kafka versions in README.

--- a/packages/kafka/data_stream/raft/agent/stream/stream.yml.hbs
+++ b/packages/kafka/data_stream/raft/agent/stream/stream.yml.hbs
@@ -1,0 +1,78 @@
+metricsets: ["jmx"]
+hosts:
+{{#each hosts}}
+  - {{this}}
+{{/each}}
+path: {{metrics_path}}
+namespace: metrics
+period: {{period}}
+http_method: {{http_method}}
+{{#if bearer_token_file}}
+bearer_token_file: {{bearer_token_file}}
+ssl.verification_mode: {{ssl.verification_mode}}
+{{/if}}
+{{#if ssl.certificate_authorities}}
+ssl.certificate_authorities:
+{{#each ssl.certificate_authorities}}
+  - {{this}}
+{{/each}}
+{{/if}}
+{{#if ssl.certificate}}
+ssl.certificate: {{ssl.certificate}}
+{{/if}}
+{{#if ssl.key}}
+ssl.key: {{ssl.key}}
+{{/if}}
+{{#if ssl.key_passphrase}}
+ssl.key_passphrase: {{ssl.key_passphrase}}
+{{/if}}
+{{#if ssl.ca_trusted_fingerprint}}
+ssl.ca_trusted_fingerprint: {{ssl.ca_trusted_fingerprint}}
+{{/if}}
+username: {{username}}
+password: {{password}}
+jmx.mappings: 
+  # Raft metrics
+  - mbean: 'kafka.server:type=raft-metrics'
+    attributes:
+      - attr: append-records-rate
+        field: append_records_rate
+      - attr: commit-latency-avg
+        field: commit_latency_avg
+      - attr: commit-latency-max
+        field: commit_latency_max
+      - attr: current-epoch
+        field: current_epoch
+      - attr: current-leader
+        field: current_leader
+      - attr: current-vote
+        field: current_vote
+      - attr: fetch-records-rate
+        field: fetch_records_rate
+      - attr: high-watermark
+        field: high_watermark
+      - attr: log-end-epoch
+        field: log_end_epoch
+      - attr: log-end-offset
+        field: log_end_offset
+      - attr: number-unknown-voter-connections
+        field: number_unknown_voter_connections
+      - attr: poll-idle-ratio-avg
+        field: poll_idle_ratio_avg
+      - attr: current-state
+        field: current_state
+      - attr: number-of-voters
+        field: number_of_voters
+{{#if headers}}
+{{headers}}
+{{/if}}
+{{#if connect_timeout}}
+connect_timeout: {{connect_timeout}}
+{{/if}}
+{{#if timeout}}
+timeout: {{timeout}}
+{{/if}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kafka/data_stream/raft/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/kafka/data_stream/raft/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,16 @@
+---
+description: Pipeline for processing Kafka Raft metrics.
+processors:
+  - rename:
+      field: jolokia.metrics
+      target_field: kafka.raft
+      ignore_missing: true
+      ignore_failure: true
+  - remove:
+      field: jolokia
+      ignore_missing: true
+      ignore_failure: true
+on_failure:
+  - set:
+      field: error.message
+      value: '{{ _ingest.on_failure_message }}'

--- a/packages/kafka/data_stream/raft/fields/agent.yml
+++ b/packages/kafka/data_stream/raft/fields/agent.yml
@@ -1,0 +1,94 @@
+- name: cloud
+  title: Cloud
+  group: 2
+  description: Fields related to the cloud or infrastructure the events are coming from.
+  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  type: group
+  fields:
+    - name: account.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      dimension: true
+      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.  Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      example: 666777888999
+    - name: availability_zone
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      dimension: true
+      description: Availability zone in which this host is running.
+      example: us-east-1c
+    - name: instance.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Instance ID of the host machine.
+      example: i-1234567890abcdef0
+      dimension: true
+    - name: provider
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
+      example: aws
+      dimension: true
+    - name: region
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      dimension: true
+      description: Region in which this host is running.
+      example: us-east-1
+    - name: image.id
+      type: keyword
+      description: Image ID for the cloud instance.
+- name: container
+  title: Container
+  group: 2
+  description: 'Container fields are used for meta information about the specific container that is the source of information.  These fields help correlate data based containers from any runtime.'
+  type: group
+  fields:
+    - name: id
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Unique container id.
+      dimension: true
+- name: host
+  title: Host
+  group: 2
+  description: 'A host is defined as a general computing instance.  ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  type: group
+  fields:
+    - name: name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      dimension: true
+      description: 'Name of the host.  It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+    - name: containerized
+      type: boolean
+      description: >
+        If the host is a container.
+
+    - name: os.build
+      type: keyword
+      example: "18D109"
+      description: >
+        OS build information.
+
+    - name: os.codename
+      type: keyword
+      example: "stretch"
+      description: >
+        OS codename, if any.
+
+- name: agent
+  title: Agent
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      dimension: true

--- a/packages/kafka/data_stream/raft/fields/base-fields.yml
+++ b/packages/kafka/data_stream/raft/fields/base-fields.yml
@@ -1,0 +1,16 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: jolokia
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.
+- name: '@timestamp'
+  type: date
+  description: Event timestamp.

--- a/packages/kafka/data_stream/raft/fields/ecs.yml
+++ b/packages/kafka/data_stream/raft/fields/ecs.yml
@@ -1,0 +1,3 @@
+- external: ecs
+  name: service.address
+  dimension: true

--- a/packages/kafka/data_stream/raft/fields/fields.yml
+++ b/packages/kafka/data_stream/raft/fields/fields.yml
@@ -1,0 +1,77 @@
+- name: kafka.raft
+  type: group
+  description: >
+    Kafka Raft metrics.
+  fields:
+    - name: append_records_rate
+      type: double
+      description: >
+        The average number of records appended per sec as the leader of the raft quorum.
+      metric_type: gauge
+    - name: commit_latency_avg
+      type: double
+      description: >
+        The average time in milliseconds to commit an entry in the raft log.
+      metric_type: gauge
+      unit: ms
+    - name: commit_latency_max
+      type: double
+      description: >
+        The maximum time in milliseconds to commit an entry in the raft log.
+      metric_type: gauge
+      unit: ms
+    - name: current_epoch
+      type: long
+      description: >
+        The current quorum epoch.
+      metric_type: gauge
+    - name: current_leader
+      type: long
+      description: >
+        The current quorum leader's id; -1 indicates unknown.
+      metric_type: gauge
+    - name: current_vote
+      type: long
+      description: >
+        The current voted id.
+      metric_type: gauge
+    - name: fetch_records_rate
+      type: double
+      description: >
+        The average number of records fetched from the leader of the raft quorum.
+      metric_type: gauge
+    - name: high_watermark
+      type: long
+      description: >
+        The high watermark maintained on this member; -1 if it is unknown.
+      metric_type: gauge
+    - name: log_end_epoch
+      type: long
+      description: >
+        The current raft log end epoch.
+      metric_type: gauge
+    - name: log_end_offset
+      type: long
+      description: >
+        The current raft log end offset.
+      metric_type: gauge
+    - name: number_unknown_voter_connections
+      type: double
+      description: >
+        Number of unknown voters whose connection information is not cached; would never be larger than quorum-size.
+      metric_type: gauge
+    - name: poll_idle_ratio_avg
+      type: double
+      description: >
+        The ratio of time the Raft IO thread is idle as opposed to doing work (e.g. handling requests or replicating from the leader).
+      metric_type: gauge
+      unit: percent
+    - name: current_state
+      type: keyword
+      description: >
+        The current state of this member; possible values are leader, candidate, voted, follower, unattached, observer.
+    - name: number_of_voters
+      type: double
+      description: >
+        Number of voters for a KRaft topic partition.
+      metric_type: gauge

--- a/packages/kafka/data_stream/raft/manifest.yml
+++ b/packages/kafka/data_stream/raft/manifest.yml
@@ -1,0 +1,128 @@
+title: Apache Kafka Raft metrics
+type: metrics
+release: beta
+streams:
+  - input: jolokia/metrics
+    title: Apache Kafka Raft metrics
+    description: Collect Apache Kafka Raft metrics using Jolokia agent.
+    vars:
+      - name: hosts
+        type: text
+        title: Hosts
+        multi: true
+        required: true
+        show_user: true
+        default:
+          - http://127.0.0.1:8778
+      - name: period
+        type: text
+        title: Period
+        multi: false
+        required: true
+        show_user: true
+        default: 10s
+      - name: metrics_path
+        type: text
+        title: Metrics Path
+        multi: false
+        required: true
+        show_user: true
+        default: /jolokia
+      - name: http_method
+        type: text
+        title: HTTP Method
+        multi: false
+        required: true
+        show_user: true
+        default: GET
+      - name: bearer_token_file
+        type: text
+        title: 'HTTP config options: bearer_token_file'
+        description: If defined, the contents of the file will be read once at initialization and then the value will be used in an HTTP Authorization header.
+        multi: false
+        secret: false
+        required: false
+        show_user: false
+      - name: ssl.verification_mode
+        type: text
+        title: SSL Verification Mode
+        description: SSL verification mode. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
+        multi: false
+        required: false
+        show_user: false
+        default: none
+      - name: ssl.certificate_authorities
+        type: text
+        title: SSL Certificate Authorities
+        description: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
+        multi: true
+        required: false
+        show_user: true
+      - name: ssl.certificate
+        type: text
+        title: SSL Certificate
+        description: SSL certificate. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
+        show_user: true
+      - name: ssl.key
+        type: text
+        title: SSL Private Key
+        description: SSL private key. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
+        show_user: true
+      - name: ssl.key_passphrase
+        type: password
+        title: SSL Key Passphrase
+        description: SSL key passphrase. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
+        secret: true
+        show_user: true
+      - name: ssl.ca_trusted_fingerprint
+        type: text
+        title: SSL CA Trusted Fingerprint
+        description: SSL CA trusted fingerprint. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
+        show_user: true
+      - name: username
+        type: text
+        title: 'HTTP config options: Username'
+        description: The username to use for basic authentication.
+        multi: false
+        required: false
+        show_user: false
+      - name: password
+        type: password
+        secret: true
+        title: 'HTTP config options: Password'
+        description: The password to use for basic authentication.
+        multi: false
+        required: false
+        show_user: false
+      - name: connect_timeout
+        type: text
+        title: 'HTTP config options: connect_timeout'
+        description: Total time limit for an HTTP connection to be completed (Default 2 seconds)
+        multi: false
+        required: false
+        show_user: false
+      - name: timeout
+        type: text
+        title: 'HTTP config options: timeout'
+        description: Total time limit for HTTP requests made by the module (Default 10 seconds)
+        multi: false
+        required: false
+        show_user: false
+      - name: headers
+        type: yaml
+        title: "HTTP config options: headers"
+        description: A list of headers to use with the HTTP request
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #   My-Custom-Header: my-custom-value
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+elasticsearch:
+  index_mode: "time_series"

--- a/packages/kafka/data_stream/raft/sample_event.json
+++ b/packages/kafka/data_stream/raft/sample_event.json
@@ -1,0 +1,99 @@
+{
+    "@timestamp": "2025-07-21T08:52:02.169Z",
+    "agent": {
+        "ephemeral_id": "9b3488ec-43b2-4927-992d-66e7916db610",
+        "id": "98300b09-b816-4ff7-87aa-a3dd3410656c",
+        "name": "elastic-agent-92636",
+        "type": "metricbeat",
+        "version": "8.16.6"
+    },
+    "cloud": {
+        "account": {
+            "id": "elastic-obs-integrations-dev"
+        },
+        "availability_zone": "asia-south1-c",
+        "instance": {
+            "id": "5798221542184199336",
+            "name": "service-integration-dev-idc-ubuntu25-4"
+        },
+        "machine": {
+            "type": "n1-standard-4"
+        },
+        "project": {
+            "id": "elastic-obs-integrations-dev"
+        },
+        "provider": "gcp",
+        "region": "asia-south1",
+        "service": {
+            "name": "GCE"
+        }
+    },
+    "data_stream": {
+        "dataset": "kafka.raft",
+        "namespace": "60294",
+        "type": "metrics"
+    },
+    "ecs": {
+        "version": "8.0.0"
+    },
+    "elastic_agent": {
+        "id": "98300b09-b816-4ff7-87aa-a3dd3410656c",
+        "snapshot": false,
+        "version": "8.16.6"
+    },
+    "event": {
+        "agent_id_status": "verified",
+        "dataset": "kafka.raft",
+        "duration": 29347144,
+        "ingested": "2025-07-21T08:52:04Z",
+        "module": "jolokia"
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "elastic-agent-92636",
+        "ip": [
+            "172.21.0.2",
+            "172.19.0.6"
+        ],
+        "mac": [
+            "0A-4F-66-38-0A-41",
+            "A2-41-CC-86-C2-F0"
+        ],
+        "name": "elastic-agent-92636",
+        "os": {
+            "family": "",
+            "kernel": "6.14.0-1006-gcp",
+            "name": "Wolfi",
+            "platform": "wolfi",
+            "type": "linux",
+            "version": "20230201"
+        }
+    },
+    "kafka": {
+        "raft": {
+            "append_records_rate": 0.672182006204757,
+            "commit_latency_avg": 0,
+            "commit_latency_max": 0,
+            "current_epoch": 1,
+            "current_leader": 1,
+            "current_state": "leader",
+            "current_vote": 1,
+            "fetch_records_rate": 0,
+            "high_watermark": 26,
+            "log_end_epoch": 1,
+            "log_end_offset": 26,
+            "number_of_voters": 1,
+            "number_unknown_voter_connections": 0,
+            "poll_idle_ratio_avg": 0.9814143775569842
+        }
+    },
+    "metricset": {
+        "name": "jmx",
+        "period": 10000
+    },
+    "service": {
+        "address": "http://kafka:8779/jolokia",
+        "type": "jolokia"
+    }
+}

--- a/packages/kafka/docs/README.md
+++ b/packages/kafka/docs/README.md
@@ -349,3 +349,161 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | kafka.topic.error.code | Topic error code. | long |  |
 | kafka.topic.name | Topic name | keyword |  |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |
+
+
+### raft
+
+The `raft` dataset collects metrics related to Kafka's Raft consensus algorithm implementation (KRaft), which is used for metadata management in Kafka without requiring ZooKeeper. KRaft mode is available in Kafka 3.0.0 and later versions.
+
+This dataset includes metrics such as:
+- Append and fetch records rates
+- Commit latency (average and maximum)
+- Current epoch, leader, and vote information
+- High watermark and log offset metrics
+- Node state and voter information
+- Poll idle ratio
+
+An example event for `raft` looks as following:
+
+```json
+{
+    "@timestamp": "2025-07-21T08:52:02.169Z",
+    "agent": {
+        "ephemeral_id": "9b3488ec-43b2-4927-992d-66e7916db610",
+        "id": "98300b09-b816-4ff7-87aa-a3dd3410656c",
+        "name": "elastic-agent-92636",
+        "type": "metricbeat",
+        "version": "8.16.6"
+    },
+    "cloud": {
+        "account": {
+            "id": "elastic-obs-integrations-dev"
+        },
+        "availability_zone": "asia-south1-c",
+        "instance": {
+            "id": "5798221542184199336",
+            "name": "service-integration-dev-idc-ubuntu25-4"
+        },
+        "machine": {
+            "type": "n1-standard-4"
+        },
+        "project": {
+            "id": "elastic-obs-integrations-dev"
+        },
+        "provider": "gcp",
+        "region": "asia-south1",
+        "service": {
+            "name": "GCE"
+        }
+    },
+    "data_stream": {
+        "dataset": "kafka.raft",
+        "namespace": "60294",
+        "type": "metrics"
+    },
+    "ecs": {
+        "version": "8.0.0"
+    },
+    "elastic_agent": {
+        "id": "98300b09-b816-4ff7-87aa-a3dd3410656c",
+        "snapshot": false,
+        "version": "8.16.6"
+    },
+    "event": {
+        "agent_id_status": "verified",
+        "dataset": "kafka.raft",
+        "duration": 29347144,
+        "ingested": "2025-07-21T08:52:04Z",
+        "module": "jolokia"
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "elastic-agent-92636",
+        "ip": [
+            "172.21.0.2",
+            "172.19.0.6"
+        ],
+        "mac": [
+            "0A-4F-66-38-0A-41",
+            "A2-41-CC-86-C2-F0"
+        ],
+        "name": "elastic-agent-92636",
+        "os": {
+            "family": "",
+            "kernel": "6.14.0-1006-gcp",
+            "name": "Wolfi",
+            "platform": "wolfi",
+            "type": "linux",
+            "version": "20230201"
+        }
+    },
+    "kafka": {
+        "raft": {
+            "append_records_rate": 0.672182006204757,
+            "commit_latency_avg": 0,
+            "commit_latency_max": 0,
+            "current_epoch": 1,
+            "current_leader": 1,
+            "current_state": "leader",
+            "current_vote": 1,
+            "fetch_records_rate": 0,
+            "high_watermark": 26,
+            "log_end_epoch": 1,
+            "log_end_offset": 26,
+            "number_of_voters": 1,
+            "number_unknown_voter_connections": 0,
+            "poll_idle_ratio_avg": 0.9814143775569842
+        }
+    },
+    "metricset": {
+        "name": "jmx",
+        "period": 10000
+    },
+    "service": {
+        "address": "http://kafka:8779/jolokia",
+        "type": "jolokia"
+    }
+}
+```
+
+**ECS Field Reference**
+
+Please refer to the following [document](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) for detailed information on ECS fields.
+
+**Exported fields**
+
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| agent.id |  | keyword |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment.  Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| event.module | Event module | constant_keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.name | Name of the host.  It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| kafka.raft.append_records_rate | The average number of records appended per sec as the leader of the raft quorum. | double |  | gauge |
+| kafka.raft.commit_latency_avg | The average time in milliseconds to commit an entry in the raft log. | double | ms | gauge |
+| kafka.raft.commit_latency_max | The maximum time in milliseconds to commit an entry in the raft log. | double | ms | gauge |
+| kafka.raft.current_epoch | The current quorum epoch. | long |  | gauge |
+| kafka.raft.current_leader | The current quorum leader's id; -1 indicates unknown. | long |  | gauge |
+| kafka.raft.current_state | The current state of this member; possible values are leader, candidate, voted, follower, unattached, observer. | keyword |  |  |
+| kafka.raft.current_vote | The current voted id. | long |  | gauge |
+| kafka.raft.fetch_records_rate | The average number of records fetched from the leader of the raft quorum. | double |  | gauge |
+| kafka.raft.high_watermark | The high watermark maintained on this member; -1 if it is unknown. | long |  | gauge |
+| kafka.raft.log_end_epoch | The current raft log end epoch. | long |  | gauge |
+| kafka.raft.log_end_offset | The current raft log end offset. | long |  | gauge |
+| kafka.raft.number_of_voters | Number of voters for a KRaft topic partition. | double |  | gauge |
+| kafka.raft.number_unknown_voter_connections | Number of unknown voters whose connection information is not cached; would never be larger than quorum-size. | double |  | gauge |
+| kafka.raft.poll_idle_ratio_avg | The ratio of time the Raft IO thread is idle as opposed to doing work (e.g. handling requests or replicating from the leader). | double | percent | gauge |
+| service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |  |

--- a/packages/kafka/manifest.yml
+++ b/packages/kafka/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: kafka
 title: Kafka
-version: "1.18.4"
+version: "1.19.0"
 description: Collect logs and metrics from Kafka servers with Elastic Agent.
 type: integration
 categories:
@@ -31,6 +31,9 @@ policy_templates:
     title: Kafka logs and metrics
     description: Collect logs and metrics from Kafka brokers
     inputs:
+      - type: jolokia/metrics
+        title: Collect JVM metrics from Kafka brokers
+        description: Collecting Kafka JVM metrics using Jolokia
       - type: logfile
         title: Collect logs from Kafka brokers
         description: Collecting Kafka log logs


### PR DESCRIPTION

- Enhancement

## Proposed commit message

Add raft dataset to the Kafka integration

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

- [x] Kafa 4.0 integration testing 

## How to test this PR locally

- `elastic-package build`
- `elastic-package stack up -v -d --services package-registry`


