### PR TITLE
feat(o365): add support for configurable oauth2 endpoint params

### DIFF
--- a/packages/o365/_dev/deploy/docker/config.yml
+++ b/packages/o365/_dev/deploy/docker/config.yml
@@ -18,24 +18,6 @@ rules:
             - "application/json"
         body: |-
           {"access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ilg1ZVhrN","token_type": "Bearer","not_before": 1549647431,"expires_in": 3600,"resource": "f2a76e08-93f2-4350-833c-965c02483b11"}
-  # CEL Input Rules
-  - path: /test-cel-tenant-id/oauth2/v2.0/token
-    methods: [POST]
-    query_params:
-      client_id: test-cel-client-id
-      client_secret: test-cel-client-secret
-      grant_type: client_credentials
-      scope: https://manage.office.com/.default
-    request_headers:
-      Content-Type:
-        - "application/x-www-form-urlencoded"
-    responses:
-      - status_code: 200
-        headers:
-          Content-Type:
-            - "application/json"
-        body: |-
-          {"access_token": "CELtoken","token_type": "Bearer","expires_in": 3600,"ext_expires_in": 3600}
   # Refresh token to get access token: https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#refresh-the-access-token
   - path: /test-cel-tenant-id/oauth2/v2.0/token
     methods: [ POST ]
@@ -64,6 +46,24 @@ rules:
             "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIyZDRkMTFhMi1mODE0LTQ2YTctOD..."
           }
           ` }}
+  # CEL Input Rules
+  - path: /test-cel-tenant-id/oauth2/v2.0/token
+    methods: [POST]
+    query_params:
+      client_id: test-cel-client-id
+      client_secret: test-cel-client-secret
+      grant_type: client_credentials
+      scope: https://manage.office.com/.default
+    request_headers:
+      Content-Type:
+        - "application/x-www-form-urlencoded"
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"access_token": "CELtoken","token_type": "Bearer","expires_in": 3600,"ext_expires_in": 3600}
   - path: /api/v1.0/test-cel-tenant-id/activity/feed/subscriptions/start
     methods: [POST]
     query_params:

--- a/packages/o365/_dev/deploy/docker/config.yml
+++ b/packages/o365/_dev/deploy/docker/config.yml
@@ -18,6 +18,34 @@ rules:
             - "application/json"
         body: |-
           {"access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ilg1ZVhrN","token_type": "Bearer","not_before": 1549647431,"expires_in": 3600,"resource": "f2a76e08-93f2-4350-833c-965c02483b11"}
+  # Refresh token to get access token: https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#refresh-the-access-token
+  - path: /test-cel-tenant-id/oauth2/v2.0/token
+    methods: [ POST ]
+    query_params:
+      scope: 'https://manage.office.com/.default'
+      refresh_token: refresh_token_123
+      grant_type: refresh_token
+    request_headers:
+      Authorization:
+        - "Basic dGVzdC1jZWwtY2xpZW50LWlkOnRlc3QtY2VsLWNsaWVudC1zZWNyZXQ="
+      Content-Type:
+        - "application/x-www-form-urlencoded"
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {{ minify_json `
+          {
+            "access_token": "CELtoken",
+            "token_type": "Bearer",
+            "expires_in": 2,
+            "scope": "https%3A%2F%2Fgraph.microsoft.com%2Fmail.read",
+            "refresh_token": "AwABAAAAvPM1KaPlrEqdFSBzjqfTGAMxZGUTdM0t4B4...",
+            "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIyZDRkMTFhMi1mODE0LTQ2YTctOD..."
+          }
+          ` }}
   # CEL Input Rules
   - path: /test-cel-tenant-id/oauth2/v2.0/token
     methods: [POST]

--- a/packages/o365/_dev/deploy/docker/config.yml
+++ b/packages/o365/_dev/deploy/docker/config.yml
@@ -18,6 +18,24 @@ rules:
             - "application/json"
         body: |-
           {"access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ilg1ZVhrN","token_type": "Bearer","not_before": 1549647431,"expires_in": 3600,"resource": "f2a76e08-93f2-4350-833c-965c02483b11"}
+  # CEL Input Rules
+  - path: /test-cel-tenant-id/oauth2/v2.0/token
+    methods: [POST]
+    query_params:
+      client_id: test-cel-client-id
+      client_secret: test-cel-client-secret
+      grant_type: client_credentials
+      scope: https://manage.office.com/.default
+    request_headers:
+      Content-Type:
+        - "application/x-www-form-urlencoded"
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"access_token": "CELtoken","token_type": "Bearer","expires_in": 3600,"ext_expires_in": 3600}
   # Refresh token to get access token: https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#refresh-the-access-token
   - path: /test-cel-tenant-id/oauth2/v2.0/token
     methods: [ POST ]
@@ -46,24 +64,6 @@ rules:
             "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIyZDRkMTFhMi1mODE0LTQ2YTctOD..."
           }
           ` }}
