### PR TITLE
[cisco_ftd] Ensure observer zone fields are set

### DIFF
--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Ensure observer zone fields are set.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/14748
 - version: "3.9.0"
   changes:
     - description: Add parsing for `EncryptPeerIP` and `VPN_Action` fields.

--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.9.1"
+  changes:
+    - description: Ensure observer zone fields are set.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.9.0"
   changes:
     - description: Add parsing for `EncryptPeerIP` and `VPN_Action` fields.

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
@@ -108,13 +108,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -256,13 +258,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -400,13 +404,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -549,13 +555,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -694,13 +702,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -838,13 +848,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -987,13 +999,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1131,13 +1145,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1276,13 +1292,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1424,13 +1442,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1568,13 +1588,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1704,13 +1726,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1850,13 +1874,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1995,13 +2021,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -2141,13 +2169,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -2289,13 +2319,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -2433,13 +2465,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -2577,13 +2611,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -2721,13 +2757,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -2861,13 +2899,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -3009,13 +3049,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-endpoint-profile.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-endpoint-profile.log-expected.json
@@ -86,12 +86,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -214,12 +216,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -342,12 +346,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -470,12 +476,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -598,12 +606,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -729,12 +739,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -860,12 +872,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -991,12 +1005,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1122,12 +1138,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1253,12 +1271,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1384,12 +1404,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1512,12 +1534,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1637,12 +1661,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1759,12 +1785,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1884,12 +1912,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -2009,12 +2039,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -2134,12 +2166,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -2259,12 +2293,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -2387,12 +2423,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -2515,12 +2553,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -2646,12 +2686,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -2777,12 +2819,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -2899,12 +2943,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -3024,12 +3070,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -3149,12 +3197,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -3274,12 +3324,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -3402,12 +3454,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -3530,12 +3584,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -3655,12 +3711,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -3780,12 +3838,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -3905,12 +3965,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -4033,12 +4095,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -4158,12 +4222,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -4280,12 +4346,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -4402,12 +4470,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -4524,12 +4594,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -4643,12 +4715,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -4765,12 +4839,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -4887,12 +4963,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -5012,12 +5090,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -5140,12 +5220,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -5262,12 +5344,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -5387,12 +5471,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -5515,12 +5601,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -5640,12 +5728,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -5759,12 +5849,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-intrusion.log-config.yml
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-intrusion.log-config.yml
@@ -1,0 +1,10 @@
+dynamic_fields:
+  "@timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}"
+fields:
+  tags:
+    - preserve_original_event
+  _temp_:
+    external_zones:
+      - output-zone
+    internal_zones:
+      - input-zone

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-intrusion.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-intrusion.log-expected.json
@@ -69,6 +69,7 @@
             "network": {
                 "application": "firefox",
                 "community_id": "1:aVBZLbVEijzexcqIhp/89fLm6Fw=",
+                "direction": "outbound",
                 "iana_number": "6",
                 "protocol": "http",
                 "transport": "tcp"
@@ -77,13 +78,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "firepower",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -184,6 +187,7 @@
             "network": {
                 "application": "firefox",
                 "community_id": "1:T2FxxCvrJYccm7bcw2QZ9tWONIo=",
+                "direction": "outbound",
                 "iana_number": "6",
                 "protocol": "http",
                 "transport": "tcp"
@@ -192,13 +196,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "firepower",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -296,6 +302,7 @@
             "message": "APP-DETECT failed FTP login attempt",
             "network": {
                 "community_id": "1:4Ze3PKactlddzol+s7PbEeCTTlk=",
+                "direction": "inbound",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -303,13 +310,15 @@
                 "egress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "hostname": "firepower",
                 "ingress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -407,6 +416,7 @@
             "message": "APP-DETECT failed FTP login attempt",
             "network": {
                 "community_id": "1:yyUSZl65LfpqAPKtrjT9QRDUlfs=",
+                "direction": "inbound",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -414,13 +424,15 @@
                 "egress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "hostname": "firepower",
                 "ingress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "product": "ftd",
                 "type": "idps",

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-security-connection.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-security-connection.log-expected.json
@@ -79,13 +79,15 @@
                 "egress": {
                     "interface": {
                         "name": "input"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "hostname": "firepower",
                 "ingress": {
                     "interface": {
                         "name": "output"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -197,13 +199,15 @@
                 "egress": {
                     "interface": {
                         "name": "input"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "hostname": "firepower",
                 "ingress": {
                     "interface": {
                         "name": "output"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -336,13 +340,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "firepower",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -479,13 +485,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "firepower",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -603,13 +611,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "firepower",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -749,13 +759,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "firepower",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -883,13 +895,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "firepower",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1025,13 +1039,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "firepower",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1146,13 +1162,15 @@
                 "egress": {
                     "interface": {
                         "name": "input"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "hostname": "firepower",
                 "ingress": {
                     "interface": {
                         "name": "output"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1277,13 +1295,15 @@
                 "egress": {
                     "interface": {
                         "name": "output"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "siem-ftd",
                 "ingress": {
                     "interface": {
                         "name": "input"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1416,12 +1436,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1537,12 +1559,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1647,12 +1671,14 @@
                 "egress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1763,12 +1789,14 @@
                 "egress": {
                     "interface": {
                         "name": "Outside"
-                    }
+                    },
+                    "zone": "Outside"
                 },
                 "ingress": {
                     "interface": {
                         "name": "Inside"
-                    }
+                    },
+                    "zone": "Inside"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -1886,13 +1914,15 @@
                 "egress": {
                     "interface": {
                         "name": "outside"
-                    }
+                    },
+                    "zone": "output-zone"
                 },
                 "hostname": "firepower",
                 "ingress": {
                     "interface": {
                         "name": "inside"
-                    }
+                    },
+                    "zone": "input-zone"
                 },
                 "product": "ftd",
                 "type": "idps",
@@ -2024,12 +2054,14 @@
                 "egress": {
                     "interface": {
                         "name": "Azure-S2S"
-                    }
+                    },
+                    "zone": "Azure"
                 },
                 "ingress": {
                     "interface": {
                         "name": "GRT"
-                    }
+                    },
+                    "zone": "GRT"
                 },
                 "product": "ftd",
                 "type": "idps",

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-security-malware-site.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-security-malware-site.log-expected.json
@@ -111,13 +111,15 @@
                 "egress": {
                     "interface": {
                         "name": "s1p2"
-                    }
+                    },
+                    "zone": "Inside-DMZ-Interface-Inline"
                 },
                 "hostname": "CISCO-SENSOR-3D",
                 "ingress": {
                     "interface": {
                         "name": "s1p1"
-                    }
+                    },
+                    "zone": "Inside-DMZ-Interface-Inline"
                 },
                 "product": "ftd",
                 "type": "idps",

--- a/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1262,6 +1262,7 @@ processors:
         EgressZone:
           target: egress_zone
           id: ["430001", "430002", "430003"]
+          ecs: [observer.egress.zone]
         EncryptPeerIP:
           target: encrypt_peer_ip
           id: ["430001", "430002", "430003"]
@@ -1338,6 +1339,7 @@ processors:
         IngressZone:
           target: ingress_zone
           id: ["430001", "430002", "430003"]
+          ecs: [observer.ingress.zone]
         InitiatorBytes:
           target: initiator_bytes
           id: ["430003"]

--- a/packages/cisco_ftd/manifest.yml
+++ b/packages/cisco_ftd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ftd
 title: Cisco FTD
-version: "3.9.0"
+version: "3.9.1"
 description: Collect logs from Cisco FTD with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- Ensure Ingress and Egress zone values are set to proper ECS fields
- This will also allow the network.direction logic to work as intended

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

## How to test this PR locally

```
cd packages/cisco_ftd
elastic-package test
```

Note: in order for network.direction to be set properly, the integration needs to be configured with `internal_zones` and `external_zones` that match zone names that are seen in the log.

## Related issues

- Closes #14749

