### PR TITLE
Add Links panel to Cassandra dashboards

### DIFF
--- a/packages/cassandra/kibana/dashboard/cassandra-25b7d6d0-1c71-11ec-84f1-e1733c643874.json
+++ b/packages/cassandra/kibana/dashboard/cassandra-25b7d6d0-1c71-11ec-84f1-e1733c643874.json
@@ -44,32 +44,31 @@
             "syncColors": false,
             "syncCursor": true,
             "syncTooltips": false,
-            "useMargins": false
+            "useMargins": true
         },
         "panelsJSON": [
             {
                 "embeddableConfig": {
                     "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
+                    "attributes": {
+                        "title": "links",
+                        "layout": "horizontal",
+                        "links": [
+                            {
+                                "label": "Logs",
+                                "type": "dashboardLink",
+                                "id": "cassandra-49e4e6e0-cc54-11ec-8c59-ed6efced90da",
+                                "order": 0,
+                                "destinationRefName": "link_cassandra-49e4e6e0-cc54-11ec-8c59-ed6efced90da_dashboard"
+                            },
+                            {
+                                "label": "Metrics",
+                                "type": "dashboardLink",
+                                "id": "cassandra-25b7d6d0-1c71-11ec-84f1-e1733c643874",
+                                "order": 1,
+                                "destinationRefName": "link_cassandra-25b7d6d0-1c71-11ec-84f1-e1733c643874_dashboard"
                             }
-                        },
-                        "description": "",
-                        "params": {
-                            "fontSize": 12,
-                            "markdown": "[Logs](#/dashboard/cassandra-49e4e6e0-cc54-11ec-8c59-ed6efced90da) | [Metrics](#/dashboard/cassandra-25b7d6d0-1c71-11ec-84f1-e1733c643874)",
-                            "openLinksInNewTab": false
-                        },
-                        "title": "Dashboards [Cassandra]",
-                        "type": "markdown",
-                        "uiState": {}
+                        ]
                     }
                 },
                 "gridData": {
@@ -80,7 +79,8 @@
                     "y": 0
                 },
                 "panelIndex": "6139e80c-4a75-4dcd-b617-96c56dd1caf8",
-                "type": "visualization"
+                "title": "",
+                "type": "links"
             },
             {
                 "embeddableConfig": {
@@ -256,7 +256,7 @@
                     "y": 4
                 },
                 "panelIndex": "ea99aa96-c9cb-49a7-ac8e-9ed3461e3aef",
-                "title": "Hosts [Metrics Cassandra]",
+                "title": "Hosts",
                 "type": "lens"
             },
             {
@@ -389,7 +389,7 @@
                     "y": 21
                 },
                 "panelIndex": "0cac5b29-e217-4b68-a61a-f389d9b8d7a1",
-                "title": "Nodes [Metrics Cassandra]",
+                "title": "Nodes",
                 "type": "lens"
             },
             {
@@ -574,7 +574,7 @@
                     "y": 38
                 },
                 "panelIndex": "995f4c8e-fa4d-42e7-86dd-d138d6d05e87",
-                "title": "Cluster Info [Metrics Cassandra]",
+                "title": "Cluster Info",
                 "type": "lens"
             },
             {
@@ -719,7 +719,7 @@
                     "y": 56
                 },
                 "panelIndex": "a6045295-4b0c-4dec-b7b8-c0404187f002",
-                "title": "Disk Usage [Metrics Cassandra]",
+                "title": "Disk Usage",
                 "type": "lens"
             },
             {
@@ -878,7 +878,7 @@
                     "y": 56
                 },
                 "panelIndex": "e600f07c-44c8-4844-8788-d456d8303f66",
-                "title": "Cache [Metrics Cassandra]",
+                "title": "Cache",
                 "type": "lens"
             },
             {
@@ -1051,7 +1051,7 @@
                     "y": 71
                 },
                 "panelIndex": "b8cef86e-7c91-4a83-ac83-994334404231",
-                "title": "Heap Memory [Metrics Cassandra]",
+                "title": "Heap Memory",
                 "type": "lens"
             },
             {
@@ -1211,7 +1211,7 @@
                     "y": 86
                 },
                 "panelIndex": "cbbbaddb-c2c9-4406-9cd5-91aaac4d4f06",
