### PR TITLE
[PANW ] Add conditional to processors populating _temp_ fields for internal and external zones

### DIFF
--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "5.3.2"
+  changes:
+    - description: Add conditional to processors populating _temp_ fields for internal and external zones.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/XXXX
 - version: "5.3.1"
   changes:
     - description: Update documentation

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/traffic.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/traffic.yml
@@ -249,10 +249,12 @@ processors:
   - set:
       field: _temp_.external_zones
       copy_from: _conf.external_zones
+      if: ctx._conf?.external_zones != null
       ignore_failure: true
   - set:
       field: _temp_.internal_zones
       copy_from: _conf.internal_zones
+      if: ctx._conf?.internal_zones != null
       ignore_failure: true
   - set:
       field: network.direction

--- a/packages/panw/manifest.yml
+++ b/packages/panw/manifest.yml
@@ -1,6 +1,6 @@
 name: panw
 title: Palo Alto Next-Gen Firewall
-version: "5.3.1"
+version: "5.3.2"
 description: Collect logs from Palo Alto next-gen firewalls with Elastic Agent.
 type: integration
 format_version: "3.0.3"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

The first 2 processors in the logic to populate the field `network.direction` relies on the existence of the fields `_conf.internal_zones` and `_conf.external_zones` if the user does not configure those fields in the integration, or if the source data does not have this field, those processors would still try to process every message and would fail because the field does not exist, this can add some extra time in the overall processing time of the ingest pipeline.

These 2 processors needs to be conditionally executed to avoid this, we detected this issue while troubleshooting the performance of the ingest pipeline.

 - Bug