### PR TITLE
fix(m365_defender): propagate state variables on error

### DIFF
--- a/packages/m365_defender/changelog.yml
+++ b/packages/m365_defender/changelog.yml
@@ -5,7 +5,7 @@
        Enhanced error handling in the CEL program for API calls to prevent `no such key: product_batch_size` errors 
        by ensuring proper propagation of the `product_batch_size` configuration during failures.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/14722
 - version: "3.13.0"
   changes:
     - description: Add `process.name` ECS mapping in alert, event, and incident data streams.

--- a/packages/m365_defender/changelog.yml
+++ b/packages/m365_defender/changelog.yml
@@ -1,4 +1,11 @@
 # newer versions go on top
+- version: "3.14.0"
+  changes:
+    - description: |
+       Enhanced error handling in the CEL program for API calls to prevent `no such key: product_batch_size` errors 
+       by ensuring proper propagation of the `product_batch_size` configuration during failures.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "3.13.0"
   changes:
     - description: Add `process.name` ECS mapping in alert, event, and incident data streams.

--- a/packages/m365_defender/data_stream/vulnerability/agent/stream/cel.yml.hbs
+++ b/packages/m365_defender/data_stream/vulnerability/agent/stream/cel.yml.hbs
@@ -39,48 +39,48 @@ state:
 redact:
   fields: ~
 program: |-
