### PR TITLE
[sql_input] add v0.6.1 to changelog (backported)

### DIFF
--- a/packages/sql_input/changelog.yml
+++ b/packages/sql_input/changelog.yml
@@ -24,6 +24,11 @@
     - description: Make hosts field secret
       type: enhancement
       link: https://github.com/elastic/integrations/pull/14128
+- version: "0.6.1"
+  changes:
+    - description: Fix manifest.yml to make package visible in Kibana `9.0.0`.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/14815
 - version: "0.6.0"
   changes:
     - description: Add support for Kibana `9.0.0`.


### PR DESCRIPTION
According to the procedure https://www.elastic.co/docs/extend/integrations/developer-workflow-support-old-package, adding a version 0.6.1 to the changelog introduced in the following PR: https://github.com/elastic/integrations/pull/14815

- Requires https://github.com/elastic/integrations/pull/14815