### PR TITLE
fix(aws.config): handle empty DescribeConfigRules responses

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.14.1"
+  changes:
+    - description: Fixed issue where empty DescribeConfigRules responses caused 'index out of bounds' errors in AWS Config integration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/14958
 - version: "3.14.0"
   changes:
     - description: Prevent logging expected agent HTTP JSON template errors.

--- a/packages/aws/data_stream/config/_dev/deploy/docker/files/config.yml
+++ b/packages/aws/data_stream/config/_dev/deploy/docker/files/config.yml
@@ -1,4 +1,22 @@
 rules:
+  # Return an empty ConfigRules list to verify the program handles empty lists
+  # appropriately.
+  - path: /
+    methods: ["POST"]
+    request_headers:
+      Content-Type:
+        - "application/x-amz-json-1.1"
+      X-Amz-Target:
+        - "StarlingDoveService.DescribeConfigRules"
+    request_body: '{"NextToken":"page3"}'
+    responses:
+      - status_code: 200
+        body: |-
+          {{ minify_json `
+          {
+            "ConfigRules": []
+          }
+          `}}
   - path: /
     methods: ["POST"]
     request_headers:
@@ -35,7 +53,8 @@ rules:
                   "SourceIdentifier": "REQUIRED_TAGS"
                 }
               }
