### PR TITLE
fix(beyondinsight_password_safe): remove cookies on auth failure

### DIFF
--- a/packages/beyondinsight_password_safe/changelog.yml
+++ b/packages/beyondinsight_password_safe/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.5.1"
+  changes:
+    - description: Fixed authentication retry logic to properly clear expired cookies and re-authenticate when receiving 401 responses.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/14987
 - version: "0.5.0"
   changes:
     - description: Standardize user fields processing across integrations.

--- a/packages/beyondinsight_password_safe/data_stream/managedaccount/agent/stream/cel.yml.hbs
+++ b/packages/beyondinsight_password_safe/data_stream/managedaccount/agent/stream/cel.yml.hbs
@@ -75,13 +75,10 @@ program: |-
   		}
   	).do_request().as(resp,
   		(resp.StatusCode == 401) ?
-  			state.with(
+  			state.drop("cursor.cookies").with(
   				{
   					"events": {"error": {"message": "Authentication expired or incorrect. Clearing and retrying...", "statuscode": string(resp.StatusCode)}},
   					"want_more": true,
-  					"cursor": {
-  						"cookies": null,
-  					},
   				}
   			)
   		:

--- a/packages/beyondinsight_password_safe/data_stream/managedsystem/agent/stream/cel.yml.hbs
+++ b/packages/beyondinsight_password_safe/data_stream/managedsystem/agent/stream/cel.yml.hbs
@@ -75,13 +75,10 @@ program: |-
   		}
   	).do_request().as(resp,
   		(resp.StatusCode == 401) ?
-  			state.with(
+  			state.drop("cursor.cookies").with(
   				{
   					"events": {"error": {"message": "Authentication expired or incorrect. Clearing and retrying...", "statuscode": string(resp.StatusCode)}},
   					"want_more": true,
-  					"cursor": {
-  						"cookies": null,
-  					},
   				}
   			)
   		:

--- a/packages/beyondinsight_password_safe/data_stream/session/agent/stream/cel.yml.hbs
+++ b/packages/beyondinsight_password_safe/data_stream/session/agent/stream/cel.yml.hbs
@@ -71,13 +71,10 @@ program: |-
   		}
   	).do_request().as(resp,
   		(resp.StatusCode == 401) ?
-  			state.with(
+  			state.drop("cursor.cookies").with(
   				{
   					"events": {"error": {"message": "User not authenticated", "statuscode": string(resp.StatusCode)}},
   					"want_more": true,
-  					"cursor": {
-  						"cookies": null,
-  					},
   				}
   			)
   		:

--- a/packages/beyondinsight_password_safe/data_stream/useraudit/agent/stream/cel.yml.hbs
+++ b/packages/beyondinsight_password_safe/data_stream/useraudit/agent/stream/cel.yml.hbs
@@ -78,11 +78,10 @@ program: |-
   			}
   		).do_request().as(resp,
   			(resp.StatusCode == 401) ?
-  				state.with(
+  				state.drop("cursor.cookies").with(
   					{
   						"events": {"error": {"message": "User not authenticated", "statuscode": string(resp.StatusCode)}},
   						"want_more": true,
-  						"cursor": state.?cursor.orValue({}).with({"cookies": null}),
   					}
   				)
   			:

--- a/packages/beyondinsight_password_safe/manifest.yml
+++ b/packages/beyondinsight_password_safe/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.0
 name: beyondinsight_password_safe
 title: BeyondInsight and Password Safe
-version: "0.5.0"
+version: "0.5.1"
 source:
   license: "Elastic-2.0"
 description: Ingest privileged access management (PAM) data from BeyondTrust's BeyondInsight PAM Reporting Platform and Password Safe, using Elastic Agent.
@@ -69,11 +69,7 @@ policy_templates:
             required: false
             show_user: false
             description: >-
-              The request tracer logs requests and responses to the agent's local file-system for debugging configurations.
-              Enabling this request tracing compromises security and should only be used for debugging. Disabling the request
-              tracer will delete any stored traces.
-              See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_enable)
-              for details.
+              The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. Disabling the request tracer will delete any stored traces. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_enable) for details.
           - name: http_client_timeout
             type: text
             title: HTTP Client Timeout


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
fix(beyondinsight_password_safe): remove cookies on auth failure

When authentication fails with 401, remove the explicit 'cookies: null' assignment
and use an empty cursor object instead. This allows the orValue() fallback logic
to work properly by checking for key existence rather than null values.

Otherwise the cookie value would never be refreshed, leading to persistent auth
failures.

Fixes: #14985
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## How to test this PR locally

[beyondinsight_password_safe-0.5.1.zip](https://github.com/user-attachments/files/21868782/beyondinsight_password_safe-0.5.1.zip)



## Related issues

- Fixes: #14985

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
