### PR TITLE
[Backport] Change stack version requirements due to the breaking changes

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,10 +1,5 @@
 # newer versions go on top
 
-- version: "2.5.2"
-  changes:
-    - description: Update `queue.filled.pct.events` to `queue.filled.pct` metric name 
-      type: enhancement
-      link: "https://github.com/elastic/integrations/pull/15244"
 - version: "2.5.1"
   changes:
     - description: Change Agent metrics dashboard memory source fields

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,5 +1,15 @@
 # newer versions go on top
 
+- version: "2.5.3"
+  changes:
+    - description: Revert metric name changes, so the package is still usable on stacks < 8.15.0
+      type: bugfix
+      link: "https://github.com/elastic/integrations/pull/15273"
+- version: "2.5.2"
+  changes:
+    - description: Update `queue.filled.pct.events` to `queue.filled.pct` metric name
+      type: enhancement
+      link: "https://github.com/elastic/integrations/pull/15244"
 - version: "2.5.1"
   changes:
     - description: Change Agent metrics dashboard memory source fields

--- a/packages/elastic_agent/data_stream/auditbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_logs/fields/fields.yml
@@ -71,7 +71,7 @@
       type: long
       metric_type: counter
       description: Maximum number of events in a queue
-    - name: queue.filled.pct
+    - name: queue.filled.pct.events
       type: float
       metric_type: gauge
       description: Maximum number of events in a queue

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
@@ -72,7 +72,7 @@
       type: long
       metric_type: counter
       description: Maximum number of events in a queue
-    - name: queue.filled.pct
+    - name: queue.filled.pct.events
       type: float
       metric_type: gauge
       description: Maximum number of events in a queue

--- a/packages/elastic_agent/data_stream/filebeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_logs/fields/fields.yml
@@ -71,7 +71,7 @@
       type: long
       metric_type: counter
       description: Maximum number of events in a queue
-    - name: queue.filled.pct
+    - name: queue.filled.pct.events
       type: float
       metric_type: gauge
       description: Maximum number of events in a queue

--- a/packages/elastic_agent/data_stream/heartbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_logs/fields/fields.yml
@@ -74,7 +74,7 @@
       type: long
       metric_type: counter
       description: Maximum number of events in a queue
-    - name: queue.filled.pct
+    - name: queue.filled.pct.events
       type: float
       metric_type: gauge
       description: Maximum number of events in a queue

--- a/packages/elastic_agent/data_stream/metricbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_logs/fields/fields.yml
@@ -71,7 +71,7 @@
       type: long
       metric_type: counter
       description: Maximum number of events in a queue
-    - name: queue.filled.pct
+    - name: queue.filled.pct.events
       type: float
       metric_type: gauge
       description: Maximum number of events in a queue

--- a/packages/elastic_agent/data_stream/osquerybeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_logs/fields/fields.yml
@@ -71,7 +71,7 @@
       type: long
       metric_type: counter
       description: Maximum number of events in a queue
-    - name: queue.filled.pct
+    - name: queue.filled.pct.events
       type: float
       metric_type: gauge
       description: Maximum number of events in a queue

--- a/packages/elastic_agent/data_stream/packetbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_logs/fields/fields.yml
@@ -71,7 +71,7 @@
       type: long
       metric_type: counter
       description: Maximum number of events in a queue
-    - name: queue.filled.pct
+    - name: queue.filled.pct.events
       type: float
       metric_type: gauge
       description: Maximum number of events in a queue

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 2.5.1
+version: 2.5.3
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 3.1.4

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 2.5.2
+version: 2.5.1
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 3.1.4


### PR DESCRIPTION
## Proposed commit message

The metric name `queue.filled.pct.events` was changed to `queue.filled.pct` in v8.15.0 by this commit https://github.com/elastic/beats/commit/f8aedce388312b782a19b053508541a0901dbf18 (PR https://github.com/elastic/beats/pull/39774).

We've fixed the metric name in the package fields by this PR https://github.com/elastic/integrations/pull/15244

However, the minimal stack version requirements remained unchanged. This would break any customers running on stack versions 8.11.2 – 8.14.3 and upgrading their Elastic Agent integration to 2.5.2.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/pull/15268
