### PR TITLE
Prefer set with copy_from

### DIFF
--- a/packages/aws/data_stream/vpcflow/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/vpcflow/elasticsearch/ingest_pipeline/default.yml
@@ -284,11 +284,11 @@ processors:
   - set:
       if: ctx.aws?.vpcflow?.account_id != null
       field: cloud.account.id
-      value: '{{aws.vpcflow.account_id}}'
+      copy_from: aws.vpcflow.account_id
   - set:
       if: 'ctx?.aws?.vpcflow?.instance_id != null && ctx.aws.vpcflow.instance_id != "-"'
       field: cloud.instance.id
-      value: '{{aws.vpcflow.instance_id}}'
+      copy_from: aws.vpcflow.instance_id
   - convert:
      field: aws.vpcflow.packets_lost_no_route
      type: long

--- a/packages/gcp/data_stream/vpcflow/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/vpcflow/elasticsearch/ingest_pipeline/default.yml
@@ -197,12 +197,12 @@ processors:
         }
   - set:
       field: source.ip
-      value: "{{source.address}}"
+      copy_from: source.address
       ignore_failure: true
       if: ctx?.source?.address != null
   - set:
       field: destination.ip
-      value: "{{destination.address}}"
+      copy_from: destination.address
       ignore_failure: true
       if: ctx?.destination?.address != null
   - convert:

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
@@ -15,7 +15,7 @@ processors:
       value: firewall
   - set:
       field: event.timezone
-      value: '{{{_conf.tz_offset}}}'
+      copy_from: _conf.tz_offset
       if: ctx._conf?.tz_offset instanceof String && !ctx._conf.tz_offset.equalsIgnoreCase('local')
 
 # Collects the first few parts of the message to be used for conditional parsing later
@@ -310,7 +310,7 @@ processors:
   - set:
       if: ctx.panw?.panos?.parent_session?.start_time != null
       field: session.start_time
-      value: '{{{panw.panos.parent_session.start_time}}}'
+      copy_from: panw.panos.parent_session.start_time
 
 # Remove NAT fields when translation was not done.
   - remove:
@@ -1524,7 +1524,7 @@ processors:
       if: ctx.panw?.panos?.threat?.id == '9999'
   - set:
       field: rule.name
-      value: '{{{panw.panos.ruleset}}}'
+      copy_from: panw.panos.ruleset
       ignore_empty_value: true
       if: ctx.rule?.name == null
   - append:


### PR DESCRIPTION
## Proposed commit message

Prefer the `copy_from` option of the `set` processor for high certain high volume integrations.

When the field to be copied is already just a string, and so the set processor with mustache isn't being used for the side effect of converting to a string, then it's quite a bit faster to use `copy_from` rather than `value` (with mustache templating).

For example, in a large cluster that I was looking at a few minutes ago, the `set` most expensive single `set` processor is this one:

```
{
  "set": {
    "field": "cloud.account.id",
    "if": "ctx.aws?.vpcflow?.account_id != null",
    "value": "{{aws.vpcflow.account_id}}"
  }
}
```

It's taking 2.8 microseconds per doc, as compared to the average of all set processor invocations for the same pipeline which is only .6 microseconds per doc. The cluster in question is processing billions and billions of documents per hour, though, so microseconds add up (and this particularly-expensive set processor is the eighth-most expensive processor for the entire pipeline).

-----

I'm marking this a draft because I'm not 100% absolutely sure about my changes or the correct process for PRs on this repo.