### PR TITLE
[DGA] Correct Readme typo

### DIFF
--- a/packages/dga/changelog.yml
+++ b/packages/dga/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.2"
+  changes:
+    - description: Correct typo in Readme
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/14358
 - version: "2.3.1"
   changes:
     - description: Update platform support docs

--- a/packages/dga/changelog.yml
+++ b/packages/dga/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Correct typo in Readme
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/14358
+      link: https://github.com/elastic/integrations/pull/15165
 - version: "2.3.1"
   changes:
     - description: Update platform support docs

--- a/packages/dga/docs/README.md
+++ b/packages/dga/docs/README.md
@@ -31,7 +31,7 @@ For more detailed information refer to the following blogs:
         ]
       }
       ```
-    - If `logs-endpoint.events.process@custom` already exists, select the three dots next to it and choose **Edit**. Click **Add a processor**. Select **Pipeline** for Processor, enter `<VERSION>-ml_dga_ingest_pipeline` for name (replacing `<VERSION>` with the current package version), and check **Ignore missing pipeline** and **Ignore failures for this processor**. Select **Add Processor**.
+    - If `logs-endpoint.events.network@custom` already exists, select the three dots next to it and choose **Edit**. Click **Add a processor**. Select **Pipeline** for Processor, enter `<VERSION>-ml_dga_ingest_pipeline` for name (replacing `<VERSION>` with the current package version), and check **Ignore missing pipeline** and **Ignore failures for this processor**. Select **Add Processor**.
     - If using an Elastic Beat such as Packetbeat, add the ingest pipeline to it by adding a simple configuration [setting](https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html#pipelines-for-beats) to `packetbeat.yml` and skip to the **Add preconfigured anomaly detection jobs** section in these instructions.
 1. **Add the required mappings to the index or component template**: Go to **Stack Management > Index Management > Component Templates**. Templates that can be edited to add custom components will be marked with a `@custom` suffix. For instance, the custom component template for Elastic Defend network events is `logs-endpoint.events.network@custom`. **Note:** Do not attempt to edit the `@package` template.
     ![Component Templates](../img/component-templates.png)

--- a/packages/dga/manifest.yml
+++ b/packages/dga/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.4
 name: dga
 title: "Domain Generation Algorithm Detection"
-version: 2.3.1
+version: 2.3.2
 source:
   license: "Elastic-2.0"
 description: "ML solution package to detect domain generation algorithm (DGA) activity in your network data."


### PR DESCRIPTION
## Proposed commit message

Corrects a typo in the readme pointing to the wrong datastream

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- ~[ ] I have verified that all data streams collect metrics or logs.~
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- ~[ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~

## Author's Checklist

## How to test this PR locally

Tested with elastic-package

## Related issues

## Screenshots

<img width="757" height="71" alt="Screenshot 2025-09-04 at 10 09 30 AM" src="https://github.com/user-attachments/assets/a6eba31e-b20f-4fc1-ac93-641c0ba2c30a" />