-  # CEL Input Rules
-  - path: /test-cel-tenant-id/oauth2/v2.0/token
-    methods: [POST]
-    query_params:
-      client_id: test-cel-client-id
-      client_secret: test-cel-client-secret
-      grant_type: client_credentials
-      scope: https://manage.office.com/.default
-    request_headers:
-      Content-Type:
-        - "application/x-www-form-urlencoded"
-    responses:
-      - status_code: 200
-        headers:
-          Content-Type:
-            - "application/json"
-        body: |-
-          {"access_token": "CELtoken","token_type": "Bearer","expires_in": 3600,"ext_expires_in": 3600}
   - path: /api/v1.0/test-cel-tenant-id/activity/feed/subscriptions/start
     methods: [POST]
     query_params:

--- a/packages/o365/_dev/deploy/docker/docker-compose.yml
+++ b/packages/o365/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   o365-cel:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.19.0
     ports:
       - 8080
     environment:

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.22.0"
+  changes:
+    - description: Add option to control all oauth2 endpoint_params.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/14924
 - version: "2.21.1"
   changes:
     - description: Add explicit mapping for `AuthenticationType` field to fix detection rule.

--- a/packages/o365/data_stream/audit/_dev/test/system/test-grant-type-refresh-token-config.yml
+++ b/packages/o365/data_stream/audit/_dev/test/system/test-grant-type-refresh-token-config.yml
@@ -1,0 +1,20 @@
+input: cel
+service: o365-cel
+vars: ~
+policy_template: o365
+data_stream:
+  vars:
+    url: http://{{Hostname}}:{{Port}}
+    token_url: http://{{Hostname}}:{{Port}}
+    preserve_original_event: true
+    client_id: test-cel-client-id
+    client_secret: test-cel-client-secret
+    azure_tenant_id: test-cel-tenant-id
+    oauth_endpoint_params: |
+      grant_type: refresh_token
+      refresh_token: 'refresh_token_123'
+    content_types: "Audit.SharePoint, Audit.General"
+    initial_interval: 12h
+    enable_request_tracer: true
+assert:
+  hit_count: 8