-                "title": "Tasks [Metrics Cassandra]",
+                "title": "Tasks",
                 "type": "lens"
             },
             {
@@ -1370,7 +1370,7 @@
                     "y": 101
                 },
                 "panelIndex": "6c8fbd31-8d67-4d86-8583-48b35a473620",
-                "title": "CAS Read/Write Latency [Metrics Cassandra]",
+                "title": "CAS Read/Write Latency",
                 "type": "lens"
             },
             {
@@ -1529,7 +1529,7 @@
                     "y": 101
                 },
                 "panelIndex": "b1d8d0cc-0873-4146-b7a9-6ed1c1f9b316",
-                "title": "Read/Write Failures [Metrics Cassandra]",
+                "title": "Read/Write Failures",
                 "type": "lens"
             },
             {
@@ -1850,7 +1850,7 @@
                     "y": 116
                 },
                 "panelIndex": "116de2a1-c967-47e2-b801-dd1d74cee1ac",
-                "title": "Dropped Message [Metrics Cassandra]",
+                "title": "Dropped Message",
                 "type": "lens"
             },
             {
@@ -2009,7 +2009,7 @@
                     "y": 116
                 },
                 "panelIndex": "e2295585-cc4f-402d-b6d8-ab54d8f300bb",
-                "title": "Read/Write Count [Metrics Cassandra]",
+                "title": "Read/Write Count",
                 "type": "lens"
             },
             {
@@ -2164,7 +2164,7 @@
                     "y": 131
                 },
                 "panelIndex": "32e9a9f0-5725-4b33-98e5-a29924847892",
-                "title": "Read Latency [Metrics Cassandra]",
+                "title": "Read Latency",
                 "type": "lens"
             },
             {
@@ -2305,7 +2305,7 @@
                     "y": 131
                 },
                 "panelIndex": "91a1108a-b151-4b79-8f20-36f2be710cd5",
-                "title": "Write Latency [Metrics Cassandra]",
+                "title": "Write Latency",
                 "type": "lens"
             },
             {
@@ -2446,7 +2446,7 @@
                     "y": 146
                 },
                 "panelIndex": "2b907dce-54fa-43ea-a865-cf4250cceae4",
-                "title": "Storage Exception [Metrics Cassandra]",
+                "title": "Storage Exception",
                 "type": "lens"
             },
             {
@@ -2587,7 +2587,7 @@
                     "y": 146
                 },
                 "panelIndex": "f5c4ffef-afcc-42b3-8e00-a88aecdf4d71",
-                "title": "Range Slice Latency [Metrics Cassandra]",
+                "title": "Range Slice Latency",
                 "type": "lens"
             },
             {
@@ -2746,7 +2746,7 @@
                     "y": 162
                 },
                 "panelIndex": "4e99fbdf-8533-41a1-aead-15c63c884f4f",
-                "title": "Unavailable Requests [Metrics Cassandra]",
+                "title": "Unavailable Requests",
                 "type": "lens"
             },
             {
@@ -2905,7 +2905,7 @@
                     "y": 162
                 },
                 "panelIndex": "9bbec20f-016d-4176-a0d7-1447ed594245",
-                "title": "Request Timeouts [Metrics Cassandra]",
+                "title": "Request Timeouts",
                 "type": "lens"
             }
         ],
@@ -3017,6 +3017,16 @@
             "id": "metrics-*",
             "name": "controlGroup_8a8cb6ef-8521-41a3-bbe8-bba0d0cfa2c3:optionsListDataView",
             "type": "index-pattern"
+        },
+        {
+            "name": "6139e80c-4a75-4dcd-b617-96c56dd1caf8:link_cassandra-49e4e6e0-cc54-11ec-8c59-ed6efced90da_dashboard",
+            "type": "dashboard",
+            "id": "cassandra-49e4e6e0-cc54-11ec-8c59-ed6efced90da"
+        },
+        {
+            "name": "6139e80c-4a75-4dcd-b617-96c56dd1caf8:link_cassandra-25b7d6d0-1c71-11ec-84f1-e1733c643874_dashboard",
+            "type": "dashboard",
+            "id": "cassandra-25b7d6d0-1c71-11ec-84f1-e1733c643874"
         }
     ],
     "type": "dashboard",

