### PR TITLE
remove `default_pipeline` instructions

### DIFF
--- a/packages/dga/changelog.yml
+++ b/packages/dga/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.3"
+  changes:
+    - description: Remove instructions to change the `default_pipeline` for an index
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/14358
 - version: "2.3.1"
   changes:
     - description: Update platform support docs

--- a/packages/dga/docs/README.md
+++ b/packages/dga/docs/README.md
@@ -60,14 +60,6 @@ For more detailed information refer to the following blogs:
       ```
     - If the `@custom` component template already exists, you will need to edit it to add mappings for data to be properly enriched. Click the three dots next to it and select **Edit**. 
     ![Component Templates](../img/component-templates-edit.png)
-    - On the index settings step, add the following. Be sure to change `<VERSION>` to the current package version.
-      ```
-      {
-        "index": {
-          "default_pipeline": "<VERSION>-ml_dga_ingest_pipeline"
-        }
-      }
-      ```
     - Proceed to the mappings step in the UI. Click **Add Field** at the bottom of the page and create an an `Object` field for `ml_is_dga`. 
     ![Component Templates](../img/field1.png)
     - Finally create two properties under `ml_is_dga`.

--- a/packages/pad/changelog.yml
+++ b/packages/pad/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.6.3"
+  changes:
+    - description: Remove instructions to change the `default_pipeline` for an index
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/14358
 - version: "0.6.2"
   changes:
     - description: Update transform mappings to use ECS

--- a/packages/pad/docs/README.md
+++ b/packages/pad/docs/README.md
@@ -54,14 +54,6 @@ The package transform supports data from Elastic Endpoint via Elastic Defend and
       ```
     - If the `@custom` component template already exists, you will need to edit it to add mappings for data to be properly enriched. Click the three dots next to it and select **Edit**. 
     ![Component Templates](../img/component-templates-edit.png)
-    - On the index settings step, add the following. Be sure to change `<VERSION>` to the current package version.
-      ```
-      {
-        "index": {
-          "default_pipeline": "<VERSION>-ml_pad_ingest_pipeline"
-        }
-      }
-      ```
     - Proceed to the mappings step in the UI. Click **Add Field** at the bottom of the page and create an `Object` field for `process`:
     ![Component Templates](../img/field1.png)
     - Create a property under Process for `command_line_entropy` of type `Double`. 

--- a/packages/problemchild/changelog.yml
+++ b/packages/problemchild/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.2"
+  changes:
+    - description: Remove instructions to change the `default_pipeline` for an index
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/14358
 - version: "2.4.1"
   changes:
     - description: Update platform support docs

--- a/packages/problemchild/docs/README.md
+++ b/packages/problemchild/docs/README.md
@@ -68,15 +68,7 @@ For more detailed information refer to the following blogs and webinar:
       }
       ```
     - If the `@custom` component template already exists, you will need to edit it to add mappings for data to be properly enriched. Click the three dots next to it and select **Edit**. 
-    ![Component Templates](../img/component-templates-edit.png)
-    - On the index settings step, add the following. Be sure to change `<VERSION>` to the current package version.
-      ```
-      {
-        "index": {
-          "default_pipeline": "<VERSION>-problem_child_ingest_pipeline"
-        }
-      }
-      ```
+    ![Component Templates](../img/component-templates-edit.png)åå
     - Proceed to the mappings step in the UI. Click **Add Field** at the bottom of the page and create a `blocklist_label` field of type `Long`:
     ![Component Templates](../img/field1.png)
     - Then create an `Object` field for `problemchild`. 


### PR DESCRIPTION
## Proposed commit message

Removes an unnecessary step from `dga`, `pad`, and `problemchild` packages that breaks upstream data streams `default_pipeline` assignments.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- ~[ ] I have verified that all data streams collect metrics or logs.~
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- ~[ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~

## How to test this PR locally

Tested with elastic-package.

## Related issues

 * https://github.com/elastic/security-ml/issues/879