### PR TITLE
use links panels instead of markdown for dashboard navigation

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.81.0"
+  changes:
+    - description: Use links panel instead of markdown for dashboard navigation.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "1.80.2"
   changes:
     - description: Fixed typos in ssl node descriptions in manifest.yml files.

--- a/packages/kubernetes/kibana/dashboard/kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013.json
@@ -36,41 +36,116 @@
     },
     "panelsJSON": [
       {
+        "type": "links",
+        "title": "Kubernetes Dashboards [Metrics Kubernetes]",
         "embeddableConfig": {
-          "enhancements": {},
-          "savedVis": {
-            "data": {
-              "aggs": [],
-              "searchSource": {
-                "filter": [],
-                "query": {
-                  "language": "kuery",
-                  "query": ""
-                }
-              }
-            },
+          "attributes": {
+            "title": "Kubernetes Dashboards [Metrics Kubernetes]",
             "description": "",
-            "params": {
-              "fontSize": 10,
-              "markdown": "[Kubernetes Overview](#/view/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c), [Kubernetes Nodes](#/view/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Pods](#/view/kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013),  [Kubernetes Deployments](#/view/kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes StatefulSets](#/view/kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013),  [Kubernetes DaemonSets](#/view/kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes CronJobs](#/view/kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Jobs](#/view/kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Volumes](#/view/kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013), [Kubernetes PV/PVC](#/view/kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Services](#/view/kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes API Server](#/view/kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56)",
-              "openLinksInNewTab": false
-            },
-            "title": "",
-            "type": "markdown",
-            "uiState": {}
-          }
+            "layout": "horizontal",
+            "links": [
+              {
+                "label": "Kubernetes Overview",
+                "type": "dashboardLink",
+                "id": "6416766e-26ec-4394-b02d-399b42ca9a6e",
+                "order": 0,
+                "destinationRefName": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard"
+              },
+              {
+                "label": "Kubernetes Nodes",
+                "type": "dashboardLink",
+                "id": "07ec2943-d3c5-4c96-beae-c5d5fde21fef",
+                "options": {
+                  "openInNewTab": false,
+                  "useCurrentDateRange": true,
+                  "useCurrentFilters": true
+                },
+                "order": 1,
+                "destinationRefName": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard"
+              },
+              {
+                "label": "Kubernetes Pods",
+                "type": "dashboardLink",
+                "id": "d0182b64-2cbf-4262-a352-9ab9a0ce48d8",
+                "order": 2,
+                "destinationRefName": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard"
+              },
+              {
+                "label": "Kubernetes Deployments",
+                "type": "dashboardLink",
+                "id": "c4b70217-9e48-4b1b-9b37-7803955a7f68",
+                "order": 3,
+                "destinationRefName": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard"
+              },
+              {
+                "label": "Kubernetes StatefulSets",
+                "type": "dashboardLink",
+                "id": "817b2767-a299-4117-9e40-bacf9d2ceeef",
+                "order": 4,
+                "destinationRefName": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard"
+              },
+              {
+                "label": "Kubernetes DaemonSets",
+                "type": "dashboardLink",
+                "id": "f67a589f-975c-409b-af5a-1ec3131916bd",
+                "order": 5,
+                "destinationRefName": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard"
+              },
+              {
+                "label": "Kubernetes Cronjobs",
+                "type": "dashboardLink",
+                "id": "7aeb19b4-8594-4187-9431-1e5e9f09b652",
+                "order": 6,
+                "destinationRefName": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard"
+              },
+              {
+                "label": "Kubernetes Jobs",
+                "type": "dashboardLink",
+                "id": "b805b8c7-e9d7-4968-9ae2-78d5fb0974ad",
+                "order": 7,
+                "destinationRefName": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard"
+              },
+              {
+                "label": "Kubernetes Volumes",
+                "type": "dashboardLink",
+                "id": "269b5aeb-9e4a-4d27-83ac-77d8aec1213f",
+                "order": 8,
+                "destinationRefName": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard"
+              },
+              {
+                "label": "Kubernetes PV/PVC",
+                "type": "dashboardLink",
+                "id": "9b4a4e12-82d3-445f-8c11-76f197f2aa8b",
+                "order": 9,
+                "destinationRefName": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard"
+              },
+              {
+                "label": "Kubernetes Services",
+                "type": "dashboardLink",
+                "id": "3e277318-8f0e-4be9-9572-0685e64684cf",
+                "order": 10,
+                "destinationRefName": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard"
+              },
+              {
+                "label": "Kubernetes API server",
+                "type": "dashboardLink",
+                "id": "808c6778-b18e-478a-8010-54bd6c8b2f3e",
+                "order": 11,
+                "destinationRefName": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard"
+              }
+            ],
+            "id": "links_panel_kubernetes_0a672d50_bcb1_11ec_b64f_7dd6e8e82013"
+          },
+          "enhancements": {}
         },
+        "panelIndex": "85ecbb8b-9606-4c19-a108-385f825ad7aa",
         "gridData": {
           "h": 7,
           "i": "85ecbb8b-9606-4c19-a108-385f825ad7aa",
           "w": 32,
           "x": 0,
           "y": 0
-        },
-        "panelIndex": "85ecbb8b-9606-4c19-a108-385f825ad7aa",
-        "title": "Kubernetes Dashboards [Metrics Kubernetes]",
-        "type": "visualization",
-        "version": "8.10.2"
+        }
       },
       {
         "embeddableConfig": {
@@ -274,7 +349,7 @@
                           "filter": {
                             "language": "kuery",
                             "query": "\"kubernetes.cronjob.next_schedule.sec\": *"
-                        },
+                          },
                           "isBucketed": false,
                           "label": "Epoch Time until Next Schedule(sec)",
                           "operationType": "last_value",
@@ -446,6 +521,66 @@
       "id": "metrics-*",
       "name": "controlGroup_f4b8cf46-4644-4713-872d-dccc4aeb1e44:optionsListDataView",
       "type": "index-pattern"
+    },
+    {
+      "name": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c"
+    },
+    {
+      "name": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56"
     }
   ],
   "managed": false,

--- a/packages/kubernetes/kibana/dashboard/kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013.json
@@ -36,41 +36,116 @@
     },
     "panelsJSON": [
       {
+        "type": "links",
+        "title": "Kubernetes Dashboards [Metrics Kubernetes]",
         "embeddableConfig": {
-          "enhancements": {},
-          "savedVis": {
-            "data": {
-              "aggs": [],
-              "searchSource": {
-                "filter": [],
-                "query": {
-                  "language": "kuery",
-                  "query": ""
-                }
-              }
-            },
+          "attributes": {
+            "title": "Kubernetes Dashboards [Metrics Kubernetes]",
             "description": "",
-            "params": {
-              "fontSize": 10,
-              "markdown": "[Kubernetes Overview](#/view/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c), [Kubernetes Nodes](#/view/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Pods](#/view/kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013),  [Kubernetes Deployments](#/view/kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes StatefulSets](#/view/kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013),  [Kubernetes DaemonSets](#/view/kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes CronJobs](#/view/kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Jobs](#/view/kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Volumes](#/view/kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013), [Kubernetes PV/PVC](#/view/kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Services](#/view/kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes API Server](#/view/kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56), [Kubernetes Proxy](#/view/kubernetes-5e649d60-9901-11e9-ba57-b7ab4e2d4b58)",
-              "openLinksInNewTab": false
-            },
-            "title": "",
-            "type": "markdown",
-            "uiState": {}
-          }
+            "layout": "horizontal",
+            "links": [
+              {
+                "label": "Kubernetes Overview",
+                "type": "dashboardLink",
+                "id": "6416766e-26ec-4394-b02d-399b42ca9a6e",
+                "order": 0,
+                "destinationRefName": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard"
+              },
+              {
+                "label": "Kubernetes Nodes",
+                "type": "dashboardLink",
+                "id": "07ec2943-d3c5-4c96-beae-c5d5fde21fef",
+                "options": {
+                  "openInNewTab": false,
+                  "useCurrentDateRange": true,
+                  "useCurrentFilters": true
+                },
+                "order": 1,
+                "destinationRefName": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard"
+              },
+              {
+                "label": "Kubernetes Pods",
+                "type": "dashboardLink",
+                "id": "d0182b64-2cbf-4262-a352-9ab9a0ce48d8",
+                "order": 2,
+                "destinationRefName": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard"
+              },
+              {
+                "label": "Kubernetes Deployments",
+                "type": "dashboardLink",
+                "id": "c4b70217-9e48-4b1b-9b37-7803955a7f68",
+                "order": 3,
+                "destinationRefName": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard"
+              },
+              {
+                "label": "Kubernetes StatefulSets",
+                "type": "dashboardLink",
+                "id": "817b2767-a299-4117-9e40-bacf9d2ceeef",
+                "order": 4,
+                "destinationRefName": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard"
+              },
+              {
+                "label": "Kubernetes DaemonSets",
+                "type": "dashboardLink",
+                "id": "f67a589f-975c-409b-af5a-1ec3131916bd",
+                "order": 5,
+                "destinationRefName": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard"
+              },
+              {
+                "label": "Kubernetes Cronjobs",
+                "type": "dashboardLink",
+                "id": "7aeb19b4-8594-4187-9431-1e5e9f09b652",
+                "order": 6,
+                "destinationRefName": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard"
+              },
+              {
+                "label": "Kubernetes Jobs",
+                "type": "dashboardLink",
+                "id": "b805b8c7-e9d7-4968-9ae2-78d5fb0974ad",
+                "order": 7,
+                "destinationRefName": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard"
+              },
+              {
+                "label": "Kubernetes Volumes",
+                "type": "dashboardLink",
+                "id": "269b5aeb-9e4a-4d27-83ac-77d8aec1213f",
+                "order": 8,
+                "destinationRefName": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard"
+              },
+              {
+                "label": "Kubernetes PV/PVC",
+                "type": "dashboardLink",
+                "id": "9b4a4e12-82d3-445f-8c11-76f197f2aa8b",
+                "order": 9,
+                "destinationRefName": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard"
+              },
+              {
+                "label": "Kubernetes Services",
+                "type": "dashboardLink",
+                "id": "3e277318-8f0e-4be9-9572-0685e64684cf",
+                "order": 10,
+                "destinationRefName": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard"
+              },
+              {
+                "label": "Kubernetes API server",
+                "type": "dashboardLink",
+                "id": "808c6778-b18e-478a-8010-54bd6c8b2f3e",
+                "order": 11,
+                "destinationRefName": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard"
+              }
+            ],
+            "id": "links_panel_kubernetes_21694370_bcb2_11ec_b64f_7dd6e8e82013"
+          },
+          "enhancements": {}
         },
+        "panelIndex": "f1e8f8c6-d644-4b1d-a7bc-fe631c232a57",
         "gridData": {
           "h": 4,
           "i": "f1e8f8c6-d644-4b1d-a7bc-fe631c232a57",
           "w": 48,
           "x": 0,
           "y": 0
-        },
-        "panelIndex": "f1e8f8c6-d644-4b1d-a7bc-fe631c232a57",
-        "title": "Kubernetes Dashboards [Metrics Kubernetes]",
-        "type": "visualization",
-        "version": "8.10.2"
+        }
       },
       {
         "embeddableConfig": {
@@ -1040,6 +1115,66 @@
       "id": "metrics-*",
       "name": "controlGroup_82c41492-acf8-4b51-bba9-ec54c99fb1ba:optionsListDataView",
       "type": "index-pattern"
+    },
+    {
+      "name": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c"
+    },
+    {
+      "name": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56"
     }
   ],
   "managed": false,

--- a/packages/kubernetes/kibana/dashboard/kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013.json
@@ -1,725 +1,861 @@
 {
-    "attributes": {
-        "controlGroupInput": {
-            "chainingSystem": "HIERARCHICAL",
-            "controlStyle": "twoLine",
-            "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-            "panelsJSON": "{\"47d0698b-fd83-4545-bd71-934ca64ce05e\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"orchestrator.cluster.name\",\"title\":\"Cluster Name\",\"id\":\"47d0698b-fd83-4545-bd71-934ca64ce05e\",\"enhancements\":{}}},\"7cbc9fff-8146-45d5-b95f-9c26c79cfacb\":{\"order\":1,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"kubernetes.namespace\",\"title\":\"Namespace Name\",\"id\":\"7cbc9fff-8146-45d5-b95f-9c26c79cfacb\",\"selectedOptions\":[],\"enhancements\":{}}},\"0768c85d-eee1-4d76-b6b7-7e47d9083a03\":{\"order\":3,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"kubernetes.volume.name\",\"title\":\"Volume Name\",\"id\":\"0768c85d-eee1-4d76-b6b7-7e47d9083a03\",\"enhancements\":{},\"selectedOptions\":[]}},\"88736cb8-4cf5-4552-bcb1-5e44e85a8a3b\":{\"type\":\"optionsListControl\",\"order\":2,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"88736cb8-4cf5-4552-bcb1-5e44e85a8a3b\",\"fieldName\":\"kubernetes.pod.name\",\"title\":\"Pod Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"wildcard\",\"enhancements\":{}}}}",
-            "showApplySelections": false
-        },
-        "description": "Metrics about Volumes",
-        "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [],
-                "query": {
-                    "language": "kuery",
-                    "query": ""
-                }
-            }
-        },
-        "optionsJSON": {
-            "hidePanelTitles": false,
-            "syncColors": false,
-            "syncCursor": true,
-            "syncTooltips": false,
-            "useMargins": true
-        },
-        "panelsJSON": [
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "params": {
-                            "fontSize": 10,
-                            "markdown": "[Kubernetes Overview](#/view/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c),\n[Kubernetes Nodes](#/view/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013), \n[Kubernetes Pods](#/view/kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013),  [Kubernetes Deployments](#/view/kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes StatefulSets](#/view/kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013),  [Kubernetes DaemonSets](#/view/kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes CronJobs](#/view/kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Jobs](#/view/kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Volumes](#/view/kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013), [Kubernetes PV/PVC](#/view/kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Services](#/view/kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes API Server](#/view/kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56)",
-                            "openLinksInNewTab": false
-                        },
-                        "title": "",
-                        "type": "markdown",
-                        "uiState": {}
-                    }
-                },
-                "gridData": {
-                    "h": 4,
-                    "i": "5a8544d0-678c-4d13-9646-96a30b24a11d",
-                    "w": 48,
-                    "x": 0,
-                    "y": 0
-                },
-                "panelIndex": "5a8544d0-678c-4d13-9646-96a30b24a11d",
-                "title": "Kubernetes Dashboards [Metrics Kubernetes]",
-                "type": "visualization"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-8ca6db64-d9e2-4d78-8585-0de352bc688b",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "1fd32ef5-16e6-4663-ab58-5a088f2fef32",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "8ca6db64-d9e2-4d78-8585-0de352bc688b": {
-                                            "columnOrder": [
-                                                "7418eadb-f312-4d73-a5af-32513d3a279d",
-                                                "a0fa33bb-08d2-41ce-a38a-8ca6bedba441",
-                                                "14e04fc5-96f6-4ca8-97d7-497f7664d9c5",
-                                                "4d708d66-873b-49cc-8616-004dd2bfc67a",
-                                                "e66442d4-51f3-43a8-829f-9cbe56443b15"
-                                            ],
-                                            "columns": {
-                                                "14e04fc5-96f6-4ca8-97d7-497f7664d9c5": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Volume Used %",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "percent",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.volume.fs.used.pct"
-                                                },
-                                                "4d708d66-873b-49cc-8616-004dd2bfc67a": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Used Bytes",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "bytes",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.volume.fs.used.bytes"
-                                                },
-                                                "7418eadb-f312-4d73-a5af-32513d3a279d": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Pod Name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "14e04fc5-96f6-4ca8-97d7-497f7664d9c5",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 50
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.pod.name"
-                                                },
-                                                "a0fa33bb-08d2-41ce-a38a-8ca6bedba441": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Volume",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "14e04fc5-96f6-4ca8-97d7-497f7664d9c5",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 50
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.volume.name"
-                                                },
-                                                "e66442d4-51f3-43a8-829f-9cbe56443b15": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Volume Size",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "bytes",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.volume.fs.capacity.bytes"
-                                                }
-                                            },
-                                            "ignoreGlobalFilters": false,
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "indexpattern": {
-                                    "layers": {}
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "field": "data_stream.dataset",
-                                        "index": "1fd32ef5-16e6-4663-ab58-5a088f2fef32",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.volume"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.volume"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "columns": [
-                                    {
-                                        "columnId": "7418eadb-f312-4d73-a5af-32513d3a279d",
-                                        "isMetric": false,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "a0fa33bb-08d2-41ce-a38a-8ca6bedba441",
-                                        "isMetric": false,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "14e04fc5-96f6-4ca8-97d7-497f7664d9c5",
-                                        "isMetric": true,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "4d708d66-873b-49cc-8616-004dd2bfc67a",
-                                        "isMetric": true,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "alignment": "right",
-                                        "columnId": "e66442d4-51f3-43a8-829f-9cbe56443b15",
-                                        "isMetric": true,
-                                        "isTransposed": false
-                                    }
-                                ],
-                                "layerId": "8ca6db64-d9e2-4d78-8585-0de352bc688b",
-                                "layerType": "data"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsDatatable"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 25,
-                    "i": "a2c9da76-6ff4-426b-ab82-52e3b3a72b6d",
-                    "w": 48,
-                    "x": 0,
-                    "y": 4
-                },
-                "panelIndex": "a2c9da76-6ff4-426b-ab82-52e3b3a72b6d",
-                "title": "Volume Usage per Pod[Metrics Kubernetes]",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-ba7fdd7b-69d9-48d5-ac00-c5602e16ccd0",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "aa3d3e9c-a555-4b69-9dc2-7f1ff0e641ff",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "ba7fdd7b-69d9-48d5-ac00-c5602e16ccd0": {
-                                            "columnOrder": [
-                                                "3d17c7ea-eb86-4234-9e24-9b304fc6da9b",
-                                                "6f2b317a-fff1-4e00-81df-b3d9c05f8f54",
-                                                "1e1cd98f-fe72-473f-86ab-e79a621f8527",
-                                                "b5cfcf26-889f-4514-a8b6-57f68267cfd2"
-                                            ],
-                                            "columns": {
-                                                "1e1cd98f-fe72-473f-86ab-e79a621f8527": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Free Inodes",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "showArrayValues": true,
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.volume.fs.inodes.free"
-                                                },
-                                                "3d17c7ea-eb86-4234-9e24-9b304fc6da9b": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Volume",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "fallback": true,
-                                                            "type": "alphabetical"
-                                                        },
-                                                        "orderDirection": "asc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.volume.name"
-                                                },
-                                                "6f2b317a-fff1-4e00-81df-b3d9c05f8f54": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Number of Inodes",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        },
-                                                        "showArrayValues": true,
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.volume.fs.inodes.count"
-                                                },
-                                                "b5cfcf26-889f-4514-a8b6-57f68267cfd2": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Used Inodes",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "showArrayValues": true,
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.volume.fs.inodes.used"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "aa3d3e9c-a555-4b69-9dc2-7f1ff0e641ff",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.volume"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.volume"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "columns": [
-                                    {
-                                        "columnId": "3d17c7ea-eb86-4234-9e24-9b304fc6da9b",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "6f2b317a-fff1-4e00-81df-b3d9c05f8f54",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "1e1cd98f-fe72-473f-86ab-e79a621f8527",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "b5cfcf26-889f-4514-a8b6-57f68267cfd2",
-                                        "isTransposed": false
-                                    }
-                                ],
-                                "layerId": "ba7fdd7b-69d9-48d5-ac00-c5602e16ccd0",
-                                "layerType": "data",
-                                "rowHeight": "single",
-                                "rowHeightLines": 1
-                            }
-                        },
-                        "title": "Filesystem Inodes Informations [Metrics Kubernetes]",
-                        "type": "lens",
-                        "visualizationType": "lnsDatatable"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 17,
-                    "i": "753d630d-1c8d-478a-8ee1-3bfffe5a6928",
-                    "w": 24,
-                    "x": 0,
-                    "y": 29
-                },
-                "panelIndex": "753d630d-1c8d-478a-8ee1-3bfffe5a6928",
-                "title": "Filesystem Inodes Informations [Metrics Kubernetes]",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-ba7fdd7b-69d9-48d5-ac00-c5602e16ccd0",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "ba7fdd7b-69d9-48d5-ac00-c5602e16ccd0": {
-                                            "columnOrder": [
-                                                "3d17c7ea-eb86-4234-9e24-9b304fc6da9b",
-                                                "6f2b317a-fff1-4e00-81df-b3d9c05f8f54",
-                                                "227c4795-30a7-48dc-990a-11fe7b4bca3c",
-                                                "a551fe3f-2761-4cfe-8b47-ed8f6d9c9540",
-                                                "a52b3682-8595-4cff-89b2-590cd5c3e6c2"
-                                            ],
-                                            "columns": {
-                                                "227c4795-30a7-48dc-990a-11fe7b4bca3c": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Fs Capacity bytes",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "bytes",
-                                                            "params": {
-                                                                "decimals": 1
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.volume.fs.capacity.bytes"
-                                                },
-                                                "3d17c7ea-eb86-4234-9e24-9b304fc6da9b": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Volume",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "6f2b317a-fff1-4e00-81df-b3d9c05f8f54",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.volume.name"
-                                                },
-                                                "6f2b317a-fff1-4e00-81df-b3d9c05f8f54": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Fs Available bytes",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "bytes",
-                                                            "params": {
-                                                                "decimals": 1
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.volume.fs.available.bytes"
-                                                },
-                                                "a52b3682-8595-4cff-89b2-590cd5c3e6c2": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.volume.fs.used.pct: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Fs Usage Pct",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "percent",
-                                                            "params": {
-                                                                "decimals": 3
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.volume.fs.used.pct"
-                                                },
-                                                "a551fe3f-2761-4cfe-8b47-ed8f6d9c9540": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Fs Used bytes",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "bytes",
-                                                            "params": {
-                                                                "decimals": 1
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.volume.fs.used.bytes"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "e2cc978e-4d26-4a84-8c40-20a4af3abf83",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.volume"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.volume"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "columns": [
-                                    {
-                                        "columnId": "3d17c7ea-eb86-4234-9e24-9b304fc6da9b",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "6f2b317a-fff1-4e00-81df-b3d9c05f8f54",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "227c4795-30a7-48dc-990a-11fe7b4bca3c",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "a551fe3f-2761-4cfe-8b47-ed8f6d9c9540",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "a52b3682-8595-4cff-89b2-590cd5c3e6c2",
-                                        "isTransposed": false
-                                    }
-                                ],
-                                "layerId": "ba7fdd7b-69d9-48d5-ac00-c5602e16ccd0",
-                                "layerType": "data",
-                                "rowHeight": "single",
-                                "rowHeightLines": 1
-                            }
-                        },
-                        "title": "Filesystem Informations [Metrics Kubernetes]",
-                        "type": "lens",
-                        "visualizationType": "lnsDatatable"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 17,
-                    "i": "875cb2ab-9474-4e32-958b-eb393485eb5e",
-                    "w": 24,
-                    "x": 24,
-                    "y": 29
-                },
-                "panelIndex": "875cb2ab-9474-4e32-958b-eb393485eb5e",
-                "title": "Filesystem Informations [Metrics Kubernetes]",
-                "type": "lens"
-            }
-        ],
-        "timeRestore": false,
-        "title": "[Metrics Kubernetes] Volumes",
-        "version": 2
+  "attributes": {
+    "controlGroupInput": {
+      "chainingSystem": "HIERARCHICAL",
+      "controlStyle": "twoLine",
+      "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
+      "panelsJSON": "{\"47d0698b-fd83-4545-bd71-934ca64ce05e\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"orchestrator.cluster.name\",\"title\":\"Cluster Name\",\"id\":\"47d0698b-fd83-4545-bd71-934ca64ce05e\",\"enhancements\":{}}},\"7cbc9fff-8146-45d5-b95f-9c26c79cfacb\":{\"order\":1,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"kubernetes.namespace\",\"title\":\"Namespace Name\",\"id\":\"7cbc9fff-8146-45d5-b95f-9c26c79cfacb\",\"selectedOptions\":[],\"enhancements\":{}}},\"0768c85d-eee1-4d76-b6b7-7e47d9083a03\":{\"order\":3,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"kubernetes.volume.name\",\"title\":\"Volume Name\",\"id\":\"0768c85d-eee1-4d76-b6b7-7e47d9083a03\",\"enhancements\":{},\"selectedOptions\":[]}},\"88736cb8-4cf5-4552-bcb1-5e44e85a8a3b\":{\"type\":\"optionsListControl\",\"order\":2,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"88736cb8-4cf5-4552-bcb1-5e44e85a8a3b\",\"fieldName\":\"kubernetes.pod.name\",\"title\":\"Pod Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"wildcard\",\"enhancements\":{}}}}",
+      "showApplySelections": false
     },
-    "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-07-05T12:54:01.330Z",
-    "created_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0",
-    "id": "kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013",
-    "managed": false,
-    "references": [
-        {
-            "id": "metrics-*",
-            "name": "a2c9da76-6ff4-426b-ab82-52e3b3a72b6d:indexpattern-datasource-layer-8ca6db64-d9e2-4d78-8585-0de352bc688b",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "a2c9da76-6ff4-426b-ab82-52e3b3a72b6d:1fd32ef5-16e6-4663-ab58-5a088f2fef32",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "753d630d-1c8d-478a-8ee1-3bfffe5a6928:indexpattern-datasource-layer-ba7fdd7b-69d9-48d5-ac00-c5602e16ccd0",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "753d630d-1c8d-478a-8ee1-3bfffe5a6928:aa3d3e9c-a555-4b69-9dc2-7f1ff0e641ff",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "875cb2ab-9474-4e32-958b-eb393485eb5e:indexpattern-datasource-layer-ba7fdd7b-69d9-48d5-ac00-c5602e16ccd0",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "controlGroup_47d0698b-fd83-4545-bd71-934ca64ce05e:optionsListDataView",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "controlGroup_7cbc9fff-8146-45d5-b95f-9c26c79cfacb:optionsListDataView",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "controlGroup_0768c85d-eee1-4d76-b6b7-7e47d9083a03:optionsListDataView",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "controlGroup_88736cb8-4cf5-4552-bcb1-5e44e85a8a3b:optionsListDataView",
-            "type": "index-pattern"
+    "description": "Metrics about Volumes",
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": {
+        "filter": [],
+        "query": {
+          "language": "kuery",
+          "query": ""
         }
+      }
+    },
+    "optionsJSON": {
+      "hidePanelTitles": false,
+      "syncColors": false,
+      "syncCursor": true,
+      "syncTooltips": false,
+      "useMargins": true
+    },
+    "panelsJSON": [
+      {
+        "type": "links",
+        "title": "Kubernetes Dashboards [Metrics Kubernetes]",
+        "embeddableConfig": {
+          "attributes": {
+            "title": "Kubernetes Dashboards [Metrics Kubernetes]",
+            "description": "",
+            "layout": "horizontal",
+            "links": [
+              {
+                "label": "Kubernetes Overview",
+                "type": "dashboardLink",
+                "id": "6416766e-26ec-4394-b02d-399b42ca9a6e",
+                "order": 0,
+                "destinationRefName": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard"
+              },
+              {
+                "label": "Kubernetes Nodes",
+                "type": "dashboardLink",
+                "id": "07ec2943-d3c5-4c96-beae-c5d5fde21fef",
+                "options": {
+                  "openInNewTab": false,
+                  "useCurrentDateRange": true,
+                  "useCurrentFilters": true
+                },
+                "order": 1,
+                "destinationRefName": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard"
+              },
+              {
+                "label": "Kubernetes Pods",
+                "type": "dashboardLink",
+                "id": "d0182b64-2cbf-4262-a352-9ab9a0ce48d8",
+                "order": 2,
+                "destinationRefName": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard"
+              },
+              {
+                "label": "Kubernetes Deployments",
+                "type": "dashboardLink",
+                "id": "c4b70217-9e48-4b1b-9b37-7803955a7f68",
+                "order": 3,
+                "destinationRefName": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard"
+              },
+              {
+                "label": "Kubernetes StatefulSets",
+                "type": "dashboardLink",
+                "id": "817b2767-a299-4117-9e40-bacf9d2ceeef",
+                "order": 4,
+                "destinationRefName": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard"
+              },
+              {
+                "label": "Kubernetes DaemonSets",
+                "type": "dashboardLink",
+                "id": "f67a589f-975c-409b-af5a-1ec3131916bd",
+                "order": 5,
+                "destinationRefName": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard"
+              },
+              {
+                "label": "Kubernetes Cronjobs",
+                "type": "dashboardLink",
+                "id": "7aeb19b4-8594-4187-9431-1e5e9f09b652",
+                "order": 6,
+                "destinationRefName": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard"
+              },
+              {
+                "label": "Kubernetes Jobs",
+                "type": "dashboardLink",
+                "id": "b805b8c7-e9d7-4968-9ae2-78d5fb0974ad",
+                "order": 7,
+                "destinationRefName": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard"
+              },
+              {
+                "label": "Kubernetes Volumes",
+                "type": "dashboardLink",
+                "id": "269b5aeb-9e4a-4d27-83ac-77d8aec1213f",
+                "order": 8,
+                "destinationRefName": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard"
+              },
+              {
+                "label": "Kubernetes PV/PVC",
+                "type": "dashboardLink",
+                "id": "9b4a4e12-82d3-445f-8c11-76f197f2aa8b",
+                "order": 9,
+                "destinationRefName": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard"
+              },
+              {
+                "label": "Kubernetes Services",
+                "type": "dashboardLink",
+                "id": "3e277318-8f0e-4be9-9572-0685e64684cf",
+                "order": 10,
+                "destinationRefName": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard"
+              },
+              {
+                "label": "Kubernetes API server",
+                "type": "dashboardLink",
+                "id": "808c6778-b18e-478a-8010-54bd6c8b2f3e",
+                "order": 11,
+                "destinationRefName": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard"
+              }
+            ],
+            "id": "links_panel_kubernetes_3912d9a0_bcb2_11ec_b64f_7dd6e8e82013"
+          },
+          "enhancements": {}
+        },
+        "panelIndex": "5a8544d0-678c-4d13-9646-96a30b24a11d",
+        "gridData": {
+          "h": 4,
+          "i": "5a8544d0-678c-4d13-9646-96a30b24a11d",
+          "w": 48,
+          "x": 0,
+          "y": 0
+        }
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-8ca6db64-d9e2-4d78-8585-0de352bc688b",
+                "type": "index-pattern"
+              },
+              {
+                "id": "metrics-*",
+                "name": "1fd32ef5-16e6-4663-ab58-5a088f2fef32",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "8ca6db64-d9e2-4d78-8585-0de352bc688b": {
+                      "columnOrder": [
+                        "7418eadb-f312-4d73-a5af-32513d3a279d",
+                        "a0fa33bb-08d2-41ce-a38a-8ca6bedba441",
+                        "14e04fc5-96f6-4ca8-97d7-497f7664d9c5",
+                        "4d708d66-873b-49cc-8616-004dd2bfc67a",
+                        "e66442d4-51f3-43a8-829f-9cbe56443b15"
+                      ],
+                      "columns": {
+                        "14e04fc5-96f6-4ca8-97d7-497f7664d9c5": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Volume Used %",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.volume.fs.used.pct"
+                        },
+                        "4d708d66-873b-49cc-8616-004dd2bfc67a": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Used Bytes",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.volume.fs.used.bytes"
+                        },
+                        "7418eadb-f312-4d73-a5af-32513d3a279d": {
+                          "customLabel": true,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Pod Name",
+                          "operationType": "terms",
+                          "params": {
+                            "exclude": [],
+                            "excludeIsRegex": false,
+                            "include": [],
+                            "includeIsRegex": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "columnId": "14e04fc5-96f6-4ca8-97d7-497f7664d9c5",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": true,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 50
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.pod.name"
+                        },
+                        "a0fa33bb-08d2-41ce-a38a-8ca6bedba441": {
+                          "customLabel": true,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Volume",
+                          "operationType": "terms",
+                          "params": {
+                            "exclude": [],
+                            "excludeIsRegex": false,
+                            "include": [],
+                            "includeIsRegex": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "columnId": "14e04fc5-96f6-4ca8-97d7-497f7664d9c5",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": true,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 50
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.volume.name"
+                        },
+                        "e66442d4-51f3-43a8-829f-9cbe56443b15": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Volume Size",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.volume.fs.capacity.bytes"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "incompleteColumns": {},
+                      "sampling": 1
+                    }
+                  }
+                },
+                "indexpattern": {
+                  "layers": {}
+                },
+                "textBased": {
+                  "layers": {}
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "field": "data_stream.dataset",
+                    "index": "1fd32ef5-16e6-4663-ab58-5a088f2fef32",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.volume"
+                    },
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.volume"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "7418eadb-f312-4d73-a5af-32513d3a279d",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "a0fa33bb-08d2-41ce-a38a-8ca6bedba441",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "14e04fc5-96f6-4ca8-97d7-497f7664d9c5",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "4d708d66-873b-49cc-8616-004dd2bfc67a",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "alignment": "right",
+                    "columnId": "e66442d4-51f3-43a8-829f-9cbe56443b15",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "layerId": "8ca6db64-d9e2-4d78-8585-0de352bc688b",
+                "layerType": "data"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsDatatable"
+          },
+          "enhancements": {},
+          "hidePanelTitles": false
+        },
+        "gridData": {
+          "h": 25,
+          "i": "a2c9da76-6ff4-426b-ab82-52e3b3a72b6d",
+          "w": 48,
+          "x": 0,
+          "y": 4
+        },
+        "panelIndex": "a2c9da76-6ff4-426b-ab82-52e3b3a72b6d",
+        "title": "Volume Usage per Pod[Metrics Kubernetes]",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-ba7fdd7b-69d9-48d5-ac00-c5602e16ccd0",
+                "type": "index-pattern"
+              },
+              {
+                "id": "metrics-*",
+                "name": "aa3d3e9c-a555-4b69-9dc2-7f1ff0e641ff",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "ba7fdd7b-69d9-48d5-ac00-c5602e16ccd0": {
+                      "columnOrder": [
+                        "3d17c7ea-eb86-4234-9e24-9b304fc6da9b",
+                        "6f2b317a-fff1-4e00-81df-b3d9c05f8f54",
+                        "1e1cd98f-fe72-473f-86ab-e79a621f8527",
+                        "b5cfcf26-889f-4514-a8b6-57f68267cfd2"
+                      ],
+                      "columns": {
+                        "1e1cd98f-fe72-473f-86ab-e79a621f8527": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Free Inodes",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": true,
+                            "sortField": "@timestamp"
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.volume.fs.inodes.free"
+                        },
+                        "3d17c7ea-eb86-4234-9e24-9b304fc6da9b": {
+                          "customLabel": true,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Volume",
+                          "operationType": "terms",
+                          "params": {
+                            "missingBucket": false,
+                            "orderBy": {
+                              "fallback": true,
+                              "type": "alphabetical"
+                            },
+                            "orderDirection": "asc",
+                            "otherBucket": true,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 10
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.volume.name"
+                        },
+                        "6f2b317a-fff1-4e00-81df-b3d9c05f8f54": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Number of Inodes",
+                          "operationType": "last_value",
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            },
+                            "showArrayValues": true,
+                            "sortField": "@timestamp"
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.volume.fs.inodes.count"
+                        },
+                        "b5cfcf26-889f-4514-a8b6-57f68267cfd2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Used Inodes",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": true,
+                            "sortField": "@timestamp"
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.volume.fs.inodes.used"
+                        }
+                      },
+                      "incompleteColumns": {}
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "aa3d3e9c-a555-4b69-9dc2-7f1ff0e641ff",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.volume"
+                    },
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.volume"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "3d17c7ea-eb86-4234-9e24-9b304fc6da9b",
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "6f2b317a-fff1-4e00-81df-b3d9c05f8f54",
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "1e1cd98f-fe72-473f-86ab-e79a621f8527",
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "b5cfcf26-889f-4514-a8b6-57f68267cfd2",
+                    "isTransposed": false
+                  }
+                ],
+                "layerId": "ba7fdd7b-69d9-48d5-ac00-c5602e16ccd0",
+                "layerType": "data",
+                "rowHeight": "single",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "Filesystem Inodes Informations [Metrics Kubernetes]",
+            "type": "lens",
+            "visualizationType": "lnsDatatable"
+          },
+          "enhancements": {},
+          "hidePanelTitles": false
+        },
+        "gridData": {
+          "h": 17,
+          "i": "753d630d-1c8d-478a-8ee1-3bfffe5a6928",
+          "w": 24,
+          "x": 0,
+          "y": 29
+        },
+        "panelIndex": "753d630d-1c8d-478a-8ee1-3bfffe5a6928",
+        "title": "Filesystem Inodes Informations [Metrics Kubernetes]",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-ba7fdd7b-69d9-48d5-ac00-c5602e16ccd0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "ba7fdd7b-69d9-48d5-ac00-c5602e16ccd0": {
+                      "columnOrder": [
+                        "3d17c7ea-eb86-4234-9e24-9b304fc6da9b",
+                        "6f2b317a-fff1-4e00-81df-b3d9c05f8f54",
+                        "227c4795-30a7-48dc-990a-11fe7b4bca3c",
+                        "a551fe3f-2761-4cfe-8b47-ed8f6d9c9540",
+                        "a52b3682-8595-4cff-89b2-590cd5c3e6c2"
+                      ],
+                      "columns": {
+                        "227c4795-30a7-48dc-990a-11fe7b4bca3c": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Fs Capacity bytes",
+                          "operationType": "average",
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.volume.fs.capacity.bytes"
+                        },
+                        "3d17c7ea-eb86-4234-9e24-9b304fc6da9b": {
+                          "customLabel": true,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Volume",
+                          "operationType": "terms",
+                          "params": {
+                            "missingBucket": false,
+                            "orderBy": {
+                              "columnId": "6f2b317a-fff1-4e00-81df-b3d9c05f8f54",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": true,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 10
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.volume.name"
+                        },
+                        "6f2b317a-fff1-4e00-81df-b3d9c05f8f54": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Fs Available bytes",
+                          "operationType": "average",
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.volume.fs.available.bytes"
+                        },
+                        "a52b3682-8595-4cff-89b2-590cd5c3e6c2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "kubernetes.volume.fs.used.pct: *"
+                          },
+                          "isBucketed": false,
+                          "label": "Fs Usage Pct",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 3
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.volume.fs.used.pct"
+                        },
+                        "a551fe3f-2761-4cfe-8b47-ed8f6d9c9540": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Fs Used bytes",
+                          "operationType": "average",
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.volume.fs.used.bytes"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "e2cc978e-4d26-4a84-8c40-20a4af3abf83",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.volume"
+                    },
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.volume"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "3d17c7ea-eb86-4234-9e24-9b304fc6da9b",
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "6f2b317a-fff1-4e00-81df-b3d9c05f8f54",
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "227c4795-30a7-48dc-990a-11fe7b4bca3c",
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "a551fe3f-2761-4cfe-8b47-ed8f6d9c9540",
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "a52b3682-8595-4cff-89b2-590cd5c3e6c2",
+                    "isTransposed": false
+                  }
+                ],
+                "layerId": "ba7fdd7b-69d9-48d5-ac00-c5602e16ccd0",
+                "layerType": "data",
+                "rowHeight": "single",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "Filesystem Informations [Metrics Kubernetes]",
+            "type": "lens",
+            "visualizationType": "lnsDatatable"
+          },
+          "enhancements": {},
+          "hidePanelTitles": false
+        },
+        "gridData": {
+          "h": 17,
+          "i": "875cb2ab-9474-4e32-958b-eb393485eb5e",
+          "w": 24,
+          "x": 24,
+          "y": 29
+        },
+        "panelIndex": "875cb2ab-9474-4e32-958b-eb393485eb5e",
+        "title": "Filesystem Informations [Metrics Kubernetes]",
+        "type": "lens"
+      }
     ],
