### PR TITLE
[amazon_security_lake] Parse JSON in `ocsf.resources.data`, `ocsf.unmapped`

### DIFF
--- a/packages/amazon_security_lake/changelog.yml
+++ b/packages/amazon_security_lake/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.7.1"
+  changes:
+    - description: Parse JSON in `ocsf.resources.data`, `ocsf.unmapped`.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/15167
 - version: "2.7.0"
   changes:
     - description: Tolerate non-ISO8601 formats in `time_dt`.

--- a/packages/amazon_security_lake/data_stream/event/_dev/test/pipeline/test-findings.log-expected.json
+++ b/packages/amazon_security_lake/data_stream/event/_dev/test/pipeline/test-findings.log-expected.json
@@ -338,20 +338,22 @@
                     "tenant_uid": "c6afe64e-4e4c-11ef-bcf9-0242ac110005",
                     "version": "1.1.0"
                 },
-                "resources": {
-                    "group": {
-                        "name": "resorts looking issues"
-                    },
-                    "namespace": "explain les collections",
-                    "owner": {
-                        "name": "Dude",
-                        "type": "Admin",
-                        "type_id": 2,
-                        "uid": "c6b0192a-4e4c-11ef-90f9-0242ac110005",
-                        "uid_alt": "recommendation highs equipped"
-                    },
-                    "type": "carb le multimedia"
-                },
+                "resources": [
+                    {
+                        "group": {
+                            "name": "resorts looking issues"
+                        },
+                        "namespace": "explain les collections",
+                        "owner": {
+                            "name": "Dude",
+                            "type": "Admin",
+                            "type_id": "2",
+                            "uid": "c6b0192a-4e4c-11ef-90f9-0242ac110005",
+                            "uid_alt": "recommendation highs equipped"
+                        },
+                        "type": "carb le multimedia"
+                    }
+                ],
                 "severity": "Fatal",
                 "severity_id": 6,
                 "start_time_dt": "2024-07-30T08:21:52.968Z",

--- a/packages/amazon_security_lake/data_stream/event/_dev/test/pipeline/test-findings.log-expected.json
+++ b/packages/amazon_security_lake/data_stream/event/_dev/test/pipeline/test-findings.log-expected.json
@@ -439,7 +439,10 @@
             "related": {
                 "user": [
                     "c6af496e-4e4c-11ef-b35b-0242ac110005",
-                    "Without"
+                    "Without",
+                    "c6b0192a-4e4c-11ef-90f9-0242ac110005",
+                    "Dude",
+                    "recommendation highs equipped"
                 ]
             },
             "tags": [

--- a/packages/amazon_security_lake/data_stream/event/_dev/test/pipeline/test-iam.log-expected.json
+++ b/packages/amazon_security_lake/data_stream/event/_dev/test/pipeline/test-iam.log-expected.json
@@ -392,20 +392,22 @@
                 "privileges": [
                     "returned funeral cave"
                 ],
-                "resources": {
-                    "group": {
-                        "name": "then nevada berkeley",
-                        "uid": "c52f1e24-6424-11ee-af05-0242ac110005"
-                    },
-                    "owner": {
-                        "domain": "regions gr dean",
-                        "email_addr": "Art@his.name",
-                        "name": "Fatty",
-                        "type": "forecast",
-                        "type_id": 99,
-                        "uid": "c52f060a-6424-11ee-b378-0242ac110005"
+                "resources": [
+                    {
+                        "group": {
+                            "name": "then nevada berkeley",
+                            "uid": "c52f1e24-6424-11ee-af05-0242ac110005"
+                        },
+                        "owner": {
+                            "domain": "regions gr dean",
+                            "email_addr": "Art@his.name",
+                            "name": "Fatty",
+                            "type": "forecast",
+                            "type_id": 99,
+                            "uid": "c52f060a-6424-11ee-b378-0242ac110005"
+                        }
                     }
-                },
+                ],
                 "severity": "Medium",
                 "severity_id": 3,
                 "start_time": "2023-10-06T08:45:58.000Z",

--- a/packages/amazon_security_lake/data_stream/event/_dev/test/pipeline/test-resources-data.log
+++ b/packages/amazon_security_lake/data_stream/event/_dev/test/pipeline/test-resources-data.log
@@ -1,0 +1,2 @@
+{"resource":{"data":"{\"key\":\"value\"}"}}
+{"resources":[{"data":"{\"key\":\"value\"}"}, {"data": {"objkey": "objvalue"}}, {"data": "notjsonstring"}, {"data": [1,2,"othertypes"]}] }

--- a/packages/amazon_security_lake/data_stream/event/_dev/test/pipeline/test-resources-data.log-expected.json
+++ b/packages/amazon_security_lake/data_stream/event/_dev/test/pipeline/test-resources-data.log-expected.json
@@ -1,0 +1,65 @@
+{
+    "expected": [
+        {
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "original": "{\"resource\":{\"data\":\"{\\\"key\\\":\\\"value\\\"}\"}}"
+            },
+            "ocsf": {
+                "resources": [
+                    {
+                        "data": {
+                            "key": "value"
+                        }
+                    }
+                ]
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ]
+        },
+        {
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "original": "{\"resources\":[{\"data\":\"{\\\"key\\\":\\\"value\\\"}\"}, {\"data\": {\"objkey\": \"objvalue\"}}, {\"data\": \"notjsonstring\"}, {\"data\": [1,2,\"othertypes\"]}] }"
+            },
+            "ocsf": {
+                "resources": [
+                    {
+                        "data": {
+                            "key": "value"
+                        }
+                    },
+                    {
+                        "data": {
+                            "objkey": "objvalue"
+                        }
+                    },
+                    {
+                        "data": {
+                            "value": "notjsonstring"
+                        }
+                    },
+                    {
+                        "data": {
+                            "value": [
+                                1,
+                                2,
+                                "othertypes"
+                            ]
+                        }
+                    }
+                ]
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ]
+        }
+    ]
+}

