### PR TITLE
Don't migrate the filters when changing the dashboard using the links

### DIFF
--- a/packages/cassandra/changelog.yml
+++ b/packages/cassandra/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.1"
+  changes:
+    - description: Don't migrate the filters when changing the dashboard using the links.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/TBD
 - version: "1.19.0"
   changes:
     - description: Use Links panel in dashboard.

--- a/packages/cassandra/kibana/dashboard/cassandra-25b7d6d0-1c71-11ec-84f1-e1733c643874.json
+++ b/packages/cassandra/kibana/dashboard/cassandra-25b7d6d0-1c71-11ec-84f1-e1733c643874.json
@@ -59,14 +59,24 @@
                                 "type": "dashboardLink",
                                 "id": "cassandra-49e4e6e0-cc54-11ec-8c59-ed6efced90da",
                                 "order": 0,
-                                "destinationRefName": "link_cassandra-49e4e6e0-cc54-11ec-8c59-ed6efced90da_dashboard"
+                                "destinationRefName": "link_cassandra-49e4e6e0-cc54-11ec-8c59-ed6efced90da_dashboard",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                }
                             },
                             {
                                 "label": "Metrics",
                                 "type": "dashboardLink",
                                 "id": "cassandra-25b7d6d0-1c71-11ec-84f1-e1733c643874",
                                 "order": 1,
-                                "destinationRefName": "link_cassandra-25b7d6d0-1c71-11ec-84f1-e1733c643874_dashboard"
+                                "destinationRefName": "link_cassandra-25b7d6d0-1c71-11ec-84f1-e1733c643874_dashboard",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                }
                             }
                         ]
                     }

--- a/packages/cassandra/manifest.yml
+++ b/packages/cassandra/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cassandra
 title: Cassandra
-version: "1.19.0"
+version: "1.19.1"
 description: This Elastic integration collects logs and metrics from cassandra.
 type: integration
 categories:


### PR DESCRIPTION


## Proposed commit message

By default the links panel take all the filters from the host dashboard to the destination dashboard. The Cassandra dashboards have a dashboard wide filter that filters the data and gets taken to the other dashboard. Therefore, as a temporary solution I disable that setting, [as discussed here](https://github.com/elastic/integrations/issues/14502#issuecomment-3195811479)

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [X] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

## How to test this PR locally

## Related issues


## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
