### PR TITLE
[Elastic Agent] Remove otelconsumer from Agent metrics dashboard

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.2"
+  changes:
+    - description: Remove otelconsumer from Agent metrics dashboard
+      type: bugfix
+      link: "https://github.com/elastic/integrations/pull/9999"
 - version: "2.2.1"
   changes:
     - description: Remove hardcoded agent.name filter

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -1793,7 +1793,6 @@
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
                                     "layers": {
                                         "99f20cec-1684-4175-b773-02c3638f2a32": {
                                             "columnOrder": [
@@ -1803,7 +1802,11 @@
                                                 "36f3abb0-7261-43e6-bc2f-7ad492094054X0",
                                                 "36f3abb0-7261-43e6-bc2f-7ad492094054X1",
                                                 "36f3abb0-7261-43e6-bc2f-7ad492094054X2",
-                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X3"
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X3",
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X4",
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X5",
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X6",
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X7"
                                             ],
                                             "columns": {
                                                 "36f3abb0-7261-43e6-bc2f-7ad492094054": {
@@ -1820,11 +1823,11 @@
                                                                 "decimals": 0
                                                             }
                                                         },
-                                                        "formula": "pick_max(differences(max(system.process.cpu.total.time.ms))/interval(),0)\n",
+                                                        "formula": "pick_max(\n  pick_max(\n    differences(\n      defaults(max(system.process.cpu.total.time.ms),0)\n      )/interval(),\n    0\n  ),\n  pick_max(\n    differences(\n      defaults(max(system.process.cpu.total.pct),0)),\n    0\n  )\n)",
                                                         "isFormulaBroken": false
                                                     },
                                                     "references": [
-                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X3"
+                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X7"
                                                     ],
                                                     "scale": "ratio"
                                                 },
@@ -1845,7 +1848,22 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Part of  CPU Usage",
-                                                    "operationType": "differences",
+                                                    "operationType": "math",
+                                                    "params": {
+                                                        "tinymathAst": {
+                                                            "args": [
+                                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X0",
+                                                                0
+                                                            ],
+                                                            "location": {
+                                                                "max": 101,
+                                                                "min": 45
+                                                            },
+                                                            "name": "defaults",
+                                                            "text": "defaults(max(system.process.cpu.total.time.ms),0)\n      ",
+                                                            "type": "function"
+                                                        }
+                                                    },
                                                     "references": [
                                                         "36f3abb0-7261-43e6-bc2f-7ad492094054X0"
                                                     ],
@@ -1856,11 +1874,71 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Part of  CPU Usage",
+                                                    "operationType": "differences",
+                                                    "references": [
+                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X1"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X3": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of  CPU Usage",
                                                     "operationType": "interval",
                                                     "references": [],
                                                     "scale": "ratio"
                                                 },
