### PR TITLE
[wiz] Add Filters to Retrieve all Types of Vulnerabilities

### DIFF
--- a/packages/wiz/changelog.yml
+++ b/packages/wiz/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.7.0"
+  changes:
+    - description: Add filters to retrieve all types of vulnerabilities in the vulnerability dataset.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.6.0"
   changes:
     - description: Add troubleshooting note in README on `event.ingested` requirement for standalone Elastic Agent.

--- a/packages/wiz/changelog.yml
+++ b/packages/wiz/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "3.7.0"
   changes:
-    - description: Add filters to retrieve all types of vulnerabilities in the vulnerability dataset.
+    - description: Add configurable toggle to include all vulnerability statuses in the vulnerability dataset.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/14664
 - version: "3.6.0"

--- a/packages/wiz/changelog.yml
+++ b/packages/wiz/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add filters to retrieve all types of vulnerabilities in the vulnerability dataset.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/14664
 - version: "3.6.0"
   changes:
     - description: Add troubleshooting note in README on `event.ingested` requirement for standalone Elastic Agent.

--- a/packages/wiz/data_stream/vulnerability/agent/stream/cel.yml.hbs
+++ b/packages/wiz/data_stream/vulnerability/agent/stream/cel.yml.hbs
@@ -25,6 +25,7 @@ state:
   initial_interval: {{initial_interval}}
   want_more: false
   batch_size: {{batch_size}}
+  include_all_vulnerability: {{include_all_vulnerability}}
   query: >-
     query VulnerabilityFindingsPage($filterBy: VulnerabilityFindingFilters $first: Int $after: String $orderBy: VulnerabilityFindingOrder) {
        vulnerabilityFindings(filterBy: $filterBy first: $first after: $after orderBy: $orderBy) {
@@ -140,7 +141,12 @@ program: |
           "first": state.batch_size,
           "after": state.?end_cursor.value.orValue(null),
           "filterBy": {
-            "status": ["RESOLVED", "OPEN", "REJECTED", "IN_PROGRESS"],
+            "status": (
+              state.?include_all_vulnerability.orValue(false) ?
+                ["RESOLVED", "OPEN", "REJECTED", "IN_PROGRESS"]
+              :
+                ["OPEN"]
+            ),
             "updatedAt": {
               "after": state.want_more ?
                   state.?cursor.first_timestamp.orValue(null)

--- a/packages/wiz/data_stream/vulnerability/agent/stream/cel.yml.hbs
+++ b/packages/wiz/data_stream/vulnerability/agent/stream/cel.yml.hbs
@@ -25,7 +25,13 @@ state:
   initial_interval: {{initial_interval}}
   want_more: false
   batch_size: {{batch_size}}
-  include_all_vulnerability: {{include_all_vulnerability}}
+  {{#if include_all_vulnerability}}
+  want_status:
+    - RESOLVED
+    - OPEN
+    - REJECTED
+    - IN_PROGRESS
+  {{/if}}
   query: >-
     query VulnerabilityFindingsPage($filterBy: VulnerabilityFindingFilters $first: Int $after: String $orderBy: VulnerabilityFindingOrder) {
        vulnerabilityFindings(filterBy: $filterBy first: $first after: $after orderBy: $orderBy) {
@@ -141,12 +147,7 @@ program: |
           "first": state.batch_size,
           "after": state.?end_cursor.value.orValue(null),
           "filterBy": {
-            "status": (
-              state.?include_all_vulnerability.orValue(false) ?
-                ["RESOLVED", "OPEN", "REJECTED", "IN_PROGRESS"]
-              :
-                ["OPEN"]
-            ),
+            ?"status": state.?want_status,
             "updatedAt": {
               "after": state.want_more ?
                   state.?cursor.first_timestamp.orValue(null)

--- a/packages/wiz/data_stream/vulnerability/agent/stream/cel.yml.hbs
+++ b/packages/wiz/data_stream/vulnerability/agent/stream/cel.yml.hbs
@@ -140,6 +140,7 @@ program: |
           "first": state.batch_size,
           "after": state.?end_cursor.value.orValue(null),
           "filterBy": {
+            "status": ["RESOLVED", "OPEN", "REJECTED", "IN_PROGRESS"],
             "updatedAt": {
               "after": state.want_more ?
                   state.?cursor.first_timestamp.orValue(null)

--- a/packages/wiz/data_stream/vulnerability/manifest.yml
+++ b/packages/wiz/data_stream/vulnerability/manifest.yml
@@ -7,6 +7,16 @@ streams:
     description: Collect Vulnerability logs from Wiz.
     template_path: cel.yml.hbs
     vars:
+      - name: include_all_vulnerability
+        required: true
+        show_user: true
+        title: Include All Vulnerability Statuses
+        description: >-
+          Enable this toggle to fetch all types of vulnerabilities, including those with statuses RESOLVED, OPEN, REJECTED, and IN_PROGRESS.
+          By default, only active vulnerabilities with the OPEN status are retrieved.
+        type: bool
+        multi: false
+        default: false
       - name: initial_interval
         type: text
         title: Initial Interval

--- a/packages/wiz/data_stream/vulnerability/manifest.yml
+++ b/packages/wiz/data_stream/vulnerability/manifest.yml
@@ -13,7 +13,7 @@ streams:
         title: Include All Vulnerability Statuses
         description: >-
           Enable this toggle to fetch all types of vulnerabilities, including those with statuses RESOLVED, OPEN, REJECTED, and IN_PROGRESS.
-          By default, only active vulnerabilities with the OPEN status are retrieved.
+          By default, the API's default filter is used.
         type: bool
         multi: false
         default: false

--- a/packages/wiz/manifest.yml
+++ b/packages/wiz/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: wiz
 title: Wiz
-version: "3.6.0"
+version: "3.7.0"
 description: Collect logs from Wiz with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message
```
wiz: add filters to retrieve all types of vulnerabilities in the vulnerability dataset

This change introduces filters to the vulnerability dataset, allowing
retrieval of all types of vulnerabilities. It enhances the dataset's
flexibility by ensuring comprehensive coverage across different
vulnerability categories.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/wiz directory.
- Run the following command to run tests.

> elastic-package test -v

## Related Issue

- Closes https://github.com/elastic/integrations/issues/14437