-    "type": "dashboard",
-    "typeMigrationVersion": "10.2.0"
+    "timeRestore": false,
+    "title": "[Metrics Kubernetes] Volumes",
+    "version": 2
+  },
+  "coreMigrationVersion": "8.8.0",
+  "created_at": "2024-07-05T12:54:01.330Z",
+  "created_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0",
+  "id": "kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013",
+  "managed": false,
+  "references": [
+    {
+      "id": "metrics-*",
+      "name": "a2c9da76-6ff4-426b-ab82-52e3b3a72b6d:indexpattern-datasource-layer-8ca6db64-d9e2-4d78-8585-0de352bc688b",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "a2c9da76-6ff4-426b-ab82-52e3b3a72b6d:1fd32ef5-16e6-4663-ab58-5a088f2fef32",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "753d630d-1c8d-478a-8ee1-3bfffe5a6928:indexpattern-datasource-layer-ba7fdd7b-69d9-48d5-ac00-c5602e16ccd0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "753d630d-1c8d-478a-8ee1-3bfffe5a6928:aa3d3e9c-a555-4b69-9dc2-7f1ff0e641ff",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "875cb2ab-9474-4e32-958b-eb393485eb5e:indexpattern-datasource-layer-ba7fdd7b-69d9-48d5-ac00-c5602e16ccd0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "controlGroup_47d0698b-fd83-4545-bd71-934ca64ce05e:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "controlGroup_7cbc9fff-8146-45d5-b95f-9c26c79cfacb:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "controlGroup_0768c85d-eee1-4d76-b6b7-7e47d9083a03:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "controlGroup_88736cb8-4cf5-4552-bcb1-5e44e85a8a3b:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "name": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c"
+    },
+    {
+      "name": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56"
+    }
+  ],
+  "type": "dashboard",
+  "typeMigrationVersion": "10.2.0"
 }

--- a/packages/kubernetes/kibana/dashboard/kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013.json
@@ -1,1618 +1,1754 @@
 {
-    "attributes": {
-        "controlGroupInput": {
-            "chainingSystem": "HIERARCHICAL",
-            "controlStyle": "twoLine",
-            "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-            "panelsJSON": "{\"8d2aec33-4ad2-4604-b59f-71ebe8a77b14\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"orchestrator.cluster.name\",\"title\":\"Cluster Name\",\"id\":\"8d2aec33-4ad2-4604-b59f-71ebe8a77b14\",\"selectedOptions\":[],\"enhancements\":{}}},\"bee5f46d-92a7-4e86-955f-85dac264e63e\":{\"order\":1,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"kubernetes.namespace\",\"title\":\"Namespace Name\",\"id\":\"bee5f46d-92a7-4e86-955f-85dac264e63e\",\"selectedOptions\":[],\"enhancements\":{}}},\"76c282b7-0d22-4b01-a80e-18564417ba5e\":{\"order\":2,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"kubernetes.pod.name\",\"title\":\"Pod Name\",\"id\":\"76c282b7-0d22-4b01-a80e-18564417ba5e\",\"selectedOptions\":[],\"enhancements\":{}}}}",
-            "showApplySelections": false
-        },
-        "description": "Metrics about Pods",
-        "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [],
-                "query": {
-                    "language": "kuery",
-                    "query": ""
-                }
-            }
-        },
-        "optionsJSON": {
-            "hidePanelTitles": false,
-            "syncColors": false,
-            "syncCursor": true,
-            "syncTooltips": false,
-            "useMargins": true
-        },
-        "panelsJSON": [
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "params": {
-                            "fontSize": 10,
-                            "markdown": "[Kubernetes Overview](#/view/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c), [Kubernetes Nodes](#/view/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Pods](#/view/kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013),  [Kubernetes Deployments](#/view/kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes StatefulSets](#/view/kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013),  [Kubernetes DaemonSets](#/view/kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes CronJobs](#/view/kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Jobs](#/view/kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Volumes](#/view/kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013), [Kubernetes PV/PVC](#/view/kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Services](#/view/kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes API Server](#/view/kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56)",
-                            "openLinksInNewTab": false
-                        },
-                        "title": "",
-                        "type": "markdown",
-                        "uiState": {}
-                    }
-                },
-                "gridData": {
-                    "h": 4,
-                    "i": "c0a8dc23-df25-4618-8603-15b76ee0ae86",
-                    "w": 48,
-                    "x": 0,
-                    "y": 0
-                },
-                "panelIndex": "c0a8dc23-df25-4618-8603-15b76ee0ae86",
-                "title": "Kubernetes Dashboards [Metrics Kubernetes]",
-                "type": "visualization"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-307ec163-d913-4ce0-8e9b-6dfc777def59",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "f30047fb-d7fd-4873-9150-6e16c369fcc8",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "307ec163-d913-4ce0-8e9b-6dfc777def59": {
-                                            "columnOrder": [
-                                                "8c03fc54-6e2d-49ff-b294-bb80ae6a1a8e",
-                                                "7b682fd2-3fd6-4834-8067-a546ab543764",
-                                                "e9919412-9d5f-4db8-96bf-ab35a7b11c87",
-                                                "b1ecf062-bf74-4458-9598-2c7018cdae3d"
-                                            ],
-                                            "columns": {
-                                                "7b682fd2-3fd6-4834-8067-a546ab543764": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.pod.status.phase: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Phase",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.pod.status.phase"
-                                                },
-                                                "8c03fc54-6e2d-49ff-b294-bb80ae6a1a8e": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Pod",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "fallback": false,
-                                                            "type": "alphabetical"
-                                                        },
-                                                        "orderDirection": "asc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 1000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.pod.name"
-                                                },
-                                                "b1ecf062-bf74-4458-9598-2c7018cdae3d": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.pod.status.scheduled: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Scheduled",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.pod.status.scheduled"
-                                                },
-                                                "e9919412-9d5f-4db8-96bf-ab35a7b11c87": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.pod.status.ready: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Ready",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.pod.status.ready"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "f30047fb-d7fd-4873-9150-6e16c369fcc8",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.state_pod"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.state_pod"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "columns": [
-                                    {
-                                        "collapseFn": "",
-                                        "columnId": "8c03fc54-6e2d-49ff-b294-bb80ae6a1a8e",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "alignment": "right",
-                                        "columnId": "7b682fd2-3fd6-4834-8067-a546ab543764",
-                                        "hidden": false,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "alignment": "right",
-                                        "columnId": "e9919412-9d5f-4db8-96bf-ab35a7b11c87",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "alignment": "right",
-                                        "columnId": "b1ecf062-bf74-4458-9598-2c7018cdae3d",
-                                        "isTransposed": false
-                                    }
-                                ],
-                                "headerRowHeight": "single",
-                                "headerRowHeightLines": 1,
-                                "layerId": "307ec163-d913-4ce0-8e9b-6dfc777def59",
-                                "layerType": "data",
-                                "paging": {
-                                    "enabled": true,
-                                    "size": 10
-                                },
-                                "sorting": {
-                                    "direction": "none"
-                                }
-                            }
-                        },
-                        "title": "Status per Pod [Metrics Kubernetes]",
-                        "type": "lens",
-                        "visualizationType": "lnsDatatable"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 15,
-                    "i": "c077515d-1668-487f-9942-2448a0c25e70",
-                    "w": 48,
-                    "x": 0,
-                    "y": 4
-                },
-                "panelIndex": "c077515d-1668-487f-9942-2448a0c25e70",
-                "title": "Status per Pod [Metrics Kubernetes]",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "9486d409-e044-43b7-a175-e25695e38cc4",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a": {
-                                            "columnOrder": [
-                                                "a83bd360-6bed-4bab-ac6c-82b8e473c2b0",
-                                                "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
-                                                "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
-                                            ],
-                                            "columns": {
-                                                "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.pod.cpu.usage.node.pct: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "CPU Usage",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "percent",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.pod.cpu.usage.node.pct"
-                                                },
-                                                "a83bd360-6bed-4bab-ac6c-82b8e473c2b0": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10 values of kubernetes.pod.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "accuracyMode": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.pod.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "9486d409-e044-43b7-a175-e25695e38cc4",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.pod"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.pod"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "curveType": "LINEAR",
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
-                                        ],
-                                        "layerId": "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "area",
-                                        "showGridlines": false,
-                                        "splitAccessor": "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
-                                        "xAccessor": "a83bd360-6bed-4bab-ac6c-82b8e473c2b0"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "legendSize": "large",
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "area",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide",
-                                "valuesInLegend": true
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 15,
-                    "i": "23852bac-d857-4a32-95f3-8100d6abd976",
-                    "w": 24,
-                    "x": 0,
-                    "y": 19
-                },
-                "panelIndex": "23852bac-d857-4a32-95f3-8100d6abd976",
-                "title": "CPU Usage as Pct of the Total Node CPU [Metrics Kubernetes]",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a": {
-                                            "columnOrder": [
-                                                "a83bd360-6bed-4bab-ac6c-82b8e473c2b0",
-                                                "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
-                                                "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
-                                            ],
-                                            "columns": {
-                                                "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": ""
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "CPU Usage",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "percent",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.pod.cpu.usage.limit.pct"
-                                                },
-                                                "a83bd360-6bed-4bab-ac6c-82b8e473c2b0": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10 values of kubernetes.pod.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "accuracyMode": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.pod.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "61027d7f-6398-4aec-b154-897b913481e4",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.pod"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.pod"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "kubernetes.pod.cpu.usage.limit.pct: *"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "curveType": "LINEAR",
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
-                                        ],
-                                        "layerId": "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "area",
-                                        "showGridlines": false,
-                                        "splitAccessor": "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
-                                        "xAccessor": "a83bd360-6bed-4bab-ac6c-82b8e473c2b0"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "legendSize": "large",
-                                    "legendStats": [
-                                        "currentAndLastValue"
-                                    ],
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "area",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 15,
-                    "i": "9567b72e-6e79-479b-a5b1-1d9f81d258bd",
-                    "w": 24,
-                    "x": 24,
-                    "y": 19
-                },
-                "panelIndex": "9567b72e-6e79-479b-a5b1-1d9f81d258bd",
-                "title": "CPU Usage as Pct of the Defined Pod Limit [Metrics Kubernetes]",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "ace482cc-b33b-47c1-89b1-a710fe45195e",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a": {
-                                            "columnOrder": [
-                                                "a83bd360-6bed-4bab-ac6c-82b8e473c2b0",
-                                                "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
-                                                "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
-                                            ],
-                                            "columns": {
-                                                "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.pod.cpu.usage.node.pct: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Memory Usage",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "percent",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.pod.memory.usage.node.pct"
-                                                },
-                                                "a83bd360-6bed-4bab-ac6c-82b8e473c2b0": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10 values of kubernetes.pod.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "accuracyMode": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.pod.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "ace482cc-b33b-47c1-89b1-a710fe45195e",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.pod"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.pod"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "curveType": "LINEAR",
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
-                                        ],
-                                        "layerId": "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "area",
-                                        "showGridlines": false,
-                                        "splitAccessor": "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
-                                        "xAccessor": "a83bd360-6bed-4bab-ac6c-82b8e473c2b0"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "legendSize": "large",
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "area",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide",
-                                "valuesInLegend": true
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 15,
-                    "i": "6b939075-346d-4aa1-b634-bf57b8cc1532",
-                    "w": 24,
-                    "x": 0,
-                    "y": 34
-                },
-                "panelIndex": "6b939075-346d-4aa1-b634-bf57b8cc1532",
-                "title": "Memory Usage as Pct of the Total Node Memory [Metrics Kubernetes]",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a": {
-                                            "columnOrder": [
-                                                "a83bd360-6bed-4bab-ac6c-82b8e473c2b0",
-                                                "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
-                                                "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
-                                            ],
-                                            "columns": {
-                                                "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": ""
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Memory Usage",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "percent",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.pod.memory.usage.limit.pct"
-                                                },
-                                                "a83bd360-6bed-4bab-ac6c-82b8e473c2b0": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10 values of kubernetes.pod.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "accuracyMode": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.pod.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "81de779f-3d8f-4f90-9a93-08ecf5d96939",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.pod"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.pod"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "kubernetes.pod.memory.usage.limit.pct:*"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "curveType": "LINEAR",
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
-                                        ],
-                                        "layerId": "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "area",
-                                        "showGridlines": false,
-                                        "splitAccessor": "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
-                                        "xAccessor": "a83bd360-6bed-4bab-ac6c-82b8e473c2b0"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "legendSize": "large",
-                                    "legendStats": [
-                                        "currentAndLastValue"
-                                    ],
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "area",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 15,
-                    "i": "54bfc973-09ca-4ebe-a777-c790087c3a91",
-                    "w": 24,
-                    "x": 24,
-                    "y": 34
-                },
-                "panelIndex": "54bfc973-09ca-4ebe-a777-c790087c3a91",
-                "title": "Memory Usage as Pct of the Defined Pod Limit [Metrics Kubernetes]",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a": {
-                                            "columnOrder": [
-                                                "a83bd360-6bed-4bab-ac6c-82b8e473c2b0",
-                                                "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
-                                                "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
-                                            ],
-                                            "columns": {
-                                                "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": ""
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Memory Usage",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "percent",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.pod.memory.working_set.limit.pct"
-                                                },
-                                                "a83bd360-6bed-4bab-ac6c-82b8e473c2b0": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10 values of kubernetes.pod.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "accuracyMode": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.pod.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "9d74e7d3-0a1c-4c8b-8635-1577d74797f7",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.pod"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.pod"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "kubernetes.pod.memory.working_set.limit.pct:*"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "curveType": "LINEAR",
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
-                                        ],
-                                        "layerId": "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "area",
-                                        "showGridlines": false,
-                                        "splitAccessor": "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
-                                        "xAccessor": "a83bd360-6bed-4bab-ac6c-82b8e473c2b0"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "legendSize": "large",
-                                    "legendStats": [
-                                        "currentAndLastValue"
-                                    ],
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "area",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 15,
-                    "i": "6459a5c9-80c5-46d8-968f-5b0a40b2eee0",
-                    "w": 24,
-                    "x": 0,
-                    "y": 49
-                },
-                "panelIndex": "6459a5c9-80c5-46d8-968f-5b0a40b2eee0",
-                "title": "Working Set Memory Usage as Pct of the Defined Pod Limit [Metrics Kubernetes]",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "710b0f49-b955-4cb8-826e-e51b3e6e7271",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a": {
-                                            "columnOrder": [
-                                                "a83bd360-6bed-4bab-ac6c-82b8e473c2b0",
-                                                "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
-                                                "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
-                                            ],
-                                            "columns": {
-                                                "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.pod.cpu.usage.node.pct: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Network Usage",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "bytes",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        },
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.pod.network.tx.bytes"
-                                                },
-                                                "a83bd360-6bed-4bab-ac6c-82b8e473c2b0": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10 values of kubernetes.pod.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "accuracyMode": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.pod.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "710b0f49-b955-4cb8-826e-e51b3e6e7271",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.pod"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.pod"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "curveType": "LINEAR",
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
-                                        ],
-                                        "layerId": "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "area",
-                                        "showGridlines": false,
-                                        "splitAccessor": "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
-                                        "xAccessor": "a83bd360-6bed-4bab-ac6c-82b8e473c2b0"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "legendSize": "large",
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "area",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide",
-                                "valuesInLegend": true
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 15,
-                    "i": "06ded777-f88c-40c8-93fa-1f0ed71ed43a",
-                    "w": 24,
-                    "x": 24,
-                    "y": 49
-                },
-                "panelIndex": "06ded777-f88c-40c8-93fa-1f0ed71ed43a",
-                "title": "Network Outgoing Bytes per Pod [Metrics Kubernetes]",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "31f6a38e-250d-4a00-9f2a-af9c53aff800",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a": {
-                                            "columnOrder": [
-                                                "a83bd360-6bed-4bab-ac6c-82b8e473c2b0",
-                                                "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
-                                                "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
-                                            ],
-                                            "columns": {
-                                                "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.pod.cpu.usage.node.pct: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Network Usage",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "bytes",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        },
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.pod.network.rx.bytes"
-                                                },
-                                                "a83bd360-6bed-4bab-ac6c-82b8e473c2b0": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10 values of kubernetes.pod.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "accuracyMode": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.pod.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "31f6a38e-250d-4a00-9f2a-af9c53aff800",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.pod"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.pod"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "curveType": "LINEAR",
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
-                                        ],
-                                        "layerId": "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "area",
-                                        "showGridlines": false,
-                                        "splitAccessor": "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
-                                        "xAccessor": "a83bd360-6bed-4bab-ac6c-82b8e473c2b0"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "legendSize": "large",
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "area",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide",
-                                "valuesInLegend": true
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 15,
-                    "i": "83f2689a-838b-4d73-8d92-8dd358c33329",
-                    "w": 24,
-                    "x": 0,
-                    "y": 64
-                },
-                "panelIndex": "83f2689a-838b-4d73-8d92-8dd358c33329",
-                "title": "Network Incoming Bytes per Pod [Metrics Kubernetes]",
-                "type": "lens"
-            }
-        ],
-        "timeRestore": false,
-        "title": "[Metrics Kubernetes] Pods",
-        "version": 2
+  "attributes": {
+    "controlGroupInput": {
+      "chainingSystem": "HIERARCHICAL",
+      "controlStyle": "twoLine",
+      "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
+      "panelsJSON": "{\"8d2aec33-4ad2-4604-b59f-71ebe8a77b14\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"orchestrator.cluster.name\",\"title\":\"Cluster Name\",\"id\":\"8d2aec33-4ad2-4604-b59f-71ebe8a77b14\",\"selectedOptions\":[],\"enhancements\":{}}},\"bee5f46d-92a7-4e86-955f-85dac264e63e\":{\"order\":1,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"kubernetes.namespace\",\"title\":\"Namespace Name\",\"id\":\"bee5f46d-92a7-4e86-955f-85dac264e63e\",\"selectedOptions\":[],\"enhancements\":{}}},\"76c282b7-0d22-4b01-a80e-18564417ba5e\":{\"order\":2,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"kubernetes.pod.name\",\"title\":\"Pod Name\",\"id\":\"76c282b7-0d22-4b01-a80e-18564417ba5e\",\"selectedOptions\":[],\"enhancements\":{}}}}",
+      "showApplySelections": false
     },
-    "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-07-25T09:40:57.719Z",
-    "created_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0",
-    "id": "kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013",
-    "managed": false,
-    "references": [
-        {
-            "id": "metrics-*",
-            "name": "c077515d-1668-487f-9942-2448a0c25e70:indexpattern-datasource-layer-307ec163-d913-4ce0-8e9b-6dfc777def59",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "c077515d-1668-487f-9942-2448a0c25e70:f30047fb-d7fd-4873-9150-6e16c369fcc8",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "23852bac-d857-4a32-95f3-8100d6abd976:indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "23852bac-d857-4a32-95f3-8100d6abd976:9486d409-e044-43b7-a175-e25695e38cc4",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "9567b72e-6e79-479b-a5b1-1d9f81d258bd:indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "6b939075-346d-4aa1-b634-bf57b8cc1532:indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "6b939075-346d-4aa1-b634-bf57b8cc1532:ace482cc-b33b-47c1-89b1-a710fe45195e",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "54bfc973-09ca-4ebe-a777-c790087c3a91:indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "6459a5c9-80c5-46d8-968f-5b0a40b2eee0:indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "06ded777-f88c-40c8-93fa-1f0ed71ed43a:indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "06ded777-f88c-40c8-93fa-1f0ed71ed43a:710b0f49-b955-4cb8-826e-e51b3e6e7271",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "83f2689a-838b-4d73-8d92-8dd358c33329:indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "83f2689a-838b-4d73-8d92-8dd358c33329:31f6a38e-250d-4a00-9f2a-af9c53aff800",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "controlGroup_8d2aec33-4ad2-4604-b59f-71ebe8a77b14:optionsListDataView",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "controlGroup_bee5f46d-92a7-4e86-955f-85dac264e63e:optionsListDataView",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "controlGroup_76c282b7-0d22-4b01-a80e-18564417ba5e:optionsListDataView",
-            "type": "index-pattern"
+    "description": "Metrics about Pods",
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": {
+        "filter": [],
+        "query": {
+          "language": "kuery",
+          "query": ""
         }
+      }
+    },
+    "optionsJSON": {
+      "hidePanelTitles": false,
+      "syncColors": false,
+      "syncCursor": true,
+      "syncTooltips": false,
+      "useMargins": true
+    },
+    "panelsJSON": [
+      {
+        "type": "links",
+        "title": "Kubernetes Dashboards [Metrics Kubernetes]",
+        "embeddableConfig": {
+          "attributes": {
+            "title": "Kubernetes Dashboards [Metrics Kubernetes]",
+            "description": "",
+            "layout": "horizontal",
+            "links": [
+              {
+                "label": "Kubernetes Overview",
+                "type": "dashboardLink",
+                "id": "6416766e-26ec-4394-b02d-399b42ca9a6e",
+                "order": 0,
+                "destinationRefName": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard"
+              },
+              {
+                "label": "Kubernetes Nodes",
+                "type": "dashboardLink",
+                "id": "07ec2943-d3c5-4c96-beae-c5d5fde21fef",
+                "options": {
+                  "openInNewTab": false,
+                  "useCurrentDateRange": true,
+                  "useCurrentFilters": true
+                },
+                "order": 1,
+                "destinationRefName": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard"
+              },
+              {
+                "label": "Kubernetes Pods",
+                "type": "dashboardLink",
+                "id": "d0182b64-2cbf-4262-a352-9ab9a0ce48d8",
+                "order": 2,
+                "destinationRefName": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard"
+              },
+              {
+                "label": "Kubernetes Deployments",
+                "type": "dashboardLink",
+                "id": "c4b70217-9e48-4b1b-9b37-7803955a7f68",
+                "order": 3,
+                "destinationRefName": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard"
+              },
+              {
+                "label": "Kubernetes StatefulSets",
+                "type": "dashboardLink",
+                "id": "817b2767-a299-4117-9e40-bacf9d2ceeef",
+                "order": 4,
+                "destinationRefName": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard"
+              },
+              {
+                "label": "Kubernetes DaemonSets",
+                "type": "dashboardLink",
+                "id": "f67a589f-975c-409b-af5a-1ec3131916bd",
+                "order": 5,
+                "destinationRefName": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard"
+              },
+              {
+                "label": "Kubernetes Cronjobs",
+                "type": "dashboardLink",
+                "id": "7aeb19b4-8594-4187-9431-1e5e9f09b652",
+                "order": 6,
+                "destinationRefName": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard"
+              },
+              {
+                "label": "Kubernetes Jobs",
+                "type": "dashboardLink",
+                "id": "b805b8c7-e9d7-4968-9ae2-78d5fb0974ad",
+                "order": 7,
+                "destinationRefName": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard"
+              },
+              {
+                "label": "Kubernetes Volumes",
+                "type": "dashboardLink",
+                "id": "269b5aeb-9e4a-4d27-83ac-77d8aec1213f",
+                "order": 8,
+                "destinationRefName": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard"
+              },
+              {
+                "label": "Kubernetes PV/PVC",
+                "type": "dashboardLink",
+                "id": "9b4a4e12-82d3-445f-8c11-76f197f2aa8b",
+                "order": 9,
+                "destinationRefName": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard"
+              },
+              {
+                "label": "Kubernetes Services",
+                "type": "dashboardLink",
+                "id": "3e277318-8f0e-4be9-9572-0685e64684cf",
+                "order": 10,
+                "destinationRefName": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard"
+              },
+              {
+                "label": "Kubernetes API server",
+                "type": "dashboardLink",
+                "id": "808c6778-b18e-478a-8010-54bd6c8b2f3e",
+                "order": 11,
+                "destinationRefName": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard"
+              }
+            ],
+            "id": "links_panel_kubernetes_3d4d9290_bcb1_11ec_b64f_7dd6e8e82013"
+          },
+          "enhancements": {}
+        },
+        "panelIndex": "c0a8dc23-df25-4618-8603-15b76ee0ae86",
+        "gridData": {
+          "h": 4,
+          "i": "c0a8dc23-df25-4618-8603-15b76ee0ae86",
+          "w": 48,
+          "x": 0,
+          "y": 0
+        }
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-307ec163-d913-4ce0-8e9b-6dfc777def59",
+                "type": "index-pattern"
+              },
+              {
+                "id": "metrics-*",
+                "name": "f30047fb-d7fd-4873-9150-6e16c369fcc8",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "307ec163-d913-4ce0-8e9b-6dfc777def59": {
+                      "columnOrder": [
+                        "8c03fc54-6e2d-49ff-b294-bb80ae6a1a8e",
+                        "7b682fd2-3fd6-4834-8067-a546ab543764",
+                        "e9919412-9d5f-4db8-96bf-ab35a7b11c87",
+                        "b1ecf062-bf74-4458-9598-2c7018cdae3d"
+                      ],
+                      "columns": {
+                        "7b682fd2-3fd6-4834-8067-a546ab543764": {
+                          "customLabel": true,
+                          "dataType": "string",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "kubernetes.pod.status.phase: *"
+                          },
+                          "isBucketed": false,
+                          "label": "Phase",
+                          "operationType": "last_value",
+                          "params": {
+                            "sortField": "@timestamp"
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.pod.status.phase"
+                        },
+                        "8c03fc54-6e2d-49ff-b294-bb80ae6a1a8e": {
+                          "customLabel": true,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Pod",
+                          "operationType": "terms",
+                          "params": {
+                            "missingBucket": false,
+                            "orderBy": {
+                              "fallback": false,
+                              "type": "alphabetical"
+                            },
+                            "orderDirection": "asc",
+                            "otherBucket": true,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 1000
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.pod.name"
+                        },
+                        "b1ecf062-bf74-4458-9598-2c7018cdae3d": {
+                          "customLabel": true,
+                          "dataType": "string",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "kubernetes.pod.status.scheduled: *"
+                          },
+                          "isBucketed": false,
+                          "label": "Scheduled",
+                          "operationType": "last_value",
+                          "params": {
+                            "sortField": "@timestamp"
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.pod.status.scheduled"
+                        },
+                        "e9919412-9d5f-4db8-96bf-ab35a7b11c87": {
+                          "customLabel": true,
+                          "dataType": "string",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "kubernetes.pod.status.ready: *"
+                          },
+                          "isBucketed": false,
+                          "label": "Ready",
+                          "operationType": "last_value",
+                          "params": {
+                            "sortField": "@timestamp"
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.pod.status.ready"
+                        }
+                      },
+                      "incompleteColumns": {}
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "f30047fb-d7fd-4873-9150-6e16c369fcc8",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.state_pod"
+                    },
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.state_pod"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "collapseFn": "",
+                    "columnId": "8c03fc54-6e2d-49ff-b294-bb80ae6a1a8e",
+                    "isTransposed": false
+                  },
+                  {
+                    "alignment": "right",
+                    "columnId": "7b682fd2-3fd6-4834-8067-a546ab543764",
+                    "hidden": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "alignment": "right",
+                    "columnId": "e9919412-9d5f-4db8-96bf-ab35a7b11c87",
+                    "isTransposed": false
+                  },
+                  {
+                    "alignment": "right",
+                    "columnId": "b1ecf062-bf74-4458-9598-2c7018cdae3d",
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "single",
+                "headerRowHeightLines": 1,
+                "layerId": "307ec163-d913-4ce0-8e9b-6dfc777def59",
+                "layerType": "data",
+                "paging": {
+                  "enabled": true,
+                  "size": 10
+                },
+                "sorting": {
+                  "direction": "none"
+                }
+              }
+            },
+            "title": "Status per Pod [Metrics Kubernetes]",
+            "type": "lens",
+            "visualizationType": "lnsDatatable"
+          },
+          "enhancements": {},
+          "hidePanelTitles": false
+        },
+        "gridData": {
+          "h": 15,
+          "i": "c077515d-1668-487f-9942-2448a0c25e70",
+          "w": 48,
+          "x": 0,
+          "y": 4
+        },
+        "panelIndex": "c077515d-1668-487f-9942-2448a0c25e70",
+        "title": "Status per Pod [Metrics Kubernetes]",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
+                "type": "index-pattern"
+              },
+              {
+                "id": "metrics-*",
+                "name": "9486d409-e044-43b7-a175-e25695e38cc4",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a": {
+                      "columnOrder": [
+                        "a83bd360-6bed-4bab-ac6c-82b8e473c2b0",
+                        "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
+                        "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
+                      ],
+                      "columns": {
+                        "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "kubernetes.pod.cpu.usage.node.pct: *"
+                          },
+                          "isBucketed": false,
+                          "label": "CPU Usage",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.pod.cpu.usage.node.pct"
+                        },
+                        "a83bd360-6bed-4bab-ac6c-82b8e473c2b0": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top 10 values of kubernetes.pod.name",
+                          "operationType": "terms",
+                          "params": {
+                            "accuracyMode": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "columnId": "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": false,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 10
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.pod.name"
+                        }
+                      },
+                      "incompleteColumns": {}
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "9486d409-e044-43b7-a175-e25695e38cc4",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.pod"
+                    },
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.pod"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "fittingFunction": "None",
+                "gridlinesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
+                    ],
+                    "layerId": "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "area",
+                    "showGridlines": false,
+                    "splitAccessor": "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
+                    "xAccessor": "a83bd360-6bed-4bab-ac6c-82b8e473c2b0"
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "legendSize": "large",
+                  "position": "right"
+                },
+                "preferredSeriesType": "area",
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "valueLabels": "hide",
+                "valuesInLegend": true
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {},
+          "hidePanelTitles": false
+        },
+        "gridData": {
+          "h": 15,
+          "i": "23852bac-d857-4a32-95f3-8100d6abd976",
+          "w": 24,
+          "x": 0,
+          "y": 19
+        },
+        "panelIndex": "23852bac-d857-4a32-95f3-8100d6abd976",
+        "title": "CPU Usage as Pct of the Total Node CPU [Metrics Kubernetes]",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a": {
+                      "columnOrder": [
+                        "a83bd360-6bed-4bab-ac6c-82b8e473c2b0",
+                        "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
+                        "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
+                      ],
+                      "columns": {
+                        "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": ""
+                          },
+                          "isBucketed": false,
+                          "label": "CPU Usage",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.pod.cpu.usage.limit.pct"
+                        },
+                        "a83bd360-6bed-4bab-ac6c-82b8e473c2b0": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top 10 values of kubernetes.pod.name",
+                          "operationType": "terms",
+                          "params": {
+                            "accuracyMode": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "columnId": "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": false,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 10
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.pod.name"
+                        }
+                      },
+                      "incompleteColumns": {}
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "61027d7f-6398-4aec-b154-897b913481e4",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.pod"
+                    },
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.pod"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "kubernetes.pod.cpu.usage.limit.pct: *"
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "fittingFunction": "None",
+                "gridlinesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
+                    ],
+                    "layerId": "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "area",
+                    "showGridlines": false,
+                    "splitAccessor": "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
+                    "xAccessor": "a83bd360-6bed-4bab-ac6c-82b8e473c2b0"
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "legendSize": "large",
+                  "legendStats": [
+                    "currentAndLastValue"
+                  ],
+                  "position": "right"
+                },
+                "preferredSeriesType": "area",
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "valueLabels": "hide"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {},
+          "hidePanelTitles": false
+        },
+        "gridData": {
+          "h": 15,
+          "i": "9567b72e-6e79-479b-a5b1-1d9f81d258bd",
+          "w": 24,
+          "x": 24,
+          "y": 19
+        },
+        "panelIndex": "9567b72e-6e79-479b-a5b1-1d9f81d258bd",
+        "title": "CPU Usage as Pct of the Defined Pod Limit [Metrics Kubernetes]",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
+                "type": "index-pattern"
+              },
+              {
+                "id": "metrics-*",
+                "name": "ace482cc-b33b-47c1-89b1-a710fe45195e",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a": {
+                      "columnOrder": [
+                        "a83bd360-6bed-4bab-ac6c-82b8e473c2b0",
+                        "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
+                        "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
+                      ],
+                      "columns": {
+                        "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "kubernetes.pod.cpu.usage.node.pct: *"
+                          },
+                          "isBucketed": false,
+                          "label": "Memory Usage",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.pod.memory.usage.node.pct"
+                        },
+                        "a83bd360-6bed-4bab-ac6c-82b8e473c2b0": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top 10 values of kubernetes.pod.name",
+                          "operationType": "terms",
+                          "params": {
+                            "accuracyMode": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "columnId": "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": false,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 10
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.pod.name"
+                        }
+                      },
+                      "incompleteColumns": {}
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "ace482cc-b33b-47c1-89b1-a710fe45195e",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.pod"
+                    },
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.pod"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "fittingFunction": "None",
+                "gridlinesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
+                    ],
+                    "layerId": "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "area",
+                    "showGridlines": false,
+                    "splitAccessor": "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
+                    "xAccessor": "a83bd360-6bed-4bab-ac6c-82b8e473c2b0"
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "legendSize": "large",
+                  "position": "right"
+                },
+                "preferredSeriesType": "area",
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "valueLabels": "hide",
+                "valuesInLegend": true
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {},
+          "hidePanelTitles": false
+        },
+        "gridData": {
+          "h": 15,
+          "i": "6b939075-346d-4aa1-b634-bf57b8cc1532",
+          "w": 24,
+          "x": 0,
+          "y": 34
+        },
+        "panelIndex": "6b939075-346d-4aa1-b634-bf57b8cc1532",
+        "title": "Memory Usage as Pct of the Total Node Memory [Metrics Kubernetes]",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a": {
+                      "columnOrder": [
+                        "a83bd360-6bed-4bab-ac6c-82b8e473c2b0",
+                        "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
+                        "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
+                      ],
+                      "columns": {
+                        "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": ""
+                          },
+                          "isBucketed": false,
+                          "label": "Memory Usage",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.pod.memory.usage.limit.pct"
+                        },
+                        "a83bd360-6bed-4bab-ac6c-82b8e473c2b0": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top 10 values of kubernetes.pod.name",
+                          "operationType": "terms",
+                          "params": {
+                            "accuracyMode": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "columnId": "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": false,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 10
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.pod.name"
+                        }
+                      },
+                      "incompleteColumns": {}
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "81de779f-3d8f-4f90-9a93-08ecf5d96939",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.pod"
+                    },
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.pod"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "kubernetes.pod.memory.usage.limit.pct:*"
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "fittingFunction": "None",
+                "gridlinesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
+                    ],
+                    "layerId": "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "area",
+                    "showGridlines": false,
+                    "splitAccessor": "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
+                    "xAccessor": "a83bd360-6bed-4bab-ac6c-82b8e473c2b0"
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "legendSize": "large",
+                  "legendStats": [
+                    "currentAndLastValue"
+                  ],
+                  "position": "right"
+                },
+                "preferredSeriesType": "area",
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "valueLabels": "hide"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {},
+          "hidePanelTitles": false
+        },
+        "gridData": {
+          "h": 15,
+          "i": "54bfc973-09ca-4ebe-a777-c790087c3a91",
+          "w": 24,
+          "x": 24,
+          "y": 34
+        },
+        "panelIndex": "54bfc973-09ca-4ebe-a777-c790087c3a91",
+        "title": "Memory Usage as Pct of the Defined Pod Limit [Metrics Kubernetes]",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a": {
+                      "columnOrder": [
+                        "a83bd360-6bed-4bab-ac6c-82b8e473c2b0",
+                        "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
+                        "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
+                      ],
+                      "columns": {
+                        "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": ""
+                          },
+                          "isBucketed": false,
+                          "label": "Memory Usage",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.pod.memory.working_set.limit.pct"
+                        },
+                        "a83bd360-6bed-4bab-ac6c-82b8e473c2b0": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top 10 values of kubernetes.pod.name",
+                          "operationType": "terms",
+                          "params": {
+                            "accuracyMode": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "columnId": "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": false,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 10
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.pod.name"
+                        }
+                      },
+                      "incompleteColumns": {}
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "9d74e7d3-0a1c-4c8b-8635-1577d74797f7",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.pod"
+                    },
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.pod"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "kubernetes.pod.memory.working_set.limit.pct:*"
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "fittingFunction": "None",
+                "gridlinesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
+                    ],
+                    "layerId": "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "area",
+                    "showGridlines": false,
+                    "splitAccessor": "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
+                    "xAccessor": "a83bd360-6bed-4bab-ac6c-82b8e473c2b0"
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "legendSize": "large",
+                  "legendStats": [
+                    "currentAndLastValue"
+                  ],
+                  "position": "right"
+                },
+                "preferredSeriesType": "area",
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "valueLabels": "hide"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {},
+          "hidePanelTitles": false
+        },
+        "gridData": {
+          "h": 15,
+          "i": "6459a5c9-80c5-46d8-968f-5b0a40b2eee0",
+          "w": 24,
+          "x": 0,
+          "y": 49
+        },
+        "panelIndex": "6459a5c9-80c5-46d8-968f-5b0a40b2eee0",
+        "title": "Working Set Memory Usage as Pct of the Defined Pod Limit [Metrics Kubernetes]",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
+                "type": "index-pattern"
+              },
+              {
+                "id": "metrics-*",
+                "name": "710b0f49-b955-4cb8-826e-e51b3e6e7271",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a": {
+                      "columnOrder": [
+                        "a83bd360-6bed-4bab-ac6c-82b8e473c2b0",
+                        "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
+                        "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
+                      ],
+                      "columns": {
+                        "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "kubernetes.pod.cpu.usage.node.pct: *"
+                          },
+                          "isBucketed": false,
+                          "label": "Network Usage",
+                          "operationType": "last_value",
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            },
+                            "sortField": "@timestamp"
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.pod.network.tx.bytes"
+                        },
+                        "a83bd360-6bed-4bab-ac6c-82b8e473c2b0": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top 10 values of kubernetes.pod.name",
+                          "operationType": "terms",
+                          "params": {
+                            "accuracyMode": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "columnId": "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": false,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 10
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.pod.name"
+                        }
+                      },
+                      "incompleteColumns": {}
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "710b0f49-b955-4cb8-826e-e51b3e6e7271",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.pod"
+                    },
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.pod"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "fittingFunction": "None",
+                "gridlinesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
+                    ],
+                    "layerId": "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "area",
+                    "showGridlines": false,
+                    "splitAccessor": "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
+                    "xAccessor": "a83bd360-6bed-4bab-ac6c-82b8e473c2b0"
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "legendSize": "large",
+                  "position": "right"
+                },
+                "preferredSeriesType": "area",
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "valueLabels": "hide",
+                "valuesInLegend": true
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {},
+          "hidePanelTitles": false
+        },
+        "gridData": {
+          "h": 15,
+          "i": "06ded777-f88c-40c8-93fa-1f0ed71ed43a",
+          "w": 24,
+          "x": 24,
+          "y": 49
+        },
+        "panelIndex": "06ded777-f88c-40c8-93fa-1f0ed71ed43a",
+        "title": "Network Outgoing Bytes per Pod [Metrics Kubernetes]",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
+                "type": "index-pattern"
+              },
+              {
+                "id": "metrics-*",
+                "name": "31f6a38e-250d-4a00-9f2a-af9c53aff800",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a": {
+                      "columnOrder": [
+                        "a83bd360-6bed-4bab-ac6c-82b8e473c2b0",
+                        "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
+                        "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
+                      ],
+                      "columns": {
+                        "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "kubernetes.pod.cpu.usage.node.pct: *"
+                          },
+                          "isBucketed": false,
+                          "label": "Network Usage",
+                          "operationType": "last_value",
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            },
+                            "sortField": "@timestamp"
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.pod.network.rx.bytes"
+                        },
+                        "a83bd360-6bed-4bab-ac6c-82b8e473c2b0": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top 10 values of kubernetes.pod.name",
+                          "operationType": "terms",
+                          "params": {
+                            "accuracyMode": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "columnId": "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": false,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 10
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.pod.name"
+                        }
+                      },
+                      "incompleteColumns": {}
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "31f6a38e-250d-4a00-9f2a-af9c53aff800",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.pod"
+                    },
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.pod"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "fittingFunction": "None",
+                "gridlinesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "86e6d540-5fd3-483e-b1a1-b575a0a5ca9c"
+                    ],
+                    "layerId": "921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "area",
+                    "showGridlines": false,
+                    "splitAccessor": "ce13a463-7e39-46f6-8d0f-14c1f9e9a0d9",
+                    "xAccessor": "a83bd360-6bed-4bab-ac6c-82b8e473c2b0"
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "legendSize": "large",
+                  "position": "right"
+                },
+                "preferredSeriesType": "area",
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "valueLabels": "hide",
+                "valuesInLegend": true
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {},
+          "hidePanelTitles": false
+        },
+        "gridData": {
+          "h": 15,
+          "i": "83f2689a-838b-4d73-8d92-8dd358c33329",
+          "w": 24,
+          "x": 0,
+          "y": 64
+        },
+        "panelIndex": "83f2689a-838b-4d73-8d92-8dd358c33329",
+        "title": "Network Incoming Bytes per Pod [Metrics Kubernetes]",
+        "type": "lens"
+      }
     ],
