### PR TITLE
[Kubernretes Otel Dashboard] Fixing filters for dashboard related to adhoc fields

### DIFF
--- a/packages/kubernetes_otel/changelog.yml
+++ b/packages/kubernetes_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.1.1
+  changes:
+    - description: Update the visualisation filters for ad-hoc fields
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12535
 - version: 1.1.0
   changes:
     - description: Add support for Kibana `9.0.0` 

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-cluster-overview.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-cluster-overview.json
@@ -10,11 +10,29 @@
                 "ignoreValidations": false
             },
             "panelsJSON": {
-                "5cebe50d-a46e-4e4d-a209-718a00a4a45d": {
+                "a040080e-8a63-4000-85fa-59cc2e48067d": {
+                    "explicitInput": {
+                        "dataViewId": "metrics-*",
+                        "fieldName": "resource.attributes.k8s.node.name",
+                        "id": "a040080e-8a63-4000-85fa-59cc2e48067d",
+                        "searchTechnique": "prefix",
+                        "selectedOptions": [],
+                        "sort": {
+                            "by": "_count",
+                            "direction": "desc"
+                        },
+                        "title": "Node"
+                    },
+                    "grow": false,
+                    "order": 1,
+                    "type": "optionsListControl",
+                    "width": "medium"
+                },
+                "d0079981-006d-4357-aed8-a05eef49b2eb": {
                     "explicitInput": {
                         "dataViewId": "metrics-*",
                         "fieldName": "resource.attributes.k8s.namespace.name",
-                        "id": "5cebe50d-a46e-4e4d-a209-718a00a4a45d",
+                        "id": "d0079981-006d-4357-aed8-a05eef49b2eb",
                         "searchTechnique": "prefix",
                         "selectedOptions": [],
                         "sort": {
@@ -28,11 +46,11 @@
                     "type": "optionsListControl",
                     "width": "medium"
                 },
-                "a01727d6-1aa3-4918-91ca-9059f18d9222": {
+                "fc4570df-08ee-4629-85db-901b3008f61a": {
                     "explicitInput": {
                         "dataViewId": "metrics-*",
                         "fieldName": "resource.attributes.k8s.cluster.name",
-                        "id": "a01727d6-1aa3-4918-91ca-9059f18d9222",
+                        "id": "fc4570df-08ee-4629-85db-901b3008f61a",
                         "searchTechnique": "prefix",
                         "selectedOptions": [],
                         "sort": {
@@ -43,24 +61,6 @@
                     },
                     "grow": false,
                     "order": 0,
-                    "type": "optionsListControl",
-                    "width": "medium"
-                },
-                "aa8e7204-6b27-441e-bcce-a30aa1da6abc": {
-                    "explicitInput": {
-                        "dataViewId": "metrics-*",
-                        "fieldName": "resource.attributes.k8s.node.name",
-                        "id": "aa8e7204-6b27-441e-bcce-a30aa1da6abc",
-                        "searchTechnique": "prefix",
-                        "selectedOptions": [],
-                        "sort": {
-                            "by": "_count",
-                            "direction": "desc"
-                        },
-                        "title": "Node"
-                    },
-                    "grow": false,
-                    "order": 1,
                     "type": "optionsListControl",
                     "width": "medium"
                 }
@@ -117,12 +117,12 @@
                 },
                 "gridData": {
                     "h": 8,
-                    "i": "1bbd5efd-b043-459b-a740-d214ef1a9565",
+                    "i": "16f7cfc5-856f-43c8-9812-21d2e8f7af3f",
                     "w": 5,
                     "x": 0,
                     "y": 0
                 },
-                "panelIndex": "1bbd5efd-b043-459b-a740-d214ef1a9565",
+                "panelIndex": "16f7cfc5-856f-43c8-9812-21d2e8f7af3f",
                 "type": "visualization"
             },
             {
@@ -211,17 +211,50 @@
                         "type": "lens",
                         "visualizationType": "lnsMetric"
                     },
-                    "enhancements": {},
-                    "hidePanelTitles": true
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "resource.attributes.k8s.node.name",
+                                "index": "fdeb2ffb-0593-4286-9b7d-b259c948f145",
+                                "key": "resource.attributes.k8s.node.name",
+                                "negate": false,
+                                "type": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "resource.attributes.k8s.node.name"
+                                }
+                            }
+                        }
+                    ],
+                    "hidePanelTitles": true,
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false
                 },
                 "gridData": {
                     "h": 4,
-                    "i": "6119419c-1899-4765-aed4-c050cde4c30a",
+                    "i": "5641261b-5eae-42f9-a381-f3031df725d7",
                     "w": 8,
                     "x": 5,
                     "y": 0
                 },
-                "panelIndex": "6119419c-1899-4765-aed4-c050cde4c30a",
+                "panelIndex": "5641261b-5eae-42f9-a381-f3031df725d7",
                 "title": "",
                 "type": "lens"
             },
@@ -507,16 +540,29 @@
                         "type": "lens",
                         "visualizationType": "lnsXY"
                     },
-                    "enhancements": {}
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false
                 },
                 "gridData": {
                     "h": 8,
-                    "i": "63a8ac8b-f7f8-4169-9f10-4a7315973102",
+                    "i": "d9687ae8-3bd7-4128-88ad-e77d841a75aa",
                     "w": 18,
                     "x": 13,
                     "y": 0
                 },
-                "panelIndex": "63a8ac8b-f7f8-4169-9f10-4a7315973102",
+                "panelIndex": "d9687ae8-3bd7-4128-88ad-e77d841a75aa",
                 "title": "CPU Usage",
                 "type": "lens"
             },
@@ -799,16 +845,29 @@
                         "type": "lens",
                         "visualizationType": "lnsXY"
                     },