-            ]
+            ],
+            "NextToken": "page3"
           }
           `}}
   - path: /

--- a/packages/aws/data_stream/config/agent/stream/cel.yml.hbs
+++ b/packages/aws/data_stream/config/agent/stream/cel.yml.hbs
@@ -220,7 +220,7 @@ program: |
               "error": {
                 "code": string(resp.StatusCode),
                 "id": string(resp.Status),
-                "message": "POST " + state.url.trim_right("/") + "DescribeConfigRules " +
+                "message": "DescribeConfigRules: POST " + state.url.trim_right("/") + " " +
                 (
                   (size(resp.Body) != 0) ?
                     string(resp.Body)
@@ -326,7 +326,7 @@ program: |
             "error": {
               "code": string(resp.StatusCode),
               "id": string(resp.Status),
-              "message": "POST " + state.url.trim_right("/") + "GetComplianceDetailsByConfigRule " + 
+              "message": "GetComplianceDetailsByConfigRule: POST " + state.url.trim_right("/") + " " +
               (
                 (size(resp.Body) != 0) ?
                   string(resp.Body)

--- a/packages/aws/data_stream/config/agent/stream/cel.yml.hbs
+++ b/packages/aws/data_stream/config/agent/stream/cel.yml.hbs
@@ -28,14 +28,18 @@ redact:
     - session_token
 program: |
   (
+    // Stage 1: Check if we have existing config rules to process
+    // If we have worklist with ConfigRules, we already fetched rules and now need to get compliance details
     has(state.?worklist.ConfigRules) && size(state.worklist.ConfigRules) > 0 ?
       {
+        // State management: preserve existing state from previous iteration
         "worklist": state.worklist,
         "batch_size": state.batch_size,
         "has_next": state.has_next,
         "next": state.next,
         "next_page": state.next_page,
 
+        // AWS SigV4 Signing: Generate signing key for GetComplianceDetailsByConfigRule request
         // Perform a succession of keyed hash operations (HMAC) on the request date, Region, and service,
         // with the AWS secret access key as the key for the initial hashing operation.
         // Refer https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html#derive-signing-key
@@ -80,8 +84,10 @@ program: |
         "tld": state.tld,
       }
     :
+      // Stage 2: First time execution - need to fetch config rules first
       (
         state.with({
+          // AWS SigV4 Signing: Generate signing key for DescribeConfigRules request
           // Perform a succession of keyed hash operations (HMAC) on the request date, Region, and service, 
           // with the AWS secret access key as the key for the initial hashing operation.
           // Refer https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html#derive-signing-key
@@ -119,6 +125,7 @@ program: |
           ].join("\n"),
         })
       ).as(state,
+        // API Call: Execute DescribeConfigRules request to get list of config rules
         post_request(
           state.url.trim_right("/"),
           "application/json",
@@ -149,8 +156,10 @@ program: |
             },
           }
         ).do_request().as(resp, (resp.StatusCode == 200) ?
+          // Response Processing: Successfully got config rules list
           resp.Body.decode_json().as(body,
             {
+              // State Update: Store the fetched config rules as worklist
               "worklist": body,
               "next": 0,
               "has_next": has(body.NextToken),
@@ -159,6 +168,7 @@ program: |
                 ?"rule_token": body.?NextToken,
               },
 
+              // AWS SigV4 Signing: Prepare signing key for next GetComplianceDetailsByConfigRule request
               // Perform a succession of keyed hash operations (HMAC) on the request date, Region, and service, 
               // with the AWS secret access key as the key for the initial hashing operation.
               // Refer https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html#derive-signing-key
@@ -204,6 +214,7 @@ program: |
             }
           )
         :
+          // Error Handling: DescribeConfigRules request failed
           {
             "events": {
               "error": {
@@ -229,9 +240,11 @@ program: |
         )
       )
   ).as(config_rules,
+    // Stage 3: Process results - either exit early on failure or fetch compliance details
     !has(config_rules.worklist) ? // Exit early due to POST failure.
       config_rules
     : has(config_rules.worklist.ConfigRules) && size(config_rules.worklist.ConfigRules) > 0 ?
+      // API Call: Execute GetComplianceDetailsByConfigRule for specific config rule
       post_request(
         state.url.trim_right("/"),
         "application/json",
@@ -264,6 +277,7 @@ program: |
           },
         }
       ).do_request().as(resp, (resp.StatusCode == 200) ?
+        // Response Processing: Successfully got compliance details
         bytes(resp.Body).decode_json().as(body,
           {
             "events": (has(body.EvaluationResults) && size(body.EvaluationResults) > 0) ?
@@ -306,6 +320,7 @@ program: |
           }
         )
       :
+        // Error Handling: GetComplianceDetailsByConfigRule request failed
         {
           "events": {
             "error": {
@@ -330,6 +345,7 @@ program: |
         }
       )
     :
+      // Final State: No config rules found, return empty result
       {
         "events": [],
         "want_more": false,

--- a/packages/aws/data_stream/config/agent/stream/cel.yml.hbs
+++ b/packages/aws/data_stream/config/agent/stream/cel.yml.hbs
@@ -201,7 +201,7 @@ program: |
                   "content-type;host;x-amz-date;x-amz-target",
                   {
                     ?"NextToken": state.?next_page.result_token,
-                    ?"ConfigRuleName": body.?ConfigRules[?0].optMap(r, r.ConfigRuleName),
+                    ?"ConfigRuleName": body.?ConfigRules[0].optMap(r, r.ConfigRuleName),
                     "Limit": int(state.batch_size)
                   }.encode_json().sha256().hex()
                 ].join("\n").sha256().hex()

--- a/packages/aws/data_stream/config/agent/stream/cel.yml.hbs
+++ b/packages/aws/data_stream/config/agent/stream/cel.yml.hbs
@@ -191,7 +191,7 @@ program: |
                   "content-type;host;x-amz-date;x-amz-target",
                   {
                     ?"NextToken": state.?next_page.result_token,
-                    "ConfigRuleName": body.ConfigRules[0].ConfigRuleName,
+                    ?"ConfigRuleName": body.?ConfigRules[?0].optMap(r, r.ConfigRuleName),
                     "Limit": int(state.batch_size)
                   }.encode_json().sha256().hex()
                 ].join("\n").sha256().hex()

--- a/packages/aws/data_stream/config/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/config/elasticsearch/ingest_pipeline/default.yml
@@ -16,6 +16,10 @@ processors:
       field: ecs.version
       tag: set_ecs_version
       value: 8.17.0
+  - terminate:
+      tag: data_collection_error
+      if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
+      description: error message set and no data to process.
   - rename:
       field: message
       tag: rename_message_to_event_original

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: aws
 title: AWS
-version: 3.14.0
+version: 3.14.1
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
fix(aws.config): handle empty DescribeConfigRules responses

This change addresses issues discovered during testing of the AWS Config
integration CEL program. The program was failing to handle empty ConfigRules
responses properly, which could occur when AWS Config has no rules configured
in a region. The failures resulted in 'index out of bounds: 0' errors.

The fix ensures that empty ConfigRules lists are handled gracefully without
causing program failures.

The error.message values now accurately reflect the URL path and include the
specific AWS Config API call being made (DescribeConfigRules vs
GetComplianceDetailsByConfigRule).

State management has been improved to consistently preserve the URL value
across all execution paths, preventing debug warnings about missing state
values.

Comments have been added to explain the different stages of the CEL program.

Closes #14955
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## Related issues

- Closes #14955

