### PR TITLE
[windows] Only try to extract extension when there is a dot in the file name in defender data stream.

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,10 @@
 # newer versions go on top
+- version: "3.1.1"
+  changes:
+    - description: |
+        Only try to extract extension when there is a dot in the file name in defender data stream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/14891
 - version: "3.1.0"
   changes:
     - description: |

--- a/packages/windows/data_stream/windows_defender/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/windows_defender/elasticsearch/ingest_pipeline/default.yml
@@ -212,6 +212,7 @@ processors:
       patterns:
         - '\.%{GREEDYDATA:file.extension}$'
       ignore_missing: true
+      if: ctx.file?.name != null && ctx.file.name.contains('.')
   - set:
       field: file.hash.sha256
       copy_from: winlog.event_data.Sha256

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 3.1.0
+version: 3.1.1
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Only try to extract extension when there is a dot in the file name in defender data stream.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
