### PR TITLE
[Security AI Prompts] First major release

### DIFF
--- a/packages/security_ai_prompts/changelog.yml
+++ b/packages/security_ai_prompts/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: "First release of the Security AI Prompts package"
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/xxx
+      link: https://github.com/elastic/integrations/pull/14678
 - version: "0.0.5"
   changes:
     - description: "Update KnowledgeBaseRetrievalTool and AskAboutESQLTool prompts"

--- a/packages/security_ai_prompts/changelog.yml
+++ b/packages/security_ai_prompts/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: "First release of the Security AI Prompts package"
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/xxx
 - version: "0.0.5"
   changes:
     - description: "Update KnowledgeBaseRetrievalTool and AskAboutESQLTool prompts"

--- a/packages/security_ai_prompts/manifest.yml
+++ b/packages/security_ai_prompts/manifest.yml
@@ -22,4 +22,4 @@ source:
   license: "Elastic-2.0"
 title: "Security AI Prompts"
 type: content
-version: 0.0.5
+version: 1.0.0


### PR DESCRIPTION
Moves Security AI Prompts package out of prerelease, version `1.0.0`