### PR TITLE
[CI] Add exception for CODE_OF_CONDUCT.md file

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -19,6 +19,7 @@
         "^.github/ISSUE_TEMPLATE/",
         "^docs/",
         "^catalog-info.yaml$",
+        "^CODE_OF_CONDUCT.md$",
         "^.buildkite/pipeline.schedule-daily.yml$",
         "^.buildkite/pipeline.schedule-weekly.yml$",
         "^.buildkite/pipeline.backport.yml$",


### PR DESCRIPTION
## Proposed commit message

Avoid triggering Buildkite builds if the only file updated is `CODE_OF_CONDUCT.md` in a given pull request.

## Related issues

- Follows #15072
