### PR TITLE
[symantec_endpoint_security] Fix loss of state in error case

### DIFF
--- a/packages/symantec_endpoint_security/changelog.yml
+++ b/packages/symantec_endpoint_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.1"
+  changes:
+    - description: Fix 'no such key: limit' error.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/15100
 - version: "1.14.0"
   changes:
     - description: Use `terminate` processor instead of `fail` processor to handle agent errors.

--- a/packages/symantec_endpoint_security/changelog.yml
+++ b/packages/symantec_endpoint_security/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.14.1"
   changes:
-    - description: Fix 'no such key: limit' error.
+    - description: "Fix 'no such key: limit' error."
       type: bugfix
       link: https://github.com/elastic/integrations/pull/15100
 - version: "1.14.0"

--- a/packages/symantec_endpoint_security/data_stream/incident/agent/stream/cel.yml.hbs
+++ b/packages/symantec_endpoint_security/data_stream/incident/agent/stream/cel.yml.hbs
@@ -25,45 +25,52 @@ state:
   want_more: false
   limit: {{batch_size}}
   next: 0
-program: |
-  (
-    state.want_more ?
-      state
-    :
-      state.with({
-        "limit": state.limit,
-        "start_date": state.?cursor.last_timestamp.orValue(string(now - duration(state.initial_interval))),
-        "end_date": now,
-        "next": state.next,
-      })
-  ).as(state,
-    post_request(
-      state.url.trim_right("/") + "/v1/incidents",
-      "application/json",
-      {
-        "limit": state.limit,
-        "start_date": state.start_date,
-        "end_date": state.end_date,
-        "next": state.next
-      }.encode_json()
-    ).do_request().as(resp, resp.StatusCode == 200 ?
-        bytes(resp.Body).decode_json().as(body, 
-          (body.?next.orValue(body.total) != body.total).as(want_more, {
-            "events": body.incidents.map(e, {
-              "message": e.encode_json(),
-            }),
-            "next": want_more ? body.next : 0,
-            "want_more": want_more,
+program: |-
+  state.with(
+    (
+      state.want_more ?
+        state
+      :
+        state.with(
+          {
             "limit": state.limit,
-            "start_date": string(state.start_date),
-            "end_date": string(state.end_date),
-            "cursor": {
-              ?"last_timestamp": want_more ?
+            "start_date": state.?cursor.last_timestamp.orValue(string(now - duration(state.initial_interval))),
+            "end_date": now,
+            "next": state.next,
+          }
+        )
+    ).as(state,
+      post_request(
+        state.url.trim_right("/") + "/v1/incidents",
+        "application/json",
+        {
+          "limit": state.limit,
+          "start_date": state.start_date,
+          "end_date": state.end_date,
+          "next": state.next,
+        }.encode_json()
+      ).do_request().as(resp, (resp.StatusCode == 200) ?
+        bytes(resp.Body).decode_json().as(body,
+          (body.?next.orValue(body.total) != body.total).as(want_more,
+            {
+              "events": body.incidents.map(e,
+                {
+                  "message": e.encode_json(),
+                }
+              ),
+              "next": want_more ? body.next : 0,
+              "want_more": want_more,
+              "limit": state.limit,
+              "start_date": string(state.start_date),
+              "end_date": string(state.end_date),
+              "cursor": {
+                ?"last_timestamp": want_more ?
                   state.?cursor.last_timestamp
                 :
                   optional.of(state.end_date),
+              },
             }
-          })
+          )
         )
       :
         {
@@ -71,16 +78,17 @@ program: |
             "error": {
               "code": string(resp.StatusCode),
               "id": string(resp.Status),
-              "message": "POST:"+(
-                size(resp.Body) != 0 ?
+              "message": "POST:" + (
+                (size(resp.Body) != 0) ?
                   string(resp.Body)
                 :
-                  string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                  string(resp.Status) + " (" + string(resp.StatusCode) + ")"
               ),
             },
           },
           "want_more": false,
         }
+      )
     )
   )
 tags:

--- a/packages/symantec_endpoint_security/manifest.yml
+++ b/packages/symantec_endpoint_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: symantec_endpoint_security
 title: Symantec Endpoint Security
-version: "1.14.0"
+version: "1.14.1"
 description: Collect logs from Symantec Endpoint Security with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[symantec_endpoint_security] Fix loss of state in error case

Failure to propagate the state in the error case was causing failures
such as:

    failed eval: ERROR: :21:50: no such key: limit

Fixed by wrapping in `state.with(...)`. Also ran celfmt.
```

## Note to reviewers

Review the diff with whitespace changes off to avoid noise from the `celfmt` reformatting.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 