### PR TITLE
[o365] Surface credential or subscription errors in Fleet status

### DIFF
--- a/packages/o365/_dev/deploy/docker/config.yml
+++ b/packages/o365/_dev/deploy/docker/config.yml
@@ -66,6 +66,21 @@ rules:
             - "application/json"
         body: |-
           {"contentType": "Audit.General","status": "enabled","webhook": null}
+  - path: /api/v1.0/test-cel-tenant-id/activity/feed/subscriptions/start
+    methods: [POST]
+    query_params:
+      contentType: "Audit.TypeRequiringAdditionalPermissions"
+      PublisherIdentifier: test-cel-tenant-id
+    request_headers:
+      Authorization:
+        - "Bearer CELtoken"
+    responses:
+      - status_code: 401
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":{"code":"AF10001","message":"The permission set (...) sent in the request does not include the expected permission."}}
   - path: /api/v1.0/test-cel-tenant-id/activity/feed/subscriptions/content
     methods: [GET]
     query_params:

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.21.0"
+  changes:
+    - description: Surface credential or subscription errors in Fleet status.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/14771
 - version: "2.20.0"
   changes:
     - description: Explain data latency in the documentation.

--- a/packages/o365/data_stream/audit/_dev/test/system/test-cel-bad-creds-config.yml
+++ b/packages/o365/data_stream/audit/_dev/test/system/test-cel-bad-creds-config.yml
@@ -1,0 +1,20 @@
+input: cel
+service: o365-cel
+vars: ~
+policy_template: o365
+data_stream:
+  vars:
+    url: http://{{Hostname}}:{{Port}}
+    token_url: http://{{Hostname}}:{{Port}}
+    preserve_original_event: true
+    client_id: test-cel-client-id
+    client_secret: test-cel-client-secret
+    azure_tenant_id: test-cel-tenant-id
+    content_types: "Audit.SharePoint, Audit.TypeRequiringAdditionalPermissions, Audit.General"
+    initial_interval: 12h
+    enable_request_tracer: true
+assert:
+  hit_count: 1
+skip:
+  reason: "Negative testing in system tests is not currently possible"
+  link: https://github.com/elastic/elastic-package/issues/2800

