### PR TITLE
[Draft] Revert the removal of winlog.event_data fields

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.2"
+  changes:
+    - description: Reverts removal of winlog.event_data fields used in detection rules.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/14756
 - version: "2.5.1"
   changes:
     - description: Fix condition in handlebar file of security data stream.

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
@@ -90,11 +90,8 @@ processors:
       if: ctx.winlog?.event_data != null && ctx.winlog.event_data.size() == 0
   - remove:
       field:
-        - winlog.event_data.SubjectUserSid
-        - winlog.event_data.SubjectUserName
         - winlog.event_data.SubjectDomainName
         - winlog.event_data.ProviderName
-        - winlog.event_data.ProcessName
         - winlog.event_data.RemoteAddress_ip
         - winlog.event_data.RemoteAddress_name
         - winlog.event_data.UserSid
@@ -104,10 +101,7 @@ processors:
         - winlog.event_data.ErrorCode
         - winlog.event_data.DeviceId
         - winlog.event_data.DeviceDescription
-        - winlog.event_data.ShareName
         - winlog.event_data.ShareLocalPath
-        - winlog.event_data.TargetUserSid
-        - winlog.event_data.TargetUserName
         - winlog.event_data.TargetDomainName
         - winlog.event_data.Param1
         - winlog.event_data.FileName

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: system
 title: System
-version: "2.5.1"
+version: "2.5.2"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Summary

Revert the removal of fields that are used in detection rules. 