### PR TITLE
Change TargetResponseTime.avg type from `long` to `double`

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "8.0.0"
+  changes:
+    - description: Change TargetResponseTime.avg from `long` to `double`.
+      type: breaking-change
+      link: https://github.com/elastic/integrations/pull/14717
 - version: "7.4.0"
   changes:
     - description: |

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "8.0.0"
+  changes:
+    - description: Change TargetResponseTime.avg from `long` to `double`.
+      type: breaking-change
+      link: https://github.com/elastic/integrations/pull/14717
 - version: "7.1.1"
   changes:
     - description: Add `data_stream.namespace` to the Amazon Inspector vulnerability latest transform's unique key so findings are tracked per namespace, preventing findings ingested into non-default namespaces from being dropped or conflated in the latest index. Bump transform's destination suffix to `-v2`.

--- a/packages/aws/data_stream/elb_metrics/fields/fields.yml
+++ b/packages/aws/data_stream/elb_metrics/fields/fields.yml
@@ -162,7 +162,7 @@
               metric_type: gauge
               description: The number of load balancer capacity units (LCU) used by your load balancer.
             - name: TargetResponseTime.avg
-              type: long
+              type: double
               metric_type: gauge
               unit: s
               description: The time elapsed after the request leaves the load balancer until the target starts to send the response headers.

--- a/packages/aws/docs/elb.md
+++ b/packages/aws/docs/elb.md
@@ -425,7 +425,7 @@ Refer to the following [document](https://www.elastic.co/guide/en/ecs/current/ec
 | aws.applicationelb.metrics.RejectedConnectionCount.sum | The number of connections that were rejected because the load balancer had reached its maximum number of connections. | long |  | gauge |
 | aws.applicationelb.metrics.RequestCount.sum | The number of requests processed over IPv4 and IPv6. | long |  | gauge |
 | aws.applicationelb.metrics.RuleEvaluations.sum | The number of rules processed by the load balancer given a request rate averaged over an hour. | long |  | gauge |
-| aws.applicationelb.metrics.TargetResponseTime.avg | The time elapsed after the request leaves the load balancer until the target starts to send the response headers. | long | s | gauge |
+| aws.applicationelb.metrics.TargetResponseTime.avg | The time elapsed after the request leaves the load balancer until the target starts to send the response headers. | double | s | gauge |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |  |
 | aws.dimensions.AvailabilityZone | Filters the metric data by the specified Availability Zone. | keyword |  |  |
 | aws.dimensions.LoadBalancer | Filters the metric data by load balancer. | keyword |  |  |

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.6.1
 name: aws
 title: AWS
-version: 7.4.0
+version: 8.0.0
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.6.1
 name: aws
 title: AWS
-version: 7.1.1
+version: 8.0.0
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Change TargetResponseTime.avg type from `long` to `double`

The values reported by AWS are floats and we lose a lot of valuable information by processing this as an int. This change will give us the granularity that we are looking for in dashboards and alerts.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist 

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

Closes: #14715

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
