### PR TITLE
[CI] Fix description written for failed tests in Serverless

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -978,8 +978,8 @@ upload_safe_logs() {
     local source="$2"
     local target="$3"
 
-    if ! ls ${source} 2>&1 > /dev/null ; then
-        echo "upload_safe_logs: artifacts files not found, nothing will be archived"
+    if ! ls ${source} > /dev/null 2>&1; then
+        echo "upload_safe_logs: artifacts files not found at ${source}, nothing will be archived"
         return
     fi
 

--- a/dev/testsreporter/_static/summary.tmpl
+++ b/dev/testsreporter/_static/summary.tmpl
@@ -1,14 +1,15 @@
+{{ if .serverless -}}
+- Serverless: {{ .serverlessProject}}
+{{ else -}}
 {{ if ne .stackVersion "" -}}
 - Stack version: {{ .stackVersion }}
 {{ else -}}
 {{ if .logsDB -}}
 - Stack version: maximum of either the version used in PR builds or 8.17.0 (GA version for LogsDB index mode)
-{{ else -}}
+{{ else if eq .subscription "basic" -}}
 - Stack version: Same as in Pull Request builds
 {{ end -}}
 {{ end -}}
-{{ if .serverless -}}
-- Serverless: {{ .serverlessProject}}
 {{ end -}}
 {{ if .logsDB -}}
 - LogsDB: enabled

--- a/dev/testsreporter/format_test.go
+++ b/dev/testsreporter/format_test.go
@@ -91,8 +91,7 @@ func TestSummary(t *testing.T) {
 				},
 				teams: []string{"team1", "team2"},
 			},
-			expected: `- Stack version: Same as in Pull Request builds
-- Serverless: observability
+			expected: `- Serverless: observability
 - Package: foo
 - Failing test: mytest
 - DataStream: data
@@ -114,8 +113,7 @@ func TestSummary(t *testing.T) {
 				},
 				teams: []string{"team1", "team2"},
 			},
-			expected: `- Stack version: Same as in Pull Request builds
-- Serverless: observability
+			expected: `- Serverless: observability
 - Package: foo
 - Failing test: mytest
 - Owners:
@@ -182,6 +180,30 @@ func TestSummary(t *testing.T) {
 				teams: []string{"team1"},
 			},
 			expected: `- Stack version: 8.16
+- Subscription: basic
+- Packages:
+    - foo
+    - bar
+- Owners:
+    - team1
+`,
+		},
+		{
+			title: "summary with basic license and logsdb",
+			resultError: &buildError{
+				dataError: dataError{
+					logsDB:       true,
+					serverless:   false,
+					subscription: "basic",
+				},
+				packages: []string{
+					"foo",
+					"bar",
+				},
+				teams: []string{"team1"},
+			},
+			expected: `- Stack version: maximum of either the version used in PR builds or 8.17.0 (GA version for LogsDB index mode)
+- LogsDB: enabled
 - Subscription: basic
 - Packages:
     - foo


### PR DESCRIPTION
## Proposed commit message

Fix the description written in the issues created by the daily CI builds in case of Serverless builds.

It was set `Stack version: Same as in Pull Request builds` but this is not true for builds testing packages with a Serverless project.


## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Add new tests to avoid regressions


## Related issues

- Relates https://github.com/elastic/integrations/issues/14873


