### PR TITLE
fix(system tests): disable webhook probe for http_endpoint inputs

### DIFF
--- a/packages/auth0/_dev/deploy/docker/docker-compose.yml
+++ b/packages/auth0/_dev/deploy/docker/docker-compose.yml
@@ -6,21 +6,23 @@ services:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:8383/auth0/logs
       - STREAM_WEBHOOK_HEADER=Authorization=abc123
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/auth0-ndjson.log
   auth0-webhook-https:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=https://elastic-agent:8384/auth0/logs
       - STREAM_WEBHOOK_HEADER=Authorization=abc123
       - STREAM_INSECURE=true
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/auth0-ndjson.log
   auth0-http-server:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     hostname: auth0
     ports:
       - 8090

--- a/packages/bbot/_dev/deploy/docker/docker-compose.yml
+++ b/packages/bbot/_dev/deploy/docker/docker-compose.yml
@@ -6,20 +6,22 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp -v /sample_logs/bbot-v*-ndjson*.log /var/log/"
   bbot-all-http:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:8381/bbot/ndjson
       - STREAM_WEBHOOK_HEADER=Authorization=abc123
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/bbot-v*-ndjson*.log
   bbot-all-https:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=https://elastic-agent:8382/bbot/ndjson
       - STREAM_WEBHOOK_HEADER=Authorization=abc123
       - STREAM_INSECURE=true

--- a/packages/beelzebub/_dev/deploy/docker/docker-compose.yml
+++ b/packages/beelzebub/_dev/deploy/docker/docker-compose.yml
@@ -6,10 +6,11 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   test-http_endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:10002/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/logs-ndjson.log

--- a/packages/bitdefender/_dev/deploy/docker/docker-compose.yml
+++ b/packages/bitdefender/_dev/deploy/docker/docker-compose.yml
@@ -1,35 +1,38 @@
 version: '2.3'
 services:
   bitdefender-push-notification-qradar-http:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:8383/bitdefender/push/notification
       - STREAM_WEBHOOK_HEADER=Authorization=abc123
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/qradar_format.log
   bitdefender-push-notification-jsonrpc-http:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:8384/bitdefender/push/notification
       - STREAM_WEBHOOK_HEADER=Authorization=abc123
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/jsonrpc_format.log
   bitdefender-push-notification-jsonrpc-https:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=https://elastic-agent:8385/bitdefender/push/notification
       - STREAM_WEBHOOK_HEADER=Authorization=abc123
       - STREAM_INSECURE=true
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/jsonrpc_format.log
   bitdefender-gravityzone-api-mock:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     hostname: bitdefender_gravityzone_api_mock
     ports:
       - 8585

--- a/packages/carbonblack_edr/_dev/deploy/docker/docker-compose.yml
+++ b/packages/carbonblack_edr/_dev/deploy/docker/docker-compose.yml
@@ -7,15 +7,16 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   carbonblack_edr-http:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9080/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/cb_edr.ndjson.log
   carbonblack_edr-tcp:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -23,7 +24,7 @@ services:
       - STREAM_ADDR=elastic-agent:9081
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/cb_edr.ndjson.log
   carbonblack_edr-udp:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/cisco_meraki/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_meraki/_dev/deploy/docker/docker-compose.yml
@@ -1,19 +1,21 @@
 version: '2.3'
 services:
   meraki-webhook-http:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_events:/sample_events:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:8686/meraki/events
     command: log --start-signal=SIGHUP --delay=5s /sample_events/meraki-mx-ndjson.log
   meraki-webhook-https:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_events:/sample_events:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=https://elastic-agent:8686/meraki/events
       - STREAM_INSECURE=true
     command: log --start-signal=SIGHUP --delay=5s /sample_events/meraki-mx-ndjson.log
@@ -24,12 +26,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   cisco_meraki-log-udp:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:8685 -p=udp /sample_logs/cisco-meraki.log
   cisco_meraki-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:8685 -p=tcp /sample_logs/cisco-meraki.log

