### PR TITLE
[Cloud Asset Inventory] Cloud Connectors Align to CSPM Azure

### DIFF
--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/manifest.yml
@@ -179,11 +179,11 @@ streams:
         - name: azure.credentials.client_certificate_path
         - name: azure.credentials.tenant_id
         - name: azure.credentials.client_certificate_password
-      single_account_cloud_connectors_federated_identity:
+      single_account_cloud_connectors:
         - name: azure.account_type
           value: single-account
         - name: azure.credentials.type
-          value: cloud_connectors_federated_identity
+          value: cloud_connectors
         - name: azure.credentials.client_id
         - name: azure.credentials.tenant_id
       single_account_arm_template:
@@ -242,7 +242,7 @@ streams:
           - text: Service Principal with Client Certificate
             value: service_principal_with_client_certificate
           - text: Cloud Connectors Federated Identity
-            value: cloud_connectors_federated_identity
+            value: cloud_connectors
       - name: azure.credentials.client_id
         type: text
         title: Client ID

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -11,7 +11,7 @@ categories:
   - cloudsecurity_cdr
 conditions:
   kibana:
-    version: ">=9.1.0"
+    version: ">=9.2.0"
   elastic:
     subscription: basic
     capabilities:
@@ -90,7 +90,7 @@ policy_templates:
             description: A URL to the ARM Template for creating a new deployment
             # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
             default: https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fcloudbeat%2F9.1%2Fdeploy%2Fasset-inventory-arm%2FARM-for-ACCOUNT_TYPE.json
-          - name: arm_template_cloud_connector_url
+          - name: arm_template_cloud_connectors_url
             type: text
             title: ARM Cloud Connectors Template URL
             multi: false


### PR DESCRIPTION
## Proposed commit message

Align to CSPM PR that adds support to Cloud Connectors Azure.
- Related: https://github.com/elastic/integrations/pull/15255

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
