### PR TITLE
docs(sentinel_one): Changes H1 for increasing SEO

### DIFF
--- a/packages/sentinel_one/docs/README.md
+++ b/packages/sentinel_one/docs/README.md
@@ -1,4 +1,4 @@
-# SentinelOne
+# SentinelOne integration
 
 The [SentinelOne](https://www.sentinelone.com/) integration collects and parses data from SentinelOne REST APIs. This integration also offers the capability to perform response actions on SentinelOne hosts directly through the Elastic Security interface (introduced with v8.12.0). Additional configuration is required; for detailed guidance, refer to [documentation](https://www.elastic.co/guide/en/security/current/response-actions-config.html).
 


### PR DESCRIPTION
## Overview

This PR updates the page title to SentinelOne integration. Since this page is a child of the main SentinelOne page in the generated docs, using the same title for both negatively impacts SEO.