### PR TITLE
[Cisco Duo] Add agentless deployment

### DIFF
--- a/packages/cisco_duo/_dev/build/docs/README.md
+++ b/packages/cisco_duo/_dev/build/docs/README.md
@@ -2,6 +2,11 @@
 
 The Cisco Duo integration collects and parses data from the [Cisco Duo Admin APIs](https://duo.com/docs/adminapi). The Duo Admin API provides programmatic access to the administrative functionality of Duo Security's two-factor authentication platform.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Compatibility
 
 This module has been tested against Cisco Duo `Core Authentication Service: D224.13` and `Admin Panel: D224.18`

--- a/packages/cisco_duo/changelog.yml
+++ b/packages/cisco_duo/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.7.0"
+  changes:
+    - description: Enable Agentless deployment.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.6.0"
   changes:
     - description: Add support for HTTP proxy configuration.

--- a/packages/cisco_duo/data_stream/activity/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_duo/data_stream/activity/elasticsearch/ingest_pipeline/default.yml
@@ -13,6 +13,11 @@ processors:
       ignore_missing: true
       if: ctx.event?.original == null
       tag: rename_event_original
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/cisco_duo/data_stream/admin/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_duo/data_stream/admin/elasticsearch/ingest_pipeline/default.yml
@@ -9,6 +9,11 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/cisco_duo/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_duo/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
@@ -9,6 +9,11 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/cisco_duo/data_stream/offline_enrollment/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_duo/data_stream/offline_enrollment/elasticsearch/ingest_pipeline/default.yml
@@ -9,6 +9,11 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/cisco_duo/data_stream/summary/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_duo/data_stream/summary/elasticsearch/ingest_pipeline/default.yml
@@ -12,6 +12,11 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/cisco_duo/data_stream/telephony/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_duo/data_stream/telephony/elasticsearch/ingest_pipeline/default.yml
@@ -7,6 +7,11 @@ processors:
   - set:
       field: event.kind
       value: event
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - rename:
       field: message
       target_field: event.original

--- a/packages/cisco_duo/data_stream/telephony_v2/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_duo/data_stream/telephony_v2/elasticsearch/ingest_pipeline/default.yml
@@ -12,6 +12,11 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/cisco_duo/data_stream/trust_monitor/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_duo/data_stream/trust_monitor/elasticsearch/ingest_pipeline/default.yml
@@ -13,6 +13,11 @@ processors:
       ignore_missing: true
       if: ctx.event?.original == null
       tag: rename_event_original
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/cisco_duo/docs/README.md
+++ b/packages/cisco_duo/docs/README.md
@@ -2,6 +2,11 @@
 
 The Cisco Duo integration collects and parses data from the [Cisco Duo Admin APIs](https://duo.com/docs/adminapi). The Duo Admin API provides programmatic access to the administrative functionality of Duo Security's two-factor authentication platform.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Compatibility
 
 This module has been tested against Cisco Duo `Core Authentication Service: D224.13` and `Admin Panel: D224.18`

--- a/packages/cisco_duo/manifest.yml
+++ b/packages/cisco_duo/manifest.yml
@@ -1,7 +1,7 @@
-format_version: "3.0.2"
+format_version: "3.4.0"
 name: cisco_duo
 title: Cisco Duo
-version: "2.6.0"
+version: "2.7.0"
 description: Collect logs from Cisco Duo with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - iam
 conditions:
   kibana:
-    version: "^8.13.0 || ^9.0.0"
+    version: "^8.16.0 || ^9.0.0"
 screenshots:
   - src: /img/dashboard-activity.png
     title: Cisco Duo trust monitor logs dashboard
@@ -48,6 +48,14 @@ policy_templates:
   - name: cisco_duo
     title: Cisco Duo logs
     description: Collect Cisco Duo logs
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        organization: security
+        division: engineering
+        team: security-service-integrations
     inputs:
       - type: httpjson
         vars:


### PR DESCRIPTION
## Proposed commit message

```
cisco_duo: add agentless deployment
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install the elastic package locally.
- Start the elastic stack using the elastic package.
- Move to integrations/packages/cisco_duo directory.
- Run the following command to run tests.

> elastic-package test -v

## Related issues

- Closes #15139

**Note**: These changes are not tested on serverless project.