-    "type": "dashboard",
-    "typeMigrationVersion": "10.2.0",
-    "updated_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
+    "timeRestore": false,
+    "title": "[Metrics Kubernetes] Pods",
+    "version": 2
+  },
+  "coreMigrationVersion": "8.8.0",
+  "created_at": "2024-07-25T09:40:57.719Z",
+  "created_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0",
+  "id": "kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013",
+  "managed": false,
+  "references": [
+    {
+      "id": "metrics-*",
+      "name": "c077515d-1668-487f-9942-2448a0c25e70:indexpattern-datasource-layer-307ec163-d913-4ce0-8e9b-6dfc777def59",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "c077515d-1668-487f-9942-2448a0c25e70:f30047fb-d7fd-4873-9150-6e16c369fcc8",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "23852bac-d857-4a32-95f3-8100d6abd976:indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "23852bac-d857-4a32-95f3-8100d6abd976:9486d409-e044-43b7-a175-e25695e38cc4",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "9567b72e-6e79-479b-a5b1-1d9f81d258bd:indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "6b939075-346d-4aa1-b634-bf57b8cc1532:indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "6b939075-346d-4aa1-b634-bf57b8cc1532:ace482cc-b33b-47c1-89b1-a710fe45195e",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "54bfc973-09ca-4ebe-a777-c790087c3a91:indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "6459a5c9-80c5-46d8-968f-5b0a40b2eee0:indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "06ded777-f88c-40c8-93fa-1f0ed71ed43a:indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "06ded777-f88c-40c8-93fa-1f0ed71ed43a:710b0f49-b955-4cb8-826e-e51b3e6e7271",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "83f2689a-838b-4d73-8d92-8dd358c33329:indexpattern-datasource-layer-921ae90c-bc32-4ce1-b4d0-bcaec7eb339a",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "83f2689a-838b-4d73-8d92-8dd358c33329:31f6a38e-250d-4a00-9f2a-af9c53aff800",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "controlGroup_8d2aec33-4ad2-4604-b59f-71ebe8a77b14:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "controlGroup_bee5f46d-92a7-4e86-955f-85dac264e63e:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "controlGroup_76c282b7-0d22-4b01-a80e-18564417ba5e:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "name": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c"
+    },
+    {
+      "name": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56"
+    }
+  ],
+  "type": "dashboard",
+  "typeMigrationVersion": "10.2.0",
+  "updated_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
 }

--- a/packages/kubernetes/kibana/dashboard/kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013.json
@@ -36,41 +36,116 @@
     },
     "panelsJSON": [
       {
+        "type": "links",
+        "title": "Kubernetes Dashboards [Metrics Kubernetes]",
         "embeddableConfig": {
-          "enhancements": {},
-          "savedVis": {
-            "data": {
-              "aggs": [],
-              "searchSource": {
-                "filter": [],
-                "query": {
-                  "language": "kuery",
-                  "query": ""
-                }
-              }
-            },
+          "attributes": {
+            "title": "Kubernetes Dashboards [Metrics Kubernetes]",
             "description": "",
-            "params": {
-              "fontSize": 10,
-              "markdown": "[Kubernetes Overview](#/view/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c), [Kubernetes Nodes](#/view/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Pods](#/view/kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013),  [Kubernetes Deployments](#/view/kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes StatefulSets](#/view/kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013),  [Kubernetes DaemonSets](#/view/kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes CronJobs](#/view/kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Jobs](#/view/kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Volumes](#/view/kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013), [Kubernetes PV/PVC](#/view/kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Services](#/view/kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes API Server](#/view/kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56)",
-              "openLinksInNewTab": false
-            },
-            "title": "",
-            "type": "markdown",
-            "uiState": {}
-          }
+            "layout": "horizontal",
+            "links": [
+              {
+                "label": "Kubernetes Overview",
+                "type": "dashboardLink",
+                "id": "6416766e-26ec-4394-b02d-399b42ca9a6e",
+                "order": 0,
+                "destinationRefName": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard"
+              },
+              {
+                "label": "Kubernetes Nodes",
+                "type": "dashboardLink",
+                "id": "07ec2943-d3c5-4c96-beae-c5d5fde21fef",
+                "options": {
+                  "openInNewTab": false,
+                  "useCurrentDateRange": true,
+                  "useCurrentFilters": true
+                },
+                "order": 1,
+                "destinationRefName": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard"
+              },
+              {
+                "label": "Kubernetes Pods",
+                "type": "dashboardLink",
+                "id": "d0182b64-2cbf-4262-a352-9ab9a0ce48d8",
+                "order": 2,
+                "destinationRefName": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard"
+              },
+              {
+                "label": "Kubernetes Deployments",
+                "type": "dashboardLink",
+                "id": "c4b70217-9e48-4b1b-9b37-7803955a7f68",
+                "order": 3,
+                "destinationRefName": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard"
+              },
+              {
+                "label": "Kubernetes StatefulSets",
+                "type": "dashboardLink",
+                "id": "817b2767-a299-4117-9e40-bacf9d2ceeef",
+                "order": 4,
+                "destinationRefName": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard"
+              },
+              {
+                "label": "Kubernetes DaemonSets",
+                "type": "dashboardLink",
+                "id": "f67a589f-975c-409b-af5a-1ec3131916bd",
+                "order": 5,
+                "destinationRefName": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard"
+              },
+              {
+                "label": "Kubernetes Cronjobs",
+                "type": "dashboardLink",
+                "id": "7aeb19b4-8594-4187-9431-1e5e9f09b652",
+                "order": 6,
+                "destinationRefName": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard"
+              },
+              {
+                "label": "Kubernetes Jobs",
+                "type": "dashboardLink",
+                "id": "b805b8c7-e9d7-4968-9ae2-78d5fb0974ad",
+                "order": 7,
+                "destinationRefName": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard"
+              },
+              {
+                "label": "Kubernetes Volumes",
+                "type": "dashboardLink",
+                "id": "269b5aeb-9e4a-4d27-83ac-77d8aec1213f",
+                "order": 8,
+                "destinationRefName": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard"
+              },
+              {
+                "label": "Kubernetes PV/PVC",
+                "type": "dashboardLink",
+                "id": "9b4a4e12-82d3-445f-8c11-76f197f2aa8b",
+                "order": 9,
+                "destinationRefName": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard"
+              },
+              {
+                "label": "Kubernetes Services",
+                "type": "dashboardLink",
+                "id": "3e277318-8f0e-4be9-9572-0685e64684cf",
+                "order": 10,
+                "destinationRefName": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard"
+              },
+              {
+                "label": "Kubernetes API server",
+                "type": "dashboardLink",
+                "id": "808c6778-b18e-478a-8010-54bd6c8b2f3e",
+                "order": 11,
+                "destinationRefName": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard"
+              }
+            ],
+            "id": "links_panel_kubernetes_5be46210_bcb1_11ec_b64f_7dd6e8e82013"
+          },
+          "enhancements": {}
         },
+        "panelIndex": "58edcf0e-d21a-4dea-8b29-e5a8d9d4d738",
         "gridData": {
           "h": 4,
           "i": "58edcf0e-d21a-4dea-8b29-e5a8d9d4d738",
           "w": 48,
           "x": 0,
           "y": 0
-        },
-        "panelIndex": "58edcf0e-d21a-4dea-8b29-e5a8d9d4d738",
-        "title": "Kubernetes Dashboards [Metrics Kubernetes]",
-        "type": "visualization",
-        "version": "8.10.2"
+        }
       },
       {
         "embeddableConfig": {
@@ -742,8 +817,8 @@
                           "customLabel": true,
                           "dataType": "number",
                           "filter": {
-                              "language": "kuery",
-                              "query": "\"kubernetes.deployment.replicas.desired\": *"
+                            "language": "kuery",
+                            "query": "\"kubernetes.deployment.replicas.desired\": *"
                           },
                           "isBucketed": false,
                           "label": "Replicas Desired",
@@ -931,6 +1006,66 @@
       "id": "metrics-*",
       "name": "controlGroup_9e437628-d460-4697-9427-616333ef6947:optionsListDataView",
       "type": "index-pattern"
+    },
+    {
+      "name": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c"
+    },
+    {
+      "name": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56"
     }
   ],
   "managed": false,

--- a/packages/kubernetes/kibana/dashboard/kubernetes-5e649d60-9901-11e9-ba57-b7ab4e2d4b58.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-5e649d60-9901-11e9-ba57-b7ab4e2d4b58.json
@@ -58,42 +58,115 @@
     },
     "panelsJSON": [
       {
-        "version": "8.9.0",
-        "type": "visualization",
+        "type": "links",
+        "title": "Kubernetes Dashboards [Metrics Kubernetes]",
+        "embeddableConfig": {
+          "attributes": {
+            "title": "Kubernetes Dashboards [Metrics Kubernetes]",
+            "description": "",
+            "layout": "horizontal",
+            "links": [
+              {
+                "label": "Kubernetes Overview",
+                "type": "dashboardLink",
+                "id": "6416766e-26ec-4394-b02d-399b42ca9a6e",
+                "order": 0,
+                "destinationRefName": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard"
+              },
+              {
+                "label": "Kubernetes Nodes",
+                "type": "dashboardLink",
+                "id": "07ec2943-d3c5-4c96-beae-c5d5fde21fef",
+                "options": {
+                  "openInNewTab": false,
+                  "useCurrentDateRange": true,
+                  "useCurrentFilters": true
+                },
+                "order": 1,
+                "destinationRefName": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard"
+              },
+              {
+                "label": "Kubernetes Pods",
+                "type": "dashboardLink",
+                "id": "d0182b64-2cbf-4262-a352-9ab9a0ce48d8",
+                "order": 2,
+                "destinationRefName": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard"
+              },
+              {
+                "label": "Kubernetes Deployments",
+                "type": "dashboardLink",
+                "id": "c4b70217-9e48-4b1b-9b37-7803955a7f68",
+                "order": 3,
+                "destinationRefName": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard"
+              },
+              {
+                "label": "Kubernetes StatefulSets",
+                "type": "dashboardLink",
+                "id": "817b2767-a299-4117-9e40-bacf9d2ceeef",
+                "order": 4,
+                "destinationRefName": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard"
+              },
+              {
+                "label": "Kubernetes DaemonSets",
+                "type": "dashboardLink",
+                "id": "f67a589f-975c-409b-af5a-1ec3131916bd",
+                "order": 5,
+                "destinationRefName": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard"
+              },
+              {
+                "label": "Kubernetes Cronjobs",
+                "type": "dashboardLink",
+                "id": "7aeb19b4-8594-4187-9431-1e5e9f09b652",
+                "order": 6,
+                "destinationRefName": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard"
+              },
+              {
+                "label": "Kubernetes Jobs",
+                "type": "dashboardLink",
+                "id": "b805b8c7-e9d7-4968-9ae2-78d5fb0974ad",
+                "order": 7,
+                "destinationRefName": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard"
+              },
+              {
+                "label": "Kubernetes Volumes",
+                "type": "dashboardLink",
+                "id": "269b5aeb-9e4a-4d27-83ac-77d8aec1213f",
+                "order": 8,
+                "destinationRefName": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard"
+              },
+              {
+                "label": "Kubernetes PV/PVC",
+                "type": "dashboardLink",
+                "id": "9b4a4e12-82d3-445f-8c11-76f197f2aa8b",
+                "order": 9,
+                "destinationRefName": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard"
+              },
+              {
+                "label": "Kubernetes Services",
+                "type": "dashboardLink",
+                "id": "3e277318-8f0e-4be9-9572-0685e64684cf",
+                "order": 10,
+                "destinationRefName": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard"
+              },
+              {
+                "label": "Kubernetes API server",
+                "type": "dashboardLink",
+                "id": "808c6778-b18e-478a-8010-54bd6c8b2f3e",
+                "order": 11,
+                "destinationRefName": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard"
+              }
+            ],
+            "id": "links_panel_kubernetes_5e649d60_9901_11e9_ba57_b7ab4e2d4b58"
+          },
+          "enhancements": {}
+        },
+        "panelIndex": "c13eb504-6afb-4fa5-8a7d-a75c5fee15b7",
         "gridData": {
           "h": 4,
           "i": "c13eb504-6afb-4fa5-8a7d-a75c5fee15b7",
           "w": 48,
           "x": 0,
           "y": 0
-        },
-        "panelIndex": "c13eb504-6afb-4fa5-8a7d-a75c5fee15b7",
-        "embeddableConfig": {
-          "enhancements": {},
-          "hidePanelTitles": true,
-          "savedVis": {
-            "data": {
-              "aggs": [],
-              "searchSource": {
-                "filter": [],
-                "query": {
-                  "language": "kuery",
-                  "query": ""
-                }
-              }
-            },
-            "description": "",
-            "id": "",
-            "params": {
-              "fontSize": 12,
-              "markdown": "### Proxy\n\nThis dashboard collects data from [kube proxy](https://kubernetes.io/docs/concepts/overview/components/#kube-proxy) endpoint. Its purpose is to give an overview of what is happening inside it and detect problems that might be happening.",
-              "openLinksInNewTab": false
-            },
-            "title": "",
-            "type": "markdown",
-            "uiState": {}
-          },
-          "type": "visualization"
         }
       },
       {
@@ -2525,6 +2598,66 @@
       "id": "metrics-*",
       "name": "controlGroup_df56c430-83b1-436e-8b9c-fb027aaa29ca:optionsListDataView",
       "type": "index-pattern"
+    },
+    {
+      "name": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c"
+    },
+    {
+      "name": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56"
     }
   ],
   "managed": false,

--- a/packages/kubernetes/kibana/dashboard/kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013.json
@@ -36,41 +36,116 @@
     },
     "panelsJSON": [
       {
+        "type": "links",
+        "title": "Kubernetes Dashboards [Metrics Kubernetes]",
         "embeddableConfig": {
-          "enhancements": {},
-          "savedVis": {
-            "data": {
-              "aggs": [],
-              "searchSource": {
-                "filter": [],
-                "query": {
-                  "language": "kuery",
-                  "query": ""
-                }
-              }
-            },
+          "attributes": {
+            "title": "Kubernetes Dashboards [Metrics Kubernetes]",
             "description": "",
-            "params": {
-              "fontSize": 10,
-              "markdown": "[Kubernetes Overview](#/view/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c), [Kubernetes Nodes](#/view/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Pods](#/view/kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013),  [Kubernetes Deployments](#/view/kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes StatefulSets](#/view/kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013),  [Kubernetes DaemonSets](#/view/kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes CronJobs](#/view/kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Jobs](#/view/kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Volumes](#/view/kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013), [Kubernetes PV/PVC](#/view/kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Services](#/view/kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes API Server](#/view/kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56)",
-              "openLinksInNewTab": false
-            },
-            "title": "",
-            "type": "markdown",
-            "uiState": {}
-          }
+            "layout": "horizontal",
+            "links": [
+              {
+                "label": "Kubernetes Overview",
+                "type": "dashboardLink",
+                "id": "6416766e-26ec-4394-b02d-399b42ca9a6e",
+                "order": 0,
+                "destinationRefName": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard"
+              },
+              {
+                "label": "Kubernetes Nodes",
+                "type": "dashboardLink",
+                "id": "07ec2943-d3c5-4c96-beae-c5d5fde21fef",
+                "options": {
+                  "openInNewTab": false,
+                  "useCurrentDateRange": true,
+                  "useCurrentFilters": true
+                },
+                "order": 1,
+                "destinationRefName": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard"
+              },
+              {
+                "label": "Kubernetes Pods",
+                "type": "dashboardLink",
+                "id": "d0182b64-2cbf-4262-a352-9ab9a0ce48d8",
+                "order": 2,
+                "destinationRefName": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard"
+              },
+              {
+                "label": "Kubernetes Deployments",
+                "type": "dashboardLink",
+                "id": "c4b70217-9e48-4b1b-9b37-7803955a7f68",
+                "order": 3,
+                "destinationRefName": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard"
+              },
+              {
+                "label": "Kubernetes StatefulSets",
+                "type": "dashboardLink",
+                "id": "817b2767-a299-4117-9e40-bacf9d2ceeef",
+                "order": 4,
+                "destinationRefName": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard"
+              },
+              {
+                "label": "Kubernetes DaemonSets",
+                "type": "dashboardLink",
+                "id": "f67a589f-975c-409b-af5a-1ec3131916bd",
+                "order": 5,
+                "destinationRefName": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard"
+              },
+              {
+                "label": "Kubernetes Cronjobs",
+                "type": "dashboardLink",
+                "id": "7aeb19b4-8594-4187-9431-1e5e9f09b652",
+                "order": 6,
+                "destinationRefName": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard"
+              },
+              {
+                "label": "Kubernetes Jobs",
+                "type": "dashboardLink",
+                "id": "b805b8c7-e9d7-4968-9ae2-78d5fb0974ad",
+                "order": 7,
+                "destinationRefName": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard"
+              },
+              {
+                "label": "Kubernetes Volumes",
+                "type": "dashboardLink",
+                "id": "269b5aeb-9e4a-4d27-83ac-77d8aec1213f",
+                "order": 8,
+                "destinationRefName": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard"
+              },
+              {
+                "label": "Kubernetes PV/PVC",
+                "type": "dashboardLink",
+                "id": "9b4a4e12-82d3-445f-8c11-76f197f2aa8b",
+                "order": 9,
+                "destinationRefName": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard"
+              },
+              {
+                "label": "Kubernetes Services",
+                "type": "dashboardLink",
+                "id": "3e277318-8f0e-4be9-9572-0685e64684cf",
+                "order": 10,
+                "destinationRefName": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard"
+              },
+              {
+                "label": "Kubernetes API server",
+                "type": "dashboardLink",
+                "id": "808c6778-b18e-478a-8010-54bd6c8b2f3e",
+                "order": 11,
+                "destinationRefName": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard"
+              }
+            ],
+            "id": "links_panel_kubernetes_85879010_bcb1_11ec_b64f_7dd6e8e82013"
+          },
+          "enhancements": {}
         },
+        "panelIndex": "573ec41e-ffc3-4c89-ba35-138bab599f07",
         "gridData": {
           "h": 4,
           "i": "573ec41e-ffc3-4c89-ba35-138bab599f07",
           "w": 48,
           "x": 0,
           "y": 0
-        },
-        "panelIndex": "573ec41e-ffc3-4c89-ba35-138bab599f07",
-        "title": "Kubernetes Dashboards [Metrics Kubernetes]",
-        "type": "visualization",
-        "version": "8.10.2"
+        }
       },
       {
         "embeddableConfig": {
@@ -690,7 +765,7 @@
                           "filter": {
                             "language": "kuery",
                             "query": "\"kubernetes.daemonset.replicas.desired\": *"
-                        },
+                          },
                           "isBucketed": false,
                           "label": "Replicas Desired",
                           "operationType": "last_value",
@@ -908,6 +983,66 @@
       "id": "metrics-*",
       "name": "controlGroup_274480d2-d432-486c-bce5-e88caa3d6b7a:optionsListDataView",
       "type": "index-pattern"
+    },
+    {
+      "name": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c"
+    },
+    {
+      "name": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56"
     }
   ],
   "managed": false,

--- a/packages/kubernetes/kibana/dashboard/kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013.json
@@ -36,41 +36,116 @@
     },
     "panelsJSON": [
       {
+        "type": "links",
+        "title": "Kubernetes Dashboards [Metrics Kubernetes]",
         "embeddableConfig": {
-          "enhancements": {},
-          "savedVis": {
-            "data": {
-              "aggs": [],
-              "searchSource": {
-                "filter": [],
-                "query": {
-                  "language": "kuery",
-                  "query": ""
-                }
-              }
-            },
+          "attributes": {
+            "title": "Kubernetes Dashboards [Metrics Kubernetes]",
             "description": "",
-            "params": {
-              "fontSize": 10,
-              "markdown": "[Kubernetes Overview](#/view/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c), [Kubernetes Nodes](#/view/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Pods](#/view/kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013),  [Kubernetes Deployments](#/view/kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes StatefulSets](#/view/kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013),  [Kubernetes DaemonSets](#/view/kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes CronJobs](#/view/kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Jobs](#/view/kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Volumes](#/view/kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013), [Kubernetes PV/PVC](#/view/kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Services](#/view/kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes API Server](#/view/kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56)",
-              "openLinksInNewTab": false
-            },
-            "title": "",
-            "type": "markdown",
-            "uiState": {}
-          }
+            "layout": "horizontal",
+            "links": [
+              {
+                "label": "Kubernetes Overview",
+                "type": "dashboardLink",
+                "id": "6416766e-26ec-4394-b02d-399b42ca9a6e",
+                "order": 0,
+                "destinationRefName": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard"
+              },
+              {
+                "label": "Kubernetes Nodes",
+                "type": "dashboardLink",
+                "id": "07ec2943-d3c5-4c96-beae-c5d5fde21fef",
+                "options": {
+                  "openInNewTab": false,
+                  "useCurrentDateRange": true,
+                  "useCurrentFilters": true
+                },
+                "order": 1,
+                "destinationRefName": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard"
+              },
+              {
+                "label": "Kubernetes Pods",
+                "type": "dashboardLink",
+                "id": "d0182b64-2cbf-4262-a352-9ab9a0ce48d8",
+                "order": 2,
+                "destinationRefName": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard"
+              },
+              {
+                "label": "Kubernetes Deployments",
+                "type": "dashboardLink",
+                "id": "c4b70217-9e48-4b1b-9b37-7803955a7f68",
+                "order": 3,
+                "destinationRefName": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard"
+              },
+              {
+                "label": "Kubernetes StatefulSets",
+                "type": "dashboardLink",
+                "id": "817b2767-a299-4117-9e40-bacf9d2ceeef",
+                "order": 4,
+                "destinationRefName": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard"
+              },
+              {
+                "label": "Kubernetes DaemonSets",
+                "type": "dashboardLink",
+                "id": "f67a589f-975c-409b-af5a-1ec3131916bd",
+                "order": 5,
+                "destinationRefName": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard"
+              },
+              {
+                "label": "Kubernetes Cronjobs",
+                "type": "dashboardLink",
+                "id": "7aeb19b4-8594-4187-9431-1e5e9f09b652",
+                "order": 6,
+                "destinationRefName": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard"
+              },
+              {
+                "label": "Kubernetes Jobs",
+                "type": "dashboardLink",
+                "id": "b805b8c7-e9d7-4968-9ae2-78d5fb0974ad",
+                "order": 7,
+                "destinationRefName": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard"
+              },
+              {
+                "label": "Kubernetes Volumes",
+                "type": "dashboardLink",
+                "id": "269b5aeb-9e4a-4d27-83ac-77d8aec1213f",
+                "order": 8,
+                "destinationRefName": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard"
+              },
+              {
+                "label": "Kubernetes PV/PVC",
+                "type": "dashboardLink",
+                "id": "9b4a4e12-82d3-445f-8c11-76f197f2aa8b",
+                "order": 9,
+                "destinationRefName": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard"
+              },
+              {
+                "label": "Kubernetes Services",
+                "type": "dashboardLink",
+                "id": "3e277318-8f0e-4be9-9572-0685e64684cf",
+                "order": 10,
+                "destinationRefName": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard"
+              },
+              {
+                "label": "Kubernetes API server",
+                "type": "dashboardLink",
+                "id": "808c6778-b18e-478a-8010-54bd6c8b2f3e",
+                "order": 11,
+                "destinationRefName": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard"
+              }
+            ],
+            "id": "links_panel_kubernetes_9bf990a0_bcb1_11ec_b64f_7dd6e8e82013"
+          },
+          "enhancements": {}
         },
+        "panelIndex": "ce57bb14-ee8a-43ba-bb57-a6f815838500",
         "gridData": {
           "h": 4,
           "i": "ce57bb14-ee8a-43ba-bb57-a6f815838500",
           "w": 48,
           "x": 0,
           "y": 0
-        },
-        "panelIndex": "ce57bb14-ee8a-43ba-bb57-a6f815838500",
-        "title": "Kubernetes Dashboards [Metrics Kubernetes]",
-        "type": "visualization",
-        "version": "8.10.2"
+        }
       },
       {
         "embeddableConfig": {
@@ -911,6 +986,66 @@
       "id": "metrics-*",
       "name": "controlGroup_0a0c6dd9-2a6f-4d7a-b4f7-1231987bc460:optionsListDataView",
       "type": "index-pattern"
+    },
+    {
+      "name": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c"
+    },
+    {
+      "name": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56"
     }
   ],
   "managed": false,

