### PR TITLE
[Cloud Security] Add elastic connector id to azure

### DIFF
--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -7,7 +7,7 @@
   changes:
     - description: Add support for Azure Cloud Connectors cloud_connector_id
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/15237
+      link: https://github.com/elastic/integrations/pull/15326
 - version: "1.1.3"
   changes:
     - description: Add support for Azure Cloud Connectors credentials

--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -3,6 +3,11 @@
 # 1.1.x - 9.2.x
 # 1.0.x - 9.1.x
 # 0.1.x - 8.15.x
+- version: "1.1.4"
+  changes:
+    - description: Add support for Azure Cloud Connectors cloud_connector_id
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/15237
 - version: "1.1.3"
   changes:
     - description: Add support for Azure Cloud Connectors credentials

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/manifest.yml
@@ -179,6 +179,14 @@ streams:
         - name: azure.credentials.client_certificate_path
         - name: azure.credentials.tenant_id
         - name: azure.credentials.client_certificate_password
+      organization_account_cloud_connectors:
+        - name: azure.account_type
+          value: organization-account
+        - name: azure.credentials.type
+          value: cloud_connectors
+        - name: azure.credentials.client_id
+        - name: azure.credentials.tenant_id
+        - name: azure.credentials.cloud_connector_id
       single_account_cloud_connectors:
         - name: azure.account_type
           value: single-account
@@ -186,6 +194,7 @@ streams:
           value: cloud_connectors
         - name: azure.credentials.client_id
         - name: azure.credentials.tenant_id
+        - name: azure.credentials.cloud_connector_id
       single_account_arm_template:
         - name: azure.account_type
           value: single-account
@@ -282,6 +291,13 @@ streams:
         show_user: true
         secret: true
         description: Required when using Service Principal with Client Certificate
+      - name: azure.credentials.cloud_connector_id
+        type: text
+        title: Elastic Cloud Connector ID
+        multi: false
+        required: false
+        show_user: true
+        description: Required when using Cloud Connectors Federated Identity
       - name: azure.supports_cloud_connectors
         type: bool
         title: Supports Cloud Connectors

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/manifest.yml
@@ -186,7 +186,7 @@ streams:
           value: cloud_connectors
         - name: azure.credentials.client_id
         - name: azure.credentials.tenant_id
-        - name: azure.credentials.cloud_connector_id
+        - name: azure_credentials_cloud_connector_id
       single_account_cloud_connectors:
         - name: azure.account_type
           value: single-account
@@ -194,7 +194,7 @@ streams:
           value: cloud_connectors
         - name: azure.credentials.client_id
         - name: azure.credentials.tenant_id
-        - name: azure.credentials.cloud_connector_id
+        - name: azure_credentials_cloud_connector_id
       single_account_arm_template:
         - name: azure.account_type
           value: single-account
@@ -291,7 +291,7 @@ streams:
         show_user: true
         secret: true
         description: Required when using Service Principal with Client Certificate
-      - name: azure.credentials.cloud_connector_id
+      - name: azure_credentials_cloud_connector_id
         type: text
         title: Elastic Cloud Connector ID
         multi: false

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_asset_inventory
 title: "Cloud Asset Discovery"
-version: "1.1.3"
+version: "1.1.4"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Discovery"

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -16,6 +16,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "3.1.0-preview05"
+  changes:
+    - description: Adding the input type "cloud_connector_id" for Azure
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/14532
 - version: "3.1.0-preview04"
   changes:
     - description: Update Indentation and adding JSON tags on some rules.

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -20,7 +20,7 @@
   changes:
     - description: Adding the input type "cloud_connector_id" for Azure
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/14532
+      link: https://github.com/elastic/integrations/pull/15326
 - version: "3.1.0-preview04"
   changes:
     - description: Update Indentation and adding JSON tags on some rules.

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -330,6 +330,7 @@ streams:
           value: cloud_connectors
         - name: azure.credentials.client_id
         - name: azure.credentials.tenant_id
+        - name: azure.credentials.cloud_connector_id
       organization_account_cloud_connectors:
         - name: azure.account_type
           value: organization-account
@@ -337,6 +338,7 @@ streams:
           value: cloud_connectors
         - name: azure.credentials.client_id
         - name: azure.credentials.tenant_id
+        - name: azure.credentials.cloud_connector_id
       single_account_arm_template:
         - name: azure.account_type
           value: single-account
@@ -419,6 +421,12 @@ streams:
         required: false
         show_user: true
         secret: true
+      - name: azure.credentials.cloud_connector_id
+        type: text
+        title: Elastic Cloud Connector ID
+        multi: false
+        required: false
+        show_user: true
       - name: azure.supports_cloud_connectors
         type: bool
         title: Supports Cloud Connectors

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -330,7 +330,7 @@ streams:
           value: cloud_connectors
         - name: azure.credentials.client_id
         - name: azure.credentials.tenant_id
-        - name: azure.credentials.cloud_connector_id
+        - name: azure_credentials_cloud_connector_id
       organization_account_cloud_connectors:
         - name: azure.account_type
           value: organization-account
@@ -338,7 +338,7 @@ streams:
           value: cloud_connectors
         - name: azure.credentials.client_id
         - name: azure.credentials.tenant_id
-        - name: azure.credentials.cloud_connector_id
+        - name: azure_credentials_cloud_connector_id
       single_account_arm_template:
         - name: azure.account_type
           value: single-account
@@ -421,12 +421,13 @@ streams:
         required: false
         show_user: true
         secret: true
-      - name: azure.credentials.cloud_connector_id
+      - name: azure_credentials_cloud_connector_id
         type: text
         title: Elastic Cloud Connector ID
         multi: false
         required: false
         show_user: true
+        description: Required when using Cloud Connectors Federated Identity
       - name: azure.supports_cloud_connectors
         type: bool
         title: Supports Cloud Connectors

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "3.1.0-preview04"
+version: "3.1.0-preview05"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION

## Proposed commit message
Add the cloud_connector_id field to the CSPM and Cloud Asset Inventory packages for Azure cloud connectors.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues
- relates https://github.com/elastic/security-team/issues/12603
## Screenshots
<img width="776" height="777" alt="Screenshot 2025-09-15 at 6 33 11 PM" src="https://github.com/user-attachments/assets/068eda2f-6356-40de-8023-9e08653dd919" />

