### PR TITLE
[CI] Fix sources backport tenable io

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -31,15 +31,16 @@ export TMP_FOLDER_TEMPLATE="${TMP_FOLDER_TEMPLATE_BASE}.XXXXXXXXX"
 REPO_BUILD_TAG="${REPO_NAME}/$(buildkite_pr_branch_build_id)"
 export REPO_BUILD_TAG
 
-AWS_SERVICE_ACCOUNT_SECRET_PATH=kv/ci-shared/platform-ingest/aws_ingest_ci
-PRIVATE_CI_GCS_CREDENTIALS_PATH=kv/ci-shared/platform-ingest/gcp-platform-ingest-ci-service-account
-
 BUILDKITE_API_TOKEN_PATH=kv/ci-shared/platform-ingest/buildkite_token
 
-EC_TOKEN_PATH=kv/ci-shared/platform-ingest/platform-ingest-ec-qa
 EC_DATA_PATH=secret/ci/elastic-integrations/ec_data
 
-# variables required for terraform
+export JOB_GCS_BUCKET_INTERNAL="ecosystem-ci-internal"
+
+# -------------
+# variables required by packages using Terraform as a service deployer
+# https://github.com/elastic/elastic-package/blob/f8f2f15a04bcc25eca00887fb147bd7f8a0f32b3/internal/servicedeployer/_static/terraform_deployer.yml#L8
+
 export ENVIRONMENT="ci"
 export REPO="${REPO_NAME}"
 
@@ -70,6 +71,15 @@ export BUILD_ID="${BUILDKITE_BUILD_NUMBER}"
 CREATED_DATE=$(date +%s%3N)
 export CREATED_DATE
 
+# -------------
+
+if [[ "${ELASTIC_PACKAGE_CUSTOMIZE_SERVICE_TEST_RUN_ID:-"false"}" == "true" ]]; then
+    # Required to customize the RunID value mainly for those packages creating resources in cloud providers
+    # via the terraform service deployer.
+    # Get the latest 4 digits of the BUILDKITE_STEP_ID
+    export ELASTIC_PACKAGE_PREFIX_SERVICE_TEST_RUN_ID="${BUILDKITE_STEP_ID: -4}"
+fi
+
 if [ -n "${ELASTIC_PACKAGE_LINKS_FILE_PATH+x}" ]; then
     # first upload pipeline does not have the environment variables defined in the YAML
     export ELASTIC_PACKAGE_LINKS_FILE_PATH=${BASE_DIR}/${ELASTIC_PACKAGE_LINKS_FILE_PATH}