--- a/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
@@ -7,8 +7,9 @@ auth.oauth2:
 {{#each token_scopes as |token_scope|}}
       - {{token_scope}}
 {{/each}}
-    endpoint_params:
-        grant_type: client_credentials
+{{#if oauth_endpoint_params}}
+    endpoint_params: {{oauth_endpoint_params}}
+{{/if}}
 {{#if token_url}}
     token_url: {{token_url}}/{{azure_tenant_id}}/oauth2/v2.0/token
 {{else if azure_tenant_id}}

--- a/packages/o365/data_stream/audit/manifest.yml
+++ b/packages/o365/data_stream/audit/manifest.yml
@@ -58,6 +58,15 @@ streams:
         required: true
         show_user: false
         secret: false
+      - name: oauth_endpoint_params
+        type: yaml
+        title: OAuth2 Endpoint Params
+        description: Endpoint Params used for OAuth2 authentication as YAML. See [documentation](https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-cel#_auth_oauth2_endpoint_params) for details.
+        show_user: false
+        default: |
+          grant_type: client_credentials
+        multi: false
+        required: true
       - name: content_types
         type: text
         title: Content Type

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft Office 365
-version: "2.21.1"
+version: "2.22.0"
 description: Collect logs from Microsoft Office 365 with Elastic Agent.
 type: integration
 format_version: "3.2.3"


### PR DESCRIPTION
## Proposed commit message

Added configurable `oauth_endpoint_params` for greater flexibility.  An
example use case is to allow overriding the default grant_type to
support using providing a static refresh_token.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues



## Screenshots

<img width="1009" height="605" alt="Screenshot 2025-08-13 at 15 21 42" src="https://github.com/user-attachments/assets/dc5a58f7-5540-49f6-939d-1dd5ca22d60e" />

> [!NOTE]  
> The above configuration treats the `refresh_token` as static configuration. If the server returns a new `refresh_token` it a response the oauth client will not use it.

-----

Request tracer log showing the oauth request.

```json
{
  "log.level": "debug",
  "@timestamp": "2025-08-13T18:42:20.704Z",
  "message": "HTTP request",
  "transaction.id": "JLSRFNTSCTDHG-1",
  "url.original": "http://svc-o365-cel:8080/test-grant-type-refresh-token-client-id/oauth2/v2.0/token",
  "url.scheme": "http",
  "url.path": "/test-grant-type-refresh-token-client-id/oauth2/v2.0/token",
  "url.domain": "svc-o365-cel",
  "url.port": "8080",
  "url.query": "",
  "http.request.method": "POST",
  "http.request.header": {
    "Authorization": [
      "Basic dGVzdC1jZWwtY2xpZW50LWlkOnRlc3QtY2VsLWNsaWVudC1zZWNyZXQ="
    ],
    "Content-Type": [
      "application/x-www-form-urlencoded"
    ]
  },
  "user_agent.original": "",
  "http.request.body.content": "grant_type=refresh_token&refresh_token=refresh_token_123&scope=https%3A%2F%2Fmanage.office.com%2F.default",
  "http.request.body.truncated": false,
  "http.request.body.bytes": 105,
  "http.request.mime_type": "application/x-www-form-urlencoded",
  "ecs.version": "1.6.0"
}
```

----


Agent policy:

```yaml
  - id: cel-o365-53d0dfa0-8026-44a7-85fc-abc9a604a5ed
    name: o365-1
    revision: 1
    type: cel
    use_output: default
    meta:
      package:
        name: o365
        version: 2.22.0
    data_stream:
      namespace: default
    package_policy_id: 53d0dfa0-8026-44a7-85fc-abc9a604a5ed
    streams:
      - id: cel-o365.audit-53d0dfa0-8026-44a7-85fc-abc9a604a5ed
        data_stream:
          dataset: o365.audit
          type: logs
        interval: 3m
        auth.oauth2:
          client.id: b
          client.secret: ${SECRET_0}
          provider: azure
          scopes:
            - https://manage.office.com/.default
          endpoint_params:
            grant_type: refresh_token
            refresh_token: '1234'
          token_url: https://login.microsoftonline.com/a/oauth2/v2.0/token
```

### Testing locally

1. Download the package zip: 
  - [o365-2.22.0.zip](https://github.com/user-attachments/files/21761937/o365-2.22.0.zip)
  - ~[o365-2.22.0-rc1.zip](https://github.com/user-attachments/files/21761198/o365-2.22.0-rc1.zip)~ (cannot be used because the -rc1 is doesn't match a regex, see https://github.com/elastic/kibana/issues/231712)

3. Navigate to the Integration page and upload.

<img width="1042" height="501" alt="1" src="https://github.com/user-attachments/assets/80f3a8c4-f787-43a7-b0e2-b0ff2edcc575" />
<img width="1034" height="628" alt="2" src="https://github.com/user-attachments/assets/c7c5f540-93b7-47ed-b1a0-df987a2c3acf" />
<img width="1049" height="662" alt="3" src="https://github.com/user-attachments/assets/77f2cf40-beae-4e65-b899-86276d5e04f6" />
<img width="1049" height="694" alt="4" src="https://github.com/user-attachments/assets/1cb86667-c320-4347-bc06-6f1efdd14714" />
<img width="1813" height="686" alt="5" src="https://github.com/user-attachments/assets/05539497-d1ff-4b7f-ae9c-208e61d1e747" />

