### PR TITLE
fix(auth0): use elastic/stream v0.20.0

### DIFF
--- a/packages/auth0/_dev/deploy/docker/docker-compose.yml
+++ b/packages/auth0/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   auth0-webhook-http:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.20.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:


### PR DESCRIPTION
## Proposed commit message

Follow up to #15355 where I missed a version update. STREAM_WEBHOOK_PROBE is only honored on >= 0.19.0 so this change is needed to fix the "only POST requests are allowed" DEGRADED agent status.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Relates #15355

## Related

- https://buildkite.com/elastic/integrations/builds/31509