### PR TITLE
[System Auth journald] Add rename condition

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.5"
+  changes:
+    - description: Add condition on rename processor to avoid pipeline errors
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/14795
 - version: "2.5.4"
   changes:
     - description: Support ISO8601 date format in security data stream pipeline.

--- a/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/journald.yml
+++ b/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/journald.yml
@@ -30,6 +30,7 @@ processors:
             description: Leave the unmatched content in message.
             field: _temp.message
             target_field: message
+            if: ctx.message == null
   - append:
       tag: append_category_process
       field: event.category

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: system
 title: System
-version: "2.5.4"
+version: "2.5.5"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
As the rename processor in the mail pipeline of the system.auth dataset renames message to event.original IF event.original is empty, the on-failure processor should also only rename _temp.message to message if message is empty.
Otherwise there will be a error on the rename processor