--- a/packages/kubernetes/kibana/dashboard/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013.json
@@ -34,42 +34,116 @@
     },
     "panelsJSON": [
       {
-        "version": "8.9.0",
-        "type": "visualization",
+        "type": "links",
+        "title": "Kubernetes Dashboards [Metrics Kubernetes]",
+        "embeddableConfig": {
+          "attributes": {
+            "title": "Kubernetes Dashboards [Metrics Kubernetes]",
+            "description": "",
+            "layout": "horizontal",
+            "links": [
+              {
+                "label": "Kubernetes Overview",
+                "type": "dashboardLink",
+                "id": "6416766e-26ec-4394-b02d-399b42ca9a6e",
+                "order": 0,
+                "destinationRefName": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard"
+              },
+              {
+                "label": "Kubernetes Nodes",
+                "type": "dashboardLink",
+                "id": "07ec2943-d3c5-4c96-beae-c5d5fde21fef",
+                "options": {
+                  "openInNewTab": false,
+                  "useCurrentDateRange": true,
+                  "useCurrentFilters": true
+                },
+                "order": 1,
+                "destinationRefName": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard"
+              },
+              {
+                "label": "Kubernetes Pods",
+                "type": "dashboardLink",
+                "id": "d0182b64-2cbf-4262-a352-9ab9a0ce48d8",
+                "order": 2,
+                "destinationRefName": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard"
+              },
+              {
+                "label": "Kubernetes Deployments",
+                "type": "dashboardLink",
+                "id": "c4b70217-9e48-4b1b-9b37-7803955a7f68",
+                "order": 3,
+                "destinationRefName": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard"
+              },
+              {
+                "label": "Kubernetes StatefulSets",
+                "type": "dashboardLink",
+                "id": "817b2767-a299-4117-9e40-bacf9d2ceeef",
+                "order": 4,
+                "destinationRefName": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard"
+              },
+              {
+                "label": "Kubernetes DaemonSets",
+                "type": "dashboardLink",
+                "id": "f67a589f-975c-409b-af5a-1ec3131916bd",
+                "order": 5,
+                "destinationRefName": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard"
+              },
+              {
+                "label": "Kubernetes Cronjobs",
+                "type": "dashboardLink",
+                "id": "7aeb19b4-8594-4187-9431-1e5e9f09b652",
+                "order": 6,
+                "destinationRefName": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard"
+              },
+              {
+                "label": "Kubernetes Jobs",
+                "type": "dashboardLink",
+                "id": "b805b8c7-e9d7-4968-9ae2-78d5fb0974ad",
+                "order": 7,
+                "destinationRefName": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard"
+              },
+              {
+                "label": "Kubernetes Volumes",
+                "type": "dashboardLink",
+                "id": "269b5aeb-9e4a-4d27-83ac-77d8aec1213f",
+                "order": 8,
+                "destinationRefName": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard"
+              },
+              {
+                "label": "Kubernetes PV/PVC",
+                "type": "dashboardLink",
+                "id": "9b4a4e12-82d3-445f-8c11-76f197f2aa8b",
+                "order": 9,
+                "destinationRefName": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard"
+              },
+              {
+                "label": "Kubernetes Services",
+                "type": "dashboardLink",
+                "id": "3e277318-8f0e-4be9-9572-0685e64684cf",
+                "order": 10,
+                "destinationRefName": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard"
+              },
+              {
+                "label": "Kubernetes API server",
+                "type": "dashboardLink",
+                "id": "808c6778-b18e-478a-8010-54bd6c8b2f3e",
+                "order": 11,
+                "destinationRefName": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard"
+              }
+            ],
+            "id": "links_panel_kubernetes_b945b7b0_bcb1_11ec_b64f_7dd6e8e82013"
+          },
+          "enhancements": {}
+        },
+        "panelIndex": "1d9fa4a6-44fe-489d-be4f-53a2eb02a2d5",
         "gridData": {
           "h": 4,
           "i": "1d9fa4a6-44fe-489d-be4f-53a2eb02a2d5",
           "w": 48,
           "x": 0,
           "y": 0
-        },
-        "panelIndex": "1d9fa4a6-44fe-489d-be4f-53a2eb02a2d5",
-        "embeddableConfig": {
-          "enhancements": {},
-          "savedVis": {
-            "data": {
-              "aggs": [],
-              "searchSource": {
-                "filter": [],
-                "query": {
-                  "language": "kuery",
-                  "query": ""
-                }
-              }
-            },
-            "description": "",
-            "params": {
-              "fontSize": 10,
-              "markdown": "[Kubernetes Overview](#/view/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c), [Kubernetes Nodes](#/view/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Pods](#/view/kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013),  [Kubernetes Deployments](#/view/kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes StatefulSets](#/view/kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013),  [Kubernetes DaemonSets](#/view/kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes CronJobs](#/view/kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Jobs](#/view/kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Volumes](#/view/kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013), [Kubernetes PV/PVC](#/view/kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Services](#/view/kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes API Server](#/view/kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56)",
-              "openLinksInNewTab": false
-            },
-            "title": "",
-            "type": "markdown",
-            "uiState": {}
-          },
-          "type": "visualization"
-        },
-        "title": "Kubernetes Dashboards [Metrics Kubernetes]"
+        }
       },
       {
         "version": "8.9.0",
@@ -2230,6 +2304,66 @@
       "id": "metrics-*",
       "name": "controlGroup_6c029002-b266-42ef-af36-fdcd73bfadef:optionsListDataView",
       "type": "index-pattern"
+    },
+    {
+      "name": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c"
+    },
+    {
+      "name": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56"
     }
   ],
   "managed": false,

--- a/packages/kubernetes/kibana/dashboard/kubernetes-bf9389f0-0c14-11ed-b760-5d1bccb47f56.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-bf9389f0-0c14-11ed-b760-5d1bccb47f56.json
@@ -60,42 +60,115 @@
     },
     "panelsJSON": [
       {
-        "version": "8.9.0",
-        "type": "visualization",
+        "type": "links",
+        "title": "Kubernetes Dashboards [Metrics Kubernetes]",
+        "embeddableConfig": {
+          "attributes": {
+            "title": "Kubernetes Dashboards [Metrics Kubernetes]",
+            "description": "",
+            "layout": "horizontal",
+            "links": [
+              {
+                "label": "Kubernetes Overview",
+                "type": "dashboardLink",
+                "id": "6416766e-26ec-4394-b02d-399b42ca9a6e",
+                "order": 0,
+                "destinationRefName": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard"
+              },
+              {
+                "label": "Kubernetes Nodes",
+                "type": "dashboardLink",
+                "id": "07ec2943-d3c5-4c96-beae-c5d5fde21fef",
+                "options": {
+                  "openInNewTab": false,
+                  "useCurrentDateRange": true,
+                  "useCurrentFilters": true
+                },
+                "order": 1,
+                "destinationRefName": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard"
+              },
+              {
+                "label": "Kubernetes Pods",
+                "type": "dashboardLink",
+                "id": "d0182b64-2cbf-4262-a352-9ab9a0ce48d8",
+                "order": 2,
+                "destinationRefName": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard"
+              },
+              {
+                "label": "Kubernetes Deployments",
+                "type": "dashboardLink",
+                "id": "c4b70217-9e48-4b1b-9b37-7803955a7f68",
+                "order": 3,
+                "destinationRefName": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard"
+              },
+              {
+                "label": "Kubernetes StatefulSets",
+                "type": "dashboardLink",
+                "id": "817b2767-a299-4117-9e40-bacf9d2ceeef",
+                "order": 4,
+                "destinationRefName": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard"
+              },
+              {
+                "label": "Kubernetes DaemonSets",
+                "type": "dashboardLink",
+                "id": "f67a589f-975c-409b-af5a-1ec3131916bd",
+                "order": 5,
+                "destinationRefName": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard"
+              },
+              {
+                "label": "Kubernetes Cronjobs",
+                "type": "dashboardLink",
+                "id": "7aeb19b4-8594-4187-9431-1e5e9f09b652",
+                "order": 6,
+                "destinationRefName": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard"
+              },
+              {
+                "label": "Kubernetes Jobs",
+                "type": "dashboardLink",
+                "id": "b805b8c7-e9d7-4968-9ae2-78d5fb0974ad",
+                "order": 7,
+                "destinationRefName": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard"
+              },
+              {
+                "label": "Kubernetes Volumes",
+                "type": "dashboardLink",
+                "id": "269b5aeb-9e4a-4d27-83ac-77d8aec1213f",
+                "order": 8,
+                "destinationRefName": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard"
+              },
+              {
+                "label": "Kubernetes PV/PVC",
+                "type": "dashboardLink",
+                "id": "9b4a4e12-82d3-445f-8c11-76f197f2aa8b",
+                "order": 9,
+                "destinationRefName": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard"
+              },
+              {
+                "label": "Kubernetes Services",
+                "type": "dashboardLink",
+                "id": "3e277318-8f0e-4be9-9572-0685e64684cf",
+                "order": 10,
+                "destinationRefName": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard"
+              },
+              {
+                "label": "Kubernetes API server",
+                "type": "dashboardLink",
+                "id": "808c6778-b18e-478a-8010-54bd6c8b2f3e",
+                "order": 11,
+                "destinationRefName": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard"
+              }
+            ],
+            "id": "links_panel_kubernetes_bf9389f0_0c14_11ed_b760_5d1bccb47f56"
+          },
+          "enhancements": {}
+        },
+        "panelIndex": "c13eb504-6afb-4fa5-8a7d-a75c5fee15b7",
         "gridData": {
           "h": 10,
           "i": "c13eb504-6afb-4fa5-8a7d-a75c5fee15b7",
           "w": 23,
           "x": 0,
           "y": 0
-        },
-        "panelIndex": "c13eb504-6afb-4fa5-8a7d-a75c5fee15b7",
-        "embeddableConfig": {
-          "enhancements": {},
-          "hidePanelTitles": true,
-          "savedVis": {
-            "data": {
-              "aggs": [],
-              "searchSource": {
-                "filter": [],
-                "query": {
-                  "language": "kuery",
-                  "query": ""
-                }
-              }
-            },
-            "description": "",
-            "id": "",
-            "params": {
-              "fontSize": 12,
-              "markdown": "### Controller Manager\n\nThis dashboard collects metrics from [kube controller manager](https://kubernetes.io/docs/concepts/overview/components/#kube-controller-manager) endpoint. Its purpose is to give an overview of what is happening inside it through the controller processes metrics and detect problems that might be happening. \n\n**WARNING**: This dataset **requires access** to the kube controller manager endpoint. Refer [here](https://docs.elastic.co/en/integrations/kubernetes#scheduler-and-controllermanager) to learn how to enable it. In some \"As a Service\" Kubernetes implementations, like GKE or AKS, it is **not possible** to access its metrics.",
-              "openLinksInNewTab": false
-            },
-            "title": "",
-            "type": "markdown",
-            "uiState": {}
-          },
-          "type": "visualization"
         }
       },
       {
@@ -3201,6 +3274,66 @@
       "id": "metrics-*",
       "name": "controlGroup_df56c430-83b1-436e-8b9c-fb027aaa29ca:optionsListDataView",
       "type": "index-pattern"
+    },
+    {
+      "name": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c"
+    },
+    {
+      "name": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56"
     }
   ],
   "managed": false,

