### PR TITLE
[CI] Update junit buildkite plugin

### DIFF
--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -97,7 +97,7 @@ steps:
   - label: ":junit: Junit annotate"
     agents:
       # requires at least "bash", "curl" and "git"
-      image: "ruby:3.4.5-bookworm"
+      image: "docker.elastic.co/ci-agent-images/buildkite-junit-annotate:1.0"
     plugins:
       - junit-annotate#v2.7.0:
           artifacts: "build/test-results/*.xml"

--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -95,13 +95,16 @@ steps:
     continue_on_failure: true
 
   - label: ":junit: Junit annotate"
+    agents:
+      # requires at least "bash", "curl" and "git"
+      image: "ruby:3.4.5-bookworm"
     plugins:
-      - junit-annotate#v2.5.0:
+      - junit-annotate#v2.7.0:
           artifacts: "build/test-results/*.xml"
           failed-download-exit-code: 0 # Not fail the build in case there are no XML files
           report-skipped: true
-    agents:
-      provider: "gcp"  # junit plugin requires docker
+          always-annotate: true
+          run-in-docker: false
 
   - label: ":github: Report failed tests"
     key: report-failed-tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -103,7 +103,7 @@ steps:
   - label: ":junit: Junit annotate"
     agents:
       # requires at least "bash", "curl" and "git"
-      image: "ruby:3.4.5-bookworm"
+      image: "docker.elastic.co/ci-agent-images/buildkite-junit-annotate:1.0"
     plugins:
       - junit-annotate#v2.7.0:
           artifacts: "build/test-results/*.xml"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -110,6 +110,7 @@ steps:
           failed-download-exit-code: 0 # Not fail the build in case there are no XML files
           report-skipped: true
           always-annotate: true
+          run-in-docker: false
 
   - label: ":github: Report failed tests"
     key: report-failed-tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,6 +37,7 @@ env:
   # All steps will have the same value, since it always gets the value
   # "BUILDKITE_STEP_ID" from the first "Upload pipeline" step.
   ELASTIC_PACKAGE_CUSTOMIZE_SERVICE_TEST_RUN_ID: "true"
+  STACK_VERSION: 9.2.0-SNAPSHOT
 
 steps:
   - label: "Get reference from target branch"
@@ -101,14 +102,15 @@ steps:
       build.env('BUILDKITE_PIPELINE_SLUG') == "integrations"
 
   - label: ":junit: Junit annotate"
+    agents:
+      # requires at least "bash", "curl" and "git"
+      image: "ruby:3.4.5-bookworm@sha256:64b669025ed6f2f2697a7fc15fc5a59d7b47d190619f3b1147b875815deb2a5f"
     plugins:
-      - junit-annotate#v2.5.0:
+      - junit-annotate#v2.7.0:
           artifacts: "build/test-results/*.xml"
           failed-download-exit-code: 0 # Not fail the build in case there are no XML files
           report-skipped: true
           always-annotate: true
-    agents:
-      provider: "gcp"  # junit plugin requires docker
 
   - label: ":github: Report failed tests"
     key: report-failed-tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,7 +37,6 @@ env:
   # All steps will have the same value, since it always gets the value
   # "BUILDKITE_STEP_ID" from the first "Upload pipeline" step.
   ELASTIC_PACKAGE_CUSTOMIZE_SERVICE_TEST_RUN_ID: "true"
-  STACK_VERSION: 9.2.0-SNAPSHOT
 
 steps:
   - label: "Get reference from target branch"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -103,7 +103,7 @@ steps:
   - label: ":junit: Junit annotate"
     agents:
       # requires at least "bash", "curl" and "git"
-      image: "ruby:3.4.5-bookworm@sha256:64b669025ed6f2f2697a7fc15fc5a59d7b47d190619f3b1147b875815deb2a5f"
+      image: "ruby:3.4.5-bookworm"
     plugins:
       - junit-annotate#v2.7.0:
           artifacts: "build/test-results/*.xml"


### PR DESCRIPTION
## Proposed commit message

Update [Buildkite junit-annotate plugin](https://github.com/buildkite-plugins/junit-annotate-buildkite-plugin) up to version 2.7.0

Set `run-in-docker: false` to use the ruby from the agent.


## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Validate with Buildkite builds using the version in main branch


