### PR TITLE
[cel] Add options for OAuth2 user/password

### DIFF
--- a/packages/cel/agent/input/input.yml.hbs
+++ b/packages/cel/agent/input/input.yml.hbs
@@ -78,6 +78,12 @@ auth.oauth2.token_url: {{oauth_token_url}}
 {{#if oauth_provider}}
 auth.oauth2.provider: {{oauth_provider}}
 {{/if}}
+{{#if oauth_user}}
+auth.oauth2.user: {{escape_string oauth_user}}
+{{/if}}
+{{#if oauth_password}}
+auth.oauth2.password: {{escape_string oauth_password}}
+{{/if}}
 {{#if oauth_scopes}}
 auth.oauth2.scopes:
 {{#each oauth_scopes as |scope|}}

--- a/packages/cel/manifest.yml
+++ b/packages/cel/manifest.yml
@@ -281,6 +281,20 @@ policy_templates:
         show_user: false
         multi: false
         required: false
+      - name: oauth_user
+        type: text
+        title: OAuth2 User
+        description: The user used as part of the authentication flow. It is required for authentication - grant type password. It is only available for provider `default`.
+        show_user: false
+        multi: false
+        required: false
+      - name: oauth_password
+        type: password
+        title: OAuth2 Password
+        description: The password used as part of the authentication flow. It is required for authentication - grant type password. It is only available for provider `default`.
+        show_user: false
+        multi: false
+        required: false
       - name: oauth_scopes
         type: text
         title: OAuth2 Scopes


### PR DESCRIPTION
## Proposed commit message

```
[cel] Add options for OAuth2 user/password
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