--- a/packages/kubernetes/kibana/dashboard/kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56.json
@@ -14,29 +14,7 @@
     "description": "Kubernetes API server metrics",
     "kibanaSavedObjectMeta": {
       "searchSourceJSON": {
-        "filter": [
-          {
-            "$state": {
-              "store": "appState"
-            },
-            "meta": {
-              "alias": null,
-              "disabled": false,
-              "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-              "key": "data_stream.dataset",
-              "negate": false,
-              "params": {
-                "query": "kubernetes.apiserver"
-              },
-              "type": "phrase"
-            },
-            "query": {
-              "match_phrase": {
-                "data_stream.dataset": "kubernetes.apiserver"
-              }
-            }
-          }
-        ],
+        "filter": [],
         "query": {
           "language": "kuery",
           "query": ""
@@ -46,48 +24,120 @@
     "optionsJSON": {
       "darkTheme": false,
       "hidePanelTitles": false,
-      "useMargins": false
+      "useMargins": true
     },
     "panelsJSON": [
       {
-        "version": "8.9.0",
-        "type": "visualization",
+        "type": "links",
+        "title": "Kubernetes Dashboards [Metrics Kubernetes]",
+        "embeddableConfig": {
+          "attributes": {
+            "title": "Kubernetes Dashboards [Metrics Kubernetes]",
+            "description": "",
+            "layout": "horizontal",
+            "links": [
+              {
+                "label": "Kubernetes Overview",
+                "type": "dashboardLink",
+                "id": "6416766e-26ec-4394-b02d-399b42ca9a6e",
+                "order": 0,
+                "destinationRefName": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard"
+              },
+              {
+                "label": "Kubernetes Nodes",
+                "type": "dashboardLink",
+                "id": "07ec2943-d3c5-4c96-beae-c5d5fde21fef",
+                "options": {
+                  "openInNewTab": false,
+                  "useCurrentDateRange": true,
+                  "useCurrentFilters": true
+                },
+                "order": 1,
+                "destinationRefName": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard"
+              },
+              {
+                "label": "Kubernetes Pods",
+                "type": "dashboardLink",
+                "id": "d0182b64-2cbf-4262-a352-9ab9a0ce48d8",
+                "order": 2,
+                "destinationRefName": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard"
+              },
+              {
+                "label": "Kubernetes Deployments",
+                "type": "dashboardLink",
+                "id": "c4b70217-9e48-4b1b-9b37-7803955a7f68",
+                "order": 3,
+                "destinationRefName": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard"
+              },
+              {
+                "label": "Kubernetes StatefulSets",
+                "type": "dashboardLink",
+                "id": "817b2767-a299-4117-9e40-bacf9d2ceeef",
+                "order": 4,
+                "destinationRefName": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard"
+              },
+              {
+                "label": "Kubernetes DaemonSets",
+                "type": "dashboardLink",
+                "id": "f67a589f-975c-409b-af5a-1ec3131916bd",
+                "order": 5,
+                "destinationRefName": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard"
+              },
+              {
+                "label": "Kubernetes Cronjobs",
+                "type": "dashboardLink",
+                "id": "7aeb19b4-8594-4187-9431-1e5e9f09b652",
+                "order": 6,
+                "destinationRefName": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard"
+              },
+              {
+                "label": "Kubernetes Jobs",
+                "type": "dashboardLink",
+                "id": "b805b8c7-e9d7-4968-9ae2-78d5fb0974ad",
+                "order": 7,
+                "destinationRefName": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard"
+              },
+              {
+                "label": "Kubernetes Volumes",
+                "type": "dashboardLink",
+                "id": "269b5aeb-9e4a-4d27-83ac-77d8aec1213f",
+                "order": 8,
+                "destinationRefName": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard"
+              },
+              {
+                "label": "Kubernetes PV/PVC",
+                "type": "dashboardLink",
+                "id": "9b4a4e12-82d3-445f-8c11-76f197f2aa8b",
+                "order": 9,
+                "destinationRefName": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard"
+              },
+              {
+                "label": "Kubernetes Services",
+                "type": "dashboardLink",
+                "id": "3e277318-8f0e-4be9-9572-0685e64684cf",
+                "order": 10,
+                "destinationRefName": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard"
+              },
+              {
+                "label": "Kubernetes API server",
+                "type": "dashboardLink",
+                "id": "808c6778-b18e-478a-8010-54bd6c8b2f3e",
+                "order": 11,
+                "destinationRefName": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard"
+              }
+            ],
+            "id": "links_panel_kubernetes_d3bd9650_0c14_11ed_b760_5d1bccb47f56"
+          },
+          "enhancements": {}
+        },
+        "panelIndex": "d79ccab2-4cce-4e41-ae01-434914884a5f",
         "gridData": {
-          "h": 5,
+          "h": 4,
           "i": "d79ccab2-4cce-4e41-ae01-434914884a5f",
           "w": 48,
           "x": 0,
           "y": 0
-        },
-        "panelIndex": "d79ccab2-4cce-4e41-ae01-434914884a5f",
-        "embeddableConfig": {
-          "enhancements": {},
-          "hidePanelTitles": false,
-          "savedVis": {
-            "data": {
-              "aggs": [],
-              "searchSource": {
-                "filter": [],
-                "query": {
-                  "language": "kuery",
-                  "query": ""
-                }
-              }
-            },
-            "description": "",
-            "id": "",
-            "params": {
-              "fontSize": 10,
-              "markdown": "[Kubernetes Overview](#/view/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c),\n[Kubernetes Nodes](#/view/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013), \n[Kubernetes Pods](#/view/kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013),  [Kubernetes Deployments](#/view/kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes StatefulSets](#/view/kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013),  [Kubernetes DaemonSets](#/view/kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes CronJobs](#/view/kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Jobs](#/view/kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Volumes](#/view/kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013), [Kubernetes PV/PVC](#/view/kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Services](#/view/kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes API Server](#/view/kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56)",
-              "openLinksInNewTab": false
-            },
-            "title": "",
-            "type": "markdown",
-            "uiState": {}
-          },
-          "type": "visualization"
-        },
-        "title": "Kubernetes Dashboards [Metrics Kubernetes]"
+        }
       },
       {
         "version": "8.9.0",
@@ -203,7 +253,39 @@
                   }
                 }
               },
-              "filters": [],
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "c4ae4d41-606a-4e77-a14c-ee57df2de184",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": [
+                      "kubernetes.apiserver"
+                    ],
+                    "type": "phrases",
+                    "value": [
+                      "kubernetes.apiserver"
+                    ]
+                  },
+                  "query": {
+                    "bool": {
+                      "minimum_should_match": 1,
+                      "should": [
+                        {
+                          "match_phrase": {
+                            "data_stream.dataset": "kubernetes.apiserver"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
               "internalReferences": [],
               "query": {
                 "language": "kuery",
@@ -412,7 +494,39 @@
                   }
                 }
               },
-              "filters": [],
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "c4ae4d41-606a-4e77-a14c-ee57df2de184",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": [
+                      "kubernetes.apiserver"
+                    ],
+                    "type": "phrases",
+                    "value": [
+                      "kubernetes.apiserver"
+                    ]
+                  },
+                  "query": {
+                    "bool": {
+                      "minimum_should_match": 1,
+                      "should": [
+                        {
+                          "match_phrase": {
+                            "data_stream.dataset": "kubernetes.apiserver"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
               "internalReferences": [],
               "query": {
                 "language": "kuery",
@@ -546,7 +660,39 @@
                   }
                 }
               },
-              "filters": [],
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "c4ae4d41-606a-4e77-a14c-ee57df2de184",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": [
+                      "kubernetes.apiserver"
+                    ],
+                    "type": "phrases",
+                    "value": [
+                      "kubernetes.apiserver"
+                    ]
+                  },
+                  "query": {
+                    "bool": {
+                      "minimum_should_match": 1,
+                      "should": [
+                        {
+                          "match_phrase": {
+                            "data_stream.dataset": "kubernetes.apiserver"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
               "query": {
                 "language": "kuery",
                 "query": ""
@@ -675,7 +821,39 @@
                   }
                 }
               },
-              "filters": [],
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "c4ae4d41-606a-4e77-a14c-ee57df2de184",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": [
+                      "kubernetes.apiserver"
+                    ],
+                    "type": "phrases",
+                    "value": [
+                      "kubernetes.apiserver"
+                    ]
+                  },
+                  "query": {
+                    "bool": {
+                      "minimum_should_match": 1,
+                      "should": [
+                        {
+                          "match_phrase": {
+                            "data_stream.dataset": "kubernetes.apiserver"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
               "query": {
                 "language": "kuery",
                 "query": ""
@@ -729,6 +907,11 @@
     },
     {
       "id": "metrics-*",
+      "name": "9db496f9-079b-4ddd-b517-cec815a7e9cb:c4ae4d41-606a-4e77-a14c-ee57df2de184",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
       "name": "97d844d4-e990-444a-8b94-34aa4dcd64cc:indexpattern-datasource-layer-8df21ece-205d-4542-bec9-e381eca92895",
       "type": "index-pattern"
     },
@@ -741,6 +924,66 @@
       "id": "metrics-*",
       "name": "9f255e7f-b213-4719-9c00-eedc2a919e2c:indexpattern-datasource-layer-fc6561f2-f85f-4096-86df-ef5dcb95627c",
       "type": "index-pattern"
+    },
+    {
+      "name": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c"
+    },
+    {
+      "name": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56"
     }
   ],
   "managed": false,

--- a/packages/kubernetes/kibana/dashboard/kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013.json
@@ -34,42 +34,116 @@
     },
     "panelsJSON": [
       {
-        "version": "8.9.0",
-        "type": "visualization",
+        "type": "links",
+        "title": "Kubernetes Dashboards [Metrics Kubernetes]",
+        "embeddableConfig": {
+          "attributes": {
+            "title": "Kubernetes Dashboards [Metrics Kubernetes]",
+            "description": "",
+            "layout": "horizontal",
+            "links": [
+              {
+                "label": "Kubernetes Overview",
+                "type": "dashboardLink",
+                "id": "6416766e-26ec-4394-b02d-399b42ca9a6e",
+                "order": 0,
+                "destinationRefName": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard"
+              },
+              {
+                "label": "Kubernetes Nodes",
+                "type": "dashboardLink",
+                "id": "07ec2943-d3c5-4c96-beae-c5d5fde21fef",
+                "options": {
+                  "openInNewTab": false,
+                  "useCurrentDateRange": true,
+                  "useCurrentFilters": true
+                },
+                "order": 1,
+                "destinationRefName": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard"
+              },
+              {
+                "label": "Kubernetes Pods",
+                "type": "dashboardLink",
+                "id": "d0182b64-2cbf-4262-a352-9ab9a0ce48d8",
+                "order": 2,
+                "destinationRefName": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard"
+              },
+              {
+                "label": "Kubernetes Deployments",
+                "type": "dashboardLink",
+                "id": "c4b70217-9e48-4b1b-9b37-7803955a7f68",
+                "order": 3,
+                "destinationRefName": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard"
+              },
+              {
+                "label": "Kubernetes StatefulSets",
+                "type": "dashboardLink",
+                "id": "817b2767-a299-4117-9e40-bacf9d2ceeef",
+                "order": 4,
+                "destinationRefName": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard"
+              },
+              {
+                "label": "Kubernetes DaemonSets",
+                "type": "dashboardLink",
+                "id": "f67a589f-975c-409b-af5a-1ec3131916bd",
+                "order": 5,
+                "destinationRefName": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard"
+              },
+              {
+                "label": "Kubernetes Cronjobs",
+                "type": "dashboardLink",
+                "id": "7aeb19b4-8594-4187-9431-1e5e9f09b652",
+                "order": 6,
+                "destinationRefName": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard"
+              },
+              {
+                "label": "Kubernetes Jobs",
+                "type": "dashboardLink",
+                "id": "b805b8c7-e9d7-4968-9ae2-78d5fb0974ad",
+                "order": 7,
+                "destinationRefName": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard"
+              },
+              {
+                "label": "Kubernetes Volumes",
+                "type": "dashboardLink",
+                "id": "269b5aeb-9e4a-4d27-83ac-77d8aec1213f",
+                "order": 8,
+                "destinationRefName": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard"
+              },
+              {
+                "label": "Kubernetes PV/PVC",
+                "type": "dashboardLink",
+                "id": "9b4a4e12-82d3-445f-8c11-76f197f2aa8b",
+                "order": 9,
+                "destinationRefName": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard"
+              },
+              {
+                "label": "Kubernetes Services",
+                "type": "dashboardLink",
+                "id": "3e277318-8f0e-4be9-9572-0685e64684cf",
+                "order": 10,
+                "destinationRefName": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard"
+              },
+              {
+                "label": "Kubernetes API server",
+                "type": "dashboardLink",
+                "id": "808c6778-b18e-478a-8010-54bd6c8b2f3e",
+                "order": 11,
+                "destinationRefName": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard"
+              }
+            ],
+            "id": "links_panel_kubernetes_dd081350_bcb1_11ec_b64f_7dd6e8e82013"
+          },
+          "enhancements": {}
+        },
+        "panelIndex": "14993ee2-7277-4012-946c-fa294f024a39",
         "gridData": {
           "h": 4,
           "i": "14993ee2-7277-4012-946c-fa294f024a39",
           "w": 48,
           "x": 0,
           "y": 0
-        },
-        "panelIndex": "14993ee2-7277-4012-946c-fa294f024a39",
-        "embeddableConfig": {
-          "enhancements": {},
-          "savedVis": {
-            "data": {
-              "aggs": [],
-              "searchSource": {
-                "filter": [],
-                "query": {
-                  "language": "kuery",
-                  "query": ""
-                }
-              }
-            },
-            "description": "",
-            "params": {
-              "fontSize": 10,
-              "markdown": "[Kubernetes Overview](#/view/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c),\n[Kubernetes Nodes](#/view/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013), \n[Kubernetes Pods](#/view/kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013),  [Kubernetes Deployments](#/view/kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes StatefulSets](#/view/kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013),  [Kubernetes DaemonSets](#/view/kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes CronJobs](#/view/kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Jobs](#/view/kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Volumes](#/view/kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013), [Kubernetes PV/PVC](#/view/kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Services](#/view/kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes API Server](#/view/kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56)",
-              "openLinksInNewTab": false
-            },
-            "title": "",
-            "type": "markdown",
-            "uiState": {}
-          },
-          "type": "visualization"
-        },
-        "title": "Kubernetes Dashboards [Metrics Kubernetes]"
+        }
       },
       {
         "version": "8.9.0",
@@ -536,6 +610,66 @@
       "id": "metrics-*",
       "name": "controlGroup_16f1ca8d-0221-4df5-ae59-42a0e0f92992:optionsListDataView",
       "type": "index-pattern"
+    },
+    {
+      "name": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c"
+    },
+    {
+      "name": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56"
     }
   ],
   "managed": false,

--- a/packages/kubernetes/kibana/dashboard/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c.json
@@ -1,3749 +1,3885 @@
 {
-    "attributes": {
-        "controlGroupInput": {
-            "chainingSystem": "HIERARCHICAL",
-            "controlStyle": "oneLine",
-            "ignoreParentSettingsJSON": {
-                "ignoreFilters": false,
-                "ignoreQuery": false,
-                "ignoreTimerange": false,
-                "ignoreValidations": false
-            },
-            "panelsJSON": {
-                "46384cc1-8597-4df0-b281-a342bf9f14b4": {
-                    "explicitInput": {
-                        "enhancements": {},
-                        "fieldName": "orchestrator.cluster.name",
-                        "id": "46384cc1-8597-4df0-b281-a342bf9f14b4",
-                        "selectedOptions": [],
-                        "title": "Cluster Name"
-                    },
-                    "grow": false,
-                    "order": 0,
-                    "type": "optionsListControl",
-                    "width": "large"
-                },
-                "b20283e9-5cbb-40f7-bfc2-2169c34258ab": {
-                    "explicitInput": {
-                        "enhancements": {},
-                        "fieldName": "kubernetes.namespace",
-                        "id": "b20283e9-5cbb-40f7-bfc2-2169c34258ab",
-                        "selectedOptions": [],
-                        "title": "Namespace"
-                    },
-                    "grow": false,
-                    "order": 1,
-                    "type": "optionsListControl",
-                    "width": "large"
-                }
-            },
-            "showApplySelections": false
+  "attributes": {
+    "controlGroupInput": {
+      "chainingSystem": "HIERARCHICAL",
+      "controlStyle": "oneLine",
+      "ignoreParentSettingsJSON": {
+        "ignoreFilters": false,
+        "ignoreQuery": false,
+        "ignoreTimerange": false,
+        "ignoreValidations": false
+      },
+      "panelsJSON": {
+        "46384cc1-8597-4df0-b281-a342bf9f14b4": {
+          "explicitInput": {
+            "enhancements": {},
+            "fieldName": "orchestrator.cluster.name",
+            "id": "46384cc1-8597-4df0-b281-a342bf9f14b4",
+            "selectedOptions": [],
+            "title": "Cluster Name"
+          },
+          "grow": false,
+          "order": 0,
+          "type": "optionsListControl",
+          "width": "large"
         },
-        "description": "Overview of Kubernetes cluster metrics",
-        "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
+        "b20283e9-5cbb-40f7-bfc2-2169c34258ab": {
+          "explicitInput": {
+            "enhancements": {},
+            "fieldName": "kubernetes.namespace",
+            "id": "b20283e9-5cbb-40f7-bfc2-2169c34258ab",
+            "selectedOptions": [],
+            "title": "Namespace"
+          },
+          "grow": false,
+          "order": 1,
+          "type": "optionsListControl",
+          "width": "large"
+        }
+      },
+      "showApplySelections": false
+    },
+    "description": "Overview of Kubernetes cluster metrics",
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": {
+        "filter": [],
+        "query": {
+          "language": "kuery",
+          "query": ""
+        }
+      }
+    },
+    "optionsJSON": {
+      "hidePanelTitles": false,
+      "syncColors": false,
+      "syncCursor": true,
+      "syncTooltips": false,
+      "useMargins": true
+    },
+    "panelsJSON": [
+      {
+        "type": "links",
+        "title": "Kubernetes Dashboards [Metrics Kubernetes]",
+        "embeddableConfig": {
+          "attributes": {
+            "title": "Kubernetes Dashboards [Metrics Kubernetes]",
+            "description": "",
+            "layout": "horizontal",
+            "links": [
+              {
+                "label": "Kubernetes Overview",
+                "type": "dashboardLink",
+                "id": "6416766e-26ec-4394-b02d-399b42ca9a6e",
+                "order": 0,
+                "destinationRefName": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard"
+              },
+              {
+                "label": "Kubernetes Nodes",
+                "type": "dashboardLink",
+                "id": "07ec2943-d3c5-4c96-beae-c5d5fde21fef",
+                "options": {
+                  "openInNewTab": false,
+                  "useCurrentDateRange": true,
+                  "useCurrentFilters": true
+                },
+                "order": 1,
+                "destinationRefName": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard"
+              },
+              {
+                "label": "Kubernetes Pods",
+                "type": "dashboardLink",
+                "id": "d0182b64-2cbf-4262-a352-9ab9a0ce48d8",
+                "order": 2,
+                "destinationRefName": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard"
+              },
+              {
+                "label": "Kubernetes Deployments",
+                "type": "dashboardLink",
+                "id": "c4b70217-9e48-4b1b-9b37-7803955a7f68",
+                "order": 3,
+                "destinationRefName": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard"
+              },
+              {
+                "label": "Kubernetes StatefulSets",
+                "type": "dashboardLink",
+                "id": "817b2767-a299-4117-9e40-bacf9d2ceeef",
+                "order": 4,
+                "destinationRefName": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard"
+              },
+              {
+                "label": "Kubernetes DaemonSets",
+                "type": "dashboardLink",
+                "id": "f67a589f-975c-409b-af5a-1ec3131916bd",
+                "order": 5,
+                "destinationRefName": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard"
+              },
+              {
+                "label": "Kubernetes Cronjobs",
+                "type": "dashboardLink",
+                "id": "7aeb19b4-8594-4187-9431-1e5e9f09b652",
+                "order": 6,
+                "destinationRefName": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard"
+              },
+              {
+                "label": "Kubernetes Jobs",
+                "type": "dashboardLink",
+                "id": "b805b8c7-e9d7-4968-9ae2-78d5fb0974ad",
+                "order": 7,
+                "destinationRefName": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard"
+              },
+              {
+                "label": "Kubernetes Volumes",
+                "type": "dashboardLink",
+                "id": "269b5aeb-9e4a-4d27-83ac-77d8aec1213f",
+                "order": 8,
+                "destinationRefName": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard"
+              },
+              {
+                "label": "Kubernetes PV/PVC",
+                "type": "dashboardLink",
+                "id": "9b4a4e12-82d3-445f-8c11-76f197f2aa8b",
+                "order": 9,
+                "destinationRefName": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard"
+              },
+              {
+                "label": "Kubernetes Services",
+                "type": "dashboardLink",
+                "id": "3e277318-8f0e-4be9-9572-0685e64684cf",
+                "order": 10,
+                "destinationRefName": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard"
+              },
+              {
+                "label": "Kubernetes API server",
+                "type": "dashboardLink",
+                "id": "808c6778-b18e-478a-8010-54bd6c8b2f3e",
+                "order": 11,
+                "destinationRefName": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard"
+              }
+            ],
+            "id": "links_panel_kubernetes_f4dc26db_1b53_4ea2_a78b_1bfab8ea267c"
+          },
+          "enhancements": {}
+        },
+        "panelIndex": "5814b672-5109-4ab0-a281-1e14a1a53f50",
+        "gridData": {
+          "h": 4,
+          "i": "5814b672-5109-4ab0-a281-1e14a1a53f50",
+          "w": 33,
+          "x": 0,
+          "y": 0
+        }
+      },
+      {
+        "embeddableConfig": {
+          "enhancements": {},
+          "hidePanelTitles": false,
+          "savedVis": {
+            "data": {
+              "aggs": [],
+              "searchSource": {
                 "filter": [],
                 "query": {
-                    "language": "kuery",
-                    "query": ""
+                  "language": "kuery",
+                  "query": ""
                 }
-            }
+              }
+            },
+            "description": "",
+            "id": "",
+            "params": {
+              "fontSize": 10,
+              "markdown": "This dashboard requires having [`kube-state-metrics`](https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment) deployed to your Kubernetes cluster to function properly. \nCheck the **Section: state_\\* and event** of the [Elastic Kubernetes integration](https://docs.elastic.co/en/integrations/kubernetes).",
+              "openLinksInNewTab": false
+            },
+            "title": "",
+            "type": "markdown",
+            "uiState": {}
+          }
         },
-        "optionsJSON": {
-            "hidePanelTitles": false,
-            "syncColors": false,
-            "syncCursor": true,
-            "syncTooltips": false,
-            "useMargins": true
+        "gridData": {
+          "h": 4,
+          "i": "adc3a53c-53f4-4041-953d-2273e2d2d408",
+          "w": 15,
+          "x": 33,
+          "y": 0
         },
-        "panelsJSON": [
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "params": {
-                            "fontSize": 10,
-                            "markdown": "[Kubernetes Overview](#/view/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c), [Kubernetes Nodes](#/view/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Pods](#/view/kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013),  [Kubernetes Deployments](#/view/kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes StatefulSets](#/view/kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013),  [Kubernetes DaemonSets](#/view/kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes CronJobs](#/view/kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Jobs](#/view/kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Volumes](#/view/kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013), [Kubernetes PV/PVC](#/view/kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Services](#/view/kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes API Server](#/view/kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56)",
-                            "openLinksInNewTab": false
-                        },
-                        "title": "",
-                        "type": "markdown",
-                        "uiState": {}
+        "panelIndex": "adc3a53c-53f4-4041-953d-2273e2d2d408",
+        "title": "Information",
+        "type": "visualization"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "0fa53a1e-0589-4380-b700-70dd489a33de": {
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "0fa53a1e-0589-4380-b700-70dd489a33de",
+                  "name": "state-pods-adhoc",
+                  "runtimeFieldMap": {
+                    "failed": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "not_running": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\" || doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "pending": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "running": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"running\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "succeeded": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"succeeded\") { emit(1) }"
+                      },
+                      "type": "long"
                     }
+                  },
+                  "sourceFilters": [],
+                  "timeFieldName": "@timestamp",
+                  "title": "metrics-*,*:metrics-*"
                 },
-                "gridData": {
-                    "h": 4,
-                    "i": "5814b672-5109-4ab0-a281-1e14a1a53f50",
-                    "w": 33,
-                    "x": 0,
-                    "y": 0
-                },
-                "panelIndex": "5814b672-5109-4ab0-a281-1e14a1a53f50",
-                "title": "Kubernetes Dashboards [Metrics Kubernetes]",
-                "type": "visualization"
-            },
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "hidePanelTitles": false,
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "id": "",
-                        "params": {
-                            "fontSize": 10,
-                            "markdown": "This dashboard requires having [`kube-state-metrics`](https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment) deployed to your Kubernetes cluster to function properly. \nCheck the **Section: state_\\* and event** of the [Elastic Kubernetes integration](https://docs.elastic.co/en/integrations/kubernetes).",
-                            "openLinksInNewTab": false
-                        },
-                        "title": "",
-                        "type": "markdown",
-                        "uiState": {}
+                "31c14ad9-51fd-465c-957c-b0171c23a0bb": {
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "31c14ad9-51fd-465c-957c-b0171c23a0bb",
+                  "name": "state_nodes",
+                  "runtimeFieldMap": {
+                    "nodes_not_ready": {
+                      "script": {
+                        "source": "if (doc['kubernetes.node.status.ready'].value == \"false\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "nodes_ready": {
+                      "script": {
+                        "source": "if (doc['kubernetes.node.status.ready'].value == \"true\") { emit(1) }"
+                      },
+                      "type": "long"
                     }
+                  },
+                  "sourceFilters": [],
+                  "timeFieldName": "@timestamp",
+                  "title": "metrics-*,*:metrics-*"
                 },
-                "gridData": {
-                    "h": 4,
-                    "i": "adc3a53c-53f4-4041-953d-2273e2d2d408",
-                    "w": 15,
-                    "x": 33,
-                    "y": 0
+                "b0224778-49e2-4916-aa97-55d3b4ddf6c1": {
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "b0224778-49e2-4916-aa97-55d3b4ddf6c1",
+                  "name": "nodes-ad-hoc",
+                  "runtimeFieldMap": {
+                    "not_ready": {
+                      "script": {
+                        "source": "if (doc['kubernetes.node.status.ready'].value == false) { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "ready": {
+                      "script": {
+                        "source": "if (doc['kubernetes.node.status.ready'].value == true) { emit(1) }"
+                      },
+                      "type": "long"
+                    }
+                  },
+                  "sourceFilters": [],
+                  "timeFieldName": "@timestamp",
+                  "title": "metrics-*,*:metrics-*"
                 },
-                "panelIndex": "adc3a53c-53f4-4041-953d-2273e2d2d408",
-                "title": "Information",
-                "type": "visualization"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "0fa53a1e-0589-4380-b700-70dd489a33de": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "0fa53a1e-0589-4380-b700-70dd489a33de",
-                                    "name": "state-pods-adhoc",
-                                    "runtimeFieldMap": {
-                                        "failed": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "not_running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\" || doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "pending": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"running\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "succeeded": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"succeeded\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                },
-                                "31c14ad9-51fd-465c-957c-b0171c23a0bb": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "31c14ad9-51fd-465c-957c-b0171c23a0bb",
-                                    "name": "state_nodes",
-                                    "runtimeFieldMap": {
-                                        "nodes_not_ready": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.node.status.ready'].value == \"false\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "nodes_ready": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.node.status.ready'].value == \"true\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                },
-                                "b0224778-49e2-4916-aa97-55d3b4ddf6c1": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "b0224778-49e2-4916-aa97-55d3b4ddf6c1",
-                                    "name": "nodes-ad-hoc",
-                                    "runtimeFieldMap": {
-                                        "not_ready": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.node.status.ready'].value == false) { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "ready": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.node.status.ready'].value == true) { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                },
-                                "d1e9a0d9-4696-43cb-b9f1-a4b0b9fe3732": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "d1e9a0d9-4696-43cb-b9f1-a4b0b9fe3732",
-                                    "name": "state_node-ad-hoc",
-                                    "runtimeFieldMap": {
-                                        "not_ready": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.node.status.ready'].value == \"false\" || doc['kubernetes.node.status.ready'].value == \"unknown\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "ready": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.node.status.ready'].value == \"true\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                },
-                                "f8fa576a-6f91-4a11-a43d-7f3964869d7d": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "f8fa576a-6f91-4a11-a43d-7f3964869d7d",
-                                    "name": "daemonsets-ad-hoc",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                }
-                            },
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "b7b25285-ced1-481d-999e-1886b3463594": {
-                                            "columnOrder": [
-                                                "977fa7a0-b026-427b-8ffd-ee07fd69b50e",
-                                                "1b46f7a2-12d8-4773-87db-118234d45186",
-                                                "4314b1bf-95bb-477a-9708-ff7324356bda",
-                                                "607cddcf-ff9a-46a5-b3d6-b6f268ead1e4"
-                                            ],
-                                            "columns": {
-                                                "1b46f7a2-12d8-4773-87db-118234d45186": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Filters",
-                                                    "operationType": "filters",
-                                                    "params": {
-                                                        "filters": [
-                                                            {
-                                                                "input": {
-                                                                    "language": "kuery",
-                                                                    "query": ""
-                                                                },
-                                                                "label": "Status"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "scale": "ordinal"
-                                                },
-                                                "4314b1bf-95bb-477a-9708-ff7324356bda": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "ready: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Ready",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "ready"
-                                                },
-                                                "607cddcf-ff9a-46a5-b3d6-b6f268ead1e4": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "not_ready: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Not Ready",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "not_ready"
-                                                },
-                                                "977fa7a0-b026-427b-8ffd-ee07fd69b50e": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10000 values of kubernetes.node.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "4314b1bf-95bb-477a-9708-ff7324356bda",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.node.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
+                "d1e9a0d9-4696-43cb-b9f1-a4b0b9fe3732": {
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "d1e9a0d9-4696-43cb-b9f1-a4b0b9fe3732",
+                  "name": "state_node-ad-hoc",
+                  "runtimeFieldMap": {
+                    "not_ready": {
+                      "script": {
+                        "source": "if (doc['kubernetes.node.status.ready'].value == \"false\" || doc['kubernetes.node.status.ready'].value == \"unknown\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "ready": {
+                      "script": {
+                        "source": "if (doc['kubernetes.node.status.ready'].value == \"true\") { emit(1) }"
+                      },
+                      "type": "long"
+                    }
+                  },
+                  "sourceFilters": [],
+                  "timeFieldName": "@timestamp",
+                  "title": "metrics-*,*:metrics-*"
+                },
+                "f8fa576a-6f91-4a11-a43d-7f3964869d7d": {
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "f8fa576a-6f91-4a11-a43d-7f3964869d7d",
+                  "name": "daemonsets-ad-hoc",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "timeFieldName": "@timestamp",
+                  "title": "metrics-*,*:metrics-*"
+                }
+              },
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "b7b25285-ced1-481d-999e-1886b3463594": {
+                      "columnOrder": [
+                        "977fa7a0-b026-427b-8ffd-ee07fd69b50e",
+                        "1b46f7a2-12d8-4773-87db-118234d45186",
+                        "4314b1bf-95bb-477a-9708-ff7324356bda",
+                        "607cddcf-ff9a-46a5-b3d6-b6f268ead1e4"
+                      ],
+                      "columns": {
+                        "1b46f7a2-12d8-4773-87db-118234d45186": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Filters",
+                          "operationType": "filters",
+                          "params": {
                             "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "31c14ad9-51fd-465c-957c-b0171c23a0bb",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.state_node"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.state_node"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [
-                                {
-                                    "id": "d1e9a0d9-4696-43cb-b9f1-a4b0b9fe3732",
-                                    "name": "indexpattern-datasource-layer-b7b25285-ced1-481d-999e-1886b3463594",
-                                    "type": "index-pattern"
-                                }
-                            ],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "gridlinesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "4314b1bf-95bb-477a-9708-ff7324356bda",
-                                            "607cddcf-ff9a-46a5-b3d6-b6f268ead1e4"
-                                        ],
-                                        "collapseFn": "sum",
-                                        "layerId": "b7b25285-ced1-481d-999e-1886b3463594",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_horizontal",
-                                        "showGridlines": false,
-                                        "splitAccessor": "977fa7a0-b026-427b-8ffd-ee07fd69b50e",
-                                        "xAccessor": "1b46f7a2-12d8-4773-87db-118234d45186",
-                                        "yConfig": [
-                                            {
-                                                "color": "#a63a38",
-                                                "forAccessor": "607cddcf-ff9a-46a5-b3d6-b6f268ead1e4"
-                                            },
-                                            {
-                                                "color": "#00bfb3",
-                                                "forAccessor": "4314b1bf-95bb-477a-9708-ff7324356bda"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false,
-                                    "position": "right",
-                                    "showSingleSeries": false
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "title": "Empty XY chart",
-                                "valueLabels": "show",
-                                "xTitle": "",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "Total Pods per Namespace [Metrics Kubernetes] (copy 1)",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 9,
-                    "i": "7116207b-48ce-4d93-9fbd-26d73af1c185",
-                    "w": 8,
-                    "x": 0,
-                    "y": 4
-                },
-                "panelIndex": "7116207b-48ce-4d93-9fbd-26d73af1c185",
-                "title": "Nodes",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-dfd1702f-213e-4fa2-98e3-5106657c62e7",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-dff09473-7596-48c7-bbf4-beccee70d845",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "dfd1702f-213e-4fa2-98e3-5106657c62e7": {
-                                            "columnOrder": [
-                                                "f0953a4e-8498-4b22-a63a-d24e4a069ed3",
-                                                "5c33dcdb-21de-4bdc-b564-ba82ed037d11",
-                                                "62125b6d-3199-420b-9d3b-46f159e15d7f"
-                                            ],
-                                            "columns": {
-                                                "5c33dcdb-21de-4bdc-b564-ba82ed037d11": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "62125b6d-3199-420b-9d3b-46f159e15d7f": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.node.status.ready:\"true\" and data_stream.dataset :\"kubernetes.state_node\" "
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Total Memory",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "bytes",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        },
-                                                        "showArrayValues": false,
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.node.memory.allocatable.bytes"
-                                                },
-                                                "f0953a4e-8498-4b22-a63a-d24e4a069ed3": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10000 values of kubernetes.node.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "missingBucket": false,
-                                                        "orderAgg": {
-                                                            "customLabel": false,
-                                                            "dataType": "number",
-                                                            "isBucketed": false,
-                                                            "label": "Count of records",
-                                                            "operationType": "count",
-                                                            "params": {},
-                                                            "scale": "ratio",
-                                                            "sourceField": "___records___"
-                                                        },
-                                                        "orderBy": {
-                                                            "type": "custom"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "secondaryFields": [],
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.node.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        },
-                                        "dff09473-7596-48c7-bbf4-beccee70d845": {
-                                            "columnOrder": [
-                                                "6677e92c-5874-49c1-979e-c16c0d3838cd",
-                                                "46082fb5-9abc-42a0-8e4d-8a8d40a66ddf",
-                                                "307be273-94a6-41ab-b93b-0debde733492"
-                                            ],
-                                            "columns": {
-                                                "307be273-94a6-41ab-b93b-0debde733492": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "data_stream.dataset :\"kubernetes.container\"    "
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Memory Used",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "bytes",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        },
-                                                        "showArrayValues": false,
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.container.memory.usage.bytes"
-                                                },
-                                                "46082fb5-9abc-42a0-8e4d-8a8d40a66ddf": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "6677e92c-5874-49c1-979e-c16c0d3838cd": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10000 values of container.id",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "missingBucket": false,
-                                                        "orderAgg": {
-                                                            "customLabel": false,
-                                                            "dataType": "number",
-                                                            "isBucketed": false,
-                                                            "label": "Count of records",
-                                                            "operationType": "count",
-                                                            "params": {},
-                                                            "scale": "ratio",
-                                                            "sourceField": "___records___"
-                                                        },
-                                                        "orderBy": {
-                                                            "type": "custom"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "secondaryFields": [],
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "container.id"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "21cde57c-0e69-4e4c-b3e9-659de2778d06",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": [
-                                            "kubernetes.container",
-                                            "kubernetes.state_node"
-                                        ],
-                                        "type": "phrases",
-                                        "value": [
-                                            "kubernetes.container",
-                                            "kubernetes.state_node"
-                                        ]
-                                    },
-                                    "query": {
-                                        "bool": {
-                                            "minimum_should_match": 1,
-                                            "should": [
-                                                {
-                                                    "match_phrase": {
-                                                        "data_stream.dataset": "kubernetes.container"
-                                                    }
-                                                },
-                                                {
-                                                    "match_phrase": {
-                                                        "data_stream.dataset": "kubernetes.state_node"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "fillOpacity": 0.5,
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "307be273-94a6-41ab-b93b-0debde733492"
-                                        ],
-                                        "collapseFn": "sum",
-                                        "layerId": "dff09473-7596-48c7-bbf4-beccee70d845",
-                                        "layerType": "data",
-                                        "palette": {
-                                            "name": "default",
-                                            "type": "palette"
-                                        },
-                                        "seriesType": "area",
-                                        "splitAccessor": "6677e92c-5874-49c1-979e-c16c0d3838cd",
-                                        "xAccessor": "46082fb5-9abc-42a0-8e4d-8a8d40a66ddf",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#00bfb3",
-                                                "forAccessor": "307be273-94a6-41ab-b93b-0debde733492"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "accessors": [
-                                            "62125b6d-3199-420b-9d3b-46f159e15d7f"
-                                        ],
-                                        "collapseFn": "sum",
-                                        "layerId": "dfd1702f-213e-4fa2-98e3-5106657c62e7",
-                                        "layerType": "data",
-                                        "palette": {
-                                            "name": "negative",
-                                            "type": "palette"
-                                        },
-                                        "seriesType": "line",
-                                        "splitAccessor": "f0953a4e-8498-4b22-a63a-d24e4a069ed3",
-                                        "xAccessor": "5c33dcdb-21de-4bdc-b564-ba82ed037d11",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#bd271e",
-                                                "forAccessor": "62125b6d-3199-420b-9d3b-46f159e15d7f"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "maxLines": 1,
-                                    "position": "top",
-                                    "shouldTruncate": true,
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "bar_stacked",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide",
-                                "xTitle": "",
-                                "yLeftExtent": {
-                                    "mode": "full"
-                                },
-                                "yLeftScale": "linear",
-                                "yRightExtent": {
-                                    "mode": "full"
-                                },
-                                "yRightScale": "linear",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 9,
-                    "i": "3ef5ba86-ebb8-4ba6-941d-ad45de8d94e2",
-                    "w": 20,
-                    "x": 8,
-                    "y": 4
-                },
-                "panelIndex": "3ef5ba86-ebb8-4ba6-941d-ad45de8d94e2",
-                "title": "Memory used vs total memory",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-c165f898-73a9-48b1-afa9-2b6e75f3cc1f",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-dde29dcf-00ae-4b80-8d9e-ab45c51efba0",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "c165f898-73a9-48b1-afa9-2b6e75f3cc1f": {
-                                            "columnOrder": [
-                                                "7113c7e7-1af9-4350-b5d2-57abcb60c633",
-                                                "af01f323-afc0-4b55-b453-8da15facfc28",
-                                                "830de93b-4051-4716-99e4-83d625a91288X0",
-                                                "830de93b-4051-4716-99e4-83d625a91288X1",
-                                                "830de93b-4051-4716-99e4-83d625a91288"
-                                            ],
-                                            "columns": {
-                                                "7113c7e7-1af9-4350-b5d2-57abcb60c633": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10000 values of container.id",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "missingBucket": false,
-                                                        "orderAgg": {
-                                                            "customLabel": false,
-                                                            "dataType": "number",
-                                                            "isBucketed": false,
-                                                            "label": "Count of records",
-                                                            "operationType": "count",
-                                                            "params": {},
-                                                            "scale": "ratio",
-                                                            "sourceField": "___records___"
-                                                        },
-                                                        "orderBy": {
-                                                            "type": "custom"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "secondaryFields": [],
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "container.id"
-                                                },
-                                                "830de93b-4051-4716-99e4-83d625a91288": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "data_stream.dataset :\"kubernetes.container\"   "
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Cores Used",
-                                                    "operationType": "formula",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number"
-                                                        },
-                                                        "formula": "last_value(kubernetes.container.cpu.usage.nanocores)/1000000000",
-                                                        "isFormulaBroken": false
-                                                    },
-                                                    "references": [
-                                                        "830de93b-4051-4716-99e4-83d625a91288X1"
-                                                    ],
-                                                    "scale": "ratio"
-                                                },
-                                                "830de93b-4051-4716-99e4-83d625a91288X0": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "data_stream.dataset :\"kubernetes.container\"   "
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Part of last_value(kubernetes.container.cpu.usage.nanocores)/1000000000",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.container.cpu.usage.nanocores"
-                                                },
-                                                "830de93b-4051-4716-99e4-83d625a91288X1": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of last_value(kubernetes.container.cpu.usage.nanocores)/1000000000",
-                                                    "operationType": "math",
-                                                    "params": {
-                                                        "tinymathAst": {
-                                                            "args": [
-                                                                "830de93b-4051-4716-99e4-83d625a91288X0",
-                                                                1000000000
-                                                            ],
-                                                            "location": {
-                                                                "max": 63,
-                                                                "min": 0
-                                                            },
-                                                            "name": "divide",
-                                                            "text": "last_value(kubernetes.container.cpu.usage.nanocores)/1000000000",
-                                                            "type": "function"
-                                                        }
-                                                    },
-                                                    "references": [
-                                                        "830de93b-4051-4716-99e4-83d625a91288X0"
-                                                    ],
-                                                    "scale": "ratio"
-                                                },
-                                                "af01f323-afc0-4b55-b453-8da15facfc28": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        },
-                                        "dde29dcf-00ae-4b80-8d9e-ab45c51efba0": {
-                                            "columnOrder": [
-                                                "f64f7970-3f7d-4f2d-88ae-9e008f2e0bc5",
-                                                "c609fc21-331c-4bbe-81c3-ef8251f3cf80",
-                                                "e1c6fec1-182f-4bf2-aa22-434cd1aa9a95"
-                                            ],
-                                            "columns": {
-                                                "c609fc21-331c-4bbe-81c3-ef8251f3cf80": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "e1c6fec1-182f-4bf2-aa22-434cd1aa9a95": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "data_stream.dataset :\"kubernetes.state_node\" and kubernetes.node.status.ready:\"true\" "
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Total Cores",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "showArrayValues": false,
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.node.cpu.allocatable.cores"
-                                                },
-                                                "f64f7970-3f7d-4f2d-88ae-9e008f2e0bc5": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10000 values of kubernetes.node.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "missingBucket": false,
-                                                        "orderAgg": {
-                                                            "customLabel": false,
-                                                            "dataType": "number",
-                                                            "isBucketed": false,
-                                                            "label": "Count of records",
-                                                            "operationType": "count",
-                                                            "params": {},
-                                                            "scale": "ratio",
-                                                            "sourceField": "___records___"
-                                                        },
-                                                        "orderBy": {
-                                                            "type": "custom"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "secondaryFields": [],
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.node.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "fbaf3405-fab6-4f09-883d-45368cf97670",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": [
-                                            "kubernetes.container",
-                                            "kubernetes.state_node"
-                                        ],
-                                        "type": "phrases",
-                                        "value": [
-                                            "kubernetes.container",
-                                            "kubernetes.state_node"
-                                        ]
-                                    },
-                                    "query": {
-                                        "bool": {
-                                            "minimum_should_match": 1,
-                                            "should": [
-                                                {
-                                                    "match_phrase": {
-                                                        "data_stream.dataset": "kubernetes.container"
-                                                    }
-                                                },
-                                                {
-                                                    "match_phrase": {
-                                                        "data_stream.dataset": "kubernetes.state_node"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "fillOpacity": 0.5,
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "830de93b-4051-4716-99e4-83d625a91288"
-                                        ],
-                                        "collapseFn": "sum",
-                                        "layerId": "c165f898-73a9-48b1-afa9-2b6e75f3cc1f",
-                                        "layerType": "data",
-                                        "palette": {
-                                            "name": "default",
-                                            "type": "palette"
-                                        },
-                                        "seriesType": "area",
-                                        "splitAccessor": "7113c7e7-1af9-4350-b5d2-57abcb60c633",
-                                        "xAccessor": "af01f323-afc0-4b55-b453-8da15facfc28",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#00bfb3",
-                                                "forAccessor": "830de93b-4051-4716-99e4-83d625a91288"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "accessors": [
-                                            "e1c6fec1-182f-4bf2-aa22-434cd1aa9a95"
-                                        ],
-                                        "collapseFn": "sum",
-                                        "layerId": "dde29dcf-00ae-4b80-8d9e-ab45c51efba0",
-                                        "layerType": "data",
-                                        "palette": {
-                                            "name": "negative",
-                                            "type": "palette"
-                                        },
-                                        "seriesType": "line",
-                                        "splitAccessor": "f64f7970-3f7d-4f2d-88ae-9e008f2e0bc5",
-                                        "xAccessor": "c609fc21-331c-4bbe-81c3-ef8251f3cf80",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#bd271e",
-                                                "forAccessor": "e1c6fec1-182f-4bf2-aa22-434cd1aa9a95"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "maxLines": 1,
-                                    "position": "top",
-                                    "shouldTruncate": true,
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "bar_stacked",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide",
-                                "xTitle": "",
-                                "yLeftExtent": {
-                                    "mode": "full"
-                                },
-                                "yLeftScale": "linear",
-                                "yRightExtent": {
-                                    "mode": "full"
-                                },
-                                "yRightScale": "linear",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 9,
-                    "i": "71969826-a34f-4931-a1a0-53787a1e9d68",
-                    "w": 20,
-                    "x": 28,
-                    "y": 4
-                },
-                "panelIndex": "71969826-a34f-4931-a1a0-53787a1e9d68",
-                "title": "Cores used vs total cores",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-2ca9773d-0221-478b-b8bc-90bb8d439f33",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "5c81359c-376d-41bd-984d-60fb106f2e33",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "2ca9773d-0221-478b-b8bc-90bb8d439f33": {
-                                            "columnOrder": [
-                                                "76e50af3-9df6-42c7-9b0e-eea21ab3650f",
-                                                "1a2ebd5d-82b1-4cf8-a934-152a5726a82f",
-                                                "0f308b41-fbc2-41aa-beef-ba6412224944"
-                                            ],
-                                            "columns": {
-                                                "0f308b41-fbc2-41aa-beef-ba6412224944": {
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.pod.status.phase : \"running\" "
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Unique count of kubernetes.pod.name",
-                                                    "operationType": "unique_count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.pod.name"
-                                                },
-                                                "1a2ebd5d-82b1-4cf8-a934-152a5726a82f": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Filters",
-                                                    "operationType": "filters",
-                                                    "params": {
-                                                        "filters": [
-                                                            {
-                                                                "input": {
-                                                                    "language": "kuery",
-                                                                    "query": ""
-                                                                },
-                                                                "label": "Pods per Namespace"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "scale": "ordinal"
-                                                },
-                                                "76e50af3-9df6-42c7-9b0e-eea21ab3650f": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 5 values of kubernetes.namespace",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "0f308b41-fbc2-41aa-beef-ba6412224944",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 5
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.namespace"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "5c81359c-376d-41bd-984d-60fb106f2e33",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.state_pod"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.state_pod"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "gridlinesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "0f308b41-fbc2-41aa-beef-ba6412224944"
-                                        ],
-                                        "layerId": "2ca9773d-0221-478b-b8bc-90bb8d439f33",
-                                        "layerType": "data",
-                                        "palette": {
-                                            "name": "status",
-                                            "type": "palette"
-                                        },
-                                        "position": "top",
-                                        "seriesType": "bar_horizontal",
-                                        "showGridlines": false,
-                                        "splitAccessor": "76e50af3-9df6-42c7-9b0e-eea21ab3650f",
-                                        "xAccessor": "1a2ebd5d-82b1-4cf8-a934-152a5726a82f"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false,
-                                    "position": "right",
-                                    "showSingleSeries": false
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "title": "Empty XY chart",
-                                "valueLabels": "show",
-                                "xTitle": "",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "i": "b1eea36d-fb25-4dbb-82d7-561ec2c39b7a",
-                    "w": 9,
-                    "x": 0,
-                    "y": 13
-                },
-                "panelIndex": "b1eea36d-fb25-4dbb-82d7-561ec2c39b7a",
-                "title": "Running pods per namespace",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "0fa53a1e-0589-4380-b700-70dd489a33de": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "0fa53a1e-0589-4380-b700-70dd489a33de",
-                                    "name": "state-pods-adhoc",
-                                    "runtimeFieldMap": {
-                                        "failed": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "not_running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\" || doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "pending": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"running\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "succeeded": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"succeeded\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                }
-                            },
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "b7b25285-ced1-481d-999e-1886b3463594": {
-                                            "columnOrder": [
-                                                "3d69345e-fb52-485a-8762-fdfaf09ea013",
-                                                "1699b42c-8ab5-43dc-a722-6d70911eae94",
-                                                "1c9e34cf-591d-4a4f-9999-67e95918e933",
-                                                "92280dfe-0252-4993-9c5d-28764c18bc13",
-                                                "1df45e80-f287-4f85-9f8e-6efaddff0f77",
-                                                "866856c3-c189-4457-9240-ab6a9d2df75d"
-                                            ],
-                                            "columns": {
-                                                "1699b42c-8ab5-43dc-a722-6d70911eae94": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Filters",
-                                                    "operationType": "filters",
-                                                    "params": {
-                                                        "filters": [
-                                                            {
-                                                                "input": {
-                                                                    "language": "kuery",
-                                                                    "query": "*"
-                                                                },
-                                                                "label": "Status"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "scale": "ordinal"
-                                                },
-                                                "1c9e34cf-591d-4a4f-9999-67e95918e933": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "running: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Running",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "showArrayValues": false,
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "running"
-                                                },
-                                                "1df45e80-f287-4f85-9f8e-6efaddff0f77": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "pending: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Pending",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "pending"
-                                                },
-                                                "3d69345e-fb52-485a-8762-fdfaf09ea013": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10000 values of kubernetes.pod.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "1df45e80-f287-4f85-9f8e-6efaddff0f77",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.pod.name"
-                                                },
-                                                "866856c3-c189-4457-9240-ab6a9d2df75d": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "failed: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Failed",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "failed"
-                                                },
-                                                "92280dfe-0252-4993-9c5d-28764c18bc13": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "succeeded: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Succeeded",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "succeeded"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "0fa53a1e-0589-4380-b700-70dd489a33de",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.state_pod"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.state_pod"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [
-                                {
-                                    "id": "0fa53a1e-0589-4380-b700-70dd489a33de",
-                                    "name": "indexpattern-datasource-layer-b7b25285-ced1-481d-999e-1886b3463594",
-                                    "type": "index-pattern"
-                                }
-                            ],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "1c9e34cf-591d-4a4f-9999-67e95918e933",
-                                            "92280dfe-0252-4993-9c5d-28764c18bc13",
-                                            "1df45e80-f287-4f85-9f8e-6efaddff0f77",
-                                            "866856c3-c189-4457-9240-ab6a9d2df75d"
-                                        ],
-                                        "collapseFn": "sum",
-                                        "layerId": "b7b25285-ced1-481d-999e-1886b3463594",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_horizontal",
-                                        "showGridlines": false,
-                                        "splitAccessor": "3d69345e-fb52-485a-8762-fdfaf09ea013",
-                                        "xAccessor": "1699b42c-8ab5-43dc-a722-6d70911eae94",
-                                        "yConfig": [
-                                            {
-                                                "color": "#bd271e",
-                                                "forAccessor": "866856c3-c189-4457-9240-ab6a9d2df75d"
-                                            },
-                                            {
-                                                "color": "#fec514",
-                                                "forAccessor": "1df45e80-f287-4f85-9f8e-6efaddff0f77"
-                                            },
-                                            {
-                                                "color": "#00bfb3",
-                                                "forAccessor": "1c9e34cf-591d-4a4f-9999-67e95918e933"
-                                            },
-                                            {
-                                                "color": "#0077cc",
-                                                "forAccessor": "92280dfe-0252-4993-9c5d-28764c18bc13"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "horizontalAlignment": "right",
-                                    "isInside": false,
-                                    "isVisible": false,
-                                    "maxLines": 1,
-                                    "position": "bottom",
-                                    "shouldTruncate": true,
-                                    "showSingleSeries": false,
-                                    "verticalAlignment": "bottom"
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "title": "Empty XY chart",
-                                "valueLabels": "show",
-                                "valuesInLegend": true,
-                                "xTitle": "",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "Total Pods per Namespace [Metrics Kubernetes] (copy 1)",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "i": "4e8a4058-d73f-47dc-b10a-127e0b5d3776",
-                    "w": 9,
-                    "x": 9,
-                    "y": 13
-                },
-                "panelIndex": "4e8a4058-d73f-47dc-b10a-127e0b5d3776",
-                "title": "Pods",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "0b9c02fc-3c21-47e2-abed-31cbc41b11cc": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "0b9c02fc-3c21-47e2-abed-31cbc41b11cc",
-                                    "name": "state_deployment-ad-hoc",
-                                    "runtimeFieldMap": {
-                                        "not_ready": {
-                                            "script": {
-                                                "source": "if (doc[\"kubernetes.deployment.replicas.desired\"].value - doc[\"kubernetes.deployment.replicas.available\"].value != 0) { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "ready": {
-                                            "script": {
-                                                "source": "if (doc[\"kubernetes.deployment.replicas.desired\"].value - doc[\"kubernetes.deployment.replicas.available\"].value == 0) { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                },
-                                "0fa53a1e-0589-4380-b700-70dd489a33de": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "0fa53a1e-0589-4380-b700-70dd489a33de",
-                                    "name": "state-pods-adhoc",
-                                    "runtimeFieldMap": {
-                                        "failed": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "not_running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\" || doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "pending": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"running\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "succeeded": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"succeeded\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                },
-                                "34c15200-5232-4a16-8fb0-36ca5a194638": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "34c15200-5232-4a16-8fb0-36ca5a194638",
-                                    "name": "deployments-ad-hoc",
-                                    "runtimeFieldMap": {
-                                        "not_running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.deployment.paused'].value == true) { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.deployment.paused'].value == false) { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                },
-                                "f8fa576a-6f91-4a11-a43d-7f3964869d7d": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "f8fa576a-6f91-4a11-a43d-7f3964869d7d",
-                                    "name": "daemonsets-ad-hoc",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                }
-                            },
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "b7b25285-ced1-481d-999e-1886b3463594": {
-                                            "columnOrder": [
-                                                "6690f3c6-3a05-47e0-8f98-5baea37f351c",
-                                                "2b790ab1-6a55-4c4c-9131-964752309c72",
-                                                "143fa2b5-a63f-4d51-9207-f6e3441dd124",
-                                                "16807879-5684-4aab-9b80-cc701f820e68"
-                                            ],
-                                            "columns": {
-                                                "143fa2b5-a63f-4d51-9207-f6e3441dd124": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "ready: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Ready",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "ready"
-                                                },
-                                                "16807879-5684-4aab-9b80-cc701f820e68": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "not_ready: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Not Ready",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "not_ready"
-                                                },
-                                                "2b790ab1-6a55-4c4c-9131-964752309c72": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Filters",
-                                                    "operationType": "filters",
-                                                    "params": {
-                                                        "filters": [
-                                                            {
-                                                                "input": {
-                                                                    "language": "kuery",
-                                                                    "query": ""
-                                                                },
-                                                                "label": "Status"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "scale": "ordinal"
-                                                },
-                                                "6690f3c6-3a05-47e0-8f98-5baea37f351c": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10000 values of kubernetes.deployment.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "143fa2b5-a63f-4d51-9207-f6e3441dd124",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.deployment.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "0b9c02fc-3c21-47e2-abed-31cbc41b11cc",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.state_deployment"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.state_deployment"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [
-                                {
-                                    "id": "0b9c02fc-3c21-47e2-abed-31cbc41b11cc",
-                                    "name": "indexpattern-datasource-layer-b7b25285-ced1-481d-999e-1886b3463594",
-                                    "type": "index-pattern"
-                                }
-                            ],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "gridlinesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "143fa2b5-a63f-4d51-9207-f6e3441dd124",
-                                            "16807879-5684-4aab-9b80-cc701f820e68"
-                                        ],
-                                        "collapseFn": "sum",
-                                        "layerId": "b7b25285-ced1-481d-999e-1886b3463594",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_horizontal",
-                                        "showGridlines": false,
-                                        "splitAccessor": "6690f3c6-3a05-47e0-8f98-5baea37f351c",
-                                        "xAccessor": "2b790ab1-6a55-4c4c-9131-964752309c72",
-                                        "yConfig": [
-                                            {
-                                                "color": "#bd271e",
-                                                "forAccessor": "16807879-5684-4aab-9b80-cc701f820e68"
-                                            },
-                                            {
-                                                "color": "#00bfb3",
-                                                "forAccessor": "143fa2b5-a63f-4d51-9207-f6e3441dd124"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false,
-                                    "position": "right",
-                                    "showSingleSeries": false
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "title": "Empty XY chart",
-                                "valueLabels": "show",
-                                "xTitle": "",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "Total Pods per Namespace [Metrics Kubernetes] (copy 1)",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "i": "ffaac795-f750-4af1-93ad-d4dbdf150edc",
-                    "w": 10,
-                    "x": 18,
-                    "y": 13
-                },
-                "panelIndex": "ffaac795-f750-4af1-93ad-d4dbdf150edc",
-                "title": "Deployments",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "0fa53a1e-0589-4380-b700-70dd489a33de": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "0fa53a1e-0589-4380-b700-70dd489a33de",
-                                    "name": "state-pods-adhoc",
-                                    "runtimeFieldMap": {
-                                        "failed": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "not_running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\" || doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "pending": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"running\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "succeeded": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"succeeded\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                },
-                                "295ecdc5-f413-4f20-9f77-74927a10d33d": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "295ecdc5-f413-4f20-9f77-74927a10d33d",
-                                    "name": "state_daemonset-ad-hoc",
-                                    "runtimeFieldMap": {
-                                        "not_ready": {
-                                            "script": {
-                                                "source": "if (doc[\"kubernetes.daemonset.replicas.desired\"].value - doc[\"kubernetes.daemonset.replicas.ready\"].value != 0) {emit(1)}"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "ready": {
-                                            "script": {
-                                                "source": "if (doc[\"kubernetes.daemonset.replicas.desired\"].value - doc[\"kubernetes.daemonset.replicas.ready\"].value == 0) {emit(1)}"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                },
-                                "f8fa576a-6f91-4a11-a43d-7f3964869d7d": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "f8fa576a-6f91-4a11-a43d-7f3964869d7d",
-                                    "name": "daemonsets-ad-hoc",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                }
-                            },
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "b7b25285-ced1-481d-999e-1886b3463594": {
-                                            "columnOrder": [
-                                                "e36fb66d-f9b0-46d3-aec4-52638d34d308",
-                                                "5b89a3a0-f94e-49c2-bc43-fdd4c7671ea5",
-                                                "0e2a3f8d-cc26-453d-bed1-b184e48756b2",
-                                                "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c"
-                                            ],
-                                            "columns": {
-                                                "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "not_ready: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Not Ready",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "not_ready"
-                                                },
-                                                "0e2a3f8d-cc26-453d-bed1-b184e48756b2": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "ready: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Ready",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "ready"
-                                                },
-                                                "5b89a3a0-f94e-49c2-bc43-fdd4c7671ea5": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Filters",
-                                                    "operationType": "filters",
-                                                    "params": {
-                                                        "filters": [
-                                                            {
-                                                                "input": {
-                                                                    "language": "kuery",
-                                                                    "query": ""
-                                                                },
-                                                                "label": "Status"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "scale": "ordinal"
-                                                },
-                                                "e36fb66d-f9b0-46d3-aec4-52638d34d308": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10000 values of kubernetes.daemonset.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "0e2a3f8d-cc26-453d-bed1-b184e48756b2",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.daemonset.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "295ecdc5-f413-4f20-9f77-74927a10d33d",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.state_daemonset"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.state_daemonset"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [
-                                {
-                                    "id": "295ecdc5-f413-4f20-9f77-74927a10d33d",
-                                    "name": "indexpattern-datasource-layer-b7b25285-ced1-481d-999e-1886b3463594",
-                                    "type": "index-pattern"
-                                }
-                            ],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "gridlinesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "0e2a3f8d-cc26-453d-bed1-b184e48756b2",
-                                            "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c"
-                                        ],
-                                        "collapseFn": "sum",
-                                        "layerId": "b7b25285-ced1-481d-999e-1886b3463594",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_horizontal",
-                                        "showGridlines": false,
-                                        "splitAccessor": "e36fb66d-f9b0-46d3-aec4-52638d34d308",
-                                        "xAccessor": "5b89a3a0-f94e-49c2-bc43-fdd4c7671ea5",
-                                        "yConfig": [
-                                            {
-                                                "color": "#bd271e",
-                                                "forAccessor": "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c"
-                                            },
-                                            {
-                                                "color": "#00bfb3",
-                                                "forAccessor": "0e2a3f8d-cc26-453d-bed1-b184e48756b2"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false,
-                                    "position": "bottom",
-                                    "showSingleSeries": false
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "title": "Empty XY chart",
-                                "valueLabels": "show",
-                                "valuesInLegend": true,
-                                "xTitle": "",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "Total Pods per Namespace [Metrics Kubernetes] (copy 1)",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "i": "a7b43ea1-450d-4eed-8c9f-cd5ff5b9d6c4",
-                    "w": 10,
-                    "x": 28,
-                    "y": 13
-                },
-                "panelIndex": "a7b43ea1-450d-4eed-8c9f-cd5ff5b9d6c4",
-                "title": "DaemonSets",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "0fa53a1e-0589-4380-b700-70dd489a33de": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "0fa53a1e-0589-4380-b700-70dd489a33de",
-                                    "name": "state-pods-adhoc",
-                                    "runtimeFieldMap": {
-                                        "failed": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "not_running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\" || doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "pending": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"running\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "succeeded": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"succeeded\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                },
-                                "dbfaeb6f-4fff-4043-8bf8-19d5345fd339": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "dbfaeb6f-4fff-4043-8bf8-19d5345fd339",
-                                    "name": "state_replicaset_ad-hoc",
-                                    "runtimeFieldMap": {
-                                        "not_ready": {
-                                            "script": {
-                                                "source": "def ready = doc['kubernetes.replicaset.replicas.ready'].value;\ndef des = doc['kubernetes.replicaset.replicas.desired'].value;\nemit(des-ready)"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                },
-                                "f8fa576a-6f91-4a11-a43d-7f3964869d7d": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "f8fa576a-6f91-4a11-a43d-7f3964869d7d",
-                                    "name": "daemonsets-ad-hoc",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                }
-                            },
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "b7b25285-ced1-481d-999e-1886b3463594": {
-                                            "columnOrder": [
-                                                "fcc76997-5b49-416b-81ba-37d65ea25296",
-                                                "446fc0b3-a6c8-4f4d-914b-748d488083a1",
-                                                "a51a9822-167b-4b8f-b7a6-3051da30164b",
-                                                "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920"
-                                            ],
-                                            "columns": {
-                                                "446fc0b3-a6c8-4f4d-914b-748d488083a1": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Filters",
-                                                    "operationType": "filters",
-                                                    "params": {
-                                                        "filters": [
-                                                            {
-                                                                "input": {
-                                                                    "language": "kuery",
-                                                                    "query": ""
-                                                                },
-                                                                "label": "Status"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "scale": "ordinal"
-                                                },
-                                                "a51a9822-167b-4b8f-b7a6-3051da30164b": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.replicaset.replicas.ready: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Ready",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.replicaset.replicas.ready"
-                                                },
-                                                "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "not_ready: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Not Ready",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "not_ready"
-                                                },
-                                                "fcc76997-5b49-416b-81ba-37d65ea25296": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10000 values of kubernetes.replicaset.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "a51a9822-167b-4b8f-b7a6-3051da30164b",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.replicaset.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "dbfaeb6f-4fff-4043-8bf8-19d5345fd339",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.state_replicaset"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.state_replicaset"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [
-                                {
-                                    "id": "dbfaeb6f-4fff-4043-8bf8-19d5345fd339",
-                                    "name": "indexpattern-datasource-layer-b7b25285-ced1-481d-999e-1886b3463594",
-                                    "type": "index-pattern"
-                                }
-                            ],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "gridlinesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "a51a9822-167b-4b8f-b7a6-3051da30164b",
-                                            "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920"
-                                        ],
-                                        "collapseFn": "sum",
-                                        "layerId": "b7b25285-ced1-481d-999e-1886b3463594",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_horizontal",
-                                        "showGridlines": false,
-                                        "splitAccessor": "fcc76997-5b49-416b-81ba-37d65ea25296",
-                                        "xAccessor": "446fc0b3-a6c8-4f4d-914b-748d488083a1",
-                                        "yConfig": [
-                                            {
-                                                "color": "#bd271e",
-                                                "forAccessor": "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920"
-                                            },
-                                            {
-                                                "color": "#00bfb3",
-                                                "forAccessor": "a51a9822-167b-4b8f-b7a6-3051da30164b"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false,
-                                    "position": "right",
-                                    "showSingleSeries": false
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "title": "Empty XY chart",
-                                "valueLabels": "show",
-                                "xTitle": "",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "Total Pods per Namespace [Metrics Kubernetes] (copy 1)",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "i": "cec0ea1d-0385-4aa8-b9f1-c0e2c73b5b0b",
-                    "w": 10,
-                    "x": 38,
-                    "y": 13
-                },
-                "panelIndex": "cec0ea1d-0385-4aa8-b9f1-c0e2c73b5b0b",
-                "title": "ReplicaSets",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "description": "Pod cpu utilization is calculated as a ratio of the node's allocatable cpu",
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-06a776d4-f25a-45c0-a54e-82d0cb913047",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "c130c98c-51ad-49ce-9e28-1dddc0329421",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "06a776d4-f25a-45c0-a54e-82d0cb913047": {
-                                            "columnOrder": [
-                                                "f4242bda-ae9c-4d7c-8cda-43f56c38acb5",
-                                                "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
-                                            ],
-                                            "columns": {
-                                                "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "\"kubernetes.pod.cpu.usage.node.pct\": *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Average Pod CPU Usage ",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "percent",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        },
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.pod.cpu.usage.node.pct"
-                                                },
-                                                "f4242bda-ae9c-4d7c-8cda-43f56c38acb5": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 5 values of kubernetes.pod.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "accuracyMode": true,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 5
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.pod.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "field": "kubernetes.pod.cpu.usage.node.pct",
-                                        "index": "c130c98c-51ad-49ce-9e28-1dddc0329421",
-                                        "key": "kubernetes.pod.cpu.usage.node.pct",
-                                        "negate": false,
-                                        "type": "exists",
-                                        "value": "exists"
-                                    },
-                                    "query": {
-                                        "exists": {
-                                            "field": "kubernetes.pod.cpu.usage.node.pct"
-                                        }
-                                    }
-                                },
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "a06a30d5-05f1-46ea-9075-3e6051f5781a",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.pod"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.pod"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
-                                        ],
-                                        "layerId": "06a776d4-f25a-45c0-a54e-82d0cb913047",
-                                        "layerType": "data",
-                                        "seriesType": "bar_horizontal",
-                                        "xAccessor": "f4242bda-ae9c-4d7c-8cda-43f56c38acb5",
-                                        "yConfig": [
-                                            {
-                                                "color": "#00bfb3",
-                                                "forAccessor": "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false,
-                                    "position": "right",
-                                    "showSingleSeries": false
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "valueLabels": "show",
-                                "xTitle": "",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "Cpu Usage per Namespace [Metrics Kubernetes]",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "description": "Pod cpu utilization is calculated as a ratio of the node's allocatable cpu",
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 11,
-                    "i": "b0a580d6-41a8-4a71-a129-0d2fcb029851",
-                    "w": 12,
-                    "x": 0,
-                    "y": 19
-                },
-                "panelIndex": "b0a580d6-41a8-4a71-a129-0d2fcb029851",
-                "title": "Top CPU intensive pods per Node",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-06a776d4-f25a-45c0-a54e-82d0cb913047",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "a06a30d5-05f1-46ea-9075-3e6051f5781a",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "9c0b0d2f-c443-4c41-b55c-c7ad0db60302",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "06a776d4-f25a-45c0-a54e-82d0cb913047": {
-                                            "columnOrder": [
-                                                "f4242bda-ae9c-4d7c-8cda-43f56c38acb5",
-                                                "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
-                                            ],
-                                            "columns": {
-                                                "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.pod.cpu.usage.limit.pct: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Average Pod CPU Usage ",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "percent",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        },
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.pod.cpu.usage.limit.pct"
-                                                },
-                                                "f4242bda-ae9c-4d7c-8cda-43f56c38acb5": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 5 values of kubernetes.pod.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "accuracyMode": true,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 5
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.pod.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "a06a30d5-05f1-46ea-9075-3e6051f5781a",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.pod"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.pod"
-                                        }
-                                    }
-                                },
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "9c0b0d2f-c443-4c41-b55c-c7ad0db60302",
-                                        "key": "kubernetes.pod.cpu.usage.limit.pct",
-                                        "negate": false,
-                                        "type": "exists",
-                                        "value": "exists"
-                                    },
-                                    "query": {
-                                        "exists": {
-                                            "field": "kubernetes.pod.cpu.usage.limit.pct"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
-                                        ],
-                                        "layerId": "06a776d4-f25a-45c0-a54e-82d0cb913047",
-                                        "layerType": "data",
-                                        "seriesType": "bar_horizontal",
-                                        "xAccessor": "f4242bda-ae9c-4d7c-8cda-43f56c38acb5",
-                                        "yConfig": [
-                                            {
-                                                "color": "#00bfb3",
-                                                "forAccessor": "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false,
-                                    "position": "right",
-                                    "showSingleSeries": false
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "valueLabels": "show",
-                                "xTitle": "",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "Cpu Usage per Namespace [Metrics Kubernetes]",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "description": "Pod cpu utilization is calculated as a ratio of the pod's total container limits. If any container is missing a limit the metric is not emitted.",
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 11,
-                    "i": "34df5a62-0b8b-491b-b2c2-5aa11f291c7f",
-                    "w": 12,
-                    "x": 12,
-                    "y": 19
-                },
-                "panelIndex": "34df5a62-0b8b-491b-b2c2-5aa11f291c7f",
-                "title": "Top CPU intensive pods per Pod Limit",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-06a776d4-f25a-45c0-a54e-82d0cb913047",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "8769bfd6-a9c7-4bab-b048-0e2fcffe8114",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "d79e5279-bd92-48b0-bd92-767cf6b8892d",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "06a776d4-f25a-45c0-a54e-82d0cb913047": {
-                                            "columnOrder": [
-                                                "f4242bda-ae9c-4d7c-8cda-43f56c38acb5",
-                                                "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
-                                            ],
-                                            "columns": {
-                                                "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.pod.memory.usage.limit.pct: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Average Pod memory Usage ",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "percent",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        },
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.pod.memory.usage.limit.pct"
-                                                },
-                                                "f4242bda-ae9c-4d7c-8cda-43f56c38acb5": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 5 values of kubernetes.pod.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "accuracyMode": true,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 5
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.pod.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "8769bfd6-a9c7-4bab-b048-0e2fcffe8114",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.pod"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.pod"
-                                        }
-                                    }
-                                },
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "d79e5279-bd92-48b0-bd92-767cf6b8892d",
-                                        "key": "kubernetes.pod.memory.usage.limit.pct",
-                                        "negate": false,
-                                        "type": "exists",
-                                        "value": "exists"
-                                    },
-                                    "query": {
-                                        "exists": {
-                                            "field": "kubernetes.pod.memory.usage.limit.pct"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
-                                        ],
-                                        "layerId": "06a776d4-f25a-45c0-a54e-82d0cb913047",
-                                        "layerType": "data",
-                                        "seriesType": "bar_horizontal",
-                                        "xAccessor": "f4242bda-ae9c-4d7c-8cda-43f56c38acb5",
-                                        "yConfig": [
-                                            {
-                                                "color": "#00bfb3",
-                                                "forAccessor": "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false,
-                                    "position": "right",
-                                    "showSingleSeries": false
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "valueLabels": "show",
-                                "xTitle": "",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "Cpu Usage per Namespace [Metrics Kubernetes]",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "description": "Pod memory utilization is calculated as a ratio of the pod's total container memory limits. If any container is missing a limit the metric is not emitted.",
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 11,
-                    "i": "27d290d0-3d53-4701-a9b7-82fc26d4dff7",
-                    "w": 12,
-                    "x": 36,
-                    "y": 19
-                },
-                "panelIndex": "27d290d0-3d53-4701-a9b7-82fc26d4dff7",
-                "title": "Top Memory intensive pods per Pod Limit",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-a69d8e15-2ebf-401c-af12-4b6762f230db",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "086a73a8-ac9d-48eb-b5b7-3c697278cc9e",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "a69d8e15-2ebf-401c-af12-4b6762f230db": {
-                                            "columnOrder": [
-                                                "be5ed114-ba6d-42c6-b8ff-da6142c14a1b",
-                                                "b0cd680f-edeb-4934-aceb-6820ad9f01ec",
-                                                "b7df21c2-ee65-47cb-9370-294846cfbb65"
-                                            ],
-                                            "columns": {
-                                                "b0cd680f-edeb-4934-aceb-6820ad9f01ec": {
-                                                    "customLabel": false,
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": false,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "b7df21c2-ee65-47cb-9370-294846cfbb65": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.event.metadata.uid: * and kubernetes.event.type : \"Warning\" "
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "New Warnings",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.event.metadata.uid"
-                                                },
-                                                "be5ed114-ba6d-42c6-b8ff-da6142c14a1b": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top values of kubernetes.event.involved_object.uid + 1 other",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "b7df21c2-ee65-47cb-9370-294846cfbb65",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "multi_terms"
-                                                        },
-                                                        "secondaryFields": [
-                                                            "kubernetes.event.type"
-                                                        ],
-                                                        "size": 1000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.event.involved_object.uid"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "086a73a8-ac9d-48eb-b5b7-3c697278cc9e",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.event"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.event"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "Linear",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "b7df21c2-ee65-47cb-9370-294846cfbb65"
-                                        ],
-                                        "collapseFn": "sum",
-                                        "layerId": "a69d8e15-2ebf-401c-af12-4b6762f230db",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_stacked",
-                                        "showGridlines": false,
-                                        "splitAccessor": "be5ed114-ba6d-42c6-b8ff-da6142c14a1b",
-                                        "xAccessor": "b0cd680f-edeb-4934-aceb-6820ad9f01ec",
-                                        "yConfig": [
-                                            {
-                                                "color": "#fec514",
-                                                "forAccessor": "b7df21c2-ee65-47cb-9370-294846cfbb65"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "bar_stacked",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide",
-                                "xTitle": "",
-                                "yLeftExtent": {
-                                    "mode": "full"
-                                },
-                                "yLeftScale": "linear",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 11,
-                    "i": "b18e07f5-a634-49b1-a732-65491c00a9b3",
-                    "w": 24,
-                    "x": 0,
-                    "y": 30
-                },
-                "panelIndex": "b18e07f5-a634-49b1-a732-65491c00a9b3",
-                "title": "Kubernetes warning events",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "description": "Pod memory utilization is calculated as a ratio of the node's allocatable memory",
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-06a776d4-f25a-45c0-a54e-82d0cb913047",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "00370cba-2ec2-4a60-931d-213ecb9916f3",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "94756f64-5bc4-4b8b-a9bb-0ecb5141a2b1",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "06a776d4-f25a-45c0-a54e-82d0cb913047": {
-                                            "columnOrder": [
-                                                "f4242bda-ae9c-4d7c-8cda-43f56c38acb5",
-                                                "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
-                                            ],
-                                            "columns": {
-                                                "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "\"kubernetes.pod.memory.usage.node.pct\": *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Average Pod memory Usage ",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "percent",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        },
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.pod.memory.usage.node.pct"
-                                                },
-                                                "f4242bda-ae9c-4d7c-8cda-43f56c38acb5": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 5 values of kubernetes.pod.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "accuracyMode": true,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 5
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.pod.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "00370cba-2ec2-4a60-931d-213ecb9916f3",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.pod"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.pod"
-                                        }
-                                    }
-                                },
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "field": "kubernetes.pod.memory.usage.node.pct",
-                                        "index": "94756f64-5bc4-4b8b-a9bb-0ecb5141a2b1",
-                                        "key": "kubernetes.pod.memory.usage.node.pct",
-                                        "negate": false,
-                                        "type": "exists",
-                                        "value": "exists"
-                                    },
-                                    "query": {
-                                        "exists": {
-                                            "field": "kubernetes.pod.memory.usage.node.pct"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
-                                        ],
-                                        "layerId": "06a776d4-f25a-45c0-a54e-82d0cb913047",
-                                        "layerType": "data",
-                                        "seriesType": "bar_horizontal",
-                                        "xAccessor": "f4242bda-ae9c-4d7c-8cda-43f56c38acb5",
-                                        "yConfig": [
-                                            {
-                                                "color": "#00bfb3",
-                                                "forAccessor": "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false,
-                                    "position": "right",
-                                    "showSingleSeries": false
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "valueLabels": "show",
-                                "xTitle": "",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "Cpu Usage per Namespace [Metrics Kubernetes]",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "description": "Pod memory utilization is calculated as a ratio of the node's allocatable memory",
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 11,
-                    "i": "dfa9777a-a9d5-469f-ab90-c1bcf6045d85",
-                    "w": 12,
-                    "x": 24,
-                    "y": 19
-                },
-                "panelIndex": "dfa9777a-a9d5-469f-ab90-c1bcf6045d85",
-                "title": "Top Memory intensive pods per Node",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "columns": [
-                            "kubernetes.event.type",
-                            "kubernetes.event.reason",
-                            "kubernetes.event.involved_object.name"
-                        ],
-                        "description": "Kubernetes Warnings",
-                        "grid": {
-                            "columns": {
-                                "kubernetes.event.involved_object.kind": {
-                                    "width": 198.30555555555554
-                                },
-                                "kubernetes.event.metadata.namespace": {
-                                    "width": 249.83333333333337
-                                },
-                                "kubernetes.event.reason": {
-                                    "width": 176.33333333333331
-                                },
-                                "kubernetes.event.type": {
-                                    "width": 156.91666666666663
-                                }
-                            }
-                        },
-                        "hideChart": false,
-                        "isTextBasedQuery": false,
-                        "kibanaSavedObjectMeta": {
-                            "searchSourceJSON": {
-                                "filter": [
-                                    {
-                                        "$state": {
-                                            "store": "appState"
-                                        },
-                                        "meta": {
-                                            "alias": null,
-                                            "disabled": false,
-                                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                                            "key": "kubernetes.event.type",
-                                            "negate": false,
-                                            "params": {
-                                                "query": "Warning"
-                                            },
-                                            "type": "phrase"
-                                        },
-                                        "query": {
-                                            "match_phrase": {
-                                                "kubernetes.event.type": "Warning"
-                                            }
-                                        }
-                                    }
-                                ],
-                                "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
-                                "query": {
-                                    "language": "kuery",
-                                    "query": "data_stream.dataset :\"kubernetes.event\" "
-                                }
-                            }
-                        },
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "rowHeight": -1,
-                        "sort": [
-                            [
-                                "@timestamp",
-                                "desc"
+                              {
+                                "input": {
+                                  "language": "kuery",
+                                  "query": ""
+                                },
+                                "label": "Status"
+                              }
                             ]
-                        ],
-                        "timeRestore": false,
-                        "title": "Kubernetes Warnings",
-                        "usesAdHocDataView": false
+                          },
+                          "scale": "ordinal"
+                        },
+                        "4314b1bf-95bb-477a-9708-ff7324356bda": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "ready: *"
+                          },
+                          "isBucketed": false,
+                          "label": "Ready",
+                          "operationType": "last_value",
+                          "params": {
+                            "sortField": "@timestamp"
+                          },
+                          "reducedTimeRange": "1m",
+                          "scale": "ratio",
+                          "sourceField": "ready"
+                        },
+                        "607cddcf-ff9a-46a5-b3d6-b6f268ead1e4": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "not_ready: *"
+                          },
+                          "isBucketed": false,
+                          "label": "Not Ready",
+                          "operationType": "last_value",
+                          "params": {
+                            "sortField": "@timestamp"
+                          },
+                          "reducedTimeRange": "1m",
+                          "scale": "ratio",
+                          "sourceField": "not_ready"
+                        },
+                        "977fa7a0-b026-427b-8ffd-ee07fd69b50e": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top 10000 values of kubernetes.node.name",
+                          "operationType": "terms",
+                          "params": {
+                            "exclude": [],
+                            "excludeIsRegex": false,
+                            "include": [],
+                            "includeIsRegex": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "columnId": "4314b1bf-95bb-477a-9708-ff7324356bda",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": true,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 10000
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.node.name"
+                        }
+                      },
+                      "incompleteColumns": {}
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "31c14ad9-51fd-465c-957c-b0171c23a0bb",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.state_node"
                     },
-                    "enhancements": {},
-                    "hidePanelTitles": false
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.state_node"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [
+                {
+                  "id": "d1e9a0d9-4696-43cb-b9f1-a4b0b9fe3732",
+                  "name": "indexpattern-datasource-layer-b7b25285-ced1-481d-999e-1886b3463594",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
                 },
-                "gridData": {
-                    "h": 11,
-                    "i": "ea51b3fb-2b45-4bee-9890-685a76fb836d",
-                    "w": 24,
-                    "x": 24,
-                    "y": 30
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
                 },
-                "panelIndex": "ea51b3fb-2b45-4bee-9890-685a76fb836d",
-                "title": "Latest Kubernetes warnings",
-                "type": "search"
+                "layers": [
+                  {
+                    "accessors": [
+                      "4314b1bf-95bb-477a-9708-ff7324356bda",
+                      "607cddcf-ff9a-46a5-b3d6-b6f268ead1e4"
+                    ],
+                    "collapseFn": "sum",
+                    "layerId": "b7b25285-ced1-481d-999e-1886b3463594",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "bar_horizontal",
+                    "showGridlines": false,
+                    "splitAccessor": "977fa7a0-b026-427b-8ffd-ee07fd69b50e",
+                    "xAccessor": "1b46f7a2-12d8-4773-87db-118234d45186",
+                    "yConfig": [
+                      {
+                        "color": "#a63a38",
+                        "forAccessor": "607cddcf-ff9a-46a5-b3d6-b6f268ead1e4"
+                      },
+                      {
+                        "color": "#00bfb3",
+                        "forAccessor": "4314b1bf-95bb-477a-9708-ff7324356bda"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": false,
+                  "position": "right",
+                  "showSingleSeries": false
+                },
+                "preferredSeriesType": "bar_horizontal",
+                "tickLabelsVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "title": "Empty XY chart",
+                "valueLabels": "show",
+                "xTitle": "",
+                "yTitle": ""
+              }
+            },
+            "title": "Total Pods per Namespace [Metrics Kubernetes] (copy 1)",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
             }
-        ],
-        "timeRestore": false,
-        "title": "[Metrics Kubernetes] Cluster Overview",
-        "version": 2
-    },
-    "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-09-09T11:49:12.715Z",
-    "created_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0",
-    "id": "kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c",
-    "managed": false,
-    "references": [
-        {
-            "id": "metrics-*",
-            "name": "3ef5ba86-ebb8-4ba6-941d-ad45de8d94e2:indexpattern-datasource-layer-dfd1702f-213e-4fa2-98e3-5106657c62e7",
-            "type": "index-pattern"
+          },
+          "hidePanelTitles": false
         },
-        {
-            "id": "metrics-*",
-            "name": "3ef5ba86-ebb8-4ba6-941d-ad45de8d94e2:indexpattern-datasource-layer-dff09473-7596-48c7-bbf4-beccee70d845",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 9,
+          "i": "7116207b-48ce-4d93-9fbd-26d73af1c185",
+          "w": 8,
+          "x": 0,
+          "y": 4
         },
-        {
-            "id": "metrics-*",
-            "name": "71969826-a34f-4931-a1a0-53787a1e9d68:indexpattern-datasource-layer-c165f898-73a9-48b1-afa9-2b6e75f3cc1f",
-            "type": "index-pattern"
+        "panelIndex": "7116207b-48ce-4d93-9fbd-26d73af1c185",
+        "title": "Nodes",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-dfd1702f-213e-4fa2-98e3-5106657c62e7",
+                "type": "index-pattern"
+              },
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-dff09473-7596-48c7-bbf4-beccee70d845",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "dfd1702f-213e-4fa2-98e3-5106657c62e7": {
+                      "columnOrder": [
+                        "f0953a4e-8498-4b22-a63a-d24e4a069ed3",
+                        "5c33dcdb-21de-4bdc-b564-ba82ed037d11",
+                        "62125b6d-3199-420b-9d3b-46f159e15d7f"
+                      ],
+                      "columns": {
+                        "5c33dcdb-21de-4bdc-b564-ba82ed037d11": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "62125b6d-3199-420b-9d3b-46f159e15d7f": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "kubernetes.node.status.ready:\"true\" and data_stream.dataset :\"kubernetes.state_node\" "
+                          },
+                          "isBucketed": false,
+                          "label": "Total Memory",
+                          "operationType": "last_value",
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            },
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.node.memory.allocatable.bytes"
+                        },
+                        "f0953a4e-8498-4b22-a63a-d24e4a069ed3": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top 10000 values of kubernetes.node.name",
+                          "operationType": "terms",
+                          "params": {
+                            "missingBucket": false,
+                            "orderAgg": {
+                              "customLabel": false,
+                              "dataType": "number",
+                              "isBucketed": false,
+                              "label": "Count of records",
+                              "operationType": "count",
+                              "params": {},
+                              "scale": "ratio",
+                              "sourceField": "___records___"
+                            },
+                            "orderBy": {
+                              "type": "custom"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": false,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "secondaryFields": [],
+                            "size": 10000
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.node.name"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    },
+                    "dff09473-7596-48c7-bbf4-beccee70d845": {
+                      "columnOrder": [
+                        "6677e92c-5874-49c1-979e-c16c0d3838cd",
+                        "46082fb5-9abc-42a0-8e4d-8a8d40a66ddf",
+                        "307be273-94a6-41ab-b93b-0debde733492"
+                      ],
+                      "columns": {
+                        "307be273-94a6-41ab-b93b-0debde733492": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "data_stream.dataset :\"kubernetes.container\"    "
+                          },
+                          "isBucketed": false,
+                          "label": "Memory Used",
+                          "operationType": "last_value",
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            },
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.container.memory.usage.bytes"
+                        },
+                        "46082fb5-9abc-42a0-8e4d-8a8d40a66ddf": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "6677e92c-5874-49c1-979e-c16c0d3838cd": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top 10000 values of container.id",
+                          "operationType": "terms",
+                          "params": {
+                            "missingBucket": false,
+                            "orderAgg": {
+                              "customLabel": false,
+                              "dataType": "number",
+                              "isBucketed": false,
+                              "label": "Count of records",
+                              "operationType": "count",
+                              "params": {},
+                              "scale": "ratio",
+                              "sourceField": "___records___"
+                            },
+                            "orderBy": {
+                              "type": "custom"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": false,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "secondaryFields": [],
+                            "size": 10000
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "container.id"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "21cde57c-0e69-4e4c-b3e9-659de2778d06",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": [
+                      "kubernetes.container",
+                      "kubernetes.state_node"
+                    ],
+                    "type": "phrases",
+                    "value": [
+                      "kubernetes.container",
+                      "kubernetes.state_node"
+                    ]
+                  },
+                  "query": {
+                    "bool": {
+                      "minimum_should_match": 1,
+                      "should": [
+                        {
+                          "match_phrase": {
+                            "data_stream.dataset": "kubernetes.container"
+                          }
+                        },
+                        {
+                          "match_phrase": {
+                            "data_stream.dataset": "kubernetes.state_node"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "fillOpacity": 0.5,
+                "fittingFunction": "None",
+                "gridlinesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "307be273-94a6-41ab-b93b-0debde733492"
+                    ],
+                    "collapseFn": "sum",
+                    "layerId": "dff09473-7596-48c7-bbf4-beccee70d845",
+                    "layerType": "data",
+                    "palette": {
+                      "name": "default",
+                      "type": "palette"
+                    },
+                    "seriesType": "area",
+                    "splitAccessor": "6677e92c-5874-49c1-979e-c16c0d3838cd",
+                    "xAccessor": "46082fb5-9abc-42a0-8e4d-8a8d40a66ddf",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "color": "#00bfb3",
+                        "forAccessor": "307be273-94a6-41ab-b93b-0debde733492"
+                      }
+                    ]
+                  },
+                  {
+                    "accessors": [
+                      "62125b6d-3199-420b-9d3b-46f159e15d7f"
+                    ],
+                    "collapseFn": "sum",
+                    "layerId": "dfd1702f-213e-4fa2-98e3-5106657c62e7",
+                    "layerType": "data",
+                    "palette": {
+                      "name": "negative",
+                      "type": "palette"
+                    },
+                    "seriesType": "line",
+                    "splitAccessor": "f0953a4e-8498-4b22-a63a-d24e4a069ed3",
+                    "xAccessor": "5c33dcdb-21de-4bdc-b564-ba82ed037d11",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "color": "#bd271e",
+                        "forAccessor": "62125b6d-3199-420b-9d3b-46f159e15d7f"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 1,
+                  "position": "top",
+                  "shouldTruncate": true,
+                  "showSingleSeries": true
+                },
+                "preferredSeriesType": "bar_stacked",
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "valueLabels": "hide",
+                "xTitle": "",
+                "yLeftExtent": {
+                  "mode": "full"
+                },
+                "yLeftScale": "linear",
+                "yRightExtent": {
+                  "mode": "full"
+                },
+                "yRightScale": "linear",
+                "yTitle": ""
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {},
+          "hidePanelTitles": false
         },
-        {
-            "id": "metrics-*",
-            "name": "71969826-a34f-4931-a1a0-53787a1e9d68:indexpattern-datasource-layer-dde29dcf-00ae-4b80-8d9e-ab45c51efba0",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 9,
+          "i": "3ef5ba86-ebb8-4ba6-941d-ad45de8d94e2",
+          "w": 20,
+          "x": 8,
+          "y": 4
         },
-        {
-            "id": "metrics-*",
-            "name": "b1eea36d-fb25-4dbb-82d7-561ec2c39b7a:indexpattern-datasource-layer-2ca9773d-0221-478b-b8bc-90bb8d439f33",
-            "type": "index-pattern"
+        "panelIndex": "3ef5ba86-ebb8-4ba6-941d-ad45de8d94e2",
+        "title": "Memory used vs total memory",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-c165f898-73a9-48b1-afa9-2b6e75f3cc1f",
+                "type": "index-pattern"
+              },
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-dde29dcf-00ae-4b80-8d9e-ab45c51efba0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "c165f898-73a9-48b1-afa9-2b6e75f3cc1f": {
+                      "columnOrder": [
+                        "7113c7e7-1af9-4350-b5d2-57abcb60c633",
+                        "af01f323-afc0-4b55-b453-8da15facfc28",
+                        "830de93b-4051-4716-99e4-83d625a91288X0",
+                        "830de93b-4051-4716-99e4-83d625a91288X1",
+                        "830de93b-4051-4716-99e4-83d625a91288"
+                      ],
+                      "columns": {
+                        "7113c7e7-1af9-4350-b5d2-57abcb60c633": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top 10000 values of container.id",
+                          "operationType": "terms",
+                          "params": {
+                            "missingBucket": false,
+                            "orderAgg": {
+                              "customLabel": false,
+                              "dataType": "number",
+                              "isBucketed": false,
+                              "label": "Count of records",
+                              "operationType": "count",
+                              "params": {},
+                              "scale": "ratio",
+                              "sourceField": "___records___"
+                            },
+                            "orderBy": {
+                              "type": "custom"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": false,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "secondaryFields": [],
+                            "size": 10000
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "container.id"
+                        },
+                        "830de93b-4051-4716-99e4-83d625a91288": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "data_stream.dataset :\"kubernetes.container\"   "
+                          },
+                          "isBucketed": false,
+                          "label": "Cores Used",
+                          "operationType": "formula",
+                          "params": {
+                            "format": {
+                              "id": "number"
+                            },
+                            "formula": "last_value(kubernetes.container.cpu.usage.nanocores)/1000000000",
+                            "isFormulaBroken": false
+                          },
+                          "references": [
+                            "830de93b-4051-4716-99e4-83d625a91288X1"
+                          ],
+                          "scale": "ratio"
+                        },
+                        "830de93b-4051-4716-99e4-83d625a91288X0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "data_stream.dataset :\"kubernetes.container\"   "
+                          },
+                          "isBucketed": false,
+                          "label": "Part of last_value(kubernetes.container.cpu.usage.nanocores)/1000000000",
+                          "operationType": "last_value",
+                          "params": {
+                            "sortField": "@timestamp"
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.container.cpu.usage.nanocores"
+                        },
+                        "830de93b-4051-4716-99e4-83d625a91288X1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Part of last_value(kubernetes.container.cpu.usage.nanocores)/1000000000",
+                          "operationType": "math",
+                          "params": {
+                            "tinymathAst": {
+                              "args": [
+                                "830de93b-4051-4716-99e4-83d625a91288X0",
+                                1000000000
+                              ],
+                              "location": {
+                                "max": 63,
+                                "min": 0
+                              },
+                              "name": "divide",
+                              "text": "last_value(kubernetes.container.cpu.usage.nanocores)/1000000000",
+                              "type": "function"
+                            }
+                          },
+                          "references": [
+                            "830de93b-4051-4716-99e4-83d625a91288X0"
+                          ],
+                          "scale": "ratio"
+                        },
+                        "af01f323-afc0-4b55-b453-8da15facfc28": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    },
+                    "dde29dcf-00ae-4b80-8d9e-ab45c51efba0": {
+                      "columnOrder": [
+                        "f64f7970-3f7d-4f2d-88ae-9e008f2e0bc5",
+                        "c609fc21-331c-4bbe-81c3-ef8251f3cf80",
+                        "e1c6fec1-182f-4bf2-aa22-434cd1aa9a95"
+                      ],
+                      "columns": {
+                        "c609fc21-331c-4bbe-81c3-ef8251f3cf80": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "e1c6fec1-182f-4bf2-aa22-434cd1aa9a95": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "data_stream.dataset :\"kubernetes.state_node\" and kubernetes.node.status.ready:\"true\" "
+                          },
+                          "isBucketed": false,
+                          "label": "Total Cores",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.node.cpu.allocatable.cores"
+                        },
+                        "f64f7970-3f7d-4f2d-88ae-9e008f2e0bc5": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top 10000 values of kubernetes.node.name",
+                          "operationType": "terms",
+                          "params": {
+                            "missingBucket": false,
+                            "orderAgg": {
+                              "customLabel": false,
+                              "dataType": "number",
+                              "isBucketed": false,
+                              "label": "Count of records",
+                              "operationType": "count",
+                              "params": {},
+                              "scale": "ratio",
+                              "sourceField": "___records___"
+                            },
+                            "orderBy": {
+                              "type": "custom"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": false,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "secondaryFields": [],
+                            "size": 10000
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.node.name"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "fbaf3405-fab6-4f09-883d-45368cf97670",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": [
+                      "kubernetes.container",
+                      "kubernetes.state_node"
+                    ],
+                    "type": "phrases",
+                    "value": [
+                      "kubernetes.container",
+                      "kubernetes.state_node"
+                    ]
+                  },
+                  "query": {
+                    "bool": {
+                      "minimum_should_match": 1,
+                      "should": [
+                        {
+                          "match_phrase": {
+                            "data_stream.dataset": "kubernetes.container"
+                          }
+                        },
+                        {
+                          "match_phrase": {
+                            "data_stream.dataset": "kubernetes.state_node"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "fillOpacity": 0.5,
+                "fittingFunction": "None",
+                "gridlinesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "830de93b-4051-4716-99e4-83d625a91288"
+                    ],
+                    "collapseFn": "sum",
+                    "layerId": "c165f898-73a9-48b1-afa9-2b6e75f3cc1f",
+                    "layerType": "data",
+                    "palette": {
+                      "name": "default",
+                      "type": "palette"
+                    },
+                    "seriesType": "area",
+                    "splitAccessor": "7113c7e7-1af9-4350-b5d2-57abcb60c633",
+                    "xAccessor": "af01f323-afc0-4b55-b453-8da15facfc28",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "color": "#00bfb3",
+                        "forAccessor": "830de93b-4051-4716-99e4-83d625a91288"
+                      }
+                    ]
+                  },
+                  {
+                    "accessors": [
+                      "e1c6fec1-182f-4bf2-aa22-434cd1aa9a95"
+                    ],
+                    "collapseFn": "sum",
+                    "layerId": "dde29dcf-00ae-4b80-8d9e-ab45c51efba0",
+                    "layerType": "data",
+                    "palette": {
+                      "name": "negative",
+                      "type": "palette"
+                    },
+                    "seriesType": "line",
+                    "splitAccessor": "f64f7970-3f7d-4f2d-88ae-9e008f2e0bc5",
+                    "xAccessor": "c609fc21-331c-4bbe-81c3-ef8251f3cf80",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "color": "#bd271e",
+                        "forAccessor": "e1c6fec1-182f-4bf2-aa22-434cd1aa9a95"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 1,
+                  "position": "top",
+                  "shouldTruncate": true,
+                  "showSingleSeries": true
+                },
+                "preferredSeriesType": "bar_stacked",
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "valueLabels": "hide",
+                "xTitle": "",
+                "yLeftExtent": {
+                  "mode": "full"
+                },
+                "yLeftScale": "linear",
+                "yRightExtent": {
+                  "mode": "full"
+                },
+                "yRightScale": "linear",
+                "yTitle": ""
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {},
+          "hidePanelTitles": false
         },
-        {
-            "id": "metrics-*",
-            "name": "b1eea36d-fb25-4dbb-82d7-561ec2c39b7a:5c81359c-376d-41bd-984d-60fb106f2e33",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 9,
+          "i": "71969826-a34f-4931-a1a0-53787a1e9d68",
+          "w": 20,
+          "x": 28,
+          "y": 4
         },
-        {
-            "id": "metrics-*",
-            "name": "b0a580d6-41a8-4a71-a129-0d2fcb029851:indexpattern-datasource-layer-06a776d4-f25a-45c0-a54e-82d0cb913047",
-            "type": "index-pattern"
+        "panelIndex": "71969826-a34f-4931-a1a0-53787a1e9d68",
+        "title": "Cores used vs total cores",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-2ca9773d-0221-478b-b8bc-90bb8d439f33",
+                "type": "index-pattern"
+              },
+              {
+                "id": "metrics-*",
+                "name": "5c81359c-376d-41bd-984d-60fb106f2e33",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "2ca9773d-0221-478b-b8bc-90bb8d439f33": {
+                      "columnOrder": [
+                        "76e50af3-9df6-42c7-9b0e-eea21ab3650f",
+                        "1a2ebd5d-82b1-4cf8-a934-152a5726a82f",
+                        "0f308b41-fbc2-41aa-beef-ba6412224944"
+                      ],
+                      "columns": {
+                        "0f308b41-fbc2-41aa-beef-ba6412224944": {
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "kubernetes.pod.status.phase : \"running\" "
+                          },
+                          "isBucketed": false,
+                          "label": "Unique count of kubernetes.pod.name",
+                          "operationType": "unique_count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.pod.name"
+                        },
+                        "1a2ebd5d-82b1-4cf8-a934-152a5726a82f": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Filters",
+                          "operationType": "filters",
+                          "params": {
+                            "filters": [
+                              {
+                                "input": {
+                                  "language": "kuery",
+                                  "query": ""
+                                },
+                                "label": "Pods per Namespace"
+                              }
+                            ]
+                          },
+                          "scale": "ordinal"
+                        },
+                        "76e50af3-9df6-42c7-9b0e-eea21ab3650f": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top 5 values of kubernetes.namespace",
+                          "operationType": "terms",
+                          "params": {
+                            "missingBucket": false,
+                            "orderBy": {
+                              "columnId": "0f308b41-fbc2-41aa-beef-ba6412224944",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": true,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 5
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.namespace"
+                        }
+                      },
+                      "incompleteColumns": {}
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "5c81359c-376d-41bd-984d-60fb106f2e33",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.state_pod"
+                    },
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.state_pod"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "0f308b41-fbc2-41aa-beef-ba6412224944"
+                    ],
+                    "layerId": "2ca9773d-0221-478b-b8bc-90bb8d439f33",
+                    "layerType": "data",
+                    "palette": {
+                      "name": "status",
+                      "type": "palette"
+                    },
+                    "position": "top",
+                    "seriesType": "bar_horizontal",
+                    "showGridlines": false,
+                    "splitAccessor": "76e50af3-9df6-42c7-9b0e-eea21ab3650f",
+                    "xAccessor": "1a2ebd5d-82b1-4cf8-a934-152a5726a82f"
+                  }
+                ],
+                "legend": {
+                  "isVisible": false,
+                  "position": "right",
+                  "showSingleSeries": false
+                },
+                "preferredSeriesType": "bar_horizontal",
+                "tickLabelsVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "title": "Empty XY chart",
+                "valueLabels": "show",
+                "xTitle": "",
+                "yTitle": ""
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {},
+          "hidePanelTitles": false
         },
-        {
-            "id": "metrics-*",
-            "name": "b0a580d6-41a8-4a71-a129-0d2fcb029851:c130c98c-51ad-49ce-9e28-1dddc0329421",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 6,
+          "i": "b1eea36d-fb25-4dbb-82d7-561ec2c39b7a",
+          "w": 9,
+          "x": 0,
+          "y": 13
         },
-        {
-            "id": "metrics-*",
-            "name": "34df5a62-0b8b-491b-b2c2-5aa11f291c7f:indexpattern-datasource-layer-06a776d4-f25a-45c0-a54e-82d0cb913047",
-            "type": "index-pattern"
+        "panelIndex": "b1eea36d-fb25-4dbb-82d7-561ec2c39b7a",
+        "title": "Running pods per namespace",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "0fa53a1e-0589-4380-b700-70dd489a33de": {
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "0fa53a1e-0589-4380-b700-70dd489a33de",
+                  "name": "state-pods-adhoc",
+                  "runtimeFieldMap": {
+                    "failed": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "not_running": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\" || doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "pending": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "running": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"running\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "succeeded": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"succeeded\") { emit(1) }"
+                      },
+                      "type": "long"
+                    }
+                  },
+                  "sourceFilters": [],
+                  "timeFieldName": "@timestamp",
+                  "title": "metrics-*,*:metrics-*"
+                }
+              },
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "b7b25285-ced1-481d-999e-1886b3463594": {
+                      "columnOrder": [
+                        "3d69345e-fb52-485a-8762-fdfaf09ea013",
+                        "1699b42c-8ab5-43dc-a722-6d70911eae94",
+                        "1c9e34cf-591d-4a4f-9999-67e95918e933",
+                        "92280dfe-0252-4993-9c5d-28764c18bc13",
+                        "1df45e80-f287-4f85-9f8e-6efaddff0f77",
+                        "866856c3-c189-4457-9240-ab6a9d2df75d"
+                      ],
+                      "columns": {
+                        "1699b42c-8ab5-43dc-a722-6d70911eae94": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Filters",
+                          "operationType": "filters",
+                          "params": {
+                            "filters": [
+                              {
+                                "input": {
+                                  "language": "kuery",
+                                  "query": "*"
+                                },
+                                "label": "Status"
+                              }
+                            ]
+                          },
+                          "scale": "ordinal"
+                        },
+                        "1c9e34cf-591d-4a4f-9999-67e95918e933": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "running: *"
+                          },
+                          "isBucketed": false,
+                          "label": "Running",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "reducedTimeRange": "1m",
+                          "scale": "ratio",
+                          "sourceField": "running"
+                        },
+                        "1df45e80-f287-4f85-9f8e-6efaddff0f77": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "pending: *"
+                          },
+                          "isBucketed": false,
+                          "label": "Pending",
+                          "operationType": "last_value",
+                          "params": {
+                            "sortField": "@timestamp"
+                          },
+                          "reducedTimeRange": "1m",
+                          "scale": "ratio",
+                          "sourceField": "pending"
+                        },
+                        "3d69345e-fb52-485a-8762-fdfaf09ea013": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top 10000 values of kubernetes.pod.name",
+                          "operationType": "terms",
+                          "params": {
+                            "exclude": [],
+                            "excludeIsRegex": false,
+                            "include": [],
+                            "includeIsRegex": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "columnId": "1df45e80-f287-4f85-9f8e-6efaddff0f77",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": true,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 10000
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.pod.name"
+                        },
+                        "866856c3-c189-4457-9240-ab6a9d2df75d": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "failed: *"
+                          },
+                          "isBucketed": false,
+                          "label": "Failed",
+                          "operationType": "last_value",
+                          "params": {
+                            "sortField": "@timestamp"
+                          },
+                          "reducedTimeRange": "1m",
+                          "scale": "ratio",
+                          "sourceField": "failed"
+                        },
+                        "92280dfe-0252-4993-9c5d-28764c18bc13": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "succeeded: *"
+                          },
+                          "isBucketed": false,
+                          "label": "Succeeded",
+                          "operationType": "last_value",
+                          "params": {
+                            "sortField": "@timestamp"
+                          },
+                          "reducedTimeRange": "1m",
+                          "scale": "ratio",
+                          "sourceField": "succeeded"
+                        }
+                      },
+                      "incompleteColumns": {}
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "0fa53a1e-0589-4380-b700-70dd489a33de",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.state_pod"
+                    },
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.state_pod"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [
+                {
+                  "id": "0fa53a1e-0589-4380-b700-70dd489a33de",
+                  "name": "indexpattern-datasource-layer-b7b25285-ced1-481d-999e-1886b3463594",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "gridlinesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "1c9e34cf-591d-4a4f-9999-67e95918e933",
+                      "92280dfe-0252-4993-9c5d-28764c18bc13",
+                      "1df45e80-f287-4f85-9f8e-6efaddff0f77",
+                      "866856c3-c189-4457-9240-ab6a9d2df75d"
+                    ],
+                    "collapseFn": "sum",
+                    "layerId": "b7b25285-ced1-481d-999e-1886b3463594",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "bar_horizontal",
+                    "showGridlines": false,
+                    "splitAccessor": "3d69345e-fb52-485a-8762-fdfaf09ea013",
+                    "xAccessor": "1699b42c-8ab5-43dc-a722-6d70911eae94",
+                    "yConfig": [
+                      {
+                        "color": "#bd271e",
+                        "forAccessor": "866856c3-c189-4457-9240-ab6a9d2df75d"
+                      },
+                      {
+                        "color": "#fec514",
+                        "forAccessor": "1df45e80-f287-4f85-9f8e-6efaddff0f77"
+                      },
+                      {
+                        "color": "#00bfb3",
+                        "forAccessor": "1c9e34cf-591d-4a4f-9999-67e95918e933"
+                      },
+                      {
+                        "color": "#0077cc",
+                        "forAccessor": "92280dfe-0252-4993-9c5d-28764c18bc13"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "horizontalAlignment": "right",
+                  "isInside": false,
+                  "isVisible": false,
+                  "maxLines": 1,
+                  "position": "bottom",
+                  "shouldTruncate": true,
+                  "showSingleSeries": false,
+                  "verticalAlignment": "bottom"
+                },
+                "preferredSeriesType": "bar_horizontal",
+                "tickLabelsVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "title": "Empty XY chart",
+                "valueLabels": "show",
+                "valuesInLegend": true,
+                "xTitle": "",
+                "yTitle": ""
+              }
+            },
+            "title": "Total Pods per Namespace [Metrics Kubernetes] (copy 1)",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": false
         },
