### PR TITLE
ti_opencti: Add script processor to drop all nulls / empty strings.

### DIFF
--- a/packages/ti_opencti/changelog.yml
+++ b/packages/ti_opencti/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add script processor to drop all nulls / empty strings.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/15129
 - version: "2.7.0"
   changes:
     - description: Use `terminate` processor instead of `fail` processor to handle agent errors.

--- a/packages/ti_opencti/changelog.yml
+++ b/packages/ti_opencti/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.8.0"
+  changes:
+    - description: Add script processor to drop all nulls / empty strings.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.7.0"
   changes:
     - description: Use `terminate` processor instead of `fail` processor to handle agent errors.

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-x509-certificate.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-x509-certificate.json
@@ -1,0 +1,65 @@
+{
+    "events": [
+        {
+            "id": "3c3a2209-1dbe-4f85-85b5-c284e63b2c40",
+            "standard_id": "indicator--569a023c-1dc9-55b9-a246-aaa23acba6b7",
+            "is_inferred": false,
+            "revoked": true,
+            "confidence": 15,
+            "lang": "en",
+            "created": "2016-08-16T14:29:16.000Z",
+            "modified": "2023-01-17T09:12:37.556Z",
+            "pattern_type": "stix",
+            "pattern_version": "2.1",
+            "pattern": "[x509-certificate:value = 'b08a4939fb88f375a2757eaddc47b1fb8b554439']",
+            "name": "b08a4939fb88f375a2757eaddc47b1fb8b554439",
+            "description": "",
+            "valid_from": "2020-08-16T14:29:16.000Z",
+            "valid_until": "2021-08-16T14:29:16.000Z",
+            "x_opencti_score": 40,
+            "x_opencti_detection": false,
+            "x_opencti_main_observable_type": "X509-Certificate",
+            "createdBy": {
+                "identity_class": "organization",
+                "name": "CIRCL"
+            },
+            "objectMarking": [
+                {
+                    "definition_type": "TLP",
+                    "definition": "TLP:CLEAR"
+                }
+            ],
+            "objectLabel": [
+                {
+                    "value": "malware"
+                }
+            ],
+            "killChainPhases": [],
+            "externalReferences": {
+                "edges": []
+            },
+            "observables": {
+                "edges": [
+                    {
+                        "node": {
+                            "entity_type": "X509-Certificate",
+                            "id": "cc34949a-5a6f-4595-afec-c3bf98c62a7d",
+                            "observable_value": "b08a4939fb88f375a2757eaddc47b1fb8b554439",
+                            "standard_id": "x509-certificate--726e8863-8941-5a1b-b345-1f0131902233",
+                            "value": "b08a4939fb88f375a2757eaddc47b1fb8b554439",
+                            "is_self_signed": true,
+                            "version": "3",
+                            "serial_number": "55FBB9C7DEBF09809D12CCAA",
+                            "signature_algorithm": "SHA256-RSA",
+                            "validity_not_before": "2025-01-05T07:45:52.000Z",
+                            "validity_not_after": ""
+                        }
+                    }
+                ],
+                "pageInfo": {
+                    "globalCount": 1
+                }
+            }
+        }
+    ]
+}

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-x509-certificate.json-expected.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-x509-certificate.json-expected.json
@@ -1,0 +1,82 @@
+{
+    "expected": [
+        {
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "threat"
+                ],
+                "created": "2016-08-16T14:29:16.000Z",
+                "id": "3c3a2209-1dbe-4f85-85b5-c284e63b2c40",
+                "kind": "enrichment",
+                "type": [
+                    "indicator"
+                ]
+            },
+            "opencti": {
+                "indicator": {
+                    "creator_identity_class": "organization",
+                    "detection": false,
+                    "invalid_or_revoked_from": "2021-08-16T14:29:16.000Z",
+                    "is_inferred": false,
+                    "lang": "en",
+                    "observables_count": 1,
+                    "pattern": "[x509-certificate:value = 'b08a4939fb88f375a2757eaddc47b1fb8b554439']",
+                    "pattern_type": "stix",
+                    "pattern_version": "2.1",
+                    "revoked": true,
+                    "score": 40,
+                    "standard_id": "indicator--569a023c-1dc9-55b9-a246-aaa23acba6b7",
+                    "valid_from": "2020-08-16T14:29:16.000Z",
+                    "valid_until": "2021-08-16T14:29:16.000Z"
+                },
+                "observable": {
+                    "x509_certificate": {
+                        "entity_type": "X509-Certificate",
+                        "id": "cc34949a-5a6f-4595-afec-c3bf98c62a7d",
+                        "is_self_signed": true,
+                        "serial_number": "55FBB9C7DEBF09809D12CCAA",
+                        "signature_algorithm": "SHA256-RSA",
+                        "standard_id": "x509-certificate--726e8863-8941-5a1b-b345-1f0131902233",
+                        "validity_not_before": "2025-01-05T07:45:52.000Z",
+                        "value": "b08a4939fb88f375a2757eaddc47b1fb8b554439",
+                        "version": "3"
+                    }
+                }
+            },
+            "tags": [
+                "forwarded",
+                "opencti-indicator",
+                "malware",
+                "ecs-indicator-detail"
+            ],
+            "threat": {
+                "feed": {
+                    "dashboard_id": "ti_opencti-83b2bef0-591c-11ee-ba5f-49a63bb985cd",
+                    "description": "Indicator data from OpenCTI",
+                    "name": "OpenCTI",
+                    "reference": "https://docs.opencti.io/latest/usage/overview/"
+                },
+                "indicator": {
+                    "confidence": "Low",
+                    "marking": {
+                        "tlp": "CLEAR"
+                    },
+                    "modified_at": "2023-01-17T09:12:37.556Z",
+                    "name": "b08a4939fb88f375a2757eaddc47b1fb8b554439",
+                    "provider": "CIRCL",
+                    "reference": "https://demo.opencti.io/dashboard/observations/indicators/3c3a2209-1dbe-4f85-85b5-c284e63b2c40",
+                    "type": "x509-certificate",
+                    "x509": {
+                        "not_before": "2025-01-05T07:45:52.000Z",
+                        "serial_number": "55FBB9C7DEBF09809D12CCAA",
+                        "signature_algorithm": "SHA256-RSA",
+                        "version_number": "3"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/packages/ti_opencti/data_stream/indicator/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_opencti/data_stream/indicator/elasticsearch/ingest_pipeline/default.yml
@@ -887,6 +887,33 @@ processors:
         false
       allow_duplicates: false
 
+  - script:
+      tag: remove-nulls
+      lang: painless
+      description: This script processor iterates over the whole document to remove fields with null values.
+      source: |
+        void handleMap(Map map) {
+          map.values().removeIf(v -> {
+            if (v instanceof Map) {
+                handleMap(v);
+            } else if (v instanceof List) {
+                handleList(v);
+            }
+            return v == null || v == '' || v == '-' || v == 'none' || (v instanceof Map && v.size() == 0) || (v instanceof List && v.size() == 0)
+          });
+        }
+        void handleList(List list) {
+          list.removeIf(v -> {
+            if (v instanceof Map) {
+                handleMap(v);
+            } else if (v instanceof List) {
+                handleList(v);
+            }
+            return v == null || v == '' || v == '-' || v == 'none' || (v instanceof Map && v.size() == 0) || (v instanceof List && v.size() == 0)
+          });
+        }
+        handleMap(ctx);
+
 ###################
 # Failure handler #
 ###################

--- a/packages/ti_opencti/manifest.yml
+++ b/packages/ti_opencti/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: ti_opencti
 title: OpenCTI
-version: "2.7.0"
+version: "2.8.0"
 description: "Ingest threat intelligence indicators from OpenCTI with Elastic Agent."
 type: integration
 source:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
In current pipeline, the empty strings inside raw data 
can create several malformed fields which are indexed 
into transform source indices due to the default setting: 
"index.mapping.ignore_malformed: true".
Since this setting is "false" inside transform's destination 
indices, the transform fails during index operation.

This PR adds script processor to remove null and 
empty strings inside raw data and not ingest them into 
the source indices avoiding malformed data at source.

PR[1] has the fix for setting the default 
"index.mapping.ignore_malformed: true"
inside transform's destination indices as well.

[1]: https://github.com/elastic/kibana/pull/232439
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Added sample data with empty strings.
Run pipeline tests:

**Current Behaviour:**

```
--- Test results for package: ti_opencti - START ---
FAILURE DETAILS:
ti_opencti/indicator test-x509-certificate.json:
[0] field "threat.indicator.x509.alternative_names" is not normalized as expected: expected array, found "" (string)
[1] field "threat.indicator.x509.issuer.common_name" is not normalized as expected: expected array, found "" (string)
[2] field "threat.indicator.x509.public_key_exponent"'s Go type, string, does not match the expected field type: long (field value: )
[3] field "threat.indicator.x509.subject.common_name" is not normalized as expected: expected array, found "" (string)
```

**After enhancement:**

```
--- Test results for package: ti_opencti - START ---
╭────────────┬─────────────┬───────────┬──────────────────────────────────────────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE    │ DATA STREAM │ TEST TYPE │ TEST NAME                                                                │ RESULT │ TIME ELAPSED │
├────────────┼─────────────┼───────────┼──────────────────────────────────────────────────────────────────────────┼────────┼──────────────┤
│ ti_opencti │ indicator   │ pipeline  │ (ingest pipeline warnings test-cryptocurrency-wallet.json)               │ PASS   │ 453.822833ms │
│ ti_opencti │ indicator   │ pipeline  │ (ingest pipeline warnings test-domain-name-with-external-reference.json) │ PASS   │ 409.831458ms │
│ ti_opencti │ indicator   │ pipeline  │ (ingest pipeline warnings test-domain-name.json)                         │ PASS   │ 436.341917ms │
│ ti_opencti │ indicator   │ pipeline  │ (ingest pipeline warnings test-email-addr.json)                          │ PASS   │ 418.976333ms │
│ ti_opencti │ indicator   │ pipeline  │ (ingest pipeline warnings test-email-message.json)                       │ PASS   │ 427.723167ms │
│ ti_opencti │ indicator   │ pipeline  │ (ingest pipeline warnings test-file-with-name.json)                      │ PASS   │ 464.295792ms │
│ ti_opencti │ indicator   │ pipeline  │ (ingest pipeline warnings test-file-with-sha256.json)                    │ PASS   │    424.282ms │
│ ti_opencti │ indicator   │ pipeline  │ (ingest pipeline warnings test-hostname.json)                            │ PASS   │   424.3725ms │
│ ti_opencti │ indicator   │ pipeline  │ (ingest pipeline warnings test-ipv4-addr-createdby-is-null.json)         │ PASS   │ 419.294166ms │
│ ti_opencti │ indicator   │ pipeline  │ (ingest pipeline warnings test-ipv4-addr.json)                           │ PASS   │ 436.308125ms │
│ ti_opencti │ indicator   │ pipeline  │ (ingest pipeline warnings test-ipv6-addr.json)                           │ PASS   │     434.27ms │
│ ti_opencti │ indicator   │ pipeline  │ (ingest pipeline warnings test-mutex.json)                               │ PASS   │ 447.116208ms │
│ ti_opencti │ indicator   │ pipeline  │ (ingest pipeline warnings test-phone-number.json)                        │ PASS   │  415.40425ms │
│ ti_opencti │ indicator   │ pipeline  │ (ingest pipeline warnings test-process.json)                             │ PASS   │ 424.007916ms │
│ ti_opencti │ indicator   │ pipeline  │ (ingest pipeline warnings test-unknown.json)                             │ PASS   │ 403.467834ms │
│ ti_opencti │ indicator   │ pipeline  │ (ingest pipeline warnings test-url.json)                                 │ PASS   │ 406.583292ms │
│ ti_opencti │ indicator   │ pipeline  │ (ingest pipeline warnings test-user-agent.json)                          │ PASS   │ 413.821958ms │
│ ti_opencti │ indicator   │ pipeline  │ (ingest pipeline warnings test-windows-registry-key-no-hive.json)        │ PASS   │ 430.372042ms │
│ ti_opencti │ indicator   │ pipeline  │ (ingest pipeline warnings test-windows-registry-key.json)                │ PASS   │ 429.864458ms │
│ ti_opencti │ indicator   │ pipeline  │ (ingest pipeline warnings test-x509-certificate.json)                    │ PASS   │ 407.427083ms │
│ ti_opencti │ indicator   │ pipeline  │ test-cryptocurrency-wallet.json                                          │ PASS   │   54.11075ms │
│ ti_opencti │ indicator   │ pipeline  │ test-domain-name-with-external-reference.json                            │ PASS   │  68.863458ms │
│ ti_opencti │ indicator   │ pipeline  │ test-domain-name.json                                                    │ PASS   │  65.926208ms │
│ ti_opencti │ indicator   │ pipeline  │ test-email-addr.json                                                     │ PASS   │  72.772542ms │
│ ti_opencti │ indicator   │ pipeline  │ test-email-message.json                                                  │ PASS   │  63.085833ms │
│ ti_opencti │ indicator   │ pipeline  │ test-file-with-name.json                                                 │ PASS   │  65.531083ms │
│ ti_opencti │ indicator   │ pipeline  │ test-file-with-sha256.json                                               │ PASS   │  60.412542ms │
│ ti_opencti │ indicator   │ pipeline  │ test-hostname.json                                                       │ PASS   │  66.375834ms │
│ ti_opencti │ indicator   │ pipeline  │ test-ipv4-addr-createdby-is-null.json                                    │ PASS   │  59.181458ms │
│ ti_opencti │ indicator   │ pipeline  │ test-ipv4-addr.json                                                      │ PASS   │  65.015125ms │
│ ti_opencti │ indicator   │ pipeline  │ test-ipv6-addr.json                                                      │ PASS   │  69.243541ms │
│ ti_opencti │ indicator   │ pipeline  │ test-mutex.json                                                          │ PASS   │  82.724291ms │
│ ti_opencti │ indicator   │ pipeline  │ test-phone-number.json                                                   │ PASS   │  58.983625ms │
│ ti_opencti │ indicator   │ pipeline  │ test-process.json                                                        │ PASS   │    60.1125ms │
│ ti_opencti │ indicator   │ pipeline  │ test-unknown.json                                                        │ PASS   │   63.07225ms │
│ ti_opencti │ indicator   │ pipeline  │ test-url.json                                                            │ PASS   │  61.340333ms │
│ ti_opencti │ indicator   │ pipeline  │ test-user-agent.json                                                     │ PASS   │  60.855917ms │
│ ti_opencti │ indicator   │ pipeline  │ test-windows-registry-key-no-hive.json                                   │ PASS   │  55.101125ms │
│ ti_opencti │ indicator   │ pipeline  │ test-windows-registry-key.json                                           │ PASS   │  66.494417ms │
│ ti_opencti │ indicator   │ pipeline  │ test-x509-certificate.json                                               │ PASS   │  62.706917ms │
╰────────────┴─────────────┴───────────┴──────────────────────────────────────────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: ti_opencti - END   ---
Done
```