-  (
-    state.?is_all_products_fetched.orValue(false) ?
-      {
-        "products": state.products,
-        "product_batch_size": state.product_batch_size,
-        "product_skip": 0,
-        "is_all_products_fetched": state.is_all_products_fetched,
-        ?"machines": state.?machines,
-        "machine_batch_size": state.machine_batch_size,
-        "machine_skip": state.machine_skip,
-        ?"is_all_machines_fetched": state.?is_all_machines_fetched,
-        ?"vulnerabilities": state.?vulnerabilities,
-        "batch_size": state.batch_size,
-        "skip": state.skip,
-        ?"is_all_vulnerabilities_fetched": state.?is_all_vulnerabilities_fetched,
-        "affected_machines_only": state.affected_machines_only,
-      }
-    :
-      request(
-        "GET",
-        state.url.trim_right("/") + "/api/vulnerabilities/machinesVulnerabilities?" + {
-          "$top": [string(state.product_batch_size)],
-          "$skip": [string(state.product_skip)],
-        }.format_query()
-      ).do_request().as(productResp, (productResp.StatusCode == 200) ?
-        productResp.Body.decode_json().as(productBody,
-          {
-            "events": [{"message": "retry"}],
-            "products": (state.?products.orValue([]) + productBody.value).flatten(),
-            "product_batch_size": state.product_batch_size,
-            "product_skip": (size(productBody.value) > 0) ? (int(state.product_skip) + int(state.product_batch_size)) : 0,
-            "is_all_products_fetched": size(productBody.value) < int(state.product_batch_size),
-            "want_more": true,
-            "machine_batch_size": state.machine_batch_size,
-            "machine_skip": state.machine_skip,
-            "batch_size": state.batch_size,
-            "skip": state.skip,
-            "affected_machines_only": state.affected_machines_only,
-          }
-        )
+  state.with(
+    (
+      state.?is_all_products_fetched.orValue(false) ?
+        {
+          "products": state.products,
+          "product_batch_size": state.product_batch_size,
+          "product_skip": 0,
+          "is_all_products_fetched": state.is_all_products_fetched,
+          ?"machines": state.?machines,
+          "machine_batch_size": state.machine_batch_size,
+          "machine_skip": state.machine_skip,
+          ?"is_all_machines_fetched": state.?is_all_machines_fetched,
+          ?"vulnerabilities": state.?vulnerabilities,
+          "batch_size": state.batch_size,
+          "skip": state.skip,
+          ?"is_all_vulnerabilities_fetched": state.?is_all_vulnerabilities_fetched,
+          "affected_machines_only": state.affected_machines_only,
+        }
       :
-        state.with(
+        request(
+          "GET",
+          state.url.trim_right("/") + "/api/vulnerabilities/machinesVulnerabilities?" + {
+            "$top": [string(state.product_batch_size)],
+            "$skip": [string(state.product_skip)],
+          }.format_query()
+        ).do_request().as(productResp, (productResp.StatusCode == 200) ?
+          productResp.Body.decode_json().as(productBody,
+            {
+              "events": [{"message": "retry"}],
+              "products": (state.?products.orValue([]) + productBody.value).flatten(),
+              "product_batch_size": state.product_batch_size,
+              "product_skip": (size(productBody.value) > 0) ? (int(state.product_skip) + int(state.product_batch_size)) : 0,
+              "is_all_products_fetched": size(productBody.value) < int(state.product_batch_size),
+              "want_more": true,
+              "machine_batch_size": state.machine_batch_size,
+              "machine_skip": state.machine_skip,
+              "batch_size": state.batch_size,
+              "skip": state.skip,
+              "affected_machines_only": state.affected_machines_only,
+            }
+          )
+        :
           {
             "events": {
               "error": {
@@ -106,52 +106,50 @@ program: |-
             "is_all_vulnerabilities_fetched": false,
           }
         )
-      )
-  ).as(products, !products.?is_all_products_fetched.orValue(false) ?
-    products
-  : products.?is_all_machines_fetched.orValue(false) ?
-    {
-      "products": products.products,
-      "product_batch_size": products.product_batch_size,
-      "product_skip": 0,
-      "is_all_products_fetched": products.is_all_products_fetched,
-      "machines": products.machines,
-      "machine_batch_size": products.machine_batch_size,
-      "machine_skip": 0,
-      "is_all_machines_fetched": products.is_all_machines_fetched,
-      ?"vulnerabilities": products.?vulnerabilities,
-      "batch_size": products.batch_size,
-      "skip": products.skip,
-      ?"is_all_vulnerabilities_fetched": products.?is_all_vulnerabilities_fetched,
-      "affected_machines_only": products.affected_machines_only,
-    }
-  :
-    request(
-      "GET",
-      state.url.trim_right("/") + "/api/machines?" + {
-        "$top": [string(products.machine_batch_size)],
-        "$skip": [string(products.machine_skip)],
-      }.format_query()
-    ).do_request().as(machineResp, (machineResp.StatusCode == 200) ?
-      machineResp.Body.decode_json().as(machineBody,
-        {
-          "events": [{"message": "retry"}],
-          "machines": (products.?machines.orValue([]) + machineBody.value).flatten(),
-          "machine_batch_size": products.machine_batch_size,
-          "machine_skip": (size(machineBody.value) > 0) ? (int(products.machine_skip) + int(products.machine_batch_size)) : 0,
-          "is_all_machines_fetched": size(machineBody.value) < int(products.machine_batch_size),
-          "want_more": true,
-          "products": products.products,
-          "product_batch_size": products.product_batch_size,
-          "product_skip": 0,
-          "is_all_products_fetched": products.is_all_products_fetched,
-          "batch_size": products.batch_size,
-          "skip": products.skip,
-          "affected_machines_only": products.affected_machines_only,
-        }
-      )
+    ).as(products, !products.?is_all_products_fetched.orValue(false) ?
+      products
+    : products.?is_all_machines_fetched.orValue(false) ?
+      {
+        "products": products.products,
+        "product_batch_size": products.product_batch_size,
+        "product_skip": 0,
+        "is_all_products_fetched": products.is_all_products_fetched,
+        "machines": products.machines,
+        "machine_batch_size": products.machine_batch_size,
+        "machine_skip": 0,
+        "is_all_machines_fetched": products.is_all_machines_fetched,
+        ?"vulnerabilities": products.?vulnerabilities,
+        "batch_size": products.batch_size,
+        "skip": products.skip,
+        ?"is_all_vulnerabilities_fetched": products.?is_all_vulnerabilities_fetched,
+        "affected_machines_only": products.affected_machines_only,
+      }
     :
-      state.with(
+      request(
+        "GET",
+        state.url.trim_right("/") + "/api/machines?" + {
+          "$top": [string(products.machine_batch_size)],
+          "$skip": [string(products.machine_skip)],
+        }.format_query()
+      ).do_request().as(machineResp, (machineResp.StatusCode == 200) ?
+        machineResp.Body.decode_json().as(machineBody,
+          {
+            "events": [{"message": "retry"}],
+            "machines": (products.?machines.orValue([]) + machineBody.value).flatten(),
+            "machine_batch_size": products.machine_batch_size,
+            "machine_skip": (size(machineBody.value) > 0) ? (int(products.machine_skip) + int(products.machine_batch_size)) : 0,
+            "is_all_machines_fetched": size(machineBody.value) < int(products.machine_batch_size),
+            "want_more": true,
+            "products": products.products,
+            "product_batch_size": products.product_batch_size,
+            "product_skip": 0,
+            "is_all_products_fetched": products.is_all_products_fetched,
+            "batch_size": products.batch_size,
+            "skip": products.skip,
+            "affected_machines_only": products.affected_machines_only,
+          }
+        )
+      :
         {
           "events": {
             "error": {
@@ -177,54 +175,52 @@ program: |-
           "is_all_vulnerabilities_fetched": false,
         }
       )
-    )
-  ).as(products_with_machines, !products_with_machines.?is_all_machines_fetched.orValue(false) ?
-    products_with_machines
-  : products_with_machines.?is_all_vulnerability_fetched.orValue(false) ?
-    {
-      "products": products_with_machines.products,
-      "product_batch_size": products_with_machines.product_batch_size,
-      "product_skip": 0,
-      "is_all_products_fetched": products_with_machines.is_all_products_fetched,
-      "machines": products_with_machines.machines,
-      "machine_batch_size": products_with_machines.machine_batch_size,
-      "machine_skip": 0,
-      "is_all_machines_fetched": products_with_machines.is_all_machines_fetched,
-      "vulnerabilities": products_with_machines.vulnerabilities,
-      "batch_size": products_with_machines.batch_size,
-      "skip": 0,
-      "is_all_vulnerability_fetched": products_with_machines.is_all_vulnerability_fetched,
-      "affected_machines_only": products_with_machines.affected_machines_only,
-    }
-  :
-    request(
-      "GET",
-      state.url.trim_right("/") + "/api/vulnerabilities?" + {
-        "$top": [string(products_with_machines.batch_size)],
-        "$skip": [string(products_with_machines.skip)],
-      }.format_query()
-    ).do_request().as(vulnerabilityResp, (vulnerabilityResp.StatusCode == 200) ?
-      vulnerabilityResp.Body.decode_json().as(vulnerabilityBody,
-        {
-          "events": [{"message": "retry"}],
-          "vulnerabilities": (products_with_machines.?vulnerabilities.orValue([]) + vulnerabilityBody.value).flatten(),
-          "batch_size": state.batch_size,
-          "skip": (size(vulnerabilityBody.value) > 0) ? (int(products_with_machines.skip) + int(products_with_machines.batch_size)) : 0,
-          "is_all_vulnerabilities_fetched": size(vulnerabilityBody.value) < int(products_with_machines.batch_size),
-          "want_more": true,
-          "products": products_with_machines.products,
-          "product_batch_size": products_with_machines.product_batch_size,
-          "product_skip": 0,
-          "is_all_products_fetched": products_with_machines.is_all_products_fetched,
-          "machines": products_with_machines.machines,
-          "machine_batch_size": products_with_machines.machine_batch_size,
-          "machine_skip": 0,
-          "is_all_machines_fetched": products_with_machines.is_all_machines_fetched,
-          "affected_machines_only": products_with_machines.affected_machines_only,
-        }
-      )
+    ).as(products_with_machines, !products_with_machines.?is_all_machines_fetched.orValue(false) ?
+      products_with_machines
+    : products_with_machines.?is_all_vulnerability_fetched.orValue(false) ?
+      {
+        "products": products_with_machines.products,
+        "product_batch_size": products_with_machines.product_batch_size,
+        "product_skip": 0,
+        "is_all_products_fetched": products_with_machines.is_all_products_fetched,
+        "machines": products_with_machines.machines,
+        "machine_batch_size": products_with_machines.machine_batch_size,
+        "machine_skip": 0,
+        "is_all_machines_fetched": products_with_machines.is_all_machines_fetched,
+        "vulnerabilities": products_with_machines.vulnerabilities,
+        "batch_size": products_with_machines.batch_size,
+        "skip": 0,
+        "is_all_vulnerability_fetched": products_with_machines.is_all_vulnerability_fetched,
+        "affected_machines_only": products_with_machines.affected_machines_only,
+      }
     :
-      state.with(
+      request(
+        "GET",
+        state.url.trim_right("/") + "/api/vulnerabilities?" + {
+          "$top": [string(products_with_machines.batch_size)],
+          "$skip": [string(products_with_machines.skip)],
+        }.format_query()
+      ).do_request().as(vulnerabilityResp, (vulnerabilityResp.StatusCode == 200) ?
+        vulnerabilityResp.Body.decode_json().as(vulnerabilityBody,
+          {
+            "events": [{"message": "retry"}],
+            "vulnerabilities": (products_with_machines.?vulnerabilities.orValue([]) + vulnerabilityBody.value).flatten(),
+            "batch_size": state.batch_size,
+            "skip": (size(vulnerabilityBody.value) > 0) ? (int(products_with_machines.skip) + int(products_with_machines.batch_size)) : 0,
+            "is_all_vulnerabilities_fetched": size(vulnerabilityBody.value) < int(products_with_machines.batch_size),
+            "want_more": true,
+            "products": products_with_machines.products,
+            "product_batch_size": products_with_machines.product_batch_size,
+            "product_skip": 0,
+            "is_all_products_fetched": products_with_machines.is_all_products_fetched,
+            "machines": products_with_machines.machines,
+            "machine_batch_size": products_with_machines.machine_batch_size,
+            "machine_skip": 0,
+            "is_all_machines_fetched": products_with_machines.is_all_machines_fetched,
+            "affected_machines_only": products_with_machines.affected_machines_only,
+          }
+        )
+      :
         {
           "events": {
             "error": {
@@ -250,41 +246,41 @@ program: |-
           "is_all_vulnerabilities_fetched": false,
         }
       )
-    )
-  ).as(all_data, !all_data.?is_all_vulnerabilities_fetched.orValue(false) ?
-    all_data
-  :
-    all_data.products.map(p, all_data.machines.filter(m, m.id == p.machineId)[0].with(p)).as(mapped_products,
-      {
-        "vulnerability_with_machines": all_data.vulnerabilities.filter(v, v.exposedMachines > 0),
-        "vulnerability_without_machines": !all_data.affected_machines_only ?
-          all_data.vulnerabilities.filter(v, v.exposedMachines == 0)
-        :
-          [],
-        "mapped_products": mapped_products,
-      }
-    ).as(final_data,
-      {
-        "events": (
-          final_data.vulnerability_with_machines.map(v,
-            final_data.mapped_products.filter(mp, mp.cveId == v.id).map(related_mapped_products,
-              {"message": v.with({"affectedMachine": related_mapped_products}).encode_json()}
+    ).as(all_data, !all_data.?is_all_vulnerabilities_fetched.orValue(false) ?
+      all_data
+    :
+      all_data.products.map(p, all_data.machines.filter(m, m.id == p.machineId)[0].with(p)).as(mapped_products,
+        {
+          "vulnerability_with_machines": all_data.vulnerabilities.filter(v, v.exposedMachines > 0),
+          "vulnerability_without_machines": !all_data.affected_machines_only ?
+            all_data.vulnerabilities.filter(v, v.exposedMachines == 0)
+          :
+            [],
+          "mapped_products": mapped_products,
+        }
+      ).as(final_data,
+        {
+          "events": (
+            final_data.vulnerability_with_machines.map(v,
+              final_data.mapped_products.filter(mp, mp.cveId == v.id).map(related_mapped_products,
+                {"message": v.with({"affectedMachine": related_mapped_products}).encode_json()}
+              )
+            ).flatten() + final_data.vulnerability_without_machines.map(v,
+              {
+                "message": v.with({"affectedMachine": null}).encode_json(),
+              }
             )
-          ).flatten() + final_data.vulnerability_without_machines.map(v,
-            {
-              "message": v.with({"affectedMachine": null}).encode_json(),
-            }
-          )
-        ).flatten(),
-        "product_batch_size": all_data.product_batch_size,
-        "product_skip": 0,
-        "machine_batch_size": all_data.machine_batch_size,
-        "machine_skip": 0,
-        "batch_size": all_data.batch_size,
-        "skip": 0,
-        "affected_machines_only": all_data.affected_machines_only,
-        "want_more": false,
-      }
+          ).flatten(),
+          "product_batch_size": all_data.product_batch_size,
+          "product_skip": 0,
+          "machine_batch_size": all_data.machine_batch_size,
+          "machine_skip": 0,
+          "batch_size": all_data.batch_size,
+          "skip": 0,
+          "affected_machines_only": all_data.affected_machines_only,
+          "want_more": false,
+        }
+      )
     )
   )
 tags:

--- a/packages/m365_defender/data_stream/vulnerability/agent/stream/cel.yml.hbs
+++ b/packages/m365_defender/data_stream/vulnerability/agent/stream/cel.yml.hbs
@@ -77,7 +77,7 @@ program: |
           })
         )
       :
-        {
+        state.with({
           "events": {
             "error": {
               "code": string(productResp.StatusCode),
@@ -93,6 +93,7 @@ program: |
           },
           "want_more": false,
         }
+       )
       )
   ).as(products, !products.?is_all_products_fetched.orValue(false) ? products : (
     products.?is_all_machines_fetched.orValue(false) ? 
@@ -132,12 +133,12 @@ program: |
           "affected_machines_only": products.affected_machines_only,
         })
       :
-        {
+        state.with({
           "events": {
             "error": {
               "code": string(machineResp.StatusCode),
               "id": string(machineResp.Status),
-              "message": "GET " + state.url.trim_right("/") + "/api/machines" + 
+              "message": "GET " + state.url.trim_right("/") + "/api/machines" +
               (
                 size(machineResp.Body) != 0 ?
                   string(machineResp.Body)
@@ -148,7 +149,8 @@ program: |
           },
           "want_more": false,
         }
-      )
+       )
+     )
   )).as(products_with_machines, !products_with_machines.?is_all_machines_fetched.orValue(false) ? products_with_machines : (
     products_with_machines.?is_all_vulnerability_fetched.orValue(false) ? 
       {
@@ -189,7 +191,7 @@ program: |
           "affected_machines_only": products_with_machines.affected_machines_only,
         })
       :
-        {
+        state.with({
           "events": {
             "error": {
               "code": string(vulnerabilityResp.StatusCode),
@@ -206,6 +208,7 @@ program: |
           "want_more": false,
         }
       )
+    )
   )).as(all_data, !all_data.?is_all_vulnerabilities_fetched.orValue(false) ? all_data : (
     (
       all_data.products.map(p, (all_data.machines.filter(m, m.id == p.machineId)[0]).with(p))

--- a/packages/m365_defender/data_stream/vulnerability/agent/stream/cel.yml.hbs
+++ b/packages/m365_defender/data_stream/vulnerability/agent/stream/cel.yml.hbs
@@ -92,6 +92,15 @@ program: |
             },
           },
           "want_more": false,
+          "products": [],
+          "product_skip": 0,
+          "is_all_products_fetched": false,
+          "machines": [],
+          "machine_skip": 0,
+          "is_all_machines_fetched": false,
+          "vulnerabilities": [],
+          "skip": 0,
+          "is_all_vulnerabilities_fetched": false
         }
        )
       )
@@ -148,6 +157,15 @@ program: |
             },
           },
           "want_more": false,
+          "products": [],
+          "product_skip": 0,
+          "is_all_products_fetched": false,
+          "machines": [],
+          "machine_skip": 0,
+          "is_all_machines_fetched": false,
+          "vulnerabilities": [],
+          "skip": 0,
+          "is_all_vulnerabilities_fetched": false
         }
        )
      )
@@ -206,6 +224,15 @@ program: |
             },
           },
           "want_more": false,
