### PR TITLE
Remove slack.context.ip_address if it is an empty string

### DIFF
--- a/packages/slack/changelog.yml
+++ b/packages/slack/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.25.1"
   changes:
-    - description: Add more robust error handling for the source.address field.
+    - description: Fix handling of empty Slack `context.ip_address` fields.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/14898
 - version: "1.25.0"

--- a/packages/slack/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/slack/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -120,6 +120,10 @@ processors:
   - user_agent:
       field: user_agent.original
       ignore_failure: true
+  - remove:
+      field: slack.context.ip_address
+      ignore_missing: true
+      if: ctx.slack?.context?.ip_address == ""
   - rename:
       field: slack.context.ip_address
       target_field: source.address
@@ -197,10 +201,6 @@ processors:
   - uri_parts:
       field: slack.audit.details.url_private
       ignore_missing: true
-  - remove:
-      field: source.address
-      ignore_missing: true
-      if: ctx?.source?.address == ""
   - convert:
       field: source.address
       target_field: source.ip

--- a/packages/slack/manifest.yml
+++ b/packages/slack/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: slack
 title: "Slack Logs"
-version: "1.25.0"
+version: "1.25.1"
 description: "Slack Logs Integration"
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

This PR fixes an issue where `source.address` can be empty in Slack but still exist as a field. This looks like `(empty)` in the results instead of `-`. Empty strings cause the pipeline to fail. The pipeline appropriately handles null values or missing fields but does not handle empty strings. This PR will fix that.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

N/A

## How to test this PR locally

Add the `remove` processor to a pipeline and run an empty string through the pipeline.

## Related issues

- Closes #14821 

## Screenshots

N/A