-        {
-            "id": "metrics-*",
-            "name": "34df5a62-0b8b-491b-b2c2-5aa11f291c7f:a06a30d5-05f1-46ea-9075-3e6051f5781a",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 6,
+          "i": "4e8a4058-d73f-47dc-b10a-127e0b5d3776",
+          "w": 9,
+          "x": 9,
+          "y": 13
         },
-        {
-            "id": "metrics-*",
-            "name": "34df5a62-0b8b-491b-b2c2-5aa11f291c7f:9c0b0d2f-c443-4c41-b55c-c7ad0db60302",
-            "type": "index-pattern"
+        "panelIndex": "4e8a4058-d73f-47dc-b10a-127e0b5d3776",
+        "title": "Pods",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "0b9c02fc-3c21-47e2-abed-31cbc41b11cc": {
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "0b9c02fc-3c21-47e2-abed-31cbc41b11cc",
+                  "name": "state_deployment-ad-hoc",
+                  "runtimeFieldMap": {
+                    "not_ready": {
+                      "script": {
+                        "source": "if (doc[\"kubernetes.deployment.replicas.desired\"].value - doc[\"kubernetes.deployment.replicas.available\"].value != 0) { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "ready": {
+                      "script": {
+                        "source": "if (doc[\"kubernetes.deployment.replicas.desired\"].value - doc[\"kubernetes.deployment.replicas.available\"].value == 0) { emit(1) }"
+                      },
+                      "type": "long"
+                    }
+                  },
+                  "sourceFilters": [],
+                  "timeFieldName": "@timestamp",
+                  "title": "metrics-*,*:metrics-*"
+                },
+                "0fa53a1e-0589-4380-b700-70dd489a33de": {
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "0fa53a1e-0589-4380-b700-70dd489a33de",
+                  "name": "state-pods-adhoc",
+                  "runtimeFieldMap": {
+                    "failed": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "not_running": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\" || doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "pending": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "running": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"running\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "succeeded": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"succeeded\") { emit(1) }"
+                      },
+                      "type": "long"
+                    }
+                  },
+                  "sourceFilters": [],
+                  "timeFieldName": "@timestamp",
+                  "title": "metrics-*,*:metrics-*"
+                },
+                "34c15200-5232-4a16-8fb0-36ca5a194638": {
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "34c15200-5232-4a16-8fb0-36ca5a194638",
+                  "name": "deployments-ad-hoc",
+                  "runtimeFieldMap": {
+                    "not_running": {
+                      "script": {
+                        "source": "if (doc['kubernetes.deployment.paused'].value == true) { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "running": {
+                      "script": {
+                        "source": "if (doc['kubernetes.deployment.paused'].value == false) { emit(1) }"
+                      },
+                      "type": "long"
+                    }
+                  },
+                  "sourceFilters": [],
+                  "timeFieldName": "@timestamp",
+                  "title": "metrics-*,*:metrics-*"
+                },
+                "f8fa576a-6f91-4a11-a43d-7f3964869d7d": {
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "f8fa576a-6f91-4a11-a43d-7f3964869d7d",
+                  "name": "daemonsets-ad-hoc",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "timeFieldName": "@timestamp",
+                  "title": "metrics-*,*:metrics-*"
+                }
+              },
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "b7b25285-ced1-481d-999e-1886b3463594": {
+                      "columnOrder": [
+                        "6690f3c6-3a05-47e0-8f98-5baea37f351c",
+                        "2b790ab1-6a55-4c4c-9131-964752309c72",
+                        "143fa2b5-a63f-4d51-9207-f6e3441dd124",
+                        "16807879-5684-4aab-9b80-cc701f820e68"
+                      ],
+                      "columns": {
+                        "143fa2b5-a63f-4d51-9207-f6e3441dd124": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "ready: *"
+                          },
+                          "isBucketed": false,
+                          "label": "Ready",
+                          "operationType": "last_value",
+                          "params": {
+                            "sortField": "@timestamp"
+                          },
+                          "reducedTimeRange": "1m",
+                          "scale": "ratio",
+                          "sourceField": "ready"
+                        },
+                        "16807879-5684-4aab-9b80-cc701f820e68": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "not_ready: *"
+                          },
+                          "isBucketed": false,
+                          "label": "Not Ready",
+                          "operationType": "last_value",
+                          "params": {
+                            "sortField": "@timestamp"
+                          },
+                          "reducedTimeRange": "1m",
+                          "scale": "ratio",
+                          "sourceField": "not_ready"
+                        },
+                        "2b790ab1-6a55-4c4c-9131-964752309c72": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Filters",
+                          "operationType": "filters",
+                          "params": {
+                            "filters": [
+                              {
+                                "input": {
+                                  "language": "kuery",
+                                  "query": ""
+                                },
+                                "label": "Status"
+                              }
+                            ]
+                          },
+                          "scale": "ordinal"
+                        },
+                        "6690f3c6-3a05-47e0-8f98-5baea37f351c": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top 10000 values of kubernetes.deployment.name",
+                          "operationType": "terms",
+                          "params": {
+                            "exclude": [],
+                            "excludeIsRegex": false,
+                            "include": [],
+                            "includeIsRegex": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "columnId": "143fa2b5-a63f-4d51-9207-f6e3441dd124",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": true,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 10000
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.deployment.name"
+                        }
+                      },
+                      "incompleteColumns": {}
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "0b9c02fc-3c21-47e2-abed-31cbc41b11cc",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.state_deployment"
+                    },
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.state_deployment"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [
+                {
+                  "id": "0b9c02fc-3c21-47e2-abed-31cbc41b11cc",
+                  "name": "indexpattern-datasource-layer-b7b25285-ced1-481d-999e-1886b3463594",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "143fa2b5-a63f-4d51-9207-f6e3441dd124",
+                      "16807879-5684-4aab-9b80-cc701f820e68"
+                    ],
+                    "collapseFn": "sum",
+                    "layerId": "b7b25285-ced1-481d-999e-1886b3463594",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "bar_horizontal",
+                    "showGridlines": false,
+                    "splitAccessor": "6690f3c6-3a05-47e0-8f98-5baea37f351c",
+                    "xAccessor": "2b790ab1-6a55-4c4c-9131-964752309c72",
+                    "yConfig": [
+                      {
+                        "color": "#bd271e",
+                        "forAccessor": "16807879-5684-4aab-9b80-cc701f820e68"
+                      },
+                      {
+                        "color": "#00bfb3",
+                        "forAccessor": "143fa2b5-a63f-4d51-9207-f6e3441dd124"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": false,
+                  "position": "right",
+                  "showSingleSeries": false
+                },
+                "preferredSeriesType": "bar_horizontal",
+                "tickLabelsVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "title": "Empty XY chart",
+                "valueLabels": "show",
+                "xTitle": "",
+                "yTitle": ""
+              }
+            },
+            "title": "Total Pods per Namespace [Metrics Kubernetes] (copy 1)",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": false
         },
