### PR TITLE
Custom TI: add filter for transform's destination index in dashboard

### DIFF
--- a/packages/ti_custom/changelog.yml
+++ b/packages/ti_custom/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add filter for transform's destination index in dashboard.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/14646
 - version: "1.2.0"
   changes:
     - description: Use `terminate` processor instead of `fail` processor to handle agent errors.

--- a/packages/ti_custom/changelog.yml
+++ b/packages/ti_custom/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Add filter for transform's destination index in dashboard.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "1.2.0"
   changes:
     - description: Use `terminate` processor instead of `fail` processor to handle agent errors.

--- a/packages/ti_custom/kibana/dashboard/ti_custom-e336dd7a-d5cb-4b7f-a6cd-85c45d0bd1ac.json
+++ b/packages/ti_custom/kibana/dashboard/ti_custom-e336dd7a-d5cb-4b7f-a6cd-85c45d0bd1ac.json
@@ -80,6 +80,28 @@
                                 "data_stream.dataset": "ti_custom.indicator"
                             }
                         }
+                    },
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "field": "labels.is_ioc_transform_source",
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
+                            "key": "labels.is_ioc_transform_source",
+                            "negate": true,
+                            "params": {
+                                "query": "true"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "labels.is_ioc_transform_source": "true"
+                            }
+                        }
                     }
                 ],
                 "query": {
@@ -993,6 +1015,11 @@
         {
             "id": "logs-*",
             "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
             "type": "index-pattern"
         },
         {

--- a/packages/ti_custom/manifest.yml
+++ b/packages/ti_custom/manifest.yml
@@ -3,7 +3,7 @@ name: ti_custom
 title: Custom Threat Intelligence
 description: Ingest threat intelligence data in STIX 2.1 format with Elastic Agent
 type: integration
-version: 1.2.0
+version: 1.2.1
 categories:
   - custom
   - security


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Added filter to the Custom Threat Intelligence dashboard so only indicators from destination index (latest transform) are shown, avoiding to display duplicated indicators.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
<img width="464" height="136" alt="image" src="https://github.com/user-attachments/assets/e1db995a-28f2-4d4b-a0f0-593e6d9eb5af" />
