### PR TITLE
feat: add tags and processors support to GCP data streams

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.43.0"
+  changes:
+    - description: Add tags and processors to GCP Billing, Cloudrun, CloudSQL, Dataproc, GKE, Loadbalancing, Pubsub and Redis.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/13777
 - version: "2.42.1"
   changes:
     - description: Remove redundant audit violation field renames.

--- a/packages/gcp/data_stream/billing/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/billing/agent/stream/stream.yml.hbs
@@ -10,3 +10,11 @@ credentials_json: '{{credentials_json}}'
 dataset_id: {{dataset_id}}
 table_pattern: {{table_pattern}}
 cost_type: {{cost_type}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}
+tags:
+{{#each tags as |tag|}}
+- {{tag}}
+{{/each}}

--- a/packages/gcp/data_stream/billing/manifest.yml
+++ b/packages/gcp/data_stream/billing/manifest.yml
@@ -32,3 +32,20 @@ streams:
         show_user: true
         description: "The type of cost this line item represents: regular, tax, adjustment, or rounding error"
         default: regular
+      - name: tags
+        type: text
+        title: Tags
+        description: Tags to include in the published event
+        multi: true
+        required: false
+        show_user: false
+        default:
+          - gcp-billing
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.

--- a/packages/gcp/data_stream/cloudrun_metrics/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/cloudrun_metrics/agent/stream/stream.yml.hbs
@@ -20,6 +20,14 @@ regions:
 {{/each}}
 {{/if}}
 exclude_labels: {{exclude_labels}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}
+tags:
+{{#each tags as |tag|}}
+  - {{tag}}
+{{/each}}
 metrics:
   - service: run
     metric_types:

--- a/packages/gcp/data_stream/cloudrun_metrics/manifest.yml
+++ b/packages/gcp/data_stream/cloudrun_metrics/manifest.yml
@@ -37,5 +37,22 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: tags
+        type: text
+        title: Tags
+        description: Tags to include in the published event
+        multi: true
+        required: false
+        show_user: false
+        default:
+          - gcp-cloudrun-metrics
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
 elasticsearch:
   index_mode: "time_series"

--- a/packages/gcp/data_stream/cloudsql_mysql/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/cloudsql_mysql/agent/stream/stream.yml.hbs
@@ -11,6 +11,14 @@ credentials_json: '{{credentials_json}}'
 region: {{region}}
 {{/if}}
 exclude_labels: {{exclude_labels}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}
+tags:
+{{#each tags as |tag|}}
+  - {{tag}}
+{{/each}}
 metrics:
   - aligner: ALIGN_NONE
     service: cloudsql

--- a/packages/gcp/data_stream/cloudsql_mysql/manifest.yml
+++ b/packages/gcp/data_stream/cloudsql_mysql/manifest.yml
@@ -23,5 +23,22 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: tags
+        type: text
+        title: Tags
+        description: Tags to include in the published event
+        multi: true
+        required: false
+        show_user: false
+        default:
+          - gcp-cloudsql-mysql
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
 elasticsearch:
   index_mode: "time_series"

--- a/packages/gcp/data_stream/cloudsql_sqlserver/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/cloudsql_sqlserver/agent/stream/stream.yml.hbs
@@ -11,6 +11,14 @@ credentials_json: '{{credentials_json}}'
 region: {{region}}
 {{/if}}
 exclude_labels: {{exclude_labels}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}
+tags:
+{{#each tags as |tag|}}
+  - {{tag}}
+{{/each}}
 metrics:
   - aligner: ALIGN_NONE
     service: cloudsql

--- a/packages/gcp/data_stream/cloudsql_sqlserver/manifest.yml
+++ b/packages/gcp/data_stream/cloudsql_sqlserver/manifest.yml
@@ -23,5 +23,22 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: tags
+        type: text
+        title: Tags
+        description: Tags to include in the published event
+        multi: true
+        required: false
+        show_user: false
+        default:
+          - gcp-cloudsql-sqlserver
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
 elasticsearch:
   index_mode: "time_series"

--- a/packages/gcp/data_stream/dataproc/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/dataproc/agent/stream/stream.yml.hbs
@@ -17,6 +17,14 @@ regions:
 {{/each}}
 {{/if}}
 exclude_labels: {{exclude_labels}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}
+tags:
+{{#each tags as |tag|}}
+  - {{tag}}
+{{/each}}
 metrics:
   - service: dataproc
     metric_types:

--- a/packages/gcp/data_stream/dataproc/manifest.yml
+++ b/packages/gcp/data_stream/dataproc/manifest.yml
@@ -31,5 +31,22 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: tags
+        type: text
+        title: Tags
+        description: Tags to include in the published event
+        multi: true
+        required: false
+        show_user: false
+        default:
+          - gcp-dataproc
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
 elasticsearch:
   index_mode: "time_series"

--- a/packages/gcp/data_stream/gke/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/gke/agent/stream/stream.yml.hbs
@@ -20,6 +20,14 @@ regions:
 {{/each}}
 {{/if}}
 exclude_labels: {{exclude_labels}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}
+tags:
+{{#each tags as |tag|}}
+  - {{tag}}
+{{/each}}
 metrics:
   - service: gke
     service_metric_prefix: kubernetes.io/

--- a/packages/gcp/data_stream/gke/manifest.yml
+++ b/packages/gcp/data_stream/gke/manifest.yml
@@ -37,5 +37,22 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: tags
+        type: text
+        title: Tags
+        description: Tags to include in the published event
+        multi: true
+        required: false
+        show_user: false
+        default:
+          - gcp-gke
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
 elasticsearch:
   index_mode: "time_series"

--- a/packages/gcp/data_stream/loadbalancing_metrics/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/loadbalancing_metrics/agent/stream/stream.yml.hbs
@@ -20,6 +20,14 @@ regions:
 {{/each}}
 {{/if}}
 exclude_labels: {{exclude_labels}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}
+tags:
+{{#each tags as |tag|}}
+  - {{tag}}
+{{/each}}
 metrics:
   - service: loadbalancing
     metric_types:

--- a/packages/gcp/data_stream/loadbalancing_metrics/manifest.yml
+++ b/packages/gcp/data_stream/loadbalancing_metrics/manifest.yml
@@ -37,5 +37,22 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: tags
+        type: text
+        title: Tags
+        description: Tags to include in the published event
+        multi: true
+        required: false
+        show_user: false
+        default:
+          - gcp-loadbalancing-metrics
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
 elasticsearch:
   index_mode: "time_series"

--- a/packages/gcp/data_stream/pubsub/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/pubsub/agent/stream/stream.yml.hbs
@@ -14,6 +14,14 @@ region: {{region}}
 zone: {{zone}}
 {{/if}}
 exclude_labels: {{exclude_labels}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}
+tags:
+{{#each tags as |tag|}}
+  - {{tag}}
+{{/each}}
 metrics:
   - service: pubsub
     metric_types:

--- a/packages/gcp/data_stream/pubsub/manifest.yml
+++ b/packages/gcp/data_stream/pubsub/manifest.yml
@@ -29,5 +29,22 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: tags
+        type: text
+        title: Tags
+        description: Tags to include in the published event
+        multi: true
+        required: false
+        show_user: false
+        default:
+          - gcp-pubsub
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
 elasticsearch:
   index_mode: "time_series"

--- a/packages/gcp/data_stream/redis/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/redis/agent/stream/stream.yml.hbs
@@ -20,6 +20,14 @@ regions:
 {{/each}}
 {{/if}}
 exclude_labels: {{exclude_labels}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}
+tags:
+{{#each tags as |tag|}}
+  - {{tag}}
+{{/each}}
 metrics:
   - service: redis
     metric_types:

--- a/packages/gcp/data_stream/redis/manifest.yml
+++ b/packages/gcp/data_stream/redis/manifest.yml
@@ -37,5 +37,22 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: tags
+        type: text
+        title: Tags
+        description: Tags to include in the published event
+        multi: true
+        required: false
+        show_user: false
+        default:
+          - gcp-redis
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
 elasticsearch:
   index_mode: "time_series"

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.42.1"
+version: "2.43.0"
 description: Collect logs and metrics from Google Cloud Platform with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

WHAT: Added support for custom tags and processors configuration to multiple GCP data streams including Billing, Cloud Run metrics, Cloud SQL (MySQL and SQL Server), Dataproc, GKE, Load Balancing metrics, Pub/Sub, and Redis.

The changes include:

Addition of a tags field (text array) with default values specific to each data stream (e.g., "gcp-billing", "gcp-cloudrun", etc.)
Addition of a processors field (YAML) allowing users to configure custom processors for data transformation and enrichment
Updated manifest.yml files for all affected data streams to include these new configuration options
Updated stream.yml.hbs templates to support the new fields
Incremented package version to 2.43.0 in manifest.yml

WHY: This enhancement provides users with greater flexibility to:

Add custom tags to events for better organization and filtering
Apply custom processors for data transformation, field reduction, or metadata enhancement before log parsing
Standardize event processing across different GCP services
Improve observability and data management capabilities
The processors execute in the Elastic Agent before logs are parsed, following the standard Elastic Agent processor configuration patterns.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [X] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

