### PR TITLE
[crowdstrike] Added a conditional JSON parsing workaround for ResourceAttributes

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Added a conditional JSON parsing workaround for `ResourceAttributes` to handle cases where it is rendered as a JSON string.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/15019
 - version: "2.0.0"
   changes:
     - description: | 

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.0.1"
+  changes:
+    - description: Added a conditional JSON parsing workaround for `ResourceAttributes` to handle cases where it is rendered as a JSON string.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.0.0"
   changes:
     - description: | 

--- a/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
@@ -3051,6 +3051,14 @@ processors:
       if: ctx.device?.id == null
 
   ## Crowdstrike fields.
+  - json:
+      field: crowdstrike.ResourceAttributes
+      tag: json_crowdstrike_ResourceAttributes
+      if: ctx.crowdstrike?.ResourceAttributes instanceof String
+      on_failure:
+        - remove:
+            field: crowdstrike.ResourceAttributes
+            ignore_missing: true
   - split:
       field: crowdstrike.FalconGroupingTags
       separator: ",\\s?"

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "2.0.0"
+version: "2.0.1"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: "3.4.0"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
crowdstrike: Implemented a conditional JSON parsing workaround for `ResourceAttributes` to
handle cases where custom rules convert the object into a JSON string, ensuring consistent
ingestion of documents.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/crowdstrike directory.
- Run the following command to run tests.
> elastic-package test

