### PR TITLE
[elastic_security] Add Support for Conditional Required Fields to Handle the Auth Type

### DIFF
--- a/packages/elastic_security/changelog.yml
+++ b/packages/elastic_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: Add support for conditional required fields to handle the authentication type.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.3.2"
   changes:
     - description: Generalize install instructions.

--- a/packages/elastic_security/data_stream/alert/manifest.yml
+++ b/packages/elastic_security/data_stream/alert/manifest.yml
@@ -5,11 +5,24 @@ streams:
     title: Elastic Security Alerts
     description: Collect Alerts from Elastic Security.
     template_path: cel.yml.hbs
+    required_vars:
+      api_key:
+        - name: auth_type
+          value: api_auth
+        - name: api_key
+      basic_auth:
+        - name: auth_type
+          value: basic_auth
+        - name: username
+        - name: password
+      bearer_auth:
+        - name: auth_type
+          value: bearer_auth
+        - name: bearer_token
     vars:
       - name: auth_type
         title: Authentication Type
         show_user: true
-        required: true
         multi: false
         type: select
         options:

--- a/packages/elastic_security/manifest.yml
+++ b/packages/elastic_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: elastic_security
 title: Elastic Security
-version: 0.3.2
+version: 0.4.0
 source:
   license: "Elastic-2.0"
 description: Collect logs from Elastic Instance with Elastic Agent.
@@ -11,7 +11,7 @@ categories:
   - siem
 conditions:
   kibana:
-    version: "^8.18.0 || ^9.0.0"
+    version: "^9.1.1"
   elastic:
     subscription: basic
 screenshots:


### PR DESCRIPTION
## Proposed commit message

```
elastic_security: add support for conditional required fields to handle the auth type.

This update introduces support for conditional required fields in the elastic_security module to better 
handle different authentication types.
Added logic to dynamically enforce required fields based on the selected auth_type.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install the elastic package locally.
- Start the elastic stack using the elastic package.
- Move to integrations/packages/elastic_security directory.
- Run the following command to run tests.

> elastic-package test -v

## Related issues

- Closes https://github.com/elastic/integrations/issues/14839

<img width="1115" height="506" alt="elastic_security-ss" src="https://github.com/user-attachments/assets/c3fe4c42-5536-4ac4-8380-e3e9e7c71531" />

