### PR TITLE
[ti_threatstream] Allow setting an advanced search query

### DIFF
--- a/packages/ti_anomali/data_stream/intelligence/agent/stream/cel.yml.hbs
+++ b/packages/ti_anomali/data_stream/intelligence/agent/stream/cel.yml.hbs
@@ -29,6 +29,7 @@ state:
   initial_interval: {{initial_interval}}
   want_more: false
   preserve_original_event: {{preserve_original_event}}
+  query: {{query}}
 redact:
   fields:
     - api_key
@@ -43,6 +44,7 @@ program: |-
   			"limit": [string(state.page_size)],
   			?"update_id__gt": state.?cursor.last_update_id.optMap(id, [string(int(id))]),
   			?"remote_api": state.remote_api_true ? optional.of(["true"]) : optional.none(), // never set remote_api=false, only true or absent
+  			?"q": state.query != null && state.query != "" ? optional.of([state.query]) : optional.none(),
   		}.format_query()
   	).with(
   		{

--- a/packages/ti_anomali/data_stream/intelligence/manifest.yml
+++ b/packages/ti_anomali/data_stream/intelligence/manifest.yml
@@ -70,6 +70,14 @@ streams:
         show_user: false
         description: >-
           The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_filename) for details.
+      - name: query
+        type: text
+        title: Advanced Search Query
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          A complex filter to be applied when requesting data, similar to those used on the Advanced search screen of the ThreatStream UI. See "Advanced Search Queries" in the Anomali ThreatStream API Reference for more information.
       - name: remote_api_true
         type: bool
         title: Get remote observables


### PR DESCRIPTION
## Proposed commit message

```
[ti_threatstream] Allow setting an advanced search query

An advanced setting that lets the user specify a value for the `q`
parameter of the request, such as `confidence>=80 and severity=high`.
```

## Notes

Relevant details from the Anomali ThreatStream API Reference Guide:

> ### Advanced Search Queries
> Most filtering criteria can be specified using filter operators described in this document. However, if
you need to specify a complex filter, you can use an advanced search query. This method allows you
to specify queries similar to those you formulate on the Advanced search screen on the
ThreatStream user interface. To specify a filter language query, use this syntax in the API call:
`&q=<filter_language_query>`. The filter operators used for the filter language query are the
symbolic form (`=`, `<`, `>`, and so on) and not the descriptive form (exact, lt, gt, and so on) and the query
must be URL encoded. See "To retrieve intelligence using an advanced search query:" on the next
page for an example.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Screenshots

<img width="1268" height="1323" alt="Screenshot 2025-08-02 at 09-39-24 Add integration - Anomali - Integrations - Elastic" src="https://github.com/user-attachments/assets/16c6d370-902f-4ca6-a952-8a4189f77a79" />