--- a/packages/cassandra/kibana/dashboard/cassandra-49e4e6e0-cc54-11ec-8c59-ed6efced90da.json
+++ b/packages/cassandra/kibana/dashboard/cassandra-49e4e6e0-cc54-11ec-8c59-ed6efced90da.json
@@ -50,27 +50,25 @@
             {
                 "embeddableConfig": {
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
+                    "attributes": {
+                        "title": "links",
+                        "layout": "horizontal",
+                        "links": [
+                            {
+                                "label": "Logs",
+                                "type": "dashboardLink",
+                                "id": "cassandra-49e4e6e0-cc54-11ec-8c59-ed6efced90da",
+                                "order": 0,
+                                "destinationRefName": "link_cassandra-49e4e6e0-cc54-11ec-8c59-ed6efced90da_dashboard"
+                            },
+                            {
+                                "label": "Metrics",
+                                "type": "dashboardLink",
+                                "id": "cassandra-25b7d6d0-1c71-11ec-84f1-e1733c643874",
+                                "order": 1,
+                                "destinationRefName": "link_cassandra-25b7d6d0-1c71-11ec-84f1-e1733c643874_dashboard"
                             }
-                        },
-                        "description": "",
-                        "params": {
-                            "fontSize": 12,
-                            "markdown": "[Logs](#/dashboard/cassandra-49e4e6e0-cc54-11ec-8c59-ed6efced90da) | [Metrics](#/dashboard/cassandra-25b7d6d0-1c71-11ec-84f1-e1733c643874)",
-                            "openLinksInNewTab": false
-                        },
-                        "title": "[Cassandra] Dashboards",
-                        "type": "markdown",
-                        "uiState": {}
+                        ]
                     }
                 },
                 "gridData": {
@@ -82,7 +80,7 @@
                 },
                 "panelIndex": "18399b21-a004-4caa-9955-4adcc64985be",
                 "title": "Dashboards [Cassandra]",
-                "type": "visualization"
+                "type": "links"
             },
             {
                 "embeddableConfig": {
@@ -185,7 +183,7 @@
                     "y": 0
                 },
                 "panelIndex": "c70b222f-e779-42ed-bb48-ed7531aa00c0",
-                "title": "Log Severity [Logs Cassandra]",
+                "title": "Log Severity",
                 "type": "lens"
             },
             {
@@ -231,7 +229,7 @@
                     "y": 5
                 },
                 "panelIndex": "fe3c04b7-1e67-4df3-b00a-03cc435213dc",
-                "title": "Cassandra Log Search [Logs Cassandra]",
+                "title": "Cassandra Log Search",
                 "type": "search"
             }
         ],
@@ -273,6 +271,16 @@
             "id": "logs-*",
             "name": "controlGroup_6a41cd35-66c0-4d68-9403-d593ffe78487:optionsListDataView",
             "type": "index-pattern"
+        },
+        {
+            "name": "18399b21-a004-4caa-9955-4adcc64985be:link_cassandra-49e4e6e0-cc54-11ec-8c59-ed6efced90da_dashboard",
+            "type": "dashboard",
+            "id": "cassandra-49e4e6e0-cc54-11ec-8c59-ed6efced90da"
+        },
+        {
+            "name": "18399b21-a004-4caa-9955-4adcc64985be:link_cassandra-25b7d6d0-1c71-11ec-84f1-e1733c643874_dashboard",
+            "type": "dashboard",
+            "id": "cassandra-25b7d6d0-1c71-11ec-84f1-e1733c643874"
         }
     ],
     "type": "dashboard",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Replaced the Markdown panel with links between dashboards, replaced with the Links panel for the Cassandra Integration. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

#13630

## Screenshots
Before:
<img width="1469" height="495" alt="Screenshot 2025-07-29 at 09 28 23" src="https://github.com/user-attachments/assets/a8732b46-4ee8-4a34-814a-feae3e4a8c24" />
After:
<img width="1714" height="495" alt="Screenshot 2025-07-29 at 09 27 06" src="https://github.com/user-attachments/assets/62e2f4e7-5f67-467b-9459-7da5e11302ef" />

