### PR TITLE
[Cloud Security Posture] Support Azure cloud connector

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,6 +1,7 @@
 # newer versions go on top
 # version map:
 # IMPORTANT: this map doesn't apply to serverless where package availability depends on the spec version https://github.com/elastic/kibana/blob/main/config/serverless.yml#L14-L15
+# 3.1.x - 9.2.x
 # 3.0.x - 9.1.x
 # 2.0.x - 8.19.x
 # 1.13.x - 8.18.x, 9.0.x
@@ -15,6 +16,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "3.1.0-preview01"
+  changes:
+    - description: Add Cloud Connectors variables for Azure CSPM input
+      type: enhancement
+      link:
 - version: "3.0.1"
   changes:
     - description: Save GCP Project ID as string

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -323,6 +323,13 @@ streams:
         - name: azure.credentials.client_certificate_path
         - name: azure.credentials.tenant_id
         - name: azure.credentials.client_certificate_password
+      single_account_cloud_connectors_federated_identity:
+        - name: azure.account_type
+          value: single-account
+        - name: azure.credentials.type
+          value: cloud_connectors_federated_identity
+        - name: azure.credentials.client_id
+        - name: azure.credentials.tenant_id
       single_account_arm_template:
         - name: azure.account_type
           value: single-account

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "3.0.1"
+version: "3.0.2-preview01"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"
@@ -11,7 +11,7 @@ categories:
   - cloudsecurity_cdr
 conditions:
   kibana:
-    version: "^9.1.0"
+    version: "^9.2.0"
   elastic:
     subscription: basic
     capabilities:

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -169,6 +169,15 @@ policy_templates:
             description: A URL to the ARM Template for creating a new deployment
             # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
             default: https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fcloudbeat%2F8.19%2Fdeploy%2Fazure%2FARM-for-ACCOUNT_TYPE.json
+          - name: arm_template_cloud_connector_url
+            type: text
+            title: ARM Cloud Connectors Template URL
+            multi: false
+            required: true
+            show_user: false
+            description: A URL to the ARM Template for creating a Cloud Connectors managed identity
+            # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
+            default: https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fcloudbeat%2Fmain%2Fdeploy%2Fazure%2FARM-for-cloud-connectors-ACCOUNT_TYPE.json
   - name: vuln_mgmt
     title: Cloud Native Vulnerability Management (CNVM)
     description: Scan for cloud workload vulnerabilities


### PR DESCRIPTION
## Proposed commit message

Cloud Security Posture: Azure
Add support for a new credentials type `cloud_connectors_federated_identity`.
This method expects:
`ClientID`
`TenantID`

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Resolves: https://github.com/elastic/security-team/issues/12605

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
