### PR TITLE
[websocket][proofpoint_on_demand] - Fixed system test failure issue

### DIFF
--- a/packages/proofpoint_on_demand/_dev/deploy/docker/websocket-mock-service/main.go
+++ b/packages/proofpoint_on_demand/_dev/deploy/docker/websocket-mock-service/main.go
@@ -37,7 +37,6 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		log.Println(err)
 		return
 	}
-	defer conn.Close()
 
 	var responseMessage string
 

--- a/packages/proofpoint_on_demand/data_stream/audit/_dev/test/system/test-default-config.yml
+++ b/packages/proofpoint_on_demand/data_stream/audit/_dev/test/system/test-default-config.yml
@@ -1,7 +1,4 @@
 input: websocket
-skip:
-  reason: "Issues with unit state change (HEALTHY->DEGRADED) after latest metrics additions."
-  link: https://github.com/elastic/integrations/issues/14854
 service: proofpoint_on_demand-websocket
 vars:
   url: ws://{{Hostname}}:{{Port}}

--- a/packages/proofpoint_on_demand/data_stream/mail/_dev/test/system/test-default-config.yml
+++ b/packages/proofpoint_on_demand/data_stream/mail/_dev/test/system/test-default-config.yml
@@ -1,7 +1,4 @@
 input: websocket
-skip:
-  reason: "Issues with unit state change (HEALTHY->DEGRADED) after latest metrics additions."
-  link: https://github.com/elastic/integrations/issues/14854
 service: proofpoint_on_demand-websocket
 vars:
   url: ws://{{Hostname}}:{{Port}}

--- a/packages/proofpoint_on_demand/data_stream/message/_dev/test/system/test-default-config.yml
+++ b/packages/proofpoint_on_demand/data_stream/message/_dev/test/system/test-default-config.yml
@@ -1,7 +1,4 @@
 input: websocket
-skip:
-  reason: "Issues with unit state change (HEALTHY->DEGRADED) after latest metrics additions."
-  link: https://github.com/elastic/integrations/issues/14854
 service: proofpoint_on_demand-websocket
 vars:
   url: ws://{{Hostname}}:{{Port}}

--- a/packages/websocket/_dev/deploy/docker/websocket-mock-service/main.go
+++ b/packages/websocket/_dev/deploy/docker/websocket-mock-service/main.go
@@ -17,7 +17,6 @@ func main() {
 }
 
 func handleWebSocket(w http.ResponseWriter, r *http.Request) {
-
 	if r.URL.Path == "/health" {
 		return
 	}
@@ -41,7 +40,6 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		log.Println(err)
 		return
 	}
-	defer conn.Close()
 
 	var responseMessage []map[string]string
 

--- a/packages/websocket/_dev/test/system/test-auth-config.yml
+++ b/packages/websocket/_dev/test/system/test-auth-config.yml
@@ -7,3 +7,5 @@ vars:
     bytes(state.response).decode_json().as(body,{
       "events": body,
     })
+assert:
+  hit_count: 1

--- a/packages/websocket/_dev/test/system/test-get-config.yml
+++ b/packages/websocket/_dev/test/system/test-get-config.yml
@@ -11,3 +11,5 @@ vars:
         "max_ts": body.map(e, e.ts).max()
       }
     })
+assert:
+  hit_count: 2


### PR DESCRIPTION
## Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug

## Proposed commit message
```
Fixed system test failures from streaming input based
integrations and re-enabled system tests for 
proofpoint_on_demand.
```

## Note
Since this is only related to system tests, changelog and version increments have not been done.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
- Closes https://github.com/elastic/integrations/issues/14854


## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
