### PR TITLE
[httpjson] Add options for OAuth2 user/password

### DIFF
--- a/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
+++ b/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
@@ -28,6 +28,12 @@ auth.oauth2.token_url: {{oauth_token_url}}
 {{#if oauth_provider}}
 auth.oauth2.provider: {{oauth_provider}}
 {{/if}}
+{{#if oauth_user}}
+auth.oauth2.user: {{escape_string oauth_user}}
+{{/if}}
+{{#if oauth_password}}
+auth.oauth2.password: {{escape_string oauth_password}}
+{{/if}}
 {{#if oauth_scopes}}
 auth.oauth2.scopes:
 {{#each oauth_scopes as |scope i|}}

--- a/packages/httpjson/data_stream/generic/manifest.yml
+++ b/packages/httpjson/data_stream/generic/manifest.yml
@@ -217,6 +217,20 @@ streams:
         show_user: false
         multi: false
         required: false
+      - name: oauth_user
+        type: text
+        title: OAuth2 User
+        description: The user used as part of the authentication flow. It is required for authentication - grant type password. It is only available for provider `default`.
+        show_user: false
+        multi: false
+        required: false
+      - name: oauth_password
+        type: password
+        title: OAuth2 Password
+        description: The password used as part of the authentication flow. It is required for authentication - grant type password. It is only available for provider `default`.
+        show_user: false
+        multi: false
+        required: false
       - name: oauth_scopes
         type: text
         title: Oauth2 Scopes


### PR DESCRIPTION
## Proposed commit message

```
[httpjson] Add options for OAuth2 user/password
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 