@@ -80,7 +90,7 @@ if [[ ( "${BUILDKITE_PIPELINE_SLUG}" =~ ^(integrations|integrations-test-stack)$
     # This step MUST be the first one and not run in parallel with any other step to ensure
     # that there is just one value for this variable
     if is_pr ; then
-        git fetch -v origin ${BUILDKITE_PULL_REQUEST_BASE_BRANCH}
+        git fetch -v origin "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
         commit_main=$(git rev-parse --verify FETCH_HEAD)
         buildkite-agent meta-data set "REPOSITORY_TARGET_BRANCH_COMMIT" "${commit_main}"
     fi
@@ -102,24 +112,9 @@ if [[ "${BUILDKITE_PIPELINE_SLUG}" =~ ^(integrations|integrations-test-stack)$ ]
     if [[ "${BUILDKITE_STEP_KEY}" == "publish-benchmarks" ]]; then
         BUILDKITE_API_TOKEN=$(retry 5 vault kv get -field buildkite_token "${BUILDKITE_API_TOKEN_PATH}")
         export BUILDKITE_API_TOKEN
-        GITHUB_TOKEN=$VAULT_GITHUB_TOKEN
-        export GITHUB_TOKEN
     fi
 
     if [[ "${BUILDKITE_STEP_KEY}" =~ ^test-integrations- ]]; then
-        ELASTIC_PACKAGE_AWS_SECRET_KEY=$(retry 5 vault kv get -field secret_key "${AWS_SERVICE_ACCOUNT_SECRET_PATH}")
-        export ELASTIC_PACKAGE_AWS_SECRET_KEY
-        ELASTIC_PACKAGE_AWS_ACCESS_KEY=$(retry 5 vault kv get -field access_key "${AWS_SERVICE_ACCOUNT_SECRET_PATH}")
-        export ELASTIC_PACKAGE_AWS_ACCESS_KEY
-
-        PRIVATE_CI_GCS_CREDENTIALS_SECRET=$(retry 5 vault kv get -field plaintext -format=json "${PRIVATE_CI_GCS_CREDENTIALS_PATH}")
-        export PRIVATE_CI_GCS_CREDENTIALS_SECRET
-        export JOB_GCS_BUCKET_INTERNAL="ingest-buildkite-ci"
-
-        # Environment variables required by the service deployer
-        export AWS_SECRET_ACCESS_KEY=${ELASTIC_PACKAGE_AWS_SECRET_KEY}
-        export AWS_ACCESS_KEY_ID=${ELASTIC_PACKAGE_AWS_ACCESS_KEY}
-
         BUILDKITE_API_TOKEN=$(retry 5 vault kv get -field buildkite_token "${BUILDKITE_API_TOKEN_PATH}")
         export BUILDKITE_API_TOKEN
     fi
@@ -127,37 +122,11 @@ fi
 
 if [[ "${BUILDKITE_PIPELINE_SLUG}" == "integrations-serverless" ]]; then
     if [[ "${BUILDKITE_STEP_KEY}" == "test-integrations-serverless-project" ]]; then
-        # Currently, system tests are not run when testing with an Elastic Serverless project, so it is not required to
-        # add the AWS credentials as in the integrations pipeline.
-
-        PRIVATE_CI_GCS_CREDENTIALS_SECRET=$(retry 5 vault kv get -field plaintext -format=json "${PRIVATE_CI_GCS_CREDENTIALS_PATH}")
-        export PRIVATE_CI_GCS_CREDENTIALS_SECRET
-        export JOB_GCS_BUCKET_INTERNAL="ingest-buildkite-ci"
 
         BUILDKITE_API_TOKEN=$(retry 5 vault kv get -field buildkite_token "${BUILDKITE_API_TOKEN_PATH}")
         export BUILDKITE_API_TOKEN
 
-        EC_API_KEY_SECRET=$(retry 5 vault kv get -field apiKey "${EC_TOKEN_PATH}")
-        export EC_API_KEY_SECRET
-        EC_HOST_SECRET=$(retry 5 vault kv get -field url "${EC_TOKEN_PATH}")
-        export EC_HOST_SECRET
         EC_REGION_SECRET=$(retry 5 vault read -field region_qa "${EC_DATA_PATH}")
         export EC_REGION_SECRET
     fi
 fi
-
-if [[ "$BUILDKITE_PIPELINE_SLUG" == "integrations-backport" ]]; then
-  if [[ "$BUILDKITE_STEP_KEY" == "create-backport-branch" ]]; then
-    GITHUB_USERNAME="elastic-vault-github-plugin-prod"
-    GITHUB_EMAIL="elasticmachine@elastic.co"
-    GITHUB_TOKEN=$VAULT_GITHUB_TOKEN
-    export GITHUB_TOKEN GITHUB_EMAIL GITHUB_USERNAME
-  fi
-fi
-
-if [[ "$BUILDKITE_PIPELINE_SLUG" == "integrations" || "$BUILDKITE_PIPELINE_SLUG" == "integrations-serverless" ]]; then
-  if [[ "$BUILDKITE_STEP_KEY" == "report-failed-tests" ]]; then
-    export GITHUB_TOKEN="${VAULT_GITHUB_TOKEN}"
-  fi
-fi
-

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -4,49 +4,52 @@ source .buildkite/scripts/common.sh
 
 set -euo pipefail
 
-if [[ "$BUILDKITE_PIPELINE_SLUG" =~ ^(integrations|integrations-test-stack)$ ]]; then
-    # FIXME: update condition depending on the pipeline steps triggered
-    if [[ "$BUILDKITE_STEP_KEY" =~ ^test-integrations- ]]; then
-        unset ELASTIC_PACKAGE_AWS_ACCESS_KEY
-        unset ELASTIC_PACKAGE_AWS_SECRET_KEY
-        unset AWS_ACCESS_KEY_ID
-        unset AWS_SECRET_ACCESS_KEY
-
-        # Ensure that kind cluster is deleted
-        delete_kind_cluster
-
-        # Ensure elastic stack is stopped
-        if [ -f "${ELASTIC_PACKAGE_BIN}" ]; then
-            echo "--- Take down the Elastic stack"
-            ${ELASTIC_PACKAGE_BIN} stack down -v
-        fi
+should_run_stack_down() {
+    # as first check, ensure that the elastic-package binary exists
+    if [ ! -f "${ELASTIC_PACKAGE_BIN}" ]; then
+        return 1
     fi
-fi
 
-if [[ "$BUILDKITE_PIPELINE_SLUG" == "integrations-serverless" ]]; then
-    if [[ "$BUILDKITE_STEP_KEY" == "test-integrations-serverless-project" ]]; then
-        unset ELASTIC_PACKAGE_AWS_ACCESS_KEY
-        unset ELASTIC_PACKAGE_AWS_SECRET_KEY
-        unset AWS_ACCESS_KEY_ID
-        unset AWS_SECRET_ACCESS_KEY
-
-        # Ensure that kind cluster is deleted
-        delete_kind_cluster
-
-        # Ensure elastic stack is stopped
-        if [ -f "${ELASTIC_PACKAGE_BIN}" ]; then
-            echo "--- Take down the Elastic stack"
-            EC_API_KEY=${EC_API_KEY_SECRET} EC_HOST=${EC_HOST_SECRET} ${ELASTIC_PACKAGE_BIN} stack down -v
-        fi
+    if is_serverless; then
+        return 0
     fi
-fi
 
-unset_secrets
-cleanup
+    if is_stack_created; then
+        return 0
+    fi
 
-google_cloud_logout_active_account
+    return 1
+}
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "integrations-backport" && "$BUILDKITE_STEP_KEY" == "create-backport-branch" ]]; then
   cd "${WORKSPACE}"
   git config remote.origin.url "https://github.com/elastic/integrations.git"
 fi
+
+exit_code=0
+if [[ "$BUILDKITE_PIPELINE_SLUG" =~ ^(integrations|integrations-test-stack|integrations-serverless)$ ]]; then
+    # it should match "^test-integration-" steps created in the integrations and integrations-test-stack pipelines (e.g. test-integration-apache or test-integration-aws)
+    # as well as the step ID "test-integrations-serverless-project" from the "integrations-serverless" pipeline
+    if [[ "$BUILDKITE_STEP_KEY" =~ ^test-integrations- ]]; then
+
+        # Ensure that kind cluster is deleted
+        delete_kind_cluster
+
+        # Ensure elastic stack is stopped
+        if should_run_stack_down; then
+            echo "--- Take down the Elastic stack"
+            if ! ${ELASTIC_PACKAGE_BIN} stack down -v ; then
+                exit_code=1
+            fi
+        fi
+
+        echo "+++ :bookmark: Documentation to access logs"
+        inline_link "https://docs.elastic.dev/ingest-dev-docs/elastic-packages/ecosystem-ci-pipelines#private-logs"
+    fi
+fi
+
+echo "--- Cleaning up"
+unset_secrets
+cleanup
+
+exit "${exit_code}"

--- a/.buildkite/pipeline.backport.yml
+++ b/.buildkite/pipeline.backport.yml
@@ -4,6 +4,8 @@ name: "integrations-backport"
 
 env:
   YQ_VERSION: 'v4.35.2'
+  # Agent images used in pipeline steps
+  LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
 
 steps:
 
@@ -49,6 +51,13 @@ steps:
   - label: "Creating the backport branch"
     key: "create-backport-branch"
     command: ".buildkite/scripts/backport_branch.sh"
+    agents:
+      image: "${LINUX_AGENT_IMAGE}"
+    env:
+      GITHUB_EMAIL: "elasticmachine@elastic.co"
+      GITHUB_USERNAME: "elastic-vault-github-plugin-prod"
+    plugins:
+      - elastic/vault-github-token#v0.1.0:
     depends_on:
       - step: "input-variables"
         allow_failure: false

--- a/.buildkite/pipeline.schedule-daily.yml
+++ b/.buildkite/pipeline.schedule-daily.yml
@@ -21,7 +21,7 @@ steps:
       env:
         SERVERLESS: "false"
         FORCE_CHECK_ALL: "true"
-        STACK_VERSION: 7.17.28
+        STACK_VERSION: 7.17.29
     depends_on:
       - step: "check"
         allow_failure: false
@@ -86,13 +86,13 @@ steps:
     if: |
       build.env('TEST_PACKAGES_BASIC_SUBSCRIPTION') == "true"
 
-  - label: "Check integrations local stacks - Stack Version v9.1"
+  - label: "Check integrations local stacks - Stack Version v9.2"
     trigger: "integrations"
     build:
       env:
         SERVERLESS: "false"
         FORCE_CHECK_ALL: "true"
-        STACK_VERSION: 9.1.0-SNAPSHOT
+        STACK_VERSION: 9.2.0-SNAPSHOT
         PUBLISH_COVERAGE_REPORTS: "false"
     depends_on:
       - step: "check"

--- a/.buildkite/pipeline.schedule-weekly.yml
+++ b/.buildkite/pipeline.schedule-weekly.yml
@@ -28,13 +28,13 @@ steps:
       - step: "check"
         allow_failure: false
 
-  - label: "Check integrations local stacks and non-wolfi images for Elastic Agent - Stack Version v9.1"
+  - label: "Check integrations local stacks and non-wolfi images for Elastic Agent - Stack Version v9.2"
     trigger: "integrations"
     build:
       env:
         SERVERLESS: "false"
         FORCE_CHECK_ALL: "true"
-        STACK_VERSION: 9.1.0-SNAPSHOT
+        STACK_VERSION: 9.2.0-SNAPSHOT
         PUBLISH_COVERAGE_REPORTS: "false"
         ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI: "true"
     depends_on:

--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -6,7 +6,7 @@ env:
   DOCKER_COMPOSE_VERSION: "v2.24.1"
   DOCKER_VERSION: "false" # not required to set since system tests are not running yet
   KIND_VERSION: 'v0.27.0'
-  K8S_VERSION: 'v1.32.0'
+  K8S_VERSION: 'v1.33.0'
   YQ_VERSION: 'v4.35.2'
   IMAGE_UBUNTU_X86_64: "family/core-ubuntu-2204"
   GH_CLI_VERSION: "2.29.0"
@@ -67,6 +67,22 @@ steps:
     agents:
       provider: "gcp"
       image: "${IMAGE_UBUNTU_X86_64}"
+    plugins:
+      # See https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/integrations/01-aws-buildkite-oidc.tf
+      # This plugin creates the environment variables required by the service deployer (AWS_SECRET_ACCESS_KEY and AWS_SECRET_KEY_ID)
+      - elastic/oblt-aws-auth#v0.1.0:
+          duration: 10800 # seconds
+      # See https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/integrations/01-gcp-buildkite-oidc.tf
+      # This plugin authenticates to CI Google Cloud using the OIDC token.
+      - elastic/oblt-google-auth#v1.3.0:
+          lifetime: 10800 # seconds
+          project-id: "elastic-observability-ci"
+          project-number: "911195782929"
+          lifetime: 10800 # seconds
+      - avaly/gcp-secret-manager#v1.2.0:
+          env:
+            EC_API_KEY: elastic-cloud-observability-team-qa-api-key
+            EC_HOST: elastic-cloud-observability-team-qa-endpoint
     artifact_paths:
       - "build/test-results/*.xml"
       - "build/elastic-stack-dump/*/logs/*.log"
@@ -94,6 +110,8 @@ steps:
       image: "${LINUX_AGENT_IMAGE}"
       cpu: "8"
       memory: "4G"
+    plugins:
+      - elastic/vault-github-token#v0.1.0:
     # not fail build if this step fails
     soft_fail: true
     # run this step when if it is triggered by the daily job

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ env:
   DOCKER_COMPOSE_VERSION: "v2.24.1"
   DOCKER_VERSION: "26.1.2"
   KIND_VERSION: 'v0.27.0'
-  K8S_VERSION: 'v1.32.0'
+  K8S_VERSION: 'v1.33.0'
   YQ_VERSION: 'v4.35.2'
   JQ_VERSION: '1.7'
   GH_CLI_VERSION: "2.29.0"
@@ -30,6 +30,13 @@ env:
   ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI: "${ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI:-false}"
   # Disable checking for newer versions
   ELASTIC_PACKAGE_CHECK_UPDATE_DISABLED: "true"
+  # Customize Service Test Run ID used by elastic-package
+  # It requires to be customized in .buildkite/hooks/pre-command
+  # Defining here in this file an environment variable like this:
+  # ELASTIC_PACKAGE_CUSTOMIZE_SERVICE_TEST_RUN_ID: "${BUILDKITE_STEP_ID: -4}"
+  # All steps will have the same value, since it always gets the value
+  # "BUILDKITE_STEP_ID" from the first "Upload pipeline" step.
+  ELASTIC_PACKAGE_CUSTOMIZE_SERVICE_TEST_RUN_ID: "true"
 
 steps:
   - label: "Get reference from target branch"
@@ -37,6 +44,11 @@ steps:
     command: "echo 'Get reference from main'"
     agents:
       image: "${LINUX_AGENT_IMAGE}"
+    if: |
+      build.env('BUILDKITE_PULL_REQUEST') != "false"
+
+  - wait: ~
+    continue_on_failure: false
 
   - label: ":white_check_mark: Check go sources"
     key: "check"
@@ -45,9 +57,6 @@ steps:
       image: "${LINUX_AGENT_IMAGE}"
       cpu: "8"
       memory: "4G"
-    depends_on:
-      - step: "reference-target-branch"
-        allow_failure: false
 
   - label: "Trigger integrations"
     key: "test-integrations"
@@ -70,6 +79,8 @@ steps:
       image: "${LINUX_AGENT_IMAGE}"
       cpu: "8"
       memory: "4G"
+    plugins:
+      - elastic/vault-github-token#v0.1.0:
     if: |
       build.env('BUILDKITE_PULL_REQUEST') != "false" &&
       build.env('BUILDKITE_PIPELINE_SLUG') == "integrations"
@@ -108,6 +119,8 @@ steps:
       image: "${LINUX_AGENT_IMAGE}"
       cpu: "8"
       memory: "4G"
+    plugins:
+      - elastic/vault-github-token#v0.1.0:
     # not fail build if this step fails
     soft_fail: true
     # run this step when if it is triggered by the daily job

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -13,7 +13,17 @@
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$|^/test benchmark fullreport$",
       "skip_ci_labels": [],
       "skip_target_branches": [],
-      "skip_ci_on_only_changed": ["^.github/workflows/", "^.github/dependabot.yml", "^.github/ISSUE_TEMPLATE/", "^docs/"],
+      "skip_ci_on_only_changed": [
+        "^.github/workflows/",
+        "^.github/dependabot.yml$",
+        "^.github/ISSUE_TEMPLATE/",
+        "^docs/",
+        "^catalog-info.yaml$",
+        "^.buildkite/pipeline.schedule-daily.yml$",
+        "^.buildkite/pipeline.schedule-weekly.yml$",
+        "^.buildkite/pipeline.backport.yml$",
+        "^.buildkite/pull-requests.json$"
+      ],
       "always_require_ci_on_changed": []
     },
     {

--- a/.buildkite/scripts/check_sources.sh
+++ b/.buildkite/scripts/check_sources.sh
@@ -10,3 +10,6 @@ with_mage
 mage -v check
 
 check_git_diff
+
+use_elastic_package
+${ELASTIC_PACKAGE_BIN} links check

--- a/.buildkite/scripts/check_sources.sh
+++ b/.buildkite/scripts/check_sources.sh
@@ -10,6 +10,3 @@ with_mage
 mage -v check
 
 check_git_diff
-
-use_elastic_package
-${ELASTIC_PACKAGE_BIN} links check

--- a/.buildkite/scripts/test_one_package.sh
+++ b/.buildkite/scripts/test_one_package.sh
@@ -28,7 +28,9 @@ use_elastic_package
 pushd packages > /dev/null
 exit_code=0
 if ! process_package "${package}" ; then
-    echo "[${package}] failed"
+    # keep this message as a collapsed group in Buildkite, so it
+    # is not hidden by the previous collapsed group.
+    echo "--- [${package}] failed"
     exit_code=1
 fi
 popd > /dev/null

--- a/.buildkite/scripts/trigger_integrations_in_parallel.sh
+++ b/.buildkite/scripts/trigger_integrations_in_parallel.sh
@@ -88,6 +88,17 @@ for package in ${PACKAGE_LIST}; do
         FORCE_CHECK_ALL: "${FORCE_CHECK_ALL}"
         SERVERLESS: "false"
         UPLOAD_SAFE_LOGS: ${UPLOAD_SAFE_LOGS}
+      plugins:
+        # See https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/integrations/01-aws-buildkite-oidc.tf
+        # This plugin creates the environment variables required by the service deployer (AWS_SECRET_ACCESS_KEY and AWS_SECRET_KEY_ID)
+        - elastic/oblt-aws-auth#v0.1.0:
+            duration: 10800 # seconds
+        # See https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/integrations/01-gcp-buildkite-oidc.tf
+        # This plugin authenticates to Google Cloud using the OIDC token.
+        - elastic/oblt-google-auth#v1.3.0:
+            lifetime: 10800 # seconds
+            project-id: "elastic-observability-ci"
+            project-number: "911195782929"
       artifact_paths:
         - build/test-results/*.xml
         - build/test-coverage/*.xml


### PR DESCRIPTION
## Proposed commit message

This PR fixes the `Check Sources` step.
The automation copied the latest changes in `.buildkite/scripts/check_sources.sh` , that contains the new `elastic-package links` command.

This command is available starting on v0.113.0, but this backport branch uses v0.111.0.

Backport branch created in this pipeline: https://buildkite.com/elastic/integrations-backport/builds/191

cc @StacieClark-Elastic 


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Relates https://github.com/elastic/integrations/pull/14594

