### PR TITLE
[symantec_endpoint_security] Lower the package spec version

### DIFF
--- a/packages/symantec_endpoint_security/changelog.yml
+++ b/packages/symantec_endpoint_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.2"
+  changes:
+    - description: Lower the package spec version.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/15102
 - version: "1.14.1"
   changes:
     - description: "Fix 'no such key: limit' error."

--- a/packages/symantec_endpoint_security/manifest.yml
+++ b/packages/symantec_endpoint_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: symantec_endpoint_security
 title: Symantec Endpoint Security
-version: "1.14.1"
+version: "1.14.2"
 description: Collect logs from Symantec Endpoint Security with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[symantec_endpoint_security] Lower the package spec version

Lowering it to 3.3.2 includes the required package-spec support for the
terminate processor[1], without getting ahead of the maximum version
supported in Kibana 9.0.x[2].

[1]: https://github.com/elastic/package-spec/pull/857
[2]: https://github.com/elastic/kibana/blob/v9.0.6/x-pack/platform/plugins/shared/fleet/server/config.ts#L30
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 