### PR TITLE
[Cloud Security] Add `aws` prefix to CSPM vars

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -15,6 +15,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "4.0.0-preview01"
+  changes:
+    - description: Changed AWS input vars with aws. prefix
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/14791
 - version: "3.0.1"
   changes:
     - description: Save GCP Project ID as string

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/aws.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/aws.yml.hbs
@@ -23,20 +23,38 @@ config:
         {{#if access_key_id}}
         access_key_id: {{access_key_id}}
         {{/if}}
+        {{#if aws.access_key_id}}
+        access_key_id: {{aws.access_key_id}}
+        {{/if}}
         {{#if secret_access_key}}
         secret_access_key: {{secret_access_key}}
+        {{/if}}
+        {{#if aws.secret_access_key}}
+        secret_access_key: {{aws.secret_access_key}}
         {{/if}}
         {{#if session_token}}
         session_token: {{session_token}}
         {{/if}}
+        {{#if aws.session_token}}
+        session_token: {{aws.session_token}}
+        {{/if}}
         {{#if shared_credential_file}}
         shared_credential_file: {{shared_credential_file}}
+        {{/if}}
+        {{#if aws.shared_credential_file}}
+        shared_credential_file: {{aws.shared_credential_file}}
         {{/if}}
         {{#if credential_profile_name}}
         credential_profile_name: {{credential_profile_name}}
         {{/if}}
+        {{#if aws.credential_profile_name}}
+        credential_profile_name: {{aws.credential_profile_name}}
+        {{/if}}
         {{#if role_arn}}
         role_arn: {{role_arn}}
+        {{/if}}
+        {{#if aws.role_arn}}
+        role_arn: {{aws.role_arn}}
         {{/if}}
         {{#if aws.credentials.external_id}}
         external_id: {{aws.credentials.external_id}}

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -91,26 +91,26 @@ streams:
       assume_role:
         - name: aws.credentials.type
           value: assume_role
-        - name: role_arn
+        - name: aws.role_arn
         - name: aws.account_type
       direct_access_keys:
         - name: aws.credentials.type
           value: direct_access_keys
-        - name: access_key_id
-        - name: secret_access_key
+        - name: aws.access_key_id
+        - name: aws.secret_access_key
         - name: aws.account_type
       temporary_session:
         - name: aws.credentials.type
           value: temporary_keys
-        - name: access_key_id
-        - name: secret_access_key
-        - name: session_token
+        - name: aws.access_key_id
+        - name: aws.secret_access_key
+        - name: aws.session_token
         - name: aws.account_type
       shared_credentials:
         - name: aws.credentials.type
           value: shared_credentials
-        - name: shared_credential_file
-        - name: credential_profile_name
+        - name: aws.shared_credential_file
+        - name: aws.credential_profile_name
         - name: aws.account_type
       cloud_formation:
         - name: aws.credentials.type
@@ -126,7 +126,7 @@ streams:
         - name: aws.credentials.type
           value: cloud_connectors
         - name: aws.account_type
-        - name: role_arn
+        - name: aws.role_arn
         - name: aws.credentials.external_id
     vars:
       - name: condition
@@ -137,41 +137,41 @@ streams:
         multi: false
         required: false
         show_user: false
-      - name: access_key_id
+      - name: aws.access_key_id
         type: text
         title: Access Key ID
         multi: false
         required: false
         show_user: true
         secret: false
-      - name: secret_access_key
+      - name: aws.secret_access_key
         type: password
         title: Secret Access Key
         multi: false
         required: false
         show_user: true
         secret: true
-      - name: session_token
+      - name: aws.session_token
         type: text
         title: Session Token
         multi: false
         required: false
         show_user: true
         secret: false
-      - name: shared_credential_file
+      - name: aws.shared_credential_file
         type: text
         title: Shared Credential File
         multi: false
         required: false
         show_user: false
         description: Directory of the shared credentials file
-      - name: credential_profile_name
+      - name: aws.credential_profile_name
         type: text
         title: Credential Profile Name
         multi: false
         required: false
         show_user: false
-      - name: role_arn
+      - name: aws.role_arn
         type: text
         title: ARN Role
         multi: false

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "3.0.1"
+version: "4.0.0-preview01"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION

## Proposed commit message
Add `aws` prefix to CSPM vars

This change is needed so we can use the same input variables for CSPM and Cloud Asset Inventory in order to make integration with the CloudSetup component.



## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## Related issues
- https://github.com/elastic/security-team/issues/13207
- https://github.com/elastic/kibana/pull/231343