--- a/packages/cloudflare_logpush/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cloudflare_logpush/_dev/deploy/docker/docker-compose.yml
@@ -1,170 +1,191 @@
 version: '2.3'
 services:
   cloudflare-logpush-audit-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/audit
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/audit.log
   cloudflare-logpush-dlp-forensic-copies-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/dlp_forensic_copies
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/dlp_forensic_copies.log
   cloudflare-logpush-dns-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/dns
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/dns.log
   cloudflare-logpush-email-security-alerts-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/email_security_alerts
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/email_security_alerts.log
   cloudflare-logpush-firewall-event-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/firewall_event
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/firewall_event.log
   cloudflare-logpush-http-request-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/http_request
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/http_request.log
   cloudflare-logpush-nel-report-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/nel_report
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/nel_report.log
   cloudflare-logpush-network-analytics-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/network_analytics
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/network_analytics.log
   cloudflare-logpush-spectrum-event-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/spectrum_event
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/spectrum_event.log
   cloudflare-logpush-gateway-dns-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/gateway_dns
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/gateway_dns.log
   cloudflare-logpush-gateway-http-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/gateway_http
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/gateway_http.log
   cloudflare-logpush-gateway-network-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/gateway_network
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/gateway_network.log
   cloudflare-logpush-network-session-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/network_session
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/network_session.log
   cloudflare-logpush-page-shield-events-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/page_shield_events
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/page_shield_events.log
   cloudflare-logpush-casb-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/casb
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/casb.log
   cloudflare-logpush-access-request-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/access_request
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/access_request.log
   cloudflare-logpush-device-posture-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/device_posture
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/device_posture.log
   cloudflare-logpush-workers-trace-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/workers_trace
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/workers_trace.log
   cloudflare-logpush-magic-ids-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/magic_ids
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/magic_ids.log
   cloudflare-logpush-sinkhole-http-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/sinkhole_http
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/sinkhole_http.log
   cloudflare-logpush-dns-firewall-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/dns_firewall
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/dns_firewall.log

--- a/packages/f5_bigip/_dev/deploy/docker/docker-compose.yml
+++ b/packages/f5_bigip/_dev/deploy/docker/docker-compose.yml
@@ -7,10 +7,11 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   f5-bigip-log-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9551/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/log.log

--- a/packages/gigamon/_dev/deploy/docker/docker-compose.yml
+++ b/packages/gigamon/_dev/deploy/docker/docker-compose.yml
@@ -1,11 +1,12 @@
 version: "2.3"
 services:
   gigamon-ami-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9559/
       - STREAM_WEBHOOK_HEADER=Content-Type=application/ndjson
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/ami-http_endpoint.log

--- a/packages/http_endpoint/_dev/deploy/docker/docker-compose.yml
+++ b/packages/http_endpoint/_dev/deploy/docker/docker-compose.yml
@@ -1,11 +1,12 @@
 version: '2.3'
 services:
   test-webhook-http:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9515/json
       - STREAM_WEBHOOK_HEADER=Content-Type=application/json
       - STREAM_WEBHOOK_USERNAME=abc123
@@ -14,11 +15,12 @@ services:
       - STREAM_DELAY=10s
     command: log /sample_logs/test-webhook.log
   test-webhook-http-ack:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9516/json?wait_for_completion_timeout=1m
       - STREAM_WEBHOOK_HEADER=Content-Type=application/json
       - STREAM_WEBHOOK_USERNAME=abc123

--- a/packages/jamf_compliance_reporter/_dev/deploy/docker/docker-compose.yml
+++ b/packages/jamf_compliance_reporter/_dev/deploy/docker/docker-compose.yml
@@ -1,15 +1,16 @@
 version: "2.3"
 services:
   jamf-compliance-reporter-log-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9551/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/log.log
   jamf-compliance-reporter-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9552 -p=tcp /sample_logs/log.log

--- a/packages/jamf_pro/_dev/deploy/docker/docker-compose.yml
+++ b/packages/jamf_pro/_dev/deploy/docker/docker-compose.yml
@@ -1,16 +1,17 @@
 version: "2.3"
 services:
   jamf_pro_events:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./events:/events:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9202/jamf-pro-events
       - STREAM_WEBHOOK_HEADER=Authorization=mysecrettoken
     command: log --start-signal=SIGHUP --delay=5s /events/computer_added.log
   jamf_pro_api_stub:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     ports:
       - 8080
     volumes:

--- a/packages/jamf_protect/_dev/deploy/docker/docker-compose.yml
+++ b/packages/jamf_protect/_dev/deploy/docker/docker-compose.yml
@@ -1,42 +1,47 @@
 version: "2.3"
 services:
   jamf-protect-alerts-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9551/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/alerts.log
   jamf-protect-telemetry-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9550/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/telemetry.log
   jamf-protect-telemetry-legacy-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9555/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/telemetry-legacy.log
   jamf-protect-webthreats-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9552/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/webthreats.log
   jamf-protect-webtraffic-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9553/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/webtraffic.log

--- a/packages/opencanary/_dev/deploy/docker/docker-compose.yml
+++ b/packages/opencanary/_dev/deploy/docker/docker-compose.yml
@@ -7,10 +7,11 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   test-http_endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:10002/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/events.log

--- a/packages/ping_one/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ping_one/_dev/deploy/docker/docker-compose.yml
@@ -1,15 +1,16 @@
 version: '2.3'
 services:
   ping-one-audit-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9577/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/audit.log
   ping_one:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     hostname: ping_one
     ports:
       - 8080

--- a/packages/sysdig/_dev/deploy/docker/docker-compose.yml
+++ b/packages/sysdig/_dev/deploy/docker/docker-compose.yml
@@ -1,14 +1,15 @@
 services:
   sysdig-alerts-http:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9035/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/sysdig.log
   sysdig:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     hostname: sysdig
     ports:
       - 8090

--- a/packages/tanium/_dev/deploy/docker/docker-compose.yml
+++ b/packages/tanium/_dev/deploy/docker/docker-compose.yml
@@ -1,80 +1,86 @@
 version: '2.3'
 services:
   tanium-tcp-action_history:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9081 -p=tcp /sample_logs/action_history.log
   tanium-tcp-client_status:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9082 -p=tcp /sample_logs/client_status.log
   tanium-tcp-discover:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9083 -p=tcp /sample_logs/discover.log
   tanium-tcp-endpoint_config:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9084 -p=tcp /sample_logs/endpoint_config.log
   tanium-tcp-reporting:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9085 -p=tcp /sample_logs/reporting.log
   tanium-tcp-threat_response:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9086 -p=tcp /sample_logs/threat_response.log
   tanium-action_history-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9087/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/action_history.log
   tanium-client_status-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9088/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/client_status.log
   tanium-discover-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9089/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/discover.log
   tanium-endpoint_config-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9090/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/endpoint_config.log
   tanium-reporting-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9091/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/reporting.log
   tanium-threat_response-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9092/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/threat_response.log

--- a/packages/ti_anomali/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_anomali/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   intelligence-api:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     ports:
       - 8080
     volumes:
@@ -13,19 +13,21 @@ services:
       - --addr=:8080
       - --config=/files/intelligence-api-config.yml
   threatstream-webhook-http:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9080/
     command: log --webhook-content-type application/x-ndjson --start-signal=SIGHUP --delay=5s /sample_logs/test-threatstream-ndjson.log
   threatstream-webhook-https:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_INSECURE=true
       - STREAM_ADDR=https://elastic-agent:7443/
     command: log --webhook-content-type application/x-ndjson --start-signal=SIGHUP --delay=5s /sample_logs/test-threatstream-ndjson.log

--- a/packages/wiz/_dev/deploy/docker/docker-compose.yml
+++ b/packages/wiz/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   wiz-audit:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     hostname: wiz-audit
     ports:
       - 8090
@@ -14,7 +14,7 @@ services:
       - --addr=:8090
       - --config=/files/config-audit.yml
   wiz-cloud_configuration_finding:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     hostname: wiz-cloud_configuration_finding
     ports:
       - 8090
@@ -27,7 +27,7 @@ services:
       - --addr=:8090
       - --config=/files/config-cloud_configuration_finding.yml
   wiz-cloud_configuration_finding_full_posture:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     hostname: wiz-cloud_configuration_finding_full_posture
     ports:
       - 8090
@@ -40,7 +40,7 @@ services:
       - --addr=:8090
       - --config=/files/config-cloud_configuration_finding_full_posture.yml
   wiz-issue:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     hostname: wiz-issue
     ports:
       - 8090
@@ -53,7 +53,7 @@ services:
       - --addr=:8090
       - --config=/files/config-issue.yml
   wiz-vulnerability:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     hostname: wiz-vulnerability
     ports:
       - 8090