-                    "enhancements": {}
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false
                 },
                 "gridData": {
                     "h": 8,
-                    "i": "b126cfb5-901e-42d3-8d1f-d47e142884af",
+                    "i": "c5f29eb4-bd50-4e65-b693-a6cb08579437",
                     "w": 17,
                     "x": 31,
                     "y": 0
                 },
-                "panelIndex": "b126cfb5-901e-42d3-8d1f-d47e142884af",
+                "panelIndex": "c5f29eb4-bd50-4e65-b693-a6cb08579437",
                 "title": "Memory Usage",
                 "type": "lens"
             },
@@ -896,17 +955,51 @@
                         "type": "lens",
                         "visualizationType": "lnsMetric"
                     },
-                    "enhancements": {},
-                    "hidePanelTitles": true
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "resource.attributes.k8s.namespace.name",
+                                "index": "d632b895-3242-4f49-8d2c-ea7310b23b9a",
+                                "key": "resource.attributes.k8s.namespace.name",
+                                "negate": false,
+                                "type": "exists",
+                                "value": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "resource.attributes.k8s.namespace.name"
+                                }
+                            }
+                        }
+                    ],
+                    "hidePanelTitles": true,
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false
                 },
                 "gridData": {
                     "h": 4,
-                    "i": "e69952d8-208e-4c4e-adb1-32077a9beb81",
+                    "i": "5c805606-3ee7-4197-9921-63770e39e1d3",
                     "w": 8,
                     "x": 5,
                     "y": 4
                 },
-                "panelIndex": "e69952d8-208e-4c4e-adb1-32077a9beb81",
+                "panelIndex": "5c805606-3ee7-4197-9921-63770e39e1d3",
                 "title": "",
                 "type": "lens"
             },
@@ -944,12 +1037,12 @@
                 },
                 "gridData": {
                     "h": 8,
-                    "i": "289a9e23-48cc-4a35-bb60-ec69ecfc337a",
+                    "i": "9fac430b-db23-4a90-872f-852852d4b99f",
                     "w": 5,
                     "x": 0,
                     "y": 8
                 },
-                "panelIndex": "289a9e23-48cc-4a35-bb60-ec69ecfc337a",
+                "panelIndex": "9fac430b-db23-4a90-872f-852852d4b99f",
                 "title": "",
                 "type": "visualization"
             },
@@ -1124,16 +1217,49 @@
                         "type": "lens",
                         "visualizationType": "lnsPie"
                     },
-                    "enhancements": {}
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "metrics.k8s.node.condition_ready",
+                                "index": "eb5475c8-e2ca-4480-981d-38ddebecb0d8",
+                                "key": "metrics.k8s.node.condition_ready",
+                                "negate": false,
+                                "type": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "metrics.k8s.node.condition_ready"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false
                 },
                 "gridData": {
                     "h": 8,
-                    "i": "89a3c0ca-b3da-4ea6-94f8-b851514ee9a0",
+                    "i": "68b825d9-e1a8-4960-ac2d-0a36845f8cfa",
                     "w": 8,
                     "x": 5,
                     "y": 8
                 },
-                "panelIndex": "89a3c0ca-b3da-4ea6-94f8-b851514ee9a0",
+                "panelIndex": "68b825d9-e1a8-4960-ac2d-0a36845f8cfa",
                 "title": "Nodes Status",
                 "type": "lens"
             },
@@ -1376,16 +1502,50 @@
                         "type": "lens",
                         "visualizationType": "lnsXY"
                     },
-                    "enhancements": {}
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "resource.attributes.k8s.node.name",
+                                "index": "6f2e38ed-8fa8-426f-a951-2b138654a71e",
+                                "key": "resource.attributes.k8s.node.name",
+                                "negate": false,
+                                "type": "exists",
+                                "value": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "resource.attributes.k8s.node.name"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false
                 },
                 "gridData": {
                     "h": 8,
-                    "i": "a9af08bb-2b3f-41d7-bdf9-ac5739d4ff4d",
+                    "i": "e2034722-0c5a-42b0-b131-4480d1315eb9",
                     "w": 12,
                     "x": 13,
                     "y": 8
                 },
-                "panelIndex": "a9af08bb-2b3f-41d7-bdf9-ac5739d4ff4d",
+                "panelIndex": "e2034722-0c5a-42b0-b131-4480d1315eb9",
                 "title": "Top CPU intensive Nodes",
                 "type": "lens"
             },
@@ -1628,16 +1788,49 @@
                         "visualizationType": "lnsXY"
                     },
                     "description": "As a ratio of a node working_set to the total node allocatable memory",
-                    "enhancements": {}
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "resource.attributes.k8s.node.name",
+                                "index": "654da27d-a112-4dad-99c1-c5c33f5faaa1",
+                                "key": "resource.attributes.k8s.node.name",
+                                "negate": false,
+                                "type": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "resource.attributes.k8s.node.name"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false
                 },
                 "gridData": {
                     "h": 8,
-                    "i": "69b3ea52-4a50-42e6-9ab2-3a0cca0441cf",
+                    "i": "1bd2d3e6-0083-4c7c-88ff-8e11357cb99f",
                     "w": 12,
                     "x": 25,
                     "y": 8
                 },
-                "panelIndex": "69b3ea52-4a50-42e6-9ab2-3a0cca0441cf",
+                "panelIndex": "1bd2d3e6-0083-4c7c-88ff-8e11357cb99f",
                 "title": "Top Memory intensive Nodes",
                 "type": "lens"
             },
@@ -1884,16 +2077,50 @@
                         "type": "lens",
                         "visualizationType": "lnsXY"
                     },
-                    "enhancements": {}
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "resource.attributes.k8s.node.name",
+                                "index": "1b04b540-39ae-4cfd-8088-34a4bf3d5654",
+                                "key": "resource.attributes.k8s.node.name",
+                                "negate": false,
+                                "type": "exists",
+                                "value": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "resource.attributes.k8s.node.name"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false
                 },
                 "gridData": {
                     "h": 8,
-                    "i": "5399f854-f59b-488d-92d1-0d10e3c10417",
+                    "i": "5d14e383-8c31-401a-9d22-d12529615a93",
                     "w": 11,
                     "x": 37,
                     "y": 8
                 },