--- a/packages/amazon_security_lake/data_stream/event/_dev/test/pipeline/test-unmapped.log
+++ b/packages/amazon_security_lake/data_stream/event/_dev/test/pipeline/test-unmapped.log
@@ -1,0 +1,4 @@
+{"unmapped":"{\"key\":\"value\"}"}
+{"unmapped": {"objkey": "objvalue"}}
+{"unmapped": "notjsonstring"}
+{"unmapped": [1,2,"othertypes"]}

--- a/packages/amazon_security_lake/data_stream/event/_dev/test/pipeline/test-unmapped.log-expected.json
+++ b/packages/amazon_security_lake/data_stream/event/_dev/test/pipeline/test-unmapped.log-expected.json
@@ -1,0 +1,76 @@
+{
+    "expected": [
+        {
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "original": "{\"unmapped\":\"{\\\"key\\\":\\\"value\\\"}\"}"
+            },
+            "ocsf": {
+                "unmapped": {
+                    "key": "value"
+                }
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ]
+        },
+        {
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "original": "{\"unmapped\": {\"objkey\": \"objvalue\"}}"
+            },
+            "ocsf": {
+                "unmapped": {
+                    "objkey": "objvalue"
+                }
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ]
+        },
+        {
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "original": "{\"unmapped\": \"notjsonstring\"}"
+            },
+            "ocsf": {
+                "unmapped": {
+                    "value": "notjsonstring"
+                }
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ]
+        },
+        {
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "original": "{\"unmapped\": [1,2,\"othertypes\"]}"
+            },
+            "ocsf": {
+                "unmapped": {
+                    "value": [
+                        1,
+                        2,
+                        "othertypes"
+                    ]
+                }
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ]
+        }
+    ]
+}

--- a/packages/amazon_security_lake/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/amazon_security_lake/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -89,6 +89,27 @@ processors:
       tag: rename_resource_to_resources
       ignore_missing: true
       if: ctx.ocsf?.resources == null
+  - append:
+      field: ocsf.resources
+      value: []
+      if: ctx.ocsf?.resources != null
+  - foreach:
+      field: ocsf.resources
+      ignore_missing: true
+      processor:
+        pipeline:
+          name: '{{ IngestPipeline "pipeline_resources_data_json" }}'
+  - json:
+      field: ocsf.unmapped
+      if: ctx.ocsf?.unmapped instanceof String
+      on_failure:
+        - rename:
+            field: ocsf.unmapped
+            target_field: ocsf.unmapped.value
+  - rename:
+      field: ocsf.unmapped
+      target_field: ocsf.unmapped.value
+      if: ctx.ocsf?.unmapped != null && !(ctx.ocsf.unmapped instanceof Map)
   - rename:
       field: ocsf.finding_info_list
       target_field: ocsf.finding_info

--- a/packages/amazon_security_lake/data_stream/event/elasticsearch/ingest_pipeline/pipeline_resources_data_json.yml
+++ b/packages/amazon_security_lake/data_stream/event/elasticsearch/ingest_pipeline/pipeline_resources_data_json.yml
@@ -1,0 +1,22 @@
+---
+description: Pipeline for processing resources that may have a data string
+processors:
+  - rename:
+      field: _ingest._value
+      target_field: _tmp_resource
+  - json:
+      field: _tmp_resource.data
+      if: ctx._tmp_resource?.data instanceof String
+      on_failure:
+        - rename:
+            field: _tmp_resource.data
+            target_field: _tmp_resource.data.value
+  - rename:
+      field: _tmp_resource.data
+      target_field: _tmp_resource.data.value
+      if: ctx._tmp_resource?.data != null && !(ctx._tmp_resource.data instanceof Map)
+  - set:
+      field: _ingest._value
+      copy_from: _tmp_resource
+  - remove:
+      field: _tmp_resource

--- a/packages/amazon_security_lake/manifest.yml
+++ b/packages/amazon_security_lake/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: amazon_security_lake
 title: Amazon Security Lake
-version: "2.7.0"
+version: "2.7.1"
 description: Collect logs from Amazon Security Lake with Elastic Agent.
 type: integration
 categories: ["aws", "security"]


### PR DESCRIPTION
## Proposed commit message

```
[amazon_security_lake] Parse JSON in `ocsf.resources.data`, `ocsf.unmapped`

In case these fields are JSON strings rather than objects, parse them so
that they can be indexed as flattened.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Relates #14323