@@ -66,29 +66,32 @@ services:
       - --addr=:8090
       - --config=/files/config-vulnerability.yml
   wiz-defend-no-auth:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9588/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/defend.log
   wiz-defend-basic:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9589/
       - STREAM_USERNAME=testuser
       - STREAM_PASSWORD=xxxx
     command: log --start-signal=SIGHUP  --webhook-username=testuser --webhook-password=xxxx --delay=5s /sample_logs/defend.log
   wiz-defend-token:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9590/
       - STREAM_WEBHOOK_HEADER=testheader=abc123
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/defend.log

--- a/packages/zoom/_dev/deploy/docker/docker-compose.yml
+++ b/packages/zoom/_dev/deploy/docker/docker-compose.yml
@@ -1,20 +1,22 @@
 version: '2.3'
 services:
   zoom-webhook-http:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9080/zoom
       - STREAM_WEBHOOK_HEADER=Authorization=abc123
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/account-ndjson.log
   zoom-webhook-https:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_INSECURE=true
       - STREAM_ADDR=https://elastic-agent:7443/zoom
       - STREAM_WEBHOOK_HEADER=Authorization=abc123

--- a/packages/zscaler_zia/_dev/deploy/docker/docker-compose.yml
+++ b/packages/zscaler_zia/_dev/deploy/docker/docker-compose.yml
@@ -1,96 +1,102 @@
 version: "2.3"
 services:
   zscaler-zia-alerts-tcp:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9010 -p=tcp /sample_logs/alerts.log
   zscaler-zia-audit-tcp:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9029 -p=tcp /sample_logs/audit.log
   zscaler-zia-dns-tcp:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9011 -p=tcp /sample_logs/dns.log
   zscaler-zia-endpoint-dlp-tcp:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9023 -p=tcp /sample_logs/endpoint_dlp.log
   zscaler-zia-firewall-tcp:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9012 -p=tcp /sample_logs/firewall.log
   zscaler-zia-tunnel-tcp:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9013 -p=tcp /sample_logs/tunnel.log
   zscaler-zia-web-tcp:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9014 -p=tcp /sample_logs/web.log
   zscaler-zia-audit-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9562/
       - STREAM_WEBHOOK_HEADER=Content-Type=application/ndjson
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/audit-http_endpoint.log
   zscaler-zia-dns-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9556/
       - STREAM_WEBHOOK_HEADER=Content-Type=application/ndjson
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/dns-http_endpoint.log
   zscaler-zia-endpoint-dlp-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9561/
       - STREAM_WEBHOOK_HEADER=Content-Type=application/ndjson
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/endpoint_dlp-http_endpoint.log
   zscaler-zia-firewall-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9557/
       - STREAM_WEBHOOK_HEADER=Content-Type=application/ndjson
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/firewall-http_endpoint.log
   zscaler-zia-tunnel-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9558/
       - STREAM_WEBHOOK_HEADER=Content-Type=application/ndjson
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/tunnel-http_endpoint.log
   zscaler-zia-web-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
       - STREAM_PROTOCOL=webhook
+      - STREAM_WEBHOOK_PROBE=false
       - STREAM_ADDR=http://elastic-agent:9559/
       - STREAM_WEBHOOK_HEADER=Content-Type=application/ndjson
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/web-http_endpoint.log
   sandbox-report:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     hostname: sandbox-report
     ports:
       - 8090


### PR DESCRIPTION
## Proposed commit message

```
fix: disable webhook probe for http_endpoint inputs

The elastic/stream webhook output probes the endpoint with HEAD requests
to see if it is ready. This triggers the input to become unhealthy
because the request does not validate. This change disables the HEAD
probe. It's not really needed because elastic-package sends a SIGHUP
after the integration is running to trigger the webhook callbacks to
begin.

This fixes the following error:

> (HEALTHY->DEGRADED): request did not validate: only POST requests are allowed"

I considered changing it to STREAM_WEBHOOK_PROBE=POST, but that fails with a different
validation:

> (HEALTHY->DEGRADED): request did not validate: wrong Content-Type header, expecting application/json"

Related: #14022
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Relates #14022

## Related

- https://buildkite.com/elastic/integrations/builds/31394 (drill down to see all the `only POST requests are allowed`)