-                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X3": {
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X4": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of  CPU Usage",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "system.process.cpu.total.pct"
+                                                },
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X5": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of  CPU Usage",
+                                                    "operationType": "math",
+                                                    "params": {
+                                                        "tinymathAst": {
+                                                            "args": [
+                                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X4",
+                                                                0
+                                                            ],
+                                                            "location": {
+                                                                "max": 206,
+                                                                "min": 161
+                                                            },
+                                                            "name": "defaults",
+                                                            "text": "defaults(max(system.process.cpu.total.pct),0)",
+                                                            "type": "function"
+                                                        }
+                                                    },
+                                                    "references": [
+                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X4"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X6": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of  CPU Usage",
+                                                    "operationType": "differences",
+                                                    "references": [
+                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X5"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X7": {
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
@@ -1871,31 +1949,56 @@
                                                             "args": [
                                                                 {
                                                                     "args": [
-                                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X1",
-                                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X2"
+                                                                        {
+                                                                            "args": [
+                                                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X2",
+                                                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X3"
+                                                                            ],
+                                                                            "location": {
+                                                                                "max": 113,
+                                                                                "min": 26
+                                                                            },
+                                                                            "name": "divide",
+                                                                            "text": "differences(\n      defaults(max(system.process.cpu.total.time.ms),0)\n      )/interval()",
+                                                                            "type": "function"
+                                                                        },
+                                                                        0
                                                                     ],
                                                                     "location": {
-                                                                        "max": 70,
-                                                                        "min": 9
+                                                                        "max": 124,
+                                                                        "min": 12
                                                                     },
-                                                                    "name": "divide",
-                                                                    "text": "differences(max(system.process.cpu.total.time.ms))/interval()",
+                                                                    "name": "pick_max",
+                                                                    "text": "pick_max(\n    differences(\n      defaults(max(system.process.cpu.total.time.ms),0)\n      )/interval(),\n    0\n  )",
                                                                     "type": "function"
                                                                 },
-                                                                0
+                                                                {
+                                                                    "args": [
+                                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X6",
+                                                                        0
+                                                                    ],
+                                                                    "location": {
+                                                                        "max": 219,
+                                                                        "min": 128
+                                                                    },
+                                                                    "name": "pick_max",
+                                                                    "text": "pick_max(\n    differences(\n      defaults(max(system.process.cpu.total.pct),0)),\n    0\n  )\n",
+                                                                    "type": "function"
+                                                                }
                                                             ],
                                                             "location": {
-                                                                "max": 74,
+                                                                "max": 220,
                                                                 "min": 0
                                                             },
                                                             "name": "pick_max",
-                                                            "text": "pick_max(differences(max(system.process.cpu.total.time.ms))/interval(),0)\n",
+                                                            "text": "pick_max(\n  pick_max(\n    differences(\n      defaults(max(system.process.cpu.total.time.ms),0)\n      )/interval(),\n    0\n  ),\n  pick_max(\n    differences(\n      defaults(max(system.process.cpu.total.pct),0)),\n    0\n  )\n)",
                                                             "type": "function"
                                                         }
                                                     },
                                                     "references": [
-                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X1",
-                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X2"
+                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X2",
+                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X3",
+                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X6"
                                                     ],
                                                     "scale": "ratio"
                                                 },
@@ -1961,17 +2064,34 @@
                                         "alias": null,
                                         "disabled": false,
                                         "field": "data_stream.dataset",
-                                        "index": "a56d2368-a048-4c48-a261-e878eb2690c8",
+                                        "index": "7f71ff88-5a2c-435c-87ab-13edec063180",
                                         "key": "data_stream.dataset",
                                         "negate": false,
-                                        "params": {
-                                            "query": "elastic_agent.elastic_agent"
-                                        },
-                                        "type": "phrase"
+                                        "params": [
+                                            "elastic_agent.elastic_agent",
+                                            "elastic_agent.endpoint_security"
+                                        ],
+                                        "type": "phrases",
+                                        "value": [
+                                            "elastic_agent.elastic_agent",
+                                            "elastic_agent.endpoint_security"
+                                        ]
                                     },
                                     "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "elastic_agent.elastic_agent"
+                                        "bool": {
+                                            "minimum_should_match": 1,
+                                            "should": [
+                                                {
+                                                    "match_phrase": {
+                                                        "data_stream.dataset": "elastic_agent.elastic_agent"
+                                                    }
+                                                },
+                                                {
+                                                    "match_phrase": {
+                                                        "data_stream.dataset": "elastic_agent.endpoint_security"
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 }
@@ -2362,7 +2482,7 @@
                                                         "size": 10
                                                     },
                                                     "scale": "ordinal",
-                                                    "sourceField": "elastic_agent.process"
+                                                    "sourceField": "component.id"
                                                 },
                                                 "401c5798-78b4-40ea-8ff7-debce9f4dbeb": {
                                                     "customLabel": true,
@@ -3074,6 +3194,11 @@
                                 "id": "metrics-*",
                                 "name": "indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
                                 "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "89810bf8-aef3-4065-828d-2929e7f91db4",
+                                "type": "index-pattern"
                             }
                         ],
                         "state": {
@@ -3288,6 +3413,28 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
+                                        "field": "beat.stats.libbeat.output.type",
+                                        "index": "89810bf8-aef3-4065-828d-2929e7f91db4",
+                                        "key": "beat.stats.libbeat.output.type",
+                                        "negate": true,
+                                        "params": {
+                                            "query": "otelconsumer"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "beat.stats.libbeat.output.type": "otelconsumer"
+                                        }
+                                    }
+                                },
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
                                         "index": "b7328148-f1b1-4fb5-9cfc-8f8d66f10a8c",
                                         "key": "beat.stats.libbeat.output.type",
                                         "negate": true,