-        {
-            "id": "metrics-*",
-            "name": "27d290d0-3d53-4701-a9b7-82fc26d4dff7:indexpattern-datasource-layer-06a776d4-f25a-45c0-a54e-82d0cb913047",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 6,
+          "i": "ffaac795-f750-4af1-93ad-d4dbdf150edc",
+          "w": 10,
+          "x": 18,
+          "y": 13
         },
-        {
-            "id": "metrics-*",
-            "name": "27d290d0-3d53-4701-a9b7-82fc26d4dff7:8769bfd6-a9c7-4bab-b048-0e2fcffe8114",
-            "type": "index-pattern"
+        "panelIndex": "ffaac795-f750-4af1-93ad-d4dbdf150edc",
+        "title": "Deployments",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "0fa53a1e-0589-4380-b700-70dd489a33de": {
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "0fa53a1e-0589-4380-b700-70dd489a33de",
+                  "name": "state-pods-adhoc",
+                  "runtimeFieldMap": {
+                    "failed": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "not_running": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\" || doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "pending": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "running": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"running\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "succeeded": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"succeeded\") { emit(1) }"
+                      },
+                      "type": "long"
+                    }
+                  },
+                  "sourceFilters": [],
+                  "timeFieldName": "@timestamp",
+                  "title": "metrics-*,*:metrics-*"
+                },
+                "295ecdc5-f413-4f20-9f77-74927a10d33d": {
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "295ecdc5-f413-4f20-9f77-74927a10d33d",
+                  "name": "state_daemonset-ad-hoc",
+                  "runtimeFieldMap": {
+                    "not_ready": {
+                      "script": {
+                        "source": "if (doc[\"kubernetes.daemonset.replicas.desired\"].value - doc[\"kubernetes.daemonset.replicas.ready\"].value != 0) {emit(1)}"
+                      },
+                      "type": "long"
+                    },
+                    "ready": {
+                      "script": {
+                        "source": "if (doc[\"kubernetes.daemonset.replicas.desired\"].value - doc[\"kubernetes.daemonset.replicas.ready\"].value == 0) {emit(1)}"
+                      },
+                      "type": "long"
+                    }
+                  },
+                  "sourceFilters": [],
+                  "timeFieldName": "@timestamp",
+                  "title": "metrics-*,*:metrics-*"
+                },
+                "f8fa576a-6f91-4a11-a43d-7f3964869d7d": {
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "f8fa576a-6f91-4a11-a43d-7f3964869d7d",
+                  "name": "daemonsets-ad-hoc",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "timeFieldName": "@timestamp",
+                  "title": "metrics-*,*:metrics-*"
+                }
+              },
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "b7b25285-ced1-481d-999e-1886b3463594": {
+                      "columnOrder": [
+                        "e36fb66d-f9b0-46d3-aec4-52638d34d308",
+                        "5b89a3a0-f94e-49c2-bc43-fdd4c7671ea5",
+                        "0e2a3f8d-cc26-453d-bed1-b184e48756b2",
+                        "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c"
+                      ],
+                      "columns": {
+                        "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "not_ready: *"
+                          },
+                          "isBucketed": false,
+                          "label": "Not Ready",
+                          "operationType": "last_value",
+                          "params": {
+                            "sortField": "@timestamp"
+                          },
+                          "reducedTimeRange": "1m",
+                          "scale": "ratio",
+                          "sourceField": "not_ready"
+                        },
+                        "0e2a3f8d-cc26-453d-bed1-b184e48756b2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "ready: *"
+                          },
+                          "isBucketed": false,
+                          "label": "Ready",
+                          "operationType": "last_value",
+                          "params": {
+                            "sortField": "@timestamp"
+                          },
+                          "reducedTimeRange": "1m",
+                          "scale": "ratio",
+                          "sourceField": "ready"
+                        },
+                        "5b89a3a0-f94e-49c2-bc43-fdd4c7671ea5": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Filters",
+                          "operationType": "filters",
+                          "params": {
+                            "filters": [
+                              {
+                                "input": {
+                                  "language": "kuery",
+                                  "query": ""
+                                },
+                                "label": "Status"
+                              }
+                            ]
+                          },
+                          "scale": "ordinal"
+                        },
+                        "e36fb66d-f9b0-46d3-aec4-52638d34d308": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top 10000 values of kubernetes.daemonset.name",
+                          "operationType": "terms",
+                          "params": {
+                            "exclude": [],
+                            "excludeIsRegex": false,
+                            "include": [],
+                            "includeIsRegex": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "columnId": "0e2a3f8d-cc26-453d-bed1-b184e48756b2",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": true,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 10000
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.daemonset.name"
+                        }
+                      },
+                      "incompleteColumns": {}
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "295ecdc5-f413-4f20-9f77-74927a10d33d",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.state_daemonset"
+                    },
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.state_daemonset"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [
+                {
+                  "id": "295ecdc5-f413-4f20-9f77-74927a10d33d",
+                  "name": "indexpattern-datasource-layer-b7b25285-ced1-481d-999e-1886b3463594",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "0e2a3f8d-cc26-453d-bed1-b184e48756b2",
+                      "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c"
+                    ],
+                    "collapseFn": "sum",
+                    "layerId": "b7b25285-ced1-481d-999e-1886b3463594",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "bar_horizontal",
+                    "showGridlines": false,
+                    "splitAccessor": "e36fb66d-f9b0-46d3-aec4-52638d34d308",
+                    "xAccessor": "5b89a3a0-f94e-49c2-bc43-fdd4c7671ea5",
+                    "yConfig": [
+                      {
+                        "color": "#bd271e",
+                        "forAccessor": "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c"
+                      },
+                      {
+                        "color": "#00bfb3",
+                        "forAccessor": "0e2a3f8d-cc26-453d-bed1-b184e48756b2"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": false,
+                  "position": "bottom",
+                  "showSingleSeries": false
+                },
+                "preferredSeriesType": "bar_horizontal",
+                "tickLabelsVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "title": "Empty XY chart",
+                "valueLabels": "show",
+                "valuesInLegend": true,
+                "xTitle": "",
+                "yTitle": ""
+              }
+            },
+            "title": "Total Pods per Namespace [Metrics Kubernetes] (copy 1)",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": false
         },
-        {
-            "id": "metrics-*",
-            "name": "27d290d0-3d53-4701-a9b7-82fc26d4dff7:d79e5279-bd92-48b0-bd92-767cf6b8892d",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 6,
+          "i": "a7b43ea1-450d-4eed-8c9f-cd5ff5b9d6c4",
+          "w": 10,
+          "x": 28,
+          "y": 13
         },
-        {
-            "id": "metrics-*",
-            "name": "b18e07f5-a634-49b1-a732-65491c00a9b3:indexpattern-datasource-layer-a69d8e15-2ebf-401c-af12-4b6762f230db",
-            "type": "index-pattern"
+        "panelIndex": "a7b43ea1-450d-4eed-8c9f-cd5ff5b9d6c4",
+        "title": "DaemonSets",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "0fa53a1e-0589-4380-b700-70dd489a33de": {
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "0fa53a1e-0589-4380-b700-70dd489a33de",
+                  "name": "state-pods-adhoc",
+                  "runtimeFieldMap": {
+                    "failed": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "not_running": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\" || doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "pending": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "running": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"running\") { emit(1) }"
+                      },
+                      "type": "long"
+                    },
+                    "succeeded": {
+                      "script": {
+                        "source": "if (doc['kubernetes.pod.status.phase'].value == \"succeeded\") { emit(1) }"
+                      },
+                      "type": "long"
+                    }
+                  },
+                  "sourceFilters": [],
+                  "timeFieldName": "@timestamp",
+                  "title": "metrics-*,*:metrics-*"
+                },
+                "dbfaeb6f-4fff-4043-8bf8-19d5345fd339": {
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "dbfaeb6f-4fff-4043-8bf8-19d5345fd339",
+                  "name": "state_replicaset_ad-hoc",
+                  "runtimeFieldMap": {
+                    "not_ready": {
+                      "script": {
+                        "source": "def ready = doc['kubernetes.replicaset.replicas.ready'].value;\ndef des = doc['kubernetes.replicaset.replicas.desired'].value;\nemit(des-ready)"
+                      },
+                      "type": "long"
+                    }
+                  },
+                  "sourceFilters": [],
+                  "timeFieldName": "@timestamp",
+                  "title": "metrics-*,*:metrics-*"
+                },
+                "f8fa576a-6f91-4a11-a43d-7f3964869d7d": {
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "f8fa576a-6f91-4a11-a43d-7f3964869d7d",
+                  "name": "daemonsets-ad-hoc",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "timeFieldName": "@timestamp",
+                  "title": "metrics-*,*:metrics-*"
+                }
+              },
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "b7b25285-ced1-481d-999e-1886b3463594": {
+                      "columnOrder": [
+                        "fcc76997-5b49-416b-81ba-37d65ea25296",
+                        "446fc0b3-a6c8-4f4d-914b-748d488083a1",
+                        "a51a9822-167b-4b8f-b7a6-3051da30164b",
+                        "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920"
+                      ],
+                      "columns": {
+                        "446fc0b3-a6c8-4f4d-914b-748d488083a1": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Filters",
+                          "operationType": "filters",
+                          "params": {
+                            "filters": [
+                              {
+                                "input": {
+                                  "language": "kuery",
+                                  "query": ""
+                                },
+                                "label": "Status"
+                              }
+                            ]
+                          },
+                          "scale": "ordinal"
+                        },
+                        "a51a9822-167b-4b8f-b7a6-3051da30164b": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "kubernetes.replicaset.replicas.ready: *"
+                          },
+                          "isBucketed": false,
+                          "label": "Ready",
+                          "operationType": "last_value",
+                          "params": {
+                            "sortField": "@timestamp"
+                          },
+                          "reducedTimeRange": "1m",
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.replicaset.replicas.ready"
+                        },
+                        "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "not_ready: *"
+                          },
+                          "isBucketed": false,
+                          "label": "Not Ready",
+                          "operationType": "last_value",
+                          "params": {
+                            "sortField": "@timestamp"
+                          },
+                          "scale": "ratio",
+                          "sourceField": "not_ready"
+                        },
+                        "fcc76997-5b49-416b-81ba-37d65ea25296": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top 10000 values of kubernetes.replicaset.name",
+                          "operationType": "terms",
+                          "params": {
+                            "exclude": [],
+                            "excludeIsRegex": false,
+                            "include": [],
+                            "includeIsRegex": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "columnId": "a51a9822-167b-4b8f-b7a6-3051da30164b",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": true,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 10000
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.replicaset.name"
+                        }
+                      },
+                      "incompleteColumns": {}
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "dbfaeb6f-4fff-4043-8bf8-19d5345fd339",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.state_replicaset"
+                    },
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.state_replicaset"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [
+                {
+                  "id": "dbfaeb6f-4fff-4043-8bf8-19d5345fd339",
+                  "name": "indexpattern-datasource-layer-b7b25285-ced1-481d-999e-1886b3463594",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "a51a9822-167b-4b8f-b7a6-3051da30164b",
+                      "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920"
+                    ],
+                    "collapseFn": "sum",
+                    "layerId": "b7b25285-ced1-481d-999e-1886b3463594",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "bar_horizontal",
+                    "showGridlines": false,
+                    "splitAccessor": "fcc76997-5b49-416b-81ba-37d65ea25296",
+                    "xAccessor": "446fc0b3-a6c8-4f4d-914b-748d488083a1",
+                    "yConfig": [
+                      {
+                        "color": "#bd271e",
+                        "forAccessor": "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920"
+                      },
+                      {
+                        "color": "#00bfb3",
+                        "forAccessor": "a51a9822-167b-4b8f-b7a6-3051da30164b"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": false,
+                  "position": "right",
+                  "showSingleSeries": false
+                },
+                "preferredSeriesType": "bar_horizontal",
+                "tickLabelsVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "title": "Empty XY chart",
+                "valueLabels": "show",
+                "xTitle": "",
+                "yTitle": ""
+              }
+            },
+            "title": "Total Pods per Namespace [Metrics Kubernetes] (copy 1)",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": false
         },
-        {
-            "id": "metrics-*",
-            "name": "b18e07f5-a634-49b1-a732-65491c00a9b3:086a73a8-ac9d-48eb-b5b7-3c697278cc9e",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 6,
+          "i": "cec0ea1d-0385-4aa8-b9f1-c0e2c73b5b0b",
+          "w": 10,
+          "x": 38,
+          "y": 13
         },
-        {
-            "id": "metrics-*",
-            "name": "dfa9777a-a9d5-469f-ab90-c1bcf6045d85:indexpattern-datasource-layer-06a776d4-f25a-45c0-a54e-82d0cb913047",
-            "type": "index-pattern"
+        "panelIndex": "cec0ea1d-0385-4aa8-b9f1-c0e2c73b5b0b",
+        "title": "ReplicaSets",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "description": "Pod cpu utilization is calculated as a ratio of the node's allocatable cpu",
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-06a776d4-f25a-45c0-a54e-82d0cb913047",
+                "type": "index-pattern"
+              },
+              {
+                "id": "metrics-*",
+                "name": "c130c98c-51ad-49ce-9e28-1dddc0329421",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "06a776d4-f25a-45c0-a54e-82d0cb913047": {
+                      "columnOrder": [
+                        "f4242bda-ae9c-4d7c-8cda-43f56c38acb5",
+                        "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
+                      ],
+                      "columns": {
+                        "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "\"kubernetes.pod.cpu.usage.node.pct\": *"
+                          },
+                          "isBucketed": false,
+                          "label": "Average Pod CPU Usage ",
+                          "operationType": "last_value",
+                          "params": {
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 2
+                              }
+                            },
+                            "sortField": "@timestamp"
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.pod.cpu.usage.node.pct"
+                        },
+                        "f4242bda-ae9c-4d7c-8cda-43f56c38acb5": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top 5 values of kubernetes.pod.name",
+                          "operationType": "terms",
+                          "params": {
+                            "accuracyMode": true,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "columnId": "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": false,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 5
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.pod.name"
+                        }
+                      },
+                      "incompleteColumns": {}
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "field": "kubernetes.pod.cpu.usage.node.pct",
+                    "index": "c130c98c-51ad-49ce-9e28-1dddc0329421",
+                    "key": "kubernetes.pod.cpu.usage.node.pct",
+                    "negate": false,
+                    "type": "exists",
+                    "value": "exists"
+                  },
+                  "query": {
+                    "exists": {
+                      "field": "kubernetes.pod.cpu.usage.node.pct"
+                    }
+                  }
+                },
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "a06a30d5-05f1-46ea-9075-3e6051f5781a",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.pod"
+                    },
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.pod"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "fittingFunction": "None",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
+                    ],
+                    "layerId": "06a776d4-f25a-45c0-a54e-82d0cb913047",
+                    "layerType": "data",
+                    "seriesType": "bar_horizontal",
+                    "xAccessor": "f4242bda-ae9c-4d7c-8cda-43f56c38acb5",
+                    "yConfig": [
+                      {
+                        "color": "#00bfb3",
+                        "forAccessor": "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": false,
+                  "position": "right",
+                  "showSingleSeries": false
+                },
+                "preferredSeriesType": "bar_horizontal",
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "valueLabels": "show",
+                "xTitle": "",
+                "yTitle": ""
+              }
+            },
+            "title": "Cpu Usage per Namespace [Metrics Kubernetes]",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "description": "Pod cpu utilization is calculated as a ratio of the node's allocatable cpu",
+          "enhancements": {},
+          "hidePanelTitles": false
         },
