### PR TITLE
[Cloud Security] update wiz ingest pipeline to set vulnerability.title field

### DIFF
--- a/packages/wiz/changelog.yml
+++ b/packages/wiz/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "3.8.0-preview"
+- version: "3.8.0"
   changes:
     - description: Add title to vulnerability mappings and ingest pipeline for better support in CDR.
       type: enhancement

--- a/packages/wiz/changelog.yml
+++ b/packages/wiz/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "3.8.0-preview"
   changes:
-    - description: Add vulnerability title field in ingest pipeline.
+    - description: Add title to vulnerability mappings and ingest pipeline for better support in CDR.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/14664
+      link: https://github.com/elastic/integrations/pull/15323
 - version: "3.7.0"
   changes:
     - description: Add configurable toggle to include all vulnerability statuses in the vulnerability dataset.

--- a/packages/wiz/changelog.yml
+++ b/packages/wiz/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.8.0-preview"
+  changes:
+    - description: Add vulnerability title field in ingest pipeline.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/14664
 - version: "3.7.0"
   changes:
     - description: Add configurable toggle to include all vulnerability statuses in the vulnerability dataset.

--- a/packages/wiz/data_stream/defend/_dev/test/pipeline/test-defend.json-expected.json
+++ b/packages/wiz/data_stream/defend/_dev/test/pipeline/test-defend.json-expected.json
@@ -70,16 +70,16 @@
                     }
                 },
                 "geo": {
-                    "city_name": "Windsor",
+                    "city_name": "London",
                     "continent_name": "Europe",
                     "country_iso_code": "GB",
                     "country_name": "United Kingdom",
                     "location": {
-                        "lat": 51.4856,
-                        "lon": -0.6034
+                        "lat": 51.5142,
+                        "lon": -0.0931
                     },
-                    "region_iso_code": "GB-WNM",
-                    "region_name": "Windsor and Maidenhead"
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
                 }
             },
             "tags": [

--- a/packages/wiz/data_stream/defend/_dev/test/pipeline/test-defend.json-expected.json
+++ b/packages/wiz/data_stream/defend/_dev/test/pipeline/test-defend.json-expected.json
@@ -70,16 +70,16 @@
                     }
                 },
                 "geo": {
-                    "city_name": "London",
+                    "city_name": "Windsor",
                     "continent_name": "Europe",
                     "country_iso_code": "GB",
                     "country_name": "United Kingdom",
                     "location": {
-                        "lat": 51.5142,
-                        "lon": -0.0931
+                        "lat": 51.4856,
+                        "lon": -0.6034
                     },
-                    "region_iso_code": "GB-ENG",
-                    "region_name": "England"
+                    "region_iso_code": "GB-WNM",
+                    "region_name": "Windsor and Maidenhead"
                 }
             },
             "tags": [

--- a/packages/wiz/data_stream/vulnerability/_dev/test/pipeline/test-vulnerability.log-expected.json
+++ b/packages/wiz/data_stream/vulnerability/_dev/test/pipeline/test-vulnerability.log-expected.json
@@ -68,7 +68,8 @@
                 "score": {
                     "base": 5.5
                 },
-                "severity": "MEDIUM"
+                "severity": "MEDIUM",
+                "title": "Vulnerability found - CVE-2020-3333"
             },
             "wiz": {
                 "vulnerability": {
@@ -242,7 +243,8 @@
                     "version": "4.0.3-35.amzn2"
                 },
                 "reference": "https://alas.aws.amazon.com/AL2/ALAS-2022-1780.html",
-                "severity": "MEDIUM"
+                "severity": "MEDIUM",
+                "title": "Vulnerability found - CVE-2020-3333"
             },
             "wiz": {
                 "vulnerability": {
@@ -419,7 +421,8 @@
                     "version": "4.0.3-35.amzn2"
                 },
                 "reference": "https://alas.aws.amazon.com/AL2/ALAS-2022-1780.html",
-                "severity": "MEDIUM"
+                "severity": "MEDIUM",
+                "title": "Vulnerability found - CVE-2020-3333"
             },
             "wiz": {
                 "vulnerability": {
@@ -588,7 +591,8 @@
                     "version": "4.0.3-35.amzn2"
                 },
                 "reference": "https://alas.aws.amazon.com/AL2/ALAS-2022-1780.html",
-                "severity": "MEDIUM"
+                "severity": "MEDIUM",
+                "title": "Vulnerability found - CVE-2020-3333"
             },
             "wiz": {
                 "vulnerability": {

--- a/packages/wiz/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/wiz/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -129,9 +129,10 @@ processors:
       ignore_empty_value: true
   - set:
       field: vulnerability.title
-      tag: set_vulnerability_title
+      tag: set_vulnerability_title_from_vulnerability_id
       value: 'Vulnerability found - {{{vulnerability.id}}}'
       if: ctx.vulnerability?.id != null
+      ignore_empty_value: true
   - rename:
       field: json.CVSSSeverity
       tag: rename_CVSSSeverity

--- a/packages/wiz/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/wiz/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -127,6 +127,11 @@ processors:
       tag: set_vulnerability_id
       copy_from: wiz.vulnerability.name
       ignore_empty_value: true
+  - set:
+      field: vulnerability.title
+      tag: set_vulnerability_title
+      value: 'Vulnerability found - {{{vulnerability.id}}}'
+      if: ctx.vulnerability?.id != null
   - rename:
       field: json.CVSSSeverity
       tag: rename_CVSSSeverity

--- a/packages/wiz/data_stream/vulnerability/fields/fields.yml
+++ b/packages/wiz/data_stream/vulnerability/fields/fields.yml
@@ -157,6 +157,8 @@
 - name: vulnerability
   type: group
   fields:
+    - name: title
+      type: keyword
     - name: cwe
       type: keyword
     - name: package

--- a/packages/wiz/data_stream/vulnerability/sample_event.json
+++ b/packages/wiz/data_stream/vulnerability/sample_event.json
@@ -91,7 +91,8 @@
         "score": {
             "base": 5.5
         },
-        "severity": "MEDIUM"
+        "severity": "MEDIUM",
+        "title": "Vulnerability found - CVE-2020-3333"
     },
     "wiz": {
         "vulnerability": {

--- a/packages/wiz/docs/README.md
+++ b/packages/wiz/docs/README.md
@@ -1333,7 +1333,8 @@ An example event for `vulnerability` looks as following:
         "score": {
             "base": 5.5
         },
-        "severity": "MEDIUM"
+        "severity": "MEDIUM",
+        "title": "Vulnerability found - CVE-2020-3333"
     },
     "wiz": {
         "vulnerability": {

--- a/packages/wiz/docs/README.md
+++ b/packages/wiz/docs/README.md
@@ -1464,6 +1464,7 @@ An example event for `vulnerability` looks as following:
 | vulnerability.package.fixed_version |  | keyword |
 | vulnerability.package.name |  | keyword |
 | vulnerability.package.version |  | keyword |
+| vulnerability.title |  | keyword |
 | wiz.vulnerability.cve_description |  | keyword |
 | wiz.vulnerability.cvss_severity |  | keyword |
 | wiz.vulnerability.data_source_name |  | keyword |

--- a/packages/wiz/elasticsearch/transform/latest_cdr_vulnerabilities/fields/fields.yml
+++ b/packages/wiz/elasticsearch/transform/latest_cdr_vulnerabilities/fields/fields.yml
@@ -211,6 +211,8 @@
   fields:
     - name: cwe
       type: keyword
+    - name: title
+      type: keyword
     - name: package
       type: group
       fields:

--- a/packages/wiz/manifest.yml
+++ b/packages/wiz/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: wiz
 title: Wiz
-version: "3.8.0-preview"
+version: "3.8.0"
 description: Collect logs from Wiz with Elastic Agent.
 type: integration
 categories:

--- a/packages/wiz/manifest.yml
+++ b/packages/wiz/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: wiz
 title: Wiz
-version: "3.7.0"
+version: "3.8.0-preview"
 description: Collect logs from Wiz with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

This PR sets the vulnerability.title field by constructing a title using prefix and the vulnerability.id field if available. This is an alignment to other 3p integrations which already set this field during the ingest phase.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
1. build package with elastic-package build
2. set all necessary env variables to install the integration in your ess/serverless env
3. run elastic-package install
4. go to findings -> vulnerabilities tab - findings should appear with vulnerability.title field set.


## Related issues

https://github.com/elastic/security-team/issues/12863

## Screenshots

<img width="1901" height="929" alt="image" src="https://github.com/user-attachments/assets/383b2927-3db5-492d-a5d4-dd3f1a435246" />