@@ -3455,6 +3602,11 @@
                                 "id": "metrics-*",
                                 "name": "indexpattern-datasource-layer-99f20cec-1684-4175-b773-02c3638f2a32",
                                 "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "bc8ad325-8dac-4bb0-8673-21dcdec88caa",
+                                "type": "index-pattern"
                             }
                         ],
                         "state": {
@@ -3470,7 +3622,11 @@
                                                 "36f3abb0-7261-43e6-bc2f-7ad492094054X0",
                                                 "36f3abb0-7261-43e6-bc2f-7ad492094054X1",
                                                 "36f3abb0-7261-43e6-bc2f-7ad492094054X2",
-                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X3"
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X3",
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X4",
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X5",
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X6",
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X7"
                                             ],
                                             "columns": {
                                                 "36f3abb0-7261-43e6-bc2f-7ad492094054": {
@@ -3486,11 +3642,11 @@
                                                                 "decimals": 2
                                                             }
                                                         },
-                                                        "formula": "pick_max(differences(max(system.process.cpu.total.time.ms))/interval(),0)",
+                                                        "formula": "pick_max(\n  pick_max(\n    differences(\n      defaults(max(system.process.cpu.total.time.ms),0)\n      )/interval(),\n    0\n  ),\n  pick_max(\n    differences(\n      defaults(max(system.process.cpu.total.pct),0)),\n    0\n  )\n)",
                                                         "isFormulaBroken": false
                                                     },
                                                     "references": [
-                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X3"
+                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X7"
                                                     ],
                                                     "scale": "ratio"
                                                 },
@@ -3511,7 +3667,22 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Part of CPU Usage",
-                                                    "operationType": "differences",
+                                                    "operationType": "math",
+                                                    "params": {
+                                                        "tinymathAst": {
+                                                            "args": [
+                                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X0",
+                                                                0
+                                                            ],
+                                                            "location": {
+                                                                "max": 101,
+                                                                "min": 45
+                                                            },
+                                                            "name": "defaults",
+                                                            "text": "defaults(max(system.process.cpu.total.time.ms),0)\n      ",
+                                                            "type": "function"
+                                                        }
+                                                    },
                                                     "references": [
                                                         "36f3abb0-7261-43e6-bc2f-7ad492094054X0"
                                                     ],
@@ -3522,11 +3693,71 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Part of CPU Usage",
+                                                    "operationType": "differences",
+                                                    "references": [
+                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X1"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X3": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of CPU Usage",
                                                     "operationType": "interval",
                                                     "references": [],
                                                     "scale": "ratio"
                                                 },
-                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X3": {
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X4": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of CPU Usage",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "system.process.cpu.total.pct"
+                                                },
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X5": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of CPU Usage",
+                                                    "operationType": "math",
+                                                    "params": {
+                                                        "tinymathAst": {
+                                                            "args": [
+                                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X4",
+                                                                0
+                                                            ],
+                                                            "location": {
+                                                                "max": 206,
+                                                                "min": 161
+                                                            },
+                                                            "name": "defaults",
+                                                            "text": "defaults(max(system.process.cpu.total.pct),0)",
+                                                            "type": "function"
+                                                        }
+                                                    },
+                                                    "references": [
+                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X4"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X6": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of CPU Usage",
+                                                    "operationType": "differences",
+                                                    "references": [
+                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X5"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X7": {
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
@@ -3537,31 +3768,56 @@
                                                             "args": [
                                                                 {
                                                                     "args": [
-                                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X1",
-                                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X2"
+                                                                        {
+                                                                            "args": [
+                                                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X2",
+                                                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X3"
+                                                                            ],
+                                                                            "location": {
+                                                                                "max": 113,
+                                                                                "min": 26
+                                                                            },
+                                                                            "name": "divide",
+                                                                            "text": "differences(\n      defaults(max(system.process.cpu.total.time.ms),0)\n      )/interval()",
+                                                                            "type": "function"
+                                                                        },
+                                                                        0
                                                                     ],
                                                                     "location": {
-                                                                        "max": 70,
-                                                                        "min": 9
+                                                                        "max": 124,
+                                                                        "min": 12
                                                                     },
-                                                                    "name": "divide",
-                                                                    "text": "differences(max(system.process.cpu.total.time.ms))/interval()",
+                                                                    "name": "pick_max",
+                                                                    "text": "pick_max(\n    differences(\n      defaults(max(system.process.cpu.total.time.ms),0)\n      )/interval(),\n    0\n  )",
                                                                     "type": "function"
                                                                 },
-                                                                0
+                                                                {
+                                                                    "args": [
+                                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X6",
+                                                                        0
+                                                                    ],
+                                                                    "location": {
+                                                                        "max": 219,
+                                                                        "min": 128
+                                                                    },
+                                                                    "name": "pick_max",
+                                                                    "text": "pick_max(\n    differences(\n      defaults(max(system.process.cpu.total.pct),0)),\n    0\n  )\n",
+                                                                    "type": "function"
+                                                                }
                                                             ],
                                                             "location": {
-                                                                "max": 73,
+                                                                "max": 220,
                                                                 "min": 0
                                                             },
                                                             "name": "pick_max",
-                                                            "text": "pick_max(differences(max(system.process.cpu.total.time.ms))/interval(),0)",
+                                                            "text": "pick_max(\n  pick_max(\n    differences(\n      defaults(max(system.process.cpu.total.time.ms),0)\n      )/interval(),\n    0\n  ),\n  pick_max(\n    differences(\n      defaults(max(system.process.cpu.total.pct),0)),\n    0\n  )\n)",
                                                             "type": "function"
                                                         }
                                                     },
                                                     "references": [
-                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X1",
-                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X2"
+                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X2",
+                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X3",
+                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X6"
                                                     ],
                                                     "scale": "ratio"
                                                 },
@@ -3627,17 +3883,34 @@
                                         "alias": null,
                                         "disabled": false,
                                         "field": "data_stream.dataset",
-                                        "index": "a56d2368-a048-4c48-a261-e878eb2690c8",
+                                        "index": "bc8ad325-8dac-4bb0-8673-21dcdec88caa",
                                         "key": "data_stream.dataset",
                                         "negate": false,
-                                        "params": {
-                                            "query": "elastic_agent.elastic_agent"
-                                        },
-                                        "type": "phrase"
+                                        "params": [
+                                            "elastic_agent.elastic_agent",
+                                            "elastic_agent.endpoint_security"
+                                        ],
+                                        "type": "phrases",
+                                        "value": [
+                                            "elastic_agent.elastic_agent",
+                                            "elastic_agent.endpoint_security"
+                                        ]
                                     },
                                     "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "elastic_agent.elastic_agent"
+                                        "bool": {
+                                            "minimum_should_match": 1,
+                                            "should": [
+                                                {
+                                                    "match_phrase": {
+                                                        "data_stream.dataset": "elastic_agent.elastic_agent"
+                                                    }
+                                                },
+                                                {
+                                                    "match_phrase": {
+                                                        "data_stream.dataset": "elastic_agent.endpoint_security"
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 }
@@ -3734,7 +4007,7 @@
                                                 "30880bcc-bda9-4cb3-b86c-e1ec9f01f4a5": {
                                                     "dataType": "string",
                                                     "isBucketed": true,
-                                                    "label": "Top 10 values of elastic_agent.process",
+                                                    "label": "Top 10 values of component.id",
                                                     "operationType": "terms",
                                                     "params": {
                                                         "exclude": [],
@@ -3754,7 +4027,7 @@
                                                         "size": 10
                                                     },
                                                     "scale": "ordinal",
-                                                    "sourceField": "elastic_agent.process"
+                                                    "sourceField": "component.id"
                                                 },
                                                 "401c5798-78b4-40ea-8ff7-debce9f4dbeb": {
                                                     "customLabel": true,
@@ -6838,7 +7111,7 @@
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "Part of  ",
+                                                    "label": "Part of  Memory",
                                                     "operationType": "max",
                                                     "params": {
                                                         "emptyAsNull": false
@@ -6938,6 +7211,9 @@
                                 "legend": {
                                     "isVisible": true,
                                     "legendSize": "large",
+                                    "legendStats": [
+                                        "currentAndLastValue"
+                                    ],
                                     "position": "right",
                                     "shouldTruncate": true,
                                     "showSingleSeries": true
@@ -6950,7 +7226,6 @@
                                 },
                                 "title": "Empty XY chart",
                                 "valueLabels": "hide",
-                                "valuesInLegend": true,
                                 "yRightTitle": ""
                             }
                         },
@@ -7193,15 +7468,9 @@
         "version": 2
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2025-02-20T19:34:02.253Z",
+    "created_at": "2025-09-10T21:00:16.226Z",
     "id": "elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395",
-    "managed": false,
     "references": [
-        {
-            "id": "metrics-*",
-            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-            "type": "index-pattern"
-        },
         {
             "id": "metrics-*",
             "name": "ca491918-8011-4c39-b855-e13ae7b9b581:indexpattern-datasource-layer-2be7d580-9fee-48d0-ab61-4ba934a5dbe9",
@@ -7329,7 +7598,17 @@
         },
         {
             "id": "metrics-*",
+            "name": "d87ea2e6-8959-4b66-b61d-d72386b038ed:89810bf8-aef3-4065-828d-2929e7f91db4",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
             "name": "e8ddcef1-152d-4e3e-8022-ee7175b44b8d:indexpattern-datasource-layer-99f20cec-1684-4175-b773-02c3638f2a32",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "e8ddcef1-152d-4e3e-8022-ee7175b44b8d:bc8ad325-8dac-4bb0-8673-21dcdec88caa",
             "type": "index-pattern"
         },
         {

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 2.2.1
+version: 2.2.2
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 3.1.4


### PR DESCRIPTION
## Proposed commit message

See title

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

~~## Author's Checklist~~


## How to test this PR locally
1. Start a stack with `elastic-package`
    ```
    elastic-package stack up -v -d --version=9.2.0-SNAPSHOT
    ```
2. Create a Policy and deploy an Elastic Agent 9.2.0-SNAPSHOT
3. Go to Dev Tools and Otel for internal metrics
    ```
    PUT kbn:/api/fleet/agent_policies/<Your policy ID>
    {
       "name": "Otel Metrics",
        "namespace": "default",
        "overrides": {
             "agent": {
                  "monitoring": {
                    "_runtime_experimental": "otel"
                  }
                }
        }
    }
    ```
4. Ensure `otelconsumer` is in the metrics
  1. Go to the "[Elastic Agent] Agent metrics" dashboard
  2. Look for the "[Elastic Agent] Events with issues /s" widget
  3. You should see the otelconsumer there (see screenshots)
5. Build and instal the `elastic_agent` package
    ```
    cd /packages/elastic_agent
    elastic-package install
    ```
6. Refresh the dashboard, otelconsumer should have desappeared (see screenshot)

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/9036


## Screenshots

**Before this PR:**
<img width="1508" height="423" alt="Screenshot_2025-09-10_17-14-17" src="https://github.com/user-attachments/assets/a65092d3-9f55-43c8-9bc0-dddab09becbf" />

**After this PR:**
<img width="1510" height="427" alt="Screenshot_2025-09-10_17-06-35" src="https://github.com/user-attachments/assets/e0acd4cd-d65a-46e5-aead-ff222c47ce98" />