--- a/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
@@ -284,7 +284,7 @@ program: |-
   	)
   ).flatten().drop_empty().as(events_list,
   	events_list.collate("events_per_content_type").as(events,
-  	  events.filter(e, e.?error.message.hasValue()).as(error_events,
+  	  events.filter(e, has(e.error) && has(e.error.message)).as(error_events,
   	    error_events.size() > 0 ?
   	      // If there are errors, return a single merged error event and discard any other results
   	      {

--- a/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
@@ -260,7 +260,15 @@ program: |-
   				// When start-subscription API produces error, such as Authentication error.
   				[
   					{
-  						"events_per_content_type": [],
+  						"events_per_content_type": [{
+  						  "error": {
+  						    "message": start_subs_resp_body.?error.code.optFlatMap(code,
+  						      start_subs_resp_body.?error.message.optMap(message,
+  						        code + ": " + message
+  						      )
+  						    ).orValue(start_subs_resp_body)
+  						  }
+  						}],
   						"content_type": content_type,
   						"content_created_at": (has(state.cursor) && has(state.cursor.content_types_state_as_list)) ?
   							state.cursor.content_types_state_as_list.filter(e, e.content_type == content_type)[0].content_created_at
@@ -273,15 +281,29 @@ program: |-
   		)
   	)
   ).flatten().drop_empty().as(events_list,
-  	{
-  		"url": state.url,
-  		"base": state.base,
-  		"events": events_list.collate("events_per_content_type"),
-  		"want_more": events_list.collate("want_more_content").filter(e, e == true).size() > 0,
-  		"cursor": {
-  			"content_types_state_as_list": events_list.drop(["events_per_content_type"]),
-  		},
-  	}
+  	events_list.collate("events_per_content_type").as(events,
+  	  events.filter(e, e.?error.message.hasValue()).as(error_events,
+  	    error_events.size() > 0 ?
+  	      // If there are errors, return a single merged error event and discard any other results
+  	      {
+  	        "url": state.url,
+  	        "base": state.base,
+  	        "events": { "error": { "message": error_events.collate("error.message").join("; ") }},
+  	        "want_more": false,
+  	        ?"cursor": state.?cursor,
+  	      }
+  	    :
+  	      {
+  	        "url": state.url,
+  	        "base": state.base,
+  	        "events": events,
+  	        "want_more": events_list.collate("want_more_content").filter(e, e == true).size() > 0,
+  	        "cursor": {
+  	          "content_types_state_as_list": events_list.drop(["events_per_content_type"]),
+  	        },
+  	      }
+  	  )
+  	)
   )
 {{#if tags}}
 tags:

--- a/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
@@ -262,6 +262,8 @@ program: |-
   					{
   						"events_per_content_type": [{
   						  "error": {
+  						    "code": string(start_subs_resp.StatusCode),
+  						    "id": string(start_subs_resp.Status),
   						    "message": content_type + ": " + start_subs_resp_body.?error.code.optFlatMap(code,
   						      start_subs_resp_body.?error.message.optMap(message,
   						        code + " " + message
@@ -288,7 +290,13 @@ program: |-
   	      {
   	        "url": state.url,
   	        "base": state.base,
-  	        "events": { "error": { "message": error_events.collate("error.message").join("; ") }},
+  	        "events": {
+  	          "error": {
+  	            "code": error_events.collate("error.code").as(codes, codes.zip(codes)).keys().as(codes, codes.size() == 1 ? codes[0] : dyn(codes)),
+  	            "id": error_events.collate("error.id").as(ids, ids.zip(ids)).keys().as(ids, ids.size() == 1 ? ids[0] : dyn(ids)),
+  	            "message": error_events.collate("error.message").join("; "),
+  	          },
+  	        },
   	        "want_more": false,
   	        ?"cursor": state.?cursor,
   	      }

--- a/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
@@ -262,9 +262,9 @@ program: |-
   					{
   						"events_per_content_type": [{
   						  "error": {
-  						    "message": start_subs_resp_body.?error.code.optFlatMap(code,
+  						    "message": content_type + ": " + start_subs_resp_body.?error.code.optFlatMap(code,
   						      start_subs_resp_body.?error.message.optMap(message,
-  						        code + ": " + message
+  						        code + " " + message
   						      )
   						    ).orValue(start_subs_resp_body)
   						  }

--- a/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
@@ -284,7 +284,7 @@ program: |-
   	)
   ).flatten().drop_empty().as(events_list,
   	events_list.collate("events_per_content_type").as(events,
-  	  events.filter(e, has(e.error) && has(e.error.message)).as(error_events,
+  	  events.filter(e, has(e.?error.message)).as(error_events,
   	    error_events.size() > 0 ?
   	      // If there are errors, return a single merged error event and discard any other results
   	      {

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft Office 365
-version: "2.20.0"
+version: "2.21.0"
 description: Collect logs from Microsoft Office 365 with Elastic Agent.
 type: integration
 format_version: "3.2.3"


### PR DESCRIPTION
## Proposed commit message

```
[o365] Surface credential or subscription errors in Fleet status

Instead of ignoring errors and returning successes, if there are any
errors while creating/checking subscriptions, return an error showing
the problem, wait the interval time, and repeat everything next time.

This is intended to avoid silencing errors such as AF10001 "The
permission set () sent in the request does not include the expected
permission.".
```

## Notes

The `changelog.yml` entry assumes https://github.com/elastic/integrations/pull/14730 will be merged first.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

In the system test `data_stream/audit/_dev/test/system/test-cel-bad-creds-config.yml`, comment out the skip, run it with `--defer-cleanup 10m` and inspect the error document produced.

## Related issues

- Related https://github.com/elastic/elastic-package/issues/2800