### PR TITLE
sonarqube: Add more exclusions paths temporarily

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.sourceEncoding=UTF-8
 
 # Coverage report created by elastic-package just reference to *.yml files
 # Remove all these extensions to try to keep just *.yml files
-sonar.exclusions=**/*.java,**/Dockerfile,**/*.tf,**/*.go,**/*.yaml,**/*.xml,**/*.md,**/*.jsp
+sonar.exclusions=**/*.java,**/Dockerfile,**/*.tf,**/*.go,**/*.yaml,**/*.xml,**/*.md,**/*.jsp,packages/*/data_stream/*/lifecycle.yml,packages/*/data_stream/*/elasticsearch/ilm/*,packages/*/elasticsearch/transform/**/*,packages/*/kibana/tags.yml,packages/*/kibana/tag/*,packages/*/validation.yml
 
 # Generic test coverage report format
 # https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/test-coverage/generic-test-data/#generic-test-coverage


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
Currently almost all PRs that has changes to transform fail 
SonarQube checks because transform code is not covered 
by any of the tests. Example: https://github.com/elastic/integrations/pull/14629#issuecomment-3157614422

Until https://github.com/elastic/elastic-package/issues/2704 is implemented, this 
temporary fix ensures SonarQube skips these files where 
the coverage is not yet offered by `elastic-package` tests.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates: https://github.com/elastic/elastic-package/issues/2704
