### PR TITLE
[Docs] Remove dummy URLs

### DIFF
--- a/packages/apache_tomcat/_dev/build/docs/README.md
+++ b/packages/apache_tomcat/_dev/build/docs/README.md
@@ -129,7 +129,7 @@ You need the following information from your `Apache Tomcat instance` to configu
 
 Host Configuration Format: `http[s]://<hostname>:<port>/<metrics_path>`
 
-Example Host Configuration: `http://localhost:9090/metrics`
+Example Host Configuration: `http://<MY_LOCAL_HOST>:9090/metrics`
 
 ## Validation
 

--- a/packages/apache_tomcat/docs/README.md
+++ b/packages/apache_tomcat/docs/README.md
@@ -129,7 +129,7 @@ You need the following information from your `Apache Tomcat instance` to configu
 
 Host Configuration Format: `http[s]://<hostname>:<port>/<metrics_path>`
 
-Example Host Configuration: `http://localhost:9090/metrics`
+Example Host Configuration: `http://<MY_LOCAL_HOST>:9090/metrics`
 
 ## Validation
 


### PR DESCRIPTION
This PR removes segments that make a valid URL, including prefixes (`http://`) and TLDs (`.com`), and replaces them with non-hostable segments. 