### PR TITLE
[CI] Add elastic-package version check for links command

### DIFF
--- a/.buildkite/scripts/check_sources.sh
+++ b/.buildkite/scripts/check_sources.sh
@@ -11,5 +11,20 @@ mage -v check
 
 check_git_diff
 
-use_elastic_package
-${ELASTIC_PACKAGE_BIN} links check
+run_links_command=false
+if less_than=$(mage isElasticPackageDependencyLessThan 0.113.0) ; then
+    # links command require at least v0.113.0
+    if [[ "$less_than" == "false" ]] ; then
+        run_links_command=true
+    fi
+else
+    echo "Failed to check elastic-package version in go.mod"
+    exit 1
+fi
+
+
+if [[ "$run_links_command" == "true" ]] ; then
+    # links command require at least v0.113.0
+    use_elastic_package
+    ${ELASTIC_PACKAGE_BIN} links check
+fi

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -831,7 +831,7 @@ teardown_test_package() {
 }
 
 list_all_directories() {
-    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort
+    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort |grep -E '^elastic_package_registry$'
 }
 
 check_package() {

--- a/dev/citools/gomod.go
+++ b/dev/citools/gomod.go
@@ -1,0 +1,45 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package citools
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Masterminds/semver/v3"
+	"golang.org/x/mod/modfile"
+)
+
+func PackageVersionGoMod(path, modulePath string) (*semver.Version, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file go.mod: %w", err)
+	}
+	fileName := filepath.Base(path)
+	f, err := modfile.Parse(fileName, contents, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse go.mod: %w", err)
+	}
+	epVersion := ""
+	for _, r := range f.Require {
+		if r.Indirect {
+			continue
+		}
+		if r.Mod.Path != modulePath {
+			continue
+		}
+		epVersion = r.Mod.Version
+	}
+	if epVersion == "" {
+		return nil, fmt.Errorf("not found elastic-package dependency")
+	}
+
+	foundVersion, err := semver.NewVersion(epVersion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse version %q: %w", epVersion, err)
+	}
+	return foundVersion, nil
+}

--- a/dev/citools/gomod_test.go
+++ b/dev/citools/gomod_test.go
@@ -1,0 +1,84 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package citools
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackageVersionGoMod(t *testing.T) {
+	cases := []struct {
+		name         string
+		gomodContent string
+		modulePath   string
+		expectedVer  string
+		expectErr    bool
+	}{
+		{
+			name: "elastic-package version found",
+			gomodContent: `module example.com/test
+
+go 1.24.2
+
+require (
+	github.com/elastic/elastic-package v1.2.3
+	github.com/elastic/package-spec v0.1.0
+)
+
+require (
+	github.com/elastic/elastic-package v0.1.0 // indirect
+)
+`,
+			modulePath:  "github.com/elastic/elastic-package",
+			expectedVer: "1.2.3",
+			expectErr:   false,
+		},
+		{
+			name: "other version found",
+			gomodContent: `module example.com/test
+
+go 1.24.2
+
+require (
+	github.com/elastic/elastic-package v1.2.3
+	github.com/elastic/package-spec v0.1.0
+)
+
+require (
+	github.com/elastic/elastic-package v0.1.0 // indirect
+)
+`,
+			modulePath:  "github.com/elastic/package-spec",
+			expectedVer: "0.1.0",
+			expectErr:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			gomodPath := tmpDir + "/go.mod"
+			err := os.WriteFile(gomodPath, []byte(tc.gomodContent), 0644)
+			require.NoError(t, err, "failed to write go.mod")
+
+			version, err := PackageVersionGoMod(gomodPath, tc.modulePath)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err, "unexpected error")
+
+			expected, err := semver.NewVersion(tc.expectedVer)
+			require.NoError(t, err)
+			if !version.Equal(expected) {
+				t.Errorf("expected version %s, got %s", expected, version)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/magefile/mage v1.15.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.10.0
+	golang.org/x/mod v0.26.0
 	golang.org/x/tools v0.35.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -204,7 +205,6 @@ require (
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
 	golang.org/x/crypto v0.40.0 // indirect
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
-	golang.org/x/mod v0.26.0 // indirect
 	golang.org/x/net v0.42.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect

--- a/magefile.go
+++ b/magefile.go
@@ -30,6 +30,8 @@ const (
 	defaultPreviousLinksNumber   = 5
 	defaultMaximumTestsReported  = 20
 	defaultServerlessProjectType = "observability"
+
+	elasticPackageModulePath = "github.com/elastic/elastic-package"
 )
 
 var (
@@ -295,5 +297,27 @@ func IsVersionLessThanLogsDBGA(version string) error {
 		return nil
 	}
 	fmt.Println("false")
+	return nil
+}
+
+// IsElasticPackageDependencyLessThan checks whether or not the elastic-package version set in go.mod is less than the given version
+func IsElasticPackageDependencyLessThan(version string) error {
+	foundVersion, err := citools.PackageVersionGoMod("go.mod", elasticPackageModulePath)
+	if err != nil {
+		return fmt.Errorf("failed to get elastic-package version from go.mod: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Found elastic-package %s\n", foundVersion)
+
+	desiredVersion, err := semver.NewVersion(version)
+	if err != nil {
+		return fmt.Errorf("failed to parse version %q: %w", version, err)
+	}
+
+	value := "false"
+	if foundVersion.LessThan(desiredVersion) {
+		value = "true"
+	}
+
+	fmt.Println(value)
 	return nil
 }


### PR DESCRIPTION
## Proposed commit message

Add a check of the `elastic-package` version required to run `elastic-package links` command.

This command does not exist for backport branches created in previous commits. As example:
https://github.com/elastic/integrations/pull/14699


## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Ensure that these scripts are copied in the automation process to the backport branch.


## Related issues

- https://github.com/elastic/integrations/pull/14699

