### PR TITLE
[Carbon Black Cloud] Add agentless deployment

### DIFF
--- a/packages/carbon_black_cloud/_dev/build/docs/README.md
+++ b/packages/carbon_black_cloud/_dev/build/docs/README.md
@@ -2,6 +2,11 @@
 
 The VMware Carbon Black Cloud integration collects and parses data from the Carbon Black Cloud REST APIs and AWS S3 bucket.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Version 1.21+ Update Disclaimer
 Starting from version 1.21, if using multiple AWS data streams simultaneously configured to use AWS SQS, separate SQS queues should be configured per
 data stream. The default values of file selector regexes have been commented out for this reason. The only reason the global queue now exists is to avoid

--- a/packages/carbon_black_cloud/changelog.yml
+++ b/packages/carbon_black_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.2.0"
+  changes:
+    - description: Enable Agentless deployment.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.1.0"
   changes:
     - description: Standardize user fields processing across integrations.

--- a/packages/carbon_black_cloud/data_stream/alert_v7/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/carbon_black_cloud/data_stream/alert_v7/elasticsearch/ingest_pipeline/default.yml
@@ -10,6 +10,11 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      ignore_missing: true
+      if: ctx.event?.original != null
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/carbon_black_cloud/data_stream/asset_vulnerability_summary/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/carbon_black_cloud/data_stream/asset_vulnerability_summary/elasticsearch/ingest_pipeline/default.yml
@@ -6,6 +6,11 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      ignore_missing: true
+      if: ctx.event?.original != null
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - set:
       field: ecs.version
       value: '8.11.0'

--- a/packages/carbon_black_cloud/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/carbon_black_cloud/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -9,6 +9,11 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      ignore_missing: true
+      if: ctx.event?.original != null
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/carbon_black_cloud/data_stream/endpoint_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/carbon_black_cloud/data_stream/endpoint_event/elasticsearch/ingest_pipeline/default.yml
@@ -9,6 +9,11 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      ignore_missing: true
+      if: ctx.event?.original != null
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/carbon_black_cloud/data_stream/watchlist_hit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/carbon_black_cloud/data_stream/watchlist_hit/elasticsearch/ingest_pipeline/default.yml
@@ -12,6 +12,11 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      ignore_missing: true
+      if: ctx.event?.original != null
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/carbon_black_cloud/docs/README.md
+++ b/packages/carbon_black_cloud/docs/README.md
@@ -2,6 +2,11 @@
 
 The VMware Carbon Black Cloud integration collects and parses data from the Carbon Black Cloud REST APIs and AWS S3 bucket.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Version 1.21+ Update Disclaimer
 Starting from version 1.21, if using multiple AWS data streams simultaneously configured to use AWS SQS, separate SQS queues should be configured per
 data stream. The default values of file selector regexes have been commented out for this reason. The only reason the global queue now exists is to avoid

--- a/packages/carbon_black_cloud/manifest.yml
+++ b/packages/carbon_black_cloud/manifest.yml
@@ -1,7 +1,7 @@
-format_version: "3.0.2"
+format_version: "3.4.0"
 name: carbon_black_cloud
 title: VMware Carbon Black Cloud
-version: "3.1.0"
+version: "3.2.0"
 description: Collect logs from VMWare Carbon Black Cloud with Elastic Agent.
 type: integration
 categories:
@@ -24,6 +24,14 @@ policy_templates:
   - name: carbon_black_cloud
     title: Carbon Black Cloud
     description: Collect Logs from Carbon Black Cloud.
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        organization: security
+        division: engineering
+        team: security-service-integrations
     inputs:
       - type: httpjson
         title: Collect Carbon Black Cloud logs via API using HTTPJSON [Legacy]


### PR DESCRIPTION
## Proposed commit message

```
carbon_black_cloud: add agentless deployment
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install the elastic package locally.
- Start the elastic stack using the elastic package.
- Move to integrations/packages/carbon_black_cloud directory.
- Run the following command to run tests.

> elastic-package test -v

## Related issues

- Closes #15001