-                "panelIndex": "5399f854-f59b-488d-92d1-0d10e3c10417",
+                "panelIndex": "5d14e383-8c31-401a-9d22-d12529615a93",
                 "title": "Top Filesystem Utilization intensive Nodes",
                 "type": "lens"
             },
@@ -1929,12 +2156,12 @@
                 },
                 "gridData": {
                     "h": 4,
-                    "i": "2a39b2c7-814f-4dfe-aac5-2eda1e5ecbce",
+                    "i": "8df8d55a-94f6-4d51-ab5e-a75655eec663",
                     "w": 48,
                     "x": 0,
                     "y": 16
                 },
-                "panelIndex": "2a39b2c7-814f-4dfe-aac5-2eda1e5ecbce",
+                "panelIndex": "8df8d55a-94f6-4d51-ab5e-a75655eec663",
                 "type": "visualization"
             },
             {
@@ -2120,16 +2347,50 @@
                         "visualizationType": "lnsXY"
                     },
                     "description": "No values in specific Visualisation means that no Pod restarts took place for the specific time range",
-                    "enhancements": {}
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "resource.attributes.k8s.container.status.last_terminated_reason",
+                                "index": "0e11ca27-40f5-4300-b885-17ade4895220",
+                                "key": "resource.attributes.k8s.container.status.last_terminated_reason",
+                                "negate": false,
+                                "type": "exists",
+                                "value": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "resource.attributes.k8s.container.status.last_terminated_reason"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel AND metrics.k8s.container.restarts \u003e 0"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "7210445e-56b4-4695-8dff-c5cf8a406cad",
+                    "i": "0670db69-1cf1-45ac-9019-435d77668835",
                     "w": 11,
                     "x": 0,
                     "y": 20
                 },
-                "panelIndex": "7210445e-56b4-4695-8dff-c5cf8a406cad",
+                "panelIndex": "0670db69-1cf1-45ac-9019-435d77668835",
                 "title": "Container Restarts by Pod and Reason",
                 "type": "lens"
             },
@@ -2385,16 +2646,49 @@
                         "type": "lens",
                         "visualizationType": "lnsPie"
                     },
-                    "enhancements": {}
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "metrics.k8s.pod.phase",
+                                "index": "8d049466-cdf2-4c5b-97e3-8e3020b31c2a",
+                                "key": "metrics.k8s.pod.phase",
+                                "negate": false,
+                                "type": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "metrics.k8s.pod.phase"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "02889149-5fdd-4311-b1c5-c0e269461c67",
+                    "i": "262d8d79-adbc-4935-a246-34dc017c8905",
                     "w": 8,
                     "x": 11,
                     "y": 20
                 },
-                "panelIndex": "02889149-5fdd-4311-b1c5-c0e269461c67",
+                "panelIndex": "262d8d79-adbc-4935-a246-34dc017c8905",
                 "title": "Pods",
                 "type": "lens"
             },
@@ -2521,17 +2815,46 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "field": "metrics.k8s.deployment.available",
                                         "index": "814876a7-ed03-4a55-b207-1b306043e2fd",
-                                        "key": "metrics.k8s.deployment.available",
                                         "negate": false,
-                                        "type": "exists"
+                                        "params": [
+                                            {
+                                                "meta": {
+                                                    "disabled": false,
+                                                    "field": "metrics.k8s.deployment.available",
+                                                    "index": "814876a7-ed03-4a55-b207-1b306043e2fd",
+                                                    "key": "metrics.k8s.deployment.available",
+                                                    "negate": false,
+                                                    "type": "exists",
+                                                    "value": "exists"
+                                                },
+                                                "query": {
+                                                    "exists": {
+                                                        "field": "metrics.k8s.deployment.available"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "meta": {
+                                                    "disabled": false,
+                                                    "field": "metrics.k8s.deployment.desired",
+                                                    "index": "814876a7-ed03-4a55-b207-1b306043e2fd",
+                                                    "key": "metrics.k8s.deployment.desired",
+                                                    "negate": false,
+                                                    "type": "exists",
+                                                    "value": "exists"
+                                                },
+                                                "query": {
+                                                    "exists": {
+                                                        "field": "metrics.k8s.deployment.desired"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "relation": "AND",
+                                        "type": "combined"
                                     },
-                                    "query": {
-                                        "exists": {
-                                            "field": "metrics.k8s.deployment.available"
-                                        }
-                                    }
+                                    "query": {}
                                 }
                             ],
                             "internalReferences": [
@@ -2595,16 +2918,78 @@
                         "type": "lens",
                         "visualizationType": "lnsPie"
                     },
-                    "enhancements": {}
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "index": "814876a7-ed03-4a55-b207-1b306043e2fd",
+                                "negate": false,
+                                "params": [
+                                    {
+                                        "meta": {
+                                            "disabled": false,
+                                            "field": "metrics.k8s.deployment.available",
+                                            "index": "814876a7-ed03-4a55-b207-1b306043e2fd",
+                                            "key": "metrics.k8s.deployment.available",
+                                            "negate": false,
+                                            "type": "exists",
+                                            "value": "exists"
+                                        },
+                                        "query": {
+                                            "exists": {
+                                                "field": "metrics.k8s.deployment.available"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "meta": {
+                                            "disabled": false,
+                                            "field": "metrics.k8s.deployment.desired",
+                                            "index": "814876a7-ed03-4a55-b207-1b306043e2fd",
+                                            "key": "metrics.k8s.deployment.desired",
+                                            "negate": false,
+                                            "type": "exists",
+                                            "value": "exists"
+                                        },
+                                        "query": {
+                                            "exists": {
+                                                "field": "metrics.k8s.deployment.desired"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "relation": "AND",
+                                "type": "combined"
+                            },
+                            "query": {}
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "b7a419cc-6c19-4da4-af15-efcc8c8fbb81",
+                    "i": "88cdbb00-6811-4666-84ca-ed49fcfe33e3",
                     "w": 7,
                     "x": 19,
                     "y": 20
                 },
-                "panelIndex": "b7a419cc-6c19-4da4-af15-efcc8c8fbb81",
+                "panelIndex": "88cdbb00-6811-4666-84ca-ed49fcfe33e3",
                 "title": "Deployments",
                 "type": "lens"
             },
@@ -2731,17 +3116,46 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "field": "metrics.k8s.daemonset.ready_nodes",
                                         "index": "bd8dfa94-665d-4be3-ba79-bf8b01440d0a",
-                                        "key": "metrics.k8s.daemonset.ready_nodes",
                                         "negate": false,
-                                        "type": "exists"
+                                        "params": [
+                                            {
+                                                "meta": {
+                                                    "disabled": false,
+                                                    "field": "metrics.k8s.daemonset.ready_nodes",
+                                                    "index": "bd8dfa94-665d-4be3-ba79-bf8b01440d0a",
+                                                    "key": "metrics.k8s.daemonset.ready_nodes",
+                                                    "negate": false,
+                                                    "type": "exists",
+                                                    "value": "exists"
+                                                },
+                                                "query": {
+                                                    "exists": {
+                                                        "field": "metrics.k8s.daemonset.ready_nodes"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "meta": {
+                                                    "disabled": false,
+                                                    "field": "metrics.k8s.daemonset.desired_scheduled_nodes",
+                                                    "index": "bd8dfa94-665d-4be3-ba79-bf8b01440d0a",
+                                                    "key": "metrics.k8s.daemonset.desired_scheduled_nodes",
+                                                    "negate": false,
+                                                    "type": "exists",
+                                                    "value": "exists"
+                                                },
+                                                "query": {
+                                                    "exists": {
+                                                        "field": "metrics.k8s.daemonset.desired_scheduled_nodes"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "relation": "AND",
+                                        "type": "combined"
                                     },
-                                    "query": {
-                                        "exists": {
-                                            "field": "metrics.k8s.daemonset.ready_nodes"
-                                        }
-                                    }
+                                    "query": {}
                                 }
                             ],
                             "internalReferences": [
@@ -2805,16 +3219,78 @@
                         "type": "lens",
                         "visualizationType": "lnsPie"
                     },
-                    "enhancements": {}
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "index": "bd8dfa94-665d-4be3-ba79-bf8b01440d0a",
+                                "negate": false,
+                                "params": [
+                                    {
+                                        "meta": {
+                                            "disabled": false,
+                                            "field": "metrics.k8s.daemonset.ready_nodes",
+                                            "index": "bd8dfa94-665d-4be3-ba79-bf8b01440d0a",
+                                            "key": "metrics.k8s.daemonset.ready_nodes",
+                                            "negate": false,
+                                            "type": "exists",
+                                            "value": "exists"
+                                        },
+                                        "query": {
+                                            "exists": {
+                                                "field": "metrics.k8s.daemonset.ready_nodes"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "meta": {
+                                            "disabled": false,
+                                            "field": "metrics.k8s.daemonset.desired_scheduled_nodes",
+                                            "index": "bd8dfa94-665d-4be3-ba79-bf8b01440d0a",
+                                            "key": "metrics.k8s.daemonset.desired_scheduled_nodes",
+                                            "negate": false,
+                                            "type": "exists",
+                                            "value": "exists"
+                                        },
+                                        "query": {
+                                            "exists": {
+                                                "field": "metrics.k8s.daemonset.desired_scheduled_nodes"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "relation": "AND",
+                                "type": "combined"
+                            },
+                            "query": {}
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "23839026-7223-4c0d-94a9-80c31b6e0582",
+                    "i": "b5625da5-5a7d-4e6d-b1ef-97a2aece734c",
                     "w": 7,
                     "x": 26,
                     "y": 20
                 },
-                "panelIndex": "23839026-7223-4c0d-94a9-80c31b6e0582",
+                "panelIndex": "b5625da5-5a7d-4e6d-b1ef-97a2aece734c",
                 "title": "DaemonSets",
                 "type": "lens"
             },
@@ -2941,17 +3417,46 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "field": "metrics.k8s.statefulset.ready_pods",
                                         "index": "f69ab194-236a-4e59-9dc0-b5a1bac9e841",
-                                        "key": "metrics.k8s.statefulset.ready_pods",
                                         "negate": false,
-                                        "type": "exists"
+                                        "params": [
+                                            {
+                                                "meta": {
+                                                    "disabled": false,
+                                                    "field": "metrics.k8s.statefulset.ready_pods",
+                                                    "index": "f69ab194-236a-4e59-9dc0-b5a1bac9e841",
+                                                    "key": "metrics.k8s.statefulset.ready_pods",
+                                                    "negate": false,
+                                                    "type": "exists",
+                                                    "value": "exists"
+                                                },
+                                                "query": {
+                                                    "exists": {
+                                                        "field": "metrics.k8s.statefulset.ready_pods"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "meta": {
+                                                    "disabled": false,
+                                                    "field": "metrics.k8s.statefulset.desired_pods",
+                                                    "index": "f69ab194-236a-4e59-9dc0-b5a1bac9e841",
+                                                    "key": "metrics.k8s.statefulset.desired_pods",
+                                                    "negate": false,
+                                                    "type": "exists",
+                                                    "value": "exists"
+                                                },
+                                                "query": {
+                                                    "exists": {
+                                                        "field": "metrics.k8s.statefulset.desired_pods"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "relation": "AND",
+                                        "type": "combined"
                                     },
-                                    "query": {
-                                        "exists": {
-                                            "field": "metrics.k8s.statefulset.ready_pods"
-                                        }
-                                    }
+                                    "query": {}
                                 }
                             ],
                             "internalReferences": [
@@ -3015,16 +3520,78 @@
                         "type": "lens",
                         "visualizationType": "lnsPie"
                     },
-                    "enhancements": {}
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "index": "f69ab194-236a-4e59-9dc0-b5a1bac9e841",
+                                "negate": false,
+                                "params": [
+                                    {
+                                        "meta": {
+                                            "disabled": false,
+                                            "field": "metrics.k8s.statefulset.ready_pods",
+                                            "index": "f69ab194-236a-4e59-9dc0-b5a1bac9e841",
+                                            "key": "metrics.k8s.statefulset.ready_pods",
+                                            "negate": false,
+                                            "type": "exists",
+                                            "value": "exists"
+                                        },
+                                        "query": {
+                                            "exists": {
+                                                "field": "metrics.k8s.statefulset.ready_pods"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "meta": {
+                                            "disabled": false,
+                                            "field": "metrics.k8s.statefulset.desired_pods",
+                                            "index": "f69ab194-236a-4e59-9dc0-b5a1bac9e841",
+                                            "key": "metrics.k8s.statefulset.desired_pods",
+                                            "negate": false,
+                                            "type": "exists",
+                                            "value": "exists"
+                                        },
+                                        "query": {
+                                            "exists": {
+                                                "field": "metrics.k8s.statefulset.desired_pods"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "relation": "AND",
+                                "type": "combined"
+                            },
+                            "query": {}
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "24572e3b-041e-4de8-843b-f8bb9611e0a8",
+                    "i": "b815bacf-1643-4e3d-be11-c74a8b320874",
                     "w": 7,
                     "x": 33,
                     "y": 20
                 },
-                "panelIndex": "24572e3b-041e-4de8-843b-f8bb9611e0a8",
+                "panelIndex": "b815bacf-1643-4e3d-be11-c74a8b320874",
                 "title": "StatefulSets",
                 "type": "lens"
             },
@@ -3151,17 +3718,46 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "field": "metrics.k8s.replicaset.available",
                                         "index": "b79aec1e-320f-4bce-89bb-abb64f61d0cf",
-                                        "key": "metrics.k8s.replicaset.available",
                                         "negate": false,
-                                        "type": "exists"
+                                        "params": [
+                                            {
+                                                "meta": {
+                                                    "disabled": false,
+                                                    "field": "metrics.k8s.replicaset.available",
+                                                    "index": "b79aec1e-320f-4bce-89bb-abb64f61d0cf",
+                                                    "key": "metrics.k8s.replicaset.available",
+                                                    "negate": false,
+                                                    "type": "exists",
+                                                    "value": "exists"
+                                                },
+                                                "query": {
+                                                    "exists": {
+                                                        "field": "metrics.k8s.replicaset.available"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "meta": {
+                                                    "disabled": false,
+                                                    "field": "metrics.k8s.replicaset.desired",
+                                                    "index": "b79aec1e-320f-4bce-89bb-abb64f61d0cf",
+                                                    "key": "metrics.k8s.replicaset.desired",
+                                                    "negate": false,
+                                                    "type": "exists",
+                                                    "value": "exists"
+                                                },
+                                                "query": {
+                                                    "exists": {
+                                                        "field": "metrics.k8s.replicaset.desired"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "relation": "AND",
+                                        "type": "combined"
                                     },
-                                    "query": {
-                                        "exists": {
-                                            "field": "metrics.k8s.replicaset.available"
-                                        }
-                                    }
+                                    "query": {}
                                 }
                             ],
                             "internalReferences": [
@@ -3225,16 +3821,78 @@
                         "type": "lens",
                         "visualizationType": "lnsPie"
                     },
-                    "enhancements": {}
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "index": "b79aec1e-320f-4bce-89bb-abb64f61d0cf",
+                                "negate": false,
+                                "params": [
+                                    {
+                                        "meta": {
+                                            "disabled": false,
+                                            "field": "metrics.k8s.replicaset.available",
+                                            "index": "b79aec1e-320f-4bce-89bb-abb64f61d0cf",
+                                            "key": "metrics.k8s.replicaset.available",
+                                            "negate": false,
+                                            "type": "exists",
+                                            "value": "exists"
+                                        },
+                                        "query": {
+                                            "exists": {
+                                                "field": "metrics.k8s.replicaset.available"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "meta": {
+                                            "disabled": false,
+                                            "field": "metrics.k8s.replicaset.desired",
+                                            "index": "b79aec1e-320f-4bce-89bb-abb64f61d0cf",
+                                            "key": "metrics.k8s.replicaset.desired",
+                                            "negate": false,
+                                            "type": "exists",
+                                            "value": "exists"
+                                        },
+                                        "query": {
+                                            "exists": {
+                                                "field": "metrics.k8s.replicaset.desired"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "relation": "AND",
+                                "type": "combined"
+                            },
+                            "query": {}
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "a9e40083-eeb5-45d2-8894-de503e832517",
+                    "i": "c66e2127-e755-4534-8985-fd7ca27635b1",
                     "w": 8,
                     "x": 40,
                     "y": 20
                 },
-                "panelIndex": "a9e40083-eeb5-45d2-8894-de503e832517",
+                "panelIndex": "c66e2127-e755-4534-8985-fd7ca27635b1",
                 "title": "ReplicaSets",
                 "type": "lens"
             },
@@ -3429,16 +4087,49 @@
                         "visualizationType": "lnsXY"
                     },
                     "description": "Pod cpu utilization is calculated as a ratio of the total node's capacity",
-                    "enhancements": {}
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "metrics.k8s.pod.cpu.node.utilization",
+                                "index": "c8a8f71b-f32b-46ab-aca4-e4eda5ee48f6",
+                                "key": "metrics.k8s.pod.cpu.node.utilization",
+                                "negate": false,
+                                "type": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "metrics.k8s.pod.cpu.node.utilization"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false
                 },
                 "gridData": {
                     "h": 10,
-                    "i": "31966ad9-d620-4fd8-b962-1a3438e20d54",
+                    "i": "2ad71e36-3726-4d7d-ac7d-81033eb0a507",
                     "w": 11,
                     "x": 0,
                     "y": 26
                 },
-                "panelIndex": "31966ad9-d620-4fd8-b962-1a3438e20d54",
+                "panelIndex": "2ad71e36-3726-4d7d-ac7d-81033eb0a507",
                 "title": "Top CPU intensive pods per Node",
                 "type": "lens"
             },
@@ -3624,16 +4315,49 @@
                         "visualizationType": "lnsXY"
                     },
                     "description": "Pod cpu utilization is calculated as a ratio of the pod's total container limits. If any container is missing a limit the metric is not emitted.",
-                    "enhancements": {}
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "metrics.k8s.pod.cpu_limit_utilization",
+                                "index": "6f57f91d-975d-48f3-9857-81fd9c2299a5",
+                                "key": "metrics.k8s.pod.cpu_limit_utilization",
+                                "negate": false,
+                                "type": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "metrics.k8s.pod.cpu_limit_utilization"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false
                 },
                 "gridData": {
                     "h": 10,
-                    "i": "2c43ebc8-5c9e-4c6e-a788-1529514f4ec0",
+                    "i": "aacb15e0-9e67-4d45-b450-8d8252c6f60b",
                     "w": 12,
                     "x": 11,
                     "y": 26
                 },
-                "panelIndex": "2c43ebc8-5c9e-4c6e-a788-1529514f4ec0",
+                "panelIndex": "aacb15e0-9e67-4d45-b450-8d8252c6f60b",
                 "title": "Top CPU intensive pods per Pod Limit",
                 "type": "lens"
             },
@@ -3819,16 +4543,49 @@
                         "visualizationType": "lnsXY"
                     },
                     "description": "Pod memory utilization is calculated as a ratio of the total node's capacity",
-                    "enhancements": {}
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "metrics.k8s.pod.memory.node.utilization",
+                                "index": "9104052a-0152-4e6d-89c1-bb3c40c89576",
+                                "key": "metrics.k8s.pod.memory.node.utilization",
+                                "negate": false,
+                                "type": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "metrics.k8s.pod.memory.node.utilization"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false
                 },
                 "gridData": {
                     "h": 10,
-                    "i": "373a49e9-ffb9-4f38-98b1-39e8ab2aeba5",
+                    "i": "a50efd09-addd-4d8e-ac01-3ccfe0f9bf63",
                     "w": 13,
                     "x": 23,
                     "y": 26
                 },
-                "panelIndex": "373a49e9-ffb9-4f38-98b1-39e8ab2aeba5",
+                "panelIndex": "a50efd09-addd-4d8e-ac01-3ccfe0f9bf63",
                 "title": "Top Memory intensive pods per Node",
                 "type": "lens"
             },
@@ -4013,16 +4770,49 @@
                         "visualizationType": "lnsXY"
                     },
                     "description": "Pod memory utilization is calculated as a ratio of the pod's total container memory limits. If any container is missing a limit the metric is not emitted.",
-                    "enhancements": {}
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "metrics.k8s.pod.memory_limit_utilization",
+                                "index": "7dd9ddda-fbe9-4bed-8865-aee8e880ce2d",
+                                "key": "metrics.k8s.pod.memory_limit_utilization",
+                                "negate": false,
+                                "type": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "metrics.k8s.pod.memory_limit_utilization"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false
                 },
                 "gridData": {
                     "h": 10,
-                    "i": "492b80c4-3b48-4171-b35e-27a22eb07c54",
+                    "i": "5bec7e22-eb92-4584-abdc-914a6b3499e2",
                     "w": 12,
                     "x": 36,
                     "y": 26
                 },
-                "panelIndex": "492b80c4-3b48-4171-b35e-27a22eb07c54",
+                "panelIndex": "5bec7e22-eb92-4584-abdc-914a6b3499e2",
                 "title": "Top Memory intensive pods per Pod Limit",
                 "type": "lens"
             },
@@ -4058,12 +4848,12 @@
                 },
                 "gridData": {
                     "h": 4,
-                    "i": "36ae474f-4fee-4cc0-a865-043410a0cb0b",
+                    "i": "4b37cb9f-2a47-4a8a-b1a9-fa902ddc63f5",
                     "w": 48,
                     "x": 0,
                     "y": 36
                 },
-                "panelIndex": "36ae474f-4fee-4cc0-a865-043410a0cb0b",
+                "panelIndex": "4b37cb9f-2a47-4a8a-b1a9-fa902ddc63f5",
                 "type": "visualization"
             },
             {
@@ -4332,16 +5122,96 @@
                         "visualizationType": "lnsXY"
                     },
                     "description": "",
-                    "enhancements": {}
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "body.structured.object.kind",
+                                "index": "2bed329e-0356-4b40-99fc-e1bd065a90b3",
+                                "key": "body.structured.object.kind",
+                                "negate": false,
+                                "params": {
+                                    "query": "Event"
+                                },
+                                "type": "phrase"
+                            },
+                            "query": {
+                                "match_phrase": {
+                                    "body.structured.object.kind": "Event"
+                                }
+                            }
+                        },
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "body.structured.object.type",
+                                "index": "e9b4315f-675b-4861-abe1-20b02adc4164",
+                                "key": "body.structured.object.type",
+                                "negate": true,
+                                "params": {
+                                    "query": "Normal"
+                                },
+                                "type": "phrase"
+                            },
+                            "query": {
+                                "match_phrase": {
+                                    "body.structured.object.type": "Normal"
+                                }
+                            }
+                        },
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "data_stream.dataset",
+                                "index": "410606b6-3844-4afb-ab06-26bca8e7f730",
+                                "key": "data_stream.dataset",
+                                "negate": false,
+                                "params": {
+                                    "query": "generic.otel"
+                                },
+                                "type": "phrase"
+                            },
+                            "query": {
+                                "match_phrase": {
+                                    "data_stream.dataset": "generic.otel"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": ""
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false
                 },
                 "gridData": {
                     "h": 15,
-                    "i": "9a239282-eb82-4b53-89f5-763e4f5beb6a",
+                    "i": "461656b4-802d-4178-9d43-97c58655f7bb",
                     "w": 23,
                     "x": 0,
                     "y": 40
                 },
-                "panelIndex": "9a239282-eb82-4b53-89f5-763e4f5beb6a",
+                "panelIndex": "461656b4-802d-4178-9d43-97c58655f7bb",
                 "title": "Occurrences of Warning  Events",
                 "type": "lens"
             },
@@ -4703,148 +5573,224 @@
                         "visualizationType": "lnsDatatable"
                     },
                     "description": "",
-                    "enhancements": {}
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "data_stream.dataset",
+                                "index": "148c0eeb-8220-452b-83e8-23fcefaceace",
+                                "key": "data_stream.dataset",
+                                "negate": false,
+                                "params": {
+                                    "query": "generic.otel"
+                                },
+                                "type": "phrase"
+                            },
+                            "query": {
+                                "match_phrase": {
+                                    "data_stream.dataset": "generic.otel"
+                                }
+                            }
+                        },
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "body.structured.object.kind",
+                                "index": "d5ed4c9b-9c6f-49f0-833b-1830cb637329",
+                                "key": "body.structured.object.kind",
+                                "negate": false,
+                                "type": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "body.structured.object.kind"
+                                }
+                            }
+                        },
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "body.structured.object.type",
+                                "index": "432b9a4d-65d2-44b1-ba84-473ae598be20",
+                                "key": "body.structured.object.type",
+                                "negate": true,
+                                "params": {
+                                    "query": "Normal"
+                                },
+                                "type": "phrase"
+                            },
+                            "query": {
+                                "match_phrase": {
+                                    "body.structured.object.type": "Normal"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": ""
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false
                 },
                 "gridData": {
                     "h": 15,
-                    "i": "02eadc61-bcc8-4500-a453-42150d09ed06",
+                    "i": "d1b2c8f0-592b-4f3d-ba25-d54a060ef65c",
                     "w": 25,
                     "x": 23,
                     "y": 40
                 },
-                "panelIndex": "02eadc61-bcc8-4500-a453-42150d09ed06",
+                "panelIndex": "d1b2c8f0-592b-4f3d-ba25-d54a060ef65c",
                 "title": "Latest Warning Events",
                 "type": "lens"
             }
         ],
         "timeRestore": false,
         "title": "[OTEL][Metrics Kubernetes] Cluster Overview",
-        "version": 2
+        "version": 3
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-11-04T13:57:16.455Z",
+    "created_at": "2025-08-22T09:08:38.409Z",
     "created_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0",
     "id": "kubernetes_otel-cluster-overview",
-    "managed": false,
     "references": [
         {
             "id": "metrics-*",
-            "name": "6119419c-1899-4765-aed4-c050cde4c30a:indexpattern-datasource-layer-894781bd-2933-418c-b883-1f758794a45d",
+            "name": "5641261b-5eae-42f9-a381-f3031df725d7:indexpattern-datasource-layer-894781bd-2933-418c-b883-1f758794a45d",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "63a8ac8b-f7f8-4169-9f10-4a7315973102:indexpattern-datasource-layer-54494aa2-197e-42d6-a8ef-0072655ca351",
+            "name": "d9687ae8-3bd7-4128-88ad-e77d841a75aa:indexpattern-datasource-layer-54494aa2-197e-42d6-a8ef-0072655ca351",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "63a8ac8b-f7f8-4169-9f10-4a7315973102:indexpattern-datasource-layer-dba09ccc-6ec6-443b-8620-1eac10077772",
+            "name": "d9687ae8-3bd7-4128-88ad-e77d841a75aa:indexpattern-datasource-layer-dba09ccc-6ec6-443b-8620-1eac10077772",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "b126cfb5-901e-42d3-8d1f-d47e142884af:indexpattern-datasource-layer-54494aa2-197e-42d6-a8ef-0072655ca351",
+            "name": "c5f29eb4-bd50-4e65-b693-a6cb08579437:indexpattern-datasource-layer-54494aa2-197e-42d6-a8ef-0072655ca351",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "b126cfb5-901e-42d3-8d1f-d47e142884af:indexpattern-datasource-layer-dba09ccc-6ec6-443b-8620-1eac10077772",
+            "name": "c5f29eb4-bd50-4e65-b693-a6cb08579437:indexpattern-datasource-layer-dba09ccc-6ec6-443b-8620-1eac10077772",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "e69952d8-208e-4c4e-adb1-32077a9beb81:indexpattern-datasource-layer-894781bd-2933-418c-b883-1f758794a45d",
+            "name": "5c805606-3ee7-4197-9921-63770e39e1d3:indexpattern-datasource-layer-894781bd-2933-418c-b883-1f758794a45d",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "89a3c0ca-b3da-4ea6-94f8-b851514ee9a0:indexpattern-datasource-layer-b5e4cee3-e558-4805-b276-673a7ebff8f0",
+            "name": "68b825d9-e1a8-4960-ac2d-0a36845f8cfa:indexpattern-datasource-layer-b5e4cee3-e558-4805-b276-673a7ebff8f0",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "a9af08bb-2b3f-41d7-bdf9-ac5739d4ff4d:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
+            "name": "e2034722-0c5a-42b0-b131-4480d1315eb9:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "69b3ea52-4a50-42e6-9ab2-3a0cca0441cf:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
+            "name": "1bd2d3e6-0083-4c7c-88ff-8e11357cb99f:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "5399f854-f59b-488d-92d1-0d10e3c10417:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
+            "name": "5d14e383-8c31-401a-9d22-d12529615a93:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "5399f854-f59b-488d-92d1-0d10e3c10417:1b04b540-39ae-4cfd-8088-34a4bf3d5654",
+            "name": "5d14e383-8c31-401a-9d22-d12529615a93:1b04b540-39ae-4cfd-8088-34a4bf3d5654",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "7210445e-56b4-4695-8dff-c5cf8a406cad:indexpattern-datasource-layer-57a8eb42-6f2c-4112-9d6c-c03d982c569e",
+            "name": "0670db69-1cf1-45ac-9019-435d77668835:indexpattern-datasource-layer-57a8eb42-6f2c-4112-9d6c-c03d982c569e",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "7210445e-56b4-4695-8dff-c5cf8a406cad:0e11ca27-40f5-4300-b885-17ade4895220",
+            "name": "0670db69-1cf1-45ac-9019-435d77668835:0e11ca27-40f5-4300-b885-17ade4895220",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "31966ad9-d620-4fd8-b962-1a3438e20d54:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+            "name": "2ad71e36-3726-4d7d-ac7d-81033eb0a507:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "2c43ebc8-5c9e-4c6e-a788-1529514f4ec0:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+            "name": "aacb15e0-9e67-4d45-b450-8d8252c6f60b:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "373a49e9-ffb9-4f38-98b1-39e8ab2aeba5:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+            "name": "a50efd09-addd-4d8e-ac01-3ccfe0f9bf63:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "492b80c4-3b48-4171-b35e-27a22eb07c54:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+            "name": "5bec7e22-eb92-4584-abdc-914a6b3499e2:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "9a239282-eb82-4b53-89f5-763e4f5beb6a:indexpattern-datasource-layer-29bf96fd-6dcd-4667-8e14-8865fb5a7e63",
+            "name": "461656b4-802d-4178-9d43-97c58655f7bb:indexpattern-datasource-layer-29bf96fd-6dcd-4667-8e14-8865fb5a7e63",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "9a239282-eb82-4b53-89f5-763e4f5beb6a:2bed329e-0356-4b40-99fc-e1bd065a90b3",
+            "name": "461656b4-802d-4178-9d43-97c58655f7bb:2bed329e-0356-4b40-99fc-e1bd065a90b3",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "9a239282-eb82-4b53-89f5-763e4f5beb6a:e9b4315f-675b-4861-abe1-20b02adc4164",
+            "name": "461656b4-802d-4178-9d43-97c58655f7bb:e9b4315f-675b-4861-abe1-20b02adc4164",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "02eadc61-bcc8-4500-a453-42150d09ed06:indexpattern-datasource-layer-4581d01c-5f91-4098-bb19-36de6b81d665",
+            "name": "d1b2c8f0-592b-4f3d-ba25-d54a060ef65c:indexpattern-datasource-layer-4581d01c-5f91-4098-bb19-36de6b81d665",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "controlGroup_a01727d6-1aa3-4918-91ca-9059f18d9222:optionsListDataView",
+            "name": "controlGroup_37fac32a-4faf-4af3-961c-d9fc86892ca5:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "controlGroup_aa8e7204-6b27-441e-bcce-a30aa1da6abc:optionsListDataView",
+            "name": "controlGroup_5fbc6395-9574-4e46-9597-ef8aee3d81eb:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "controlGroup_5cebe50d-a46e-4e4d-a209-718a00a4a45d:optionsListDataView",
+            "name": "controlGroup_feb91931-38e6-4140-9280-4387f6a8e19b:optionsListDataView",
             "type": "index-pattern"
         }
     ],

--- a/packages/kubernetes_otel/manifest.yml
+++ b/packages/kubernetes_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.1
 name: kubernetes_otel
 title: "Kubernetes OpenTelemetry Assets"
-version: 1.1.0
+version: 1.1.1
 description: "Utilise the pre-built dashboard for OTel-native metrics and events collected from a Kubernetes cluster"
 type: content
 categories:


### PR DESCRIPTION
- Bug

## Proposed commit message


- WHAT: Fixing the filters on ad-hoc fields for deployments, daemonsets, replicasets and statefulesets visualisations to include all the fields that we use in the script
- WHY:  Cases reported that fields used in specfic visualisations where missing and this lead to broken dashboard. Issue visible under heavy load clusters


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## How to test this PR locally

1. Clone this branch
2. Navigate to integrations/packages/kubernetes_otel
3. Run elastic-package build from inside the folder. The version 
```bash
elastic-package build

Build the package
2025/08/22 13:34:44  INFO License text found in "/Users/andreasgkizas/elastic/integrations/LICENSE.txt" will be included in package
Package built: /Users/andreasgkizas/elastic/integrations/build/packages/kubernetes_otel-1.1.1.zip
Done
```
5. Run `elastic-package stack up -d -v --version=9.0.4` from within the same folder
6. Once kibana is available, install the kubernetes_otel version 1.1.1
7. Open https://localhost:5601/app/dashboards#/view/kubernetes_otel-cluster-overview dashboard and verify that filters are applied to deployments, daemonsets, replicasets and statefulesets visualisations 


## Screenshots
Dashboard is working with new changes

<img width="1734" height="219" alt="Screenshot 2025-08-22 at 12 53 46 PM" src="https://github.com/user-attachments/assets/7dc5c867-a94f-407d-ba61-cec4765f3312" />

Sample for filter applied:
<img width="1699" height="295" alt="Screenshot 2025-08-22 at 1 37 17 PM" src="https://github.com/user-attachments/assets/a85b496e-7a2f-4494-b1fc-e29dd9a6c3e0" />