+          "products": [],
+          "product_skip": 0,
+          "is_all_products_fetched": false,
+          "machines": [],
+          "machine_skip": 0,
+          "is_all_machines_fetched": false,
+          "vulnerabilities": [],
+          "skip": 0,
+          "is_all_vulnerabilities_fetched": false
         }
       )
     )

--- a/packages/m365_defender/data_stream/vulnerability/agent/stream/cel.yml.hbs
+++ b/packages/m365_defender/data_stream/vulnerability/agent/stream/cel.yml.hbs
@@ -38,10 +38,10 @@ state:
   affected_machines_only: {{affected_machines_only}}
 redact:
   fields: ~
-program: |
+program: |-
   (
     state.?is_all_products_fetched.orValue(false) ?
-      { 
+      {
         "products": state.products,
         "product_batch_size": state.product_batch_size,
         "product_skip": 0,
@@ -57,16 +57,19 @@ program: |
         "affected_machines_only": state.affected_machines_only,
       }
     :
-      request("GET", state.url.trim_right("/") + "/api/vulnerabilities/machinesVulnerabilities?" + {
-        "$top": [string(state.product_batch_size)],
-        "$skip": [string(state.product_skip)],
-      }.format_query()).do_request().as(productResp, productResp.StatusCode == 200 ?
-        (
-          productResp.Body.decode_json().as(productBody, {
-            "events": [{"message":"retry"}],
+      request(
+        "GET",
+        state.url.trim_right("/") + "/api/vulnerabilities/machinesVulnerabilities?" + {
+          "$top": [string(state.product_batch_size)],
+          "$skip": [string(state.product_skip)],
+        }.format_query()
+      ).do_request().as(productResp, (productResp.StatusCode == 200) ?
+        productResp.Body.decode_json().as(productBody,
+          {
+            "events": [{"message": "retry"}],
             "products": (state.?products.orValue([]) + productBody.value).flatten(),
             "product_batch_size": state.product_batch_size,
-            "product_skip": size(productBody.value) > 0 ? int(state.product_skip) + int(state.product_batch_size) : 0,
+            "product_skip": (size(productBody.value) > 0) ? (int(state.product_skip) + int(state.product_batch_size)) : 0,
             "is_all_products_fetched": size(productBody.value) < int(state.product_batch_size),
             "want_more": true,
             "machine_batch_size": state.machine_batch_size,
@@ -74,85 +77,91 @@ program: |
             "batch_size": state.batch_size,
             "skip": state.skip,
             "affected_machines_only": state.affected_machines_only,
-          })
+          }
         )
       :
-        state.with({
-          "events": {
-            "error": {
-              "code": string(productResp.StatusCode),
-              "id": string(productResp.Status),
-              "message": "GET " + state.url.trim_right("/") + "/api/vulnerabilities/machinesVulnerabilities" + 
-              (
-                size(productResp.Body) != 0 ?
-                  string(productResp.Body)
-                :
-                  string(productResp.Status) + ' (' + string(productResp.StatusCode) + ')'
-              ),
+        state.with(
+          {
+            "events": {
+              "error": {
+                "code": string(productResp.StatusCode),
+                "id": string(productResp.Status),
+                "message": "GET " + state.url.trim_right("/") + "/api/vulnerabilities/machinesVulnerabilities" + (
+                  (size(productResp.Body) != 0) ?
+                    string(productResp.Body)
+                  :
+                    string(productResp.Status) + " (" + string(productResp.StatusCode) + ")"
+                ),
+              },
             },
-          },
-          "want_more": false,
-          "products": [],
-          "product_skip": 0,
-          "is_all_products_fetched": false,
-          "machines": [],
-          "machine_skip": 0,
-          "is_all_machines_fetched": false,
-          "vulnerabilities": [],
-          "skip": 0,
-          "is_all_vulnerabilities_fetched": false
-        }
-       )
+            "want_more": false,
+            "products": [],
+            "product_skip": 0,
+            "is_all_products_fetched": false,
+            "machines": [],
+            "machine_skip": 0,
+            "is_all_machines_fetched": false,
+            "vulnerabilities": [],
+            "skip": 0,
+            "is_all_vulnerabilities_fetched": false,
+          }
+        )
       )
-  ).as(products, !products.?is_all_products_fetched.orValue(false) ? products : (
-    products.?is_all_machines_fetched.orValue(false) ? 
-      {
-        "products": products.products,
-        "product_batch_size": products.product_batch_size,
-        "product_skip": 0,
-        "is_all_products_fetched": products.is_all_products_fetched,
-        "machines": products.machines,
-        "machine_batch_size": products.machine_batch_size,
-        "machine_skip": 0,
-        "is_all_machines_fetched": products.is_all_machines_fetched,
-        ?"vulnerabilities": products.?vulnerabilities,
-        "batch_size": products.batch_size,
-        "skip": products.skip,
-        ?"is_all_vulnerabilities_fetched": products.?is_all_vulnerabilities_fetched,
-        "affected_machines_only": products.affected_machines_only,
-      }
-    :
-      request("GET", state.url.trim_right("/") + "/api/machines?" + {
+  ).as(products, !products.?is_all_products_fetched.orValue(false) ?
+    products
+  : products.?is_all_machines_fetched.orValue(false) ?
+    {
+      "products": products.products,
+      "product_batch_size": products.product_batch_size,
+      "product_skip": 0,
+      "is_all_products_fetched": products.is_all_products_fetched,
+      "machines": products.machines,
+      "machine_batch_size": products.machine_batch_size,
+      "machine_skip": 0,
+      "is_all_machines_fetched": products.is_all_machines_fetched,
+      ?"vulnerabilities": products.?vulnerabilities,
+      "batch_size": products.batch_size,
+      "skip": products.skip,
+      ?"is_all_vulnerabilities_fetched": products.?is_all_vulnerabilities_fetched,
+      "affected_machines_only": products.affected_machines_only,
+    }
+  :
+    request(
+      "GET",
+      state.url.trim_right("/") + "/api/machines?" + {
         "$top": [string(products.machine_batch_size)],
         "$skip": [string(products.machine_skip)],
-      }.format_query()).do_request().as(machineResp, machineResp.StatusCode == 200 ?
-        machineResp.Body.decode_json().as(machineBody, {
-          "events": [{"message":"retry"}],
+      }.format_query()
+    ).do_request().as(machineResp, (machineResp.StatusCode == 200) ?
+      machineResp.Body.decode_json().as(machineBody,
+        {
+          "events": [{"message": "retry"}],
           "machines": (products.?machines.orValue([]) + machineBody.value).flatten(),
           "machine_batch_size": products.machine_batch_size,
-          "machine_skip": size(machineBody.value) > 0 ? int(products.machine_skip) + int(products.machine_batch_size) : 0,
+          "machine_skip": (size(machineBody.value) > 0) ? (int(products.machine_skip) + int(products.machine_batch_size)) : 0,
           "is_all_machines_fetched": size(machineBody.value) < int(products.machine_batch_size),
           "want_more": true,
           "products": products.products,
           "product_batch_size": products.product_batch_size,
-          "product_skip" : 0,
+          "product_skip": 0,
           "is_all_products_fetched": products.is_all_products_fetched,
           "batch_size": products.batch_size,
           "skip": products.skip,
           "affected_machines_only": products.affected_machines_only,
-        })
-      :
-        state.with({
+        }
+      )
+    :
+      state.with(
+        {
           "events": {
             "error": {
               "code": string(machineResp.StatusCode),
               "id": string(machineResp.Status),
-              "message": "GET " + state.url.trim_right("/") + "/api/machines" +
-              (
-                size(machineResp.Body) != 0 ?
+              "message": "GET " + state.url.trim_right("/") + "/api/machines" + (
+                (size(machineResp.Body) != 0) ?
                   string(machineResp.Body)
                 :
-                  string(machineResp.Status) + ' (' + string(machineResp.StatusCode) + ')'
+                  string(machineResp.Status) + " (" + string(machineResp.StatusCode) + ")"
               ),
             },
           },
@@ -165,61 +174,67 @@ program: |
           "is_all_machines_fetched": false,
           "vulnerabilities": [],
           "skip": 0,
-          "is_all_vulnerabilities_fetched": false
+          "is_all_vulnerabilities_fetched": false,
         }
-       )
-     )
-  )).as(products_with_machines, !products_with_machines.?is_all_machines_fetched.orValue(false) ? products_with_machines : (
-    products_with_machines.?is_all_vulnerability_fetched.orValue(false) ? 
-      {
-        "products": products_with_machines.products,
-        "product_batch_size": products_with_machines.product_batch_size,
-        "product_skip": 0,
-        "is_all_products_fetched": products_with_machines.is_all_products_fetched,
-        "machines": products_with_machines.machines,
-        "machine_batch_size": products_with_machines.machine_batch_size,
-        "machine_skip": 0,
-        "is_all_machines_fetched": products_with_machines.is_all_machines_fetched,
-        "vulnerabilities": products_with_machines.vulnerabilities,
-        "batch_size": products_with_machines.batch_size,
-        "skip": 0,
-        "is_all_vulnerability_fetched": products_with_machines.is_all_vulnerability_fetched,
-        "affected_machines_only": products_with_machines.affected_machines_only,
-      }
-    :
-      request("GET", state.url.trim_right("/") + "/api/vulnerabilities?" + {
+      )
+    )
+  ).as(products_with_machines, !products_with_machines.?is_all_machines_fetched.orValue(false) ?
+    products_with_machines
+  : products_with_machines.?is_all_vulnerability_fetched.orValue(false) ?
+    {
+      "products": products_with_machines.products,
+      "product_batch_size": products_with_machines.product_batch_size,
+      "product_skip": 0,
+      "is_all_products_fetched": products_with_machines.is_all_products_fetched,
+      "machines": products_with_machines.machines,
+      "machine_batch_size": products_with_machines.machine_batch_size,
+      "machine_skip": 0,
+      "is_all_machines_fetched": products_with_machines.is_all_machines_fetched,
+      "vulnerabilities": products_with_machines.vulnerabilities,
+      "batch_size": products_with_machines.batch_size,
+      "skip": 0,
+      "is_all_vulnerability_fetched": products_with_machines.is_all_vulnerability_fetched,
+      "affected_machines_only": products_with_machines.affected_machines_only,
+    }
+  :
+    request(
+      "GET",
+      state.url.trim_right("/") + "/api/vulnerabilities?" + {
         "$top": [string(products_with_machines.batch_size)],
         "$skip": [string(products_with_machines.skip)],
-      }.format_query()).do_request().as(vulnerabilityResp, vulnerabilityResp.StatusCode == 200 ?
-        vulnerabilityResp.Body.decode_json().as(vulnerabilityBody, {
-          "events": [{"message":"retry"}],
+      }.format_query()
+    ).do_request().as(vulnerabilityResp, (vulnerabilityResp.StatusCode == 200) ?
+      vulnerabilityResp.Body.decode_json().as(vulnerabilityBody,
+        {
+          "events": [{"message": "retry"}],
           "vulnerabilities": (products_with_machines.?vulnerabilities.orValue([]) + vulnerabilityBody.value).flatten(),
           "batch_size": state.batch_size,
-          "skip":size(vulnerabilityBody.value) > 0 ? int(products_with_machines.skip) + int(products_with_machines.batch_size) : 0,
+          "skip": (size(vulnerabilityBody.value) > 0) ? (int(products_with_machines.skip) + int(products_with_machines.batch_size)) : 0,
           "is_all_vulnerabilities_fetched": size(vulnerabilityBody.value) < int(products_with_machines.batch_size),
           "want_more": true,
           "products": products_with_machines.products,
           "product_batch_size": products_with_machines.product_batch_size,
-          "product_skip" : 0,
+          "product_skip": 0,
           "is_all_products_fetched": products_with_machines.is_all_products_fetched,
           "machines": products_with_machines.machines,
           "machine_batch_size": products_with_machines.machine_batch_size,
           "machine_skip": 0,
           "is_all_machines_fetched": products_with_machines.is_all_machines_fetched,
           "affected_machines_only": products_with_machines.affected_machines_only,
-        })
-      :
-        state.with({
+        }
+      )
+    :
+      state.with(
+        {
           "events": {
             "error": {
               "code": string(vulnerabilityResp.StatusCode),
               "id": string(vulnerabilityResp.Status),
-              "message": "GET " + state.url.trim_right("/") + "/api/vulnerabilities" + 
-              (
-                size(vulnerabilityResp.Body) != 0 ?
+              "message": "GET " + state.url.trim_right("/") + "/api/vulnerabilities" + (
+                (size(vulnerabilityResp.Body) != 0) ?
                   string(vulnerabilityResp.Body)
                 :
-                  string(vulnerabilityResp.Status) + ' (' + string(vulnerabilityResp.StatusCode) + ')'
+                  string(vulnerabilityResp.Status) + " (" + string(vulnerabilityResp.StatusCode) + ")"
               ),
             },
           },
@@ -232,38 +247,46 @@ program: |
           "is_all_machines_fetched": false,
           "vulnerabilities": [],
           "skip": 0,
-          "is_all_vulnerabilities_fetched": false
+          "is_all_vulnerabilities_fetched": false,
         }
       )
     )
-  )).as(all_data, !all_data.?is_all_vulnerabilities_fetched.orValue(false) ? all_data : (
-    (
-      all_data.products.map(p, (all_data.machines.filter(m, m.id == p.machineId)[0]).with(p))
-    ).as(mapped_products,  {
-      "vulnerability_with_machines": all_data.vulnerabilities.filter(v, v.exposedMachines > 0),
-      "vulnerability_without_machines": !all_data.affected_machines_only ? 
-        all_data.vulnerabilities.filter(v, v.exposedMachines == 0)
-      :
-        [],
-      "mapped_products": mapped_products,
-    }).as(final_data, {
-      "events": (final_data.vulnerability_with_machines.map(v, 
-        final_data.mapped_products.filter(mp, mp.cveId == v.id).map(related_mapped_products, 
-          {"message": v.with({"affectedMachine": related_mapped_products}).encode_json()}
-        )).flatten() + final_data.vulnerability_without_machines.map(v, {
-        "message": v.with({"affectedMachine": null}).encode_json(),
-        })
-      ).flatten(),
-      "product_batch_size": all_data.product_batch_size,
-      "product_skip" : 0,
-      "machine_batch_size": all_data.machine_batch_size,
-      "machine_skip": 0,
-      "batch_size": all_data.batch_size,
-      "skip": 0,
-      "affected_machines_only": all_data.affected_machines_only,
-      "want_more": false,
-    })
-  ))
+  ).as(all_data, !all_data.?is_all_vulnerabilities_fetched.orValue(false) ?
+    all_data
+  :
+    all_data.products.map(p, all_data.machines.filter(m, m.id == p.machineId)[0].with(p)).as(mapped_products,
+      {
+        "vulnerability_with_machines": all_data.vulnerabilities.filter(v, v.exposedMachines > 0),
+        "vulnerability_without_machines": !all_data.affected_machines_only ?
+          all_data.vulnerabilities.filter(v, v.exposedMachines == 0)
+        :
+          [],
+        "mapped_products": mapped_products,
+      }
+    ).as(final_data,
+      {
+        "events": (
+          final_data.vulnerability_with_machines.map(v,
+            final_data.mapped_products.filter(mp, mp.cveId == v.id).map(related_mapped_products,
+              {"message": v.with({"affectedMachine": related_mapped_products}).encode_json()}
+            )
+          ).flatten() + final_data.vulnerability_without_machines.map(v,
+            {
+              "message": v.with({"affectedMachine": null}).encode_json(),
+            }
+          )
+        ).flatten(),
+        "product_batch_size": all_data.product_batch_size,
+        "product_skip": 0,
+        "machine_batch_size": all_data.machine_batch_size,
+        "machine_skip": 0,
+        "batch_size": all_data.batch_size,
+        "skip": 0,
+        "affected_machines_only": all_data.affected_machines_only,
+        "want_more": false,
+      }
+    )
+  )
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/m365_defender/manifest.yml
+++ b/packages/m365_defender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: m365_defender
 title: Microsoft Defender XDR
-version: "3.13.0"
+version: "3.14.0"
 description: Collect logs from Microsoft Defender XDR with Elastic Agent.
 categories:
   - "security"


### PR DESCRIPTION
## Proposed commit message
Enhanced error handling in the CEL program to prevent "no such key: product_batch_size'" errors by ensuring proper propagation of the state data configuration during failures. This was accomplished by wrapping the objects returned from errors with state.with()

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