-        {
-            "id": "metrics-*",
-            "name": "dfa9777a-a9d5-469f-ab90-c1bcf6045d85:00370cba-2ec2-4a60-931d-213ecb9916f3",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 11,
+          "i": "b0a580d6-41a8-4a71-a129-0d2fcb029851",
+          "w": 12,
+          "x": 0,
+          "y": 19
         },
-        {
-            "id": "metrics-*",
-            "name": "dfa9777a-a9d5-469f-ab90-c1bcf6045d85:94756f64-5bc4-4b8b-a9bb-0ecb5141a2b1",
-            "type": "index-pattern"
+        "panelIndex": "b0a580d6-41a8-4a71-a129-0d2fcb029851",
+        "title": "Top CPU intensive pods per Node",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-06a776d4-f25a-45c0-a54e-82d0cb913047",
+                "type": "index-pattern"
+              },
+              {
+                "id": "metrics-*",
+                "name": "a06a30d5-05f1-46ea-9075-3e6051f5781a",
+                "type": "index-pattern"
+              },
+              {
+                "id": "metrics-*",
+                "name": "9c0b0d2f-c443-4c41-b55c-c7ad0db60302",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "06a776d4-f25a-45c0-a54e-82d0cb913047": {
+                      "columnOrder": [
+                        "f4242bda-ae9c-4d7c-8cda-43f56c38acb5",
+                        "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
+                      ],
+                      "columns": {
+                        "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "kubernetes.pod.cpu.usage.limit.pct: *"
+                          },
+                          "isBucketed": false,
+                          "label": "Average Pod CPU Usage ",
+                          "operationType": "last_value",
+                          "params": {
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 2
+                              }
+                            },
+                            "sortField": "@timestamp"
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.pod.cpu.usage.limit.pct"
+                        },
+                        "f4242bda-ae9c-4d7c-8cda-43f56c38acb5": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top 5 values of kubernetes.pod.name",
+                          "operationType": "terms",
+                          "params": {
+                            "accuracyMode": true,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "columnId": "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": false,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 5
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.pod.name"
+                        }
+                      },
+                      "incompleteColumns": {}
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "a06a30d5-05f1-46ea-9075-3e6051f5781a",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.pod"
+                    },
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.pod"
+                    }
+                  }
+                },
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "9c0b0d2f-c443-4c41-b55c-c7ad0db60302",
+                    "key": "kubernetes.pod.cpu.usage.limit.pct",
+                    "negate": false,
+                    "type": "exists",
+                    "value": "exists"
+                  },
+                  "query": {
+                    "exists": {
+                      "field": "kubernetes.pod.cpu.usage.limit.pct"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "fittingFunction": "None",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
+                    ],
+                    "layerId": "06a776d4-f25a-45c0-a54e-82d0cb913047",
+                    "layerType": "data",
+                    "seriesType": "bar_horizontal",
+                    "xAccessor": "f4242bda-ae9c-4d7c-8cda-43f56c38acb5",
+                    "yConfig": [
+                      {
+                        "color": "#00bfb3",
+                        "forAccessor": "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": false,
+                  "position": "right",
+                  "showSingleSeries": false
+                },
+                "preferredSeriesType": "bar_horizontal",
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "valueLabels": "show",
+                "xTitle": "",
+                "yTitle": ""
+              }
+            },
+            "title": "Cpu Usage per Namespace [Metrics Kubernetes]",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "description": "Pod cpu utilization is calculated as a ratio of the pod's total container limits. If any container is missing a limit the metric is not emitted.",
+          "enhancements": {},
+          "hidePanelTitles": false
         },
-        {
-            "id": "metrics-*",
-            "name": "ea51b3fb-2b45-4bee-9890-685a76fb836d:kibanaSavedObjectMeta.searchSourceJSON.index",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 11,
+          "i": "34df5a62-0b8b-491b-b2c2-5aa11f291c7f",
+          "w": 12,
+          "x": 12,
+          "y": 19
         },
-        {
-            "id": "metrics-*",
-            "name": "ea51b3fb-2b45-4bee-9890-685a76fb836d:kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-            "type": "index-pattern"
+        "panelIndex": "34df5a62-0b8b-491b-b2c2-5aa11f291c7f",
+        "title": "Top CPU intensive pods per Pod Limit",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-06a776d4-f25a-45c0-a54e-82d0cb913047",
+                "type": "index-pattern"
+              },
+              {
+                "id": "metrics-*",
+                "name": "8769bfd6-a9c7-4bab-b048-0e2fcffe8114",
+                "type": "index-pattern"
+              },
+              {
+                "id": "metrics-*",
+                "name": "d79e5279-bd92-48b0-bd92-767cf6b8892d",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "06a776d4-f25a-45c0-a54e-82d0cb913047": {
+                      "columnOrder": [
+                        "f4242bda-ae9c-4d7c-8cda-43f56c38acb5",
+                        "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
+                      ],
+                      "columns": {
+                        "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "kubernetes.pod.memory.usage.limit.pct: *"
+                          },
+                          "isBucketed": false,
+                          "label": "Average Pod memory Usage ",
+                          "operationType": "last_value",
+                          "params": {
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 2
+                              }
+                            },
+                            "sortField": "@timestamp"
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.pod.memory.usage.limit.pct"
+                        },
+                        "f4242bda-ae9c-4d7c-8cda-43f56c38acb5": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top 5 values of kubernetes.pod.name",
+                          "operationType": "terms",
+                          "params": {
+                            "accuracyMode": true,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "columnId": "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": false,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 5
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.pod.name"
+                        }
+                      },
+                      "incompleteColumns": {}
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "8769bfd6-a9c7-4bab-b048-0e2fcffe8114",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.pod"
+                    },
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.pod"
+                    }
+                  }
+                },
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "d79e5279-bd92-48b0-bd92-767cf6b8892d",
+                    "key": "kubernetes.pod.memory.usage.limit.pct",
+                    "negate": false,
+                    "type": "exists",
+                    "value": "exists"
+                  },
+                  "query": {
+                    "exists": {
+                      "field": "kubernetes.pod.memory.usage.limit.pct"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "fittingFunction": "None",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
+                    ],
+                    "layerId": "06a776d4-f25a-45c0-a54e-82d0cb913047",
+                    "layerType": "data",
+                    "seriesType": "bar_horizontal",
+                    "xAccessor": "f4242bda-ae9c-4d7c-8cda-43f56c38acb5",
+                    "yConfig": [
+                      {
+                        "color": "#00bfb3",
+                        "forAccessor": "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": false,
+                  "position": "right",
+                  "showSingleSeries": false
+                },
+                "preferredSeriesType": "bar_horizontal",
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "valueLabels": "show",
+                "xTitle": "",
+                "yTitle": ""
+              }
+            },
+            "title": "Cpu Usage per Namespace [Metrics Kubernetes]",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "description": "Pod memory utilization is calculated as a ratio of the pod's total container memory limits. If any container is missing a limit the metric is not emitted.",
+          "enhancements": {},
+          "hidePanelTitles": false
         },
-        {
-            "id": "metrics-*",
-            "name": "controlGroup_46384cc1-8597-4df0-b281-a342bf9f14b4:optionsListDataView",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 11,
+          "i": "27d290d0-3d53-4701-a9b7-82fc26d4dff7",
+          "w": 12,
+          "x": 36,
+          "y": 19
         },
-        {
-            "id": "metrics-*",
-            "name": "controlGroup_b20283e9-5cbb-40f7-bfc2-2169c34258ab:optionsListDataView",
-            "type": "index-pattern"
-        }
+        "panelIndex": "27d290d0-3d53-4701-a9b7-82fc26d4dff7",
+        "title": "Top Memory intensive pods per Pod Limit",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-a69d8e15-2ebf-401c-af12-4b6762f230db",
+                "type": "index-pattern"
+              },
+              {
+                "id": "metrics-*",
+                "name": "086a73a8-ac9d-48eb-b5b7-3c697278cc9e",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "a69d8e15-2ebf-401c-af12-4b6762f230db": {
+                      "columnOrder": [
+                        "be5ed114-ba6d-42c6-b8ff-da6142c14a1b",
+                        "b0cd680f-edeb-4934-aceb-6820ad9f01ec",
+                        "b7df21c2-ee65-47cb-9370-294846cfbb65"
+                      ],
+                      "columns": {
+                        "b0cd680f-edeb-4934-aceb-6820ad9f01ec": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "b7df21c2-ee65-47cb-9370-294846cfbb65": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "kubernetes.event.metadata.uid: * and kubernetes.event.type : \"Warning\" "
+                          },
+                          "isBucketed": false,
+                          "label": "New Warnings",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.event.metadata.uid"
+                        },
+                        "be5ed114-ba6d-42c6-b8ff-da6142c14a1b": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top values of kubernetes.event.involved_object.uid + 1 other",
+                          "operationType": "terms",
+                          "params": {
+                            "missingBucket": false,
+                            "orderBy": {
+                              "columnId": "b7df21c2-ee65-47cb-9370-294846cfbb65",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": false,
+                            "parentFormat": {
+                              "id": "multi_terms"
+                            },
+                            "secondaryFields": [
+                              "kubernetes.event.type"
+                            ],
+                            "size": 1000
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.event.involved_object.uid"
+                        }
+                      },
+                      "incompleteColumns": {}
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "086a73a8-ac9d-48eb-b5b7-3c697278cc9e",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.event"
+                    },
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.event"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "fittingFunction": "Linear",
+                "gridlinesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "b7df21c2-ee65-47cb-9370-294846cfbb65"
+                    ],
+                    "collapseFn": "sum",
+                    "layerId": "a69d8e15-2ebf-401c-af12-4b6762f230db",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "bar_stacked",
+                    "showGridlines": false,
+                    "splitAccessor": "be5ed114-ba6d-42c6-b8ff-da6142c14a1b",
+                    "xAccessor": "b0cd680f-edeb-4934-aceb-6820ad9f01ec",
+                    "yConfig": [
+                      {
+                        "color": "#fec514",
+                        "forAccessor": "b7df21c2-ee65-47cb-9370-294846cfbb65"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "preferredSeriesType": "bar_stacked",
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "valueLabels": "hide",
+                "xTitle": "",
+                "yLeftExtent": {
+                  "mode": "full"
+                },
+                "yLeftScale": "linear",
+                "yTitle": ""
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {},
+          "hidePanelTitles": false
+        },
+        "gridData": {
+          "h": 11,
+          "i": "b18e07f5-a634-49b1-a732-65491c00a9b3",
+          "w": 24,
+          "x": 0,
+          "y": 30
+        },
+        "panelIndex": "b18e07f5-a634-49b1-a732-65491c00a9b3",
+        "title": "Kubernetes warning events",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "description": "Pod memory utilization is calculated as a ratio of the node's allocatable memory",
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-06a776d4-f25a-45c0-a54e-82d0cb913047",
+                "type": "index-pattern"
+              },
+              {
+                "id": "metrics-*",
+                "name": "00370cba-2ec2-4a60-931d-213ecb9916f3",
+                "type": "index-pattern"
+              },
+              {
+                "id": "metrics-*",
+                "name": "94756f64-5bc4-4b8b-a9bb-0ecb5141a2b1",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "06a776d4-f25a-45c0-a54e-82d0cb913047": {
+                      "columnOrder": [
+                        "f4242bda-ae9c-4d7c-8cda-43f56c38acb5",
+                        "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
+                      ],
+                      "columns": {
+                        "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "\"kubernetes.pod.memory.usage.node.pct\": *"
+                          },
+                          "isBucketed": false,
+                          "label": "Average Pod memory Usage ",
+                          "operationType": "last_value",
+                          "params": {
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 2
+                              }
+                            },
+                            "sortField": "@timestamp"
+                          },
+                          "scale": "ratio",
+                          "sourceField": "kubernetes.pod.memory.usage.node.pct"
+                        },
+                        "f4242bda-ae9c-4d7c-8cda-43f56c38acb5": {
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Top 5 values of kubernetes.pod.name",
+                          "operationType": "terms",
+                          "params": {
+                            "accuracyMode": true,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "columnId": "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": false,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 5
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "kubernetes.pod.name"
+                        }
+                      },
+                      "incompleteColumns": {}
+                    }
+                  }
+                }
+              },
+              "filters": [
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "index": "00370cba-2ec2-4a60-931d-213ecb9916f3",
+                    "key": "data_stream.dataset",
+                    "negate": false,
+                    "params": {
+                      "query": "kubernetes.pod"
+                    },
+                    "type": "phrase"
+                  },
+                  "query": {
+                    "match_phrase": {
+                      "data_stream.dataset": "kubernetes.pod"
+                    }
+                  }
+                },
+                {
+                  "$state": {
+                    "store": "appState"
+                  },
+                  "meta": {
+                    "alias": null,
+                    "disabled": false,
+                    "field": "kubernetes.pod.memory.usage.node.pct",
+                    "index": "94756f64-5bc4-4b8b-a9bb-0ecb5141a2b1",
+                    "key": "kubernetes.pod.memory.usage.node.pct",
+                    "negate": false,
+                    "type": "exists",
+                    "value": "exists"
+                  },
+                  "query": {
+                    "exists": {
+                      "field": "kubernetes.pod.memory.usage.node.pct"
+                    }
+                  }
+                }
+              ],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "fittingFunction": "None",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
+                    ],
+                    "layerId": "06a776d4-f25a-45c0-a54e-82d0cb913047",
+                    "layerType": "data",
+                    "seriesType": "bar_horizontal",
+                    "xAccessor": "f4242bda-ae9c-4d7c-8cda-43f56c38acb5",
+                    "yConfig": [
+                      {
+                        "color": "#00bfb3",
+                        "forAccessor": "d954ad9d-4fc7-44d3-8fe9-eecae0d8302c"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": false,
+                  "position": "right",
+                  "showSingleSeries": false
+                },
+                "preferredSeriesType": "bar_horizontal",
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": false,
+                  "yRight": true
+                },
+                "valueLabels": "show",
+                "xTitle": "",
+                "yTitle": ""
+              }
+            },
+            "title": "Cpu Usage per Namespace [Metrics Kubernetes]",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "description": "Pod memory utilization is calculated as a ratio of the node's allocatable memory",
+          "enhancements": {},
+          "hidePanelTitles": false
+        },
+        "gridData": {
+          "h": 11,
+          "i": "dfa9777a-a9d5-469f-ab90-c1bcf6045d85",
+          "w": 12,
+          "x": 24,
+          "y": 19
+        },
+        "panelIndex": "dfa9777a-a9d5-469f-ab90-c1bcf6045d85",
+        "title": "Top Memory intensive pods per Node",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "columns": [
+              "kubernetes.event.type",
+              "kubernetes.event.reason",
+              "kubernetes.event.involved_object.name"
+            ],
+            "description": "Kubernetes Warnings",
+            "grid": {
+              "columns": {
+                "kubernetes.event.involved_object.kind": {
+                  "width": 198.30555555555554
+                },
+                "kubernetes.event.metadata.namespace": {
+                  "width": 249.83333333333337
+                },
+                "kubernetes.event.reason": {
+                  "width": 176.33333333333331
+                },
+                "kubernetes.event.type": {
+                  "width": 156.91666666666663
+                }
+              }
+            },
+            "hideChart": false,
+            "isTextBasedQuery": false,
+            "kibanaSavedObjectMeta": {
+              "searchSourceJSON": {
+                "filter": [
+                  {
+                    "$state": {
+                      "store": "appState"
+                    },
+                    "meta": {
+                      "alias": null,
+                      "disabled": false,
+                      "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                      "key": "kubernetes.event.type",
+                      "negate": false,
+                      "params": {
+                        "query": "Warning"
+                      },
+                      "type": "phrase"
+                    },
+                    "query": {
+                      "match_phrase": {
+                        "kubernetes.event.type": "Warning"
+                      }
+                    }
+                  }
+                ],
+                "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+                "query": {
+                  "language": "kuery",
+                  "query": "data_stream.dataset :\"kubernetes.event\" "
+                }
+              }
+            },
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+                "type": "index-pattern"
+              },
+              {
+                "id": "metrics-*",
+                "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                "type": "index-pattern"
+              }
+            ],
+            "rowHeight": -1,
+            "sort": [
+              [
+                "@timestamp",
+                "desc"
+              ]
+            ],
+            "timeRestore": false,
+            "title": "Kubernetes Warnings",
+            "usesAdHocDataView": false
+          },
+          "enhancements": {},
+          "hidePanelTitles": false
+        },
+        "gridData": {
+          "h": 11,
+          "i": "ea51b3fb-2b45-4bee-9890-685a76fb836d",
+          "w": 24,
+          "x": 24,
+          "y": 30
+        },
+        "panelIndex": "ea51b3fb-2b45-4bee-9890-685a76fb836d",
+        "title": "Latest Kubernetes warnings",
+        "type": "search"
+      }
     ],
-    "type": "dashboard",
-    "typeMigrationVersion": "10.2.0",
-    "updated_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
+    "timeRestore": false,
+    "title": "[Metrics Kubernetes] Cluster Overview",
+    "version": 2
+  },
+  "coreMigrationVersion": "8.8.0",
+  "created_at": "2024-09-09T11:49:12.715Z",
+  "created_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0",
+  "id": "kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c",
+  "managed": false,
+  "references": [
+    {
+      "id": "metrics-*",
+      "name": "3ef5ba86-ebb8-4ba6-941d-ad45de8d94e2:indexpattern-datasource-layer-dfd1702f-213e-4fa2-98e3-5106657c62e7",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "3ef5ba86-ebb8-4ba6-941d-ad45de8d94e2:indexpattern-datasource-layer-dff09473-7596-48c7-bbf4-beccee70d845",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "71969826-a34f-4931-a1a0-53787a1e9d68:indexpattern-datasource-layer-c165f898-73a9-48b1-afa9-2b6e75f3cc1f",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "71969826-a34f-4931-a1a0-53787a1e9d68:indexpattern-datasource-layer-dde29dcf-00ae-4b80-8d9e-ab45c51efba0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "b1eea36d-fb25-4dbb-82d7-561ec2c39b7a:indexpattern-datasource-layer-2ca9773d-0221-478b-b8bc-90bb8d439f33",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "b1eea36d-fb25-4dbb-82d7-561ec2c39b7a:5c81359c-376d-41bd-984d-60fb106f2e33",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "b0a580d6-41a8-4a71-a129-0d2fcb029851:indexpattern-datasource-layer-06a776d4-f25a-45c0-a54e-82d0cb913047",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "b0a580d6-41a8-4a71-a129-0d2fcb029851:c130c98c-51ad-49ce-9e28-1dddc0329421",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "34df5a62-0b8b-491b-b2c2-5aa11f291c7f:indexpattern-datasource-layer-06a776d4-f25a-45c0-a54e-82d0cb913047",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "34df5a62-0b8b-491b-b2c2-5aa11f291c7f:a06a30d5-05f1-46ea-9075-3e6051f5781a",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "34df5a62-0b8b-491b-b2c2-5aa11f291c7f:9c0b0d2f-c443-4c41-b55c-c7ad0db60302",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "27d290d0-3d53-4701-a9b7-82fc26d4dff7:indexpattern-datasource-layer-06a776d4-f25a-45c0-a54e-82d0cb913047",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "27d290d0-3d53-4701-a9b7-82fc26d4dff7:8769bfd6-a9c7-4bab-b048-0e2fcffe8114",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "27d290d0-3d53-4701-a9b7-82fc26d4dff7:d79e5279-bd92-48b0-bd92-767cf6b8892d",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "b18e07f5-a634-49b1-a732-65491c00a9b3:indexpattern-datasource-layer-a69d8e15-2ebf-401c-af12-4b6762f230db",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "b18e07f5-a634-49b1-a732-65491c00a9b3:086a73a8-ac9d-48eb-b5b7-3c697278cc9e",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "dfa9777a-a9d5-469f-ab90-c1bcf6045d85:indexpattern-datasource-layer-06a776d4-f25a-45c0-a54e-82d0cb913047",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "dfa9777a-a9d5-469f-ab90-c1bcf6045d85:00370cba-2ec2-4a60-931d-213ecb9916f3",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "dfa9777a-a9d5-469f-ab90-c1bcf6045d85:94756f64-5bc4-4b8b-a9bb-0ecb5141a2b1",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "ea51b3fb-2b45-4bee-9890-685a76fb836d:kibanaSavedObjectMeta.searchSourceJSON.index",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "ea51b3fb-2b45-4bee-9890-685a76fb836d:kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "controlGroup_46384cc1-8597-4df0-b281-a342bf9f14b4:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "controlGroup_b20283e9-5cbb-40f7-bfc2-2169c34258ab:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "name": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c"
+    },
+    {
+      "name": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56"
+    }
+  ],
+  "type": "dashboard",
+  "typeMigrationVersion": "10.2.0",
+  "updated_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
 }

--- a/packages/kubernetes/kibana/dashboard/kubernetes-f5ab5510-9c94-11e9-94fd-c91206cd5249.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-f5ab5510-9c94-11e9-94fd-c91206cd5249.json
@@ -58,42 +58,115 @@
     },
     "panelsJSON": [
       {
-        "version": "8.9.0",
-        "type": "visualization",
+        "type": "links",
+        "title": "Kubernetes Dashboards [Metrics Kubernetes]",
+        "embeddableConfig": {
+          "attributes": {
+            "title": "Kubernetes Dashboards [Metrics Kubernetes]",
+            "description": "",
+            "layout": "horizontal",
+            "links": [
+              {
+                "label": "Kubernetes Overview",
+                "type": "dashboardLink",
+                "id": "6416766e-26ec-4394-b02d-399b42ca9a6e",
+                "order": 0,
+                "destinationRefName": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard"
+              },
+              {
+                "label": "Kubernetes Nodes",
+                "type": "dashboardLink",
+                "id": "07ec2943-d3c5-4c96-beae-c5d5fde21fef",
+                "options": {
+                  "openInNewTab": false,
+                  "useCurrentDateRange": true,
+                  "useCurrentFilters": true
+                },
+                "order": 1,
+                "destinationRefName": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard"
+              },
+              {
+                "label": "Kubernetes Pods",
+                "type": "dashboardLink",
+                "id": "d0182b64-2cbf-4262-a352-9ab9a0ce48d8",
+                "order": 2,
+                "destinationRefName": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard"
+              },
+              {
+                "label": "Kubernetes Deployments",
+                "type": "dashboardLink",
+                "id": "c4b70217-9e48-4b1b-9b37-7803955a7f68",
+                "order": 3,
+                "destinationRefName": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard"
+              },
+              {
+                "label": "Kubernetes StatefulSets",
+                "type": "dashboardLink",
+                "id": "817b2767-a299-4117-9e40-bacf9d2ceeef",
+                "order": 4,
+                "destinationRefName": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard"
+              },
+              {
+                "label": "Kubernetes DaemonSets",
+                "type": "dashboardLink",
+                "id": "f67a589f-975c-409b-af5a-1ec3131916bd",
+                "order": 5,
+                "destinationRefName": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard"
+              },
+              {
+                "label": "Kubernetes Cronjobs",
+                "type": "dashboardLink",
+                "id": "7aeb19b4-8594-4187-9431-1e5e9f09b652",
+                "order": 6,
+                "destinationRefName": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard"
+              },
+              {
+                "label": "Kubernetes Jobs",
+                "type": "dashboardLink",
+                "id": "b805b8c7-e9d7-4968-9ae2-78d5fb0974ad",
+                "order": 7,
+                "destinationRefName": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard"
+              },
+              {
+                "label": "Kubernetes Volumes",
+                "type": "dashboardLink",
+                "id": "269b5aeb-9e4a-4d27-83ac-77d8aec1213f",
+                "order": 8,
+                "destinationRefName": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard"
+              },
+              {
+                "label": "Kubernetes PV/PVC",
+                "type": "dashboardLink",
+                "id": "9b4a4e12-82d3-445f-8c11-76f197f2aa8b",
+                "order": 9,
+                "destinationRefName": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard"
+              },
+              {
+                "label": "Kubernetes Services",
+                "type": "dashboardLink",
+                "id": "3e277318-8f0e-4be9-9572-0685e64684cf",
+                "order": 10,
+                "destinationRefName": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard"
+              },
+              {
+                "label": "Kubernetes API server",
+                "type": "dashboardLink",
+                "id": "808c6778-b18e-478a-8010-54bd6c8b2f3e",
+                "order": 11,
+                "destinationRefName": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard"
+              }
+            ],
+            "id": "links_panel_kubernetes_f5ab5510_9c94_11e9_94fd_c91206cd5249"
+          },
+          "enhancements": {}
+        },
+        "panelIndex": "c13eb504-6afb-4fa5-8a7d-a75c5fee15b7",
         "gridData": {
           "h": 12,
           "i": "c13eb504-6afb-4fa5-8a7d-a75c5fee15b7",
           "w": 13,
           "x": 0,
           "y": 0
-        },
-        "panelIndex": "c13eb504-6afb-4fa5-8a7d-a75c5fee15b7",
-        "embeddableConfig": {
-          "enhancements": {},
-          "hidePanelTitles": true,
-          "savedVis": {
-            "data": {
-              "aggs": [],
-              "searchSource": {
-                "filter": [],
-                "query": {
-                  "language": "kuery",
-                  "query": ""
-                }
-              }
-            },
-            "description": "",
-            "id": "",
-            "params": {
-              "fontSize": 12,
-              "markdown": "### Scheduler\n\nThis dashboard collects metrics from [kube scheduler](https://kubernetes.io/docs/concepts/overview/components/#kube-scheduler) endpoint. Its purpose is to give an overview of what is happening inside it through this component metrics and detect problems that might be happening. \n\n**WARNING**: This dataset **requires access** to the Kubernetes scheduler endpoint. Refer [here](https://docs.elastic.co/en/integrations/kubernetes#scheduler-and-controllermanager) to learn how to enable it. In some \"As a Service\" Kubernetes implementations, like GKE or AKS, it is **not possible** to access its metrics.",
-              "openLinksInNewTab": false
-            },
-            "title": "",
-            "type": "markdown",
-            "uiState": {}
-          },
-          "type": "visualization"
         }
       },
       {
@@ -3685,6 +3758,66 @@
       "id": "metrics-*",
       "name": "controlGroup_df56c430-83b1-436e-8b9c-fb027aaa29ca:optionsListDataView",
       "type": "index-pattern"
+    },
+    {
+      "name": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c"
+    },
+    {
+      "name": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56"
     }
   ],
   "managed": false,

--- a/packages/kubernetes/kibana/dashboard/kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013.json
@@ -34,42 +34,116 @@
     },
     "panelsJSON": [
       {
-        "version": "8.9.0",
-        "type": "visualization",
+        "type": "links",
+        "title": "Kubernetes Dashboards [Metrics Kubernetes]",
+        "embeddableConfig": {
+          "attributes": {
+            "title": "Kubernetes Dashboards [Metrics Kubernetes]",
+            "description": "",
+            "layout": "horizontal",
+            "links": [
+              {
+                "label": "Kubernetes Overview",
+                "type": "dashboardLink",
+                "id": "6416766e-26ec-4394-b02d-399b42ca9a6e",
+                "order": 0,
+                "destinationRefName": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard"
+              },
+              {
+                "label": "Kubernetes Nodes",
+                "type": "dashboardLink",
+                "id": "07ec2943-d3c5-4c96-beae-c5d5fde21fef",
+                "options": {
+                  "openInNewTab": false,
+                  "useCurrentDateRange": true,
+                  "useCurrentFilters": true
+                },
+                "order": 1,
+                "destinationRefName": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard"
+              },
+              {
+                "label": "Kubernetes Pods",
+                "type": "dashboardLink",
+                "id": "d0182b64-2cbf-4262-a352-9ab9a0ce48d8",
+                "order": 2,
+                "destinationRefName": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard"
+              },
+              {
+                "label": "Kubernetes Deployments",
+                "type": "dashboardLink",
+                "id": "c4b70217-9e48-4b1b-9b37-7803955a7f68",
+                "order": 3,
+                "destinationRefName": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard"
+              },
+              {
+                "label": "Kubernetes StatefulSets",
+                "type": "dashboardLink",
+                "id": "817b2767-a299-4117-9e40-bacf9d2ceeef",
+                "order": 4,
+                "destinationRefName": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard"
+              },
+              {
+                "label": "Kubernetes DaemonSets",
+                "type": "dashboardLink",
+                "id": "f67a589f-975c-409b-af5a-1ec3131916bd",
+                "order": 5,
+                "destinationRefName": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard"
+              },
+              {
+                "label": "Kubernetes Cronjobs",
+                "type": "dashboardLink",
+                "id": "7aeb19b4-8594-4187-9431-1e5e9f09b652",
+                "order": 6,
+                "destinationRefName": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard"
+              },
+              {
+                "label": "Kubernetes Jobs",
+                "type": "dashboardLink",
+                "id": "b805b8c7-e9d7-4968-9ae2-78d5fb0974ad",
+                "order": 7,
+                "destinationRefName": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard"
+              },
+              {
+                "label": "Kubernetes Volumes",
+                "type": "dashboardLink",
+                "id": "269b5aeb-9e4a-4d27-83ac-77d8aec1213f",
+                "order": 8,
+                "destinationRefName": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard"
+              },
+              {
+                "label": "Kubernetes PV/PVC",
+                "type": "dashboardLink",
+                "id": "9b4a4e12-82d3-445f-8c11-76f197f2aa8b",
+                "order": 9,
+                "destinationRefName": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard"
+              },
+              {
+                "label": "Kubernetes Services",
+                "type": "dashboardLink",
+                "id": "3e277318-8f0e-4be9-9572-0685e64684cf",
+                "order": 10,
+                "destinationRefName": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard"
+              },
+              {
+                "label": "Kubernetes API server",
+                "type": "dashboardLink",
+                "id": "808c6778-b18e-478a-8010-54bd6c8b2f3e",
+                "order": 11,
+                "destinationRefName": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard"
+              }
+            ],
+            "id": "links_panel_kubernetes_ff1b3850_bcb1_11ec_b64f_7dd6e8e82013"
+          },
+          "enhancements": {}
+        },
+        "panelIndex": "60c70dea-d4f0-43ea-a43f-7927dcf5c34d",
         "gridData": {
           "h": 4,
           "i": "60c70dea-d4f0-43ea-a43f-7927dcf5c34d",
           "w": 48,
           "x": 0,
           "y": 0
-        },
-        "panelIndex": "60c70dea-d4f0-43ea-a43f-7927dcf5c34d",
-        "embeddableConfig": {
-          "enhancements": {},
-          "savedVis": {
-            "data": {
-              "aggs": [],
-              "searchSource": {
-                "filter": [],
-                "query": {
-                  "language": "kuery",
-                  "query": ""
-                }
-              }
-            },
-            "description": "",
-            "params": {
-              "fontSize": 10,
-              "markdown": "[Kubernetes Overview](#/view/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c),\n[Kubernetes Nodes](#/view/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013), \n[Kubernetes Pods](#/view/kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013),  [Kubernetes Deployments](#/view/kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes StatefulSets](#/view/kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013),  [Kubernetes DaemonSets](#/view/kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes CronJobs](#/view/kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Jobs](#/view/kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Volumes](#/view/kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013), [Kubernetes PV/PVC](#/view/kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes Services](#/view/kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013), [Kubernetes API Server](#/view/kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56)",
-              "openLinksInNewTab": false
-            },
-            "title": "",
-            "type": "markdown",
-            "uiState": {}
-          },
-          "type": "visualization"
-        },
-        "title": "Kubernetes Dashboards [Metrics Kubernetes]"
+        }
       },
       {
         "version": "8.9.0",
@@ -310,6 +384,66 @@
       "id": "metrics-*",
       "name": "controlGroup_c749b037-7a98-4555-822b-cb9a52395dbb:optionsListDataView",
       "type": "index-pattern"
+    },
+    {
+      "name": "link_6416766e-26ec-4394-b02d-399b42ca9a6e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c"
+    },
+    {
+      "name": "link_07ec2943-d3c5-4c96-beae-c5d5fde21fef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_d0182b64-2cbf-4262-a352-9ab9a0ce48d8_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_c4b70217-9e48-4b1b-9b37-7803955a7f68_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_817b2767-a299-4117-9e40-bacf9d2ceeef_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_f67a589f-975c-409b-af5a-1ec3131916bd_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_7aeb19b4-8594-4187-9431-1e5e9f09b652_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_b805b8c7-e9d7-4968-9ae2-78d5fb0974ad_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_269b5aeb-9e4a-4d27-83ac-77d8aec1213f_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_9b4a4e12-82d3-445f-8c11-76f197f2aa8b_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-dd081350-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_3e277318-8f0e-4be9-9572-0685e64684cf_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013"
+    },
+    {
+      "name": "link_808c6778-b18e-478a-8010-54bd6c8b2f3e_dashboard",
+      "type": "dashboard",
+      "id": "kubernetes-d3bd9650-0c14-11ed-b760-5d1bccb47f56"
     }
   ],
   "managed": false,

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: kubernetes
 title: Kubernetes
-version: 1.80.2
+version: 1.81.0
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
This PR replaces the markdown navigation section at the top of most K8s dashboards with a native 'Links' panel which maintains filters between navigation.

_Copilot wrote most of these changes. I visually verified they look correct, and the package still builds. But as a note to the reviewer, please double check you're happy that nothing else changed here._ 

I was not able to include the panel as a reference due to 'links' not being allowed in package-spec, so the json is repeated in every dashboard. I know we generally prefer inline visualisations, but in this case it seems like a reference would be significantly better from a maintanence POV. We should potentially resolve this by allowing links JSON in packages under kibana/links.

The existing markdown panels are replaced without modification to sizing or position, so you end up with some looking kinda weird. e.g.

This existing markdown panel:

<img width="1554" height="1045" alt="Screenshot 2025-07-21 at 11 35 38" src="https://github.com/user-attachments/assets/1bd371ee-903d-4a64-b317-aac80c6d56cc" />

becomes like this:


<img width="1554" height="1045" alt="Screenshot 2025-07-21 at 11 35 41" src="https://github.com/user-attachments/assets/f0dda88e-d108-4c53-a3a2-d8d8d276242e" />

This sucked in the first place, so I don't think anything got worse.

Because the links panel retains query filters as you navigate between dashboards, I also had to modify the API server dashboard to use per-panel filtering instead of at the top level. I also enabled margins on this one, since it's a simple boolean toggle, and it was only one not using them. 

Before:

<img width="1554" height="1045" alt="Screenshot 2025-07-21 at 11 36 29" src="https://github.com/user-attachments/assets/66a1f33f-9fe6-419c-b7ca-c7e300feedb9" />

After:

<img width="1550" height="1045" alt="Screenshot 2025-07-21 at 11 55 05" src="https://github.com/user-attachments/assets/adabe2b5-ec5a-4efb-94c8-b332a0c4dd69" />

Another sucky part of this change is that you have to scroll the links panel to get to the links 'further down' (on the right). If we want to be able to have the links fill more vertical space we need to take this up with the dashboards team.

Fixes https://github.com/elastic/kibana/issues/202471.