### PR TITLE
Enhance Zscaler ZIA dashboards with Table of Contents Links panel

### DIFF
--- a/packages/zscaler_zia/changelog.yml
+++ b/packages/zscaler_zia/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.15.2"
+  changes:
+    - description: Use links panels in the dashboards.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/TBD
 - version: "3.15.1"
   changes:
     - description: Fix `pkg_version` parameter in the `check_template_version` script in ingest pipelines.

--- a/packages/zscaler_zia/kibana/dashboard/zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635.json
+++ b/packages/zscaler_zia/kibana/dashboard/zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635.json
@@ -50,6 +50,135 @@
             {
                 "embeddableConfig": {
                     "enhancements": {},
+                    "attributes": {
+                        "title": "links",
+                        "layout": "vertical",
+                        "links": [
+                            {
+                                "label": "Overview",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e",
+                                "order": 0,
+                                "destinationRefName": "link_zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e_dashboard"
+                            },
+                            {
+                                "label": "Audit",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635",
+                                "order": 1,
+                                "destinationRefName": "link_zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635_dashboard"
+                            },
+                            {
+                                "label": "DNS",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84",
+                                "order": 2,
+                                "destinationRefName": "link_zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Endpoint DLP",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42",
+                                "order": 3,
+                                "destinationRefName": "link_zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42_dashboard"
+                            },
+                            {
+                                "label": "Firewall",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84",
+                                "order": 4,
+                                "destinationRefName": "link_zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Sandbox Report",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416",
+                                "order": 5,
+                                "destinationRefName": "link_zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416_dashboard"
+                            },
+                            {
+                                "label": "Tunnel",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84",
+                                "order": 6,
+                                "destinationRefName": "link_zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Web Overview",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84",
+                                "order": 7,
+                                "destinationRefName": "link_zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Web Access Control",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6",
+                                "order": 8,
+                                "destinationRefName": "link_zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6_dashboard"
+                            }
+                        ]
+                    }
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "634126cc-38ec-44ef-8d41-5284634071eb",
+                    "w": 12,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "634126cc-38ec-44ef-8d41-5284634071eb",
+                "title": "Table of Contents",
+                "type": "links"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
                     "hidePanelTitles": false,
                     "savedVis": {
                         "data": {
@@ -66,7 +195,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**Zscaler ZIA**\n\n[Overview](#/dashboard/zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e)\n- [**Audit (This Page)**](#/dashboard/zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635)\n- [DNS](#/dashboard/zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84)\n- [Endpoint DLP](#/dashboard/zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42)\n- [Firewall](#/dashboard/zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84)\n- [Sandbox Report](#/dashboard/zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416)\n- [Tunnel](#/dashboard/zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84)\n- Web\n  - [Web Overview](#/dashboard/zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84)\n  - [Web Access Control](#/dashboard/zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6)\n\n**Overview**\n\nThis dashboard provides a comprehensive overview of Zscaler ZIA audit logs. It includes line charts for actions, failed actions, interface and login attempts over time, bar charts for activities, categories, and subcategories, pie charts for event results and interfaces, and a table for the top 10 source IPs. These visualizations help monitor system activities, identify patterns, and ensure security and operational integrity.\n\n[**Integrations Page**](/app/integrations/detail/zscaler_zia/overview)",
+                            "markdown": "**Zscaler ZIA**\n\nThis dashboard provides a comprehensive overview of Zscaler ZIA audit logs. It includes line charts for actions, failed actions, interface and login attempts over time, bar charts for activities, categories, and subcategories, pie charts for event results and interfaces, and a table for the top 10 source IPs. These visualizations help monitor system activities, identify patterns, and ensure security and operational integrity.\n\n[**Integrations Page**](/app/integrations/detail/zscaler_zia/overview)",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -75,14 +204,14 @@
                     }
                 },
                 "gridData": {
-                    "h": 30,
+                    "h": 15,
                     "i": "634126cc-38ec-44ef-8d41-5284634071eb",
                     "w": 12,
                     "x": 0,
-                    "y": 0
+                    "y": 15
                 },
-                "panelIndex": "634126cc-38ec-44ef-8d41-5284634071eb",
-                "title": "Table of Contents",
+                "panelIndex": "634126cc-38ec-44ef-8d41-5284634071eb_1",
+                "title": "Overview",
                 "type": "visualization"
             },
             {
@@ -222,7 +351,7 @@
                     "y": 0
                 },
                 "panelIndex": "cf1758b6-e6be-4629-9ac6-18df1945b238",
-                "title": "Audit Events by Interface [Logs Zscaler ZIA]",
+                "title": "Audit Events by Interface",
                 "type": "lens"
             },
             {
@@ -362,7 +491,7 @@
                     "y": 0
                 },
                 "panelIndex": "7da403ae-289d-40bc-9555-ac892c44130e",
-                "title": "Audit Events by Result [Logs Zscaler ZIA]",
+                "title": "Audit Events by Result",
                 "type": "lens"
             },
             {
@@ -550,7 +679,7 @@
                     "y": 15
                 },
                 "panelIndex": "29fa0c86-41ee-466e-959a-67ba474c5087",
-                "title": "Audit Events by Activity [Logs Zscaler ZIA]",
+                "title": "Audit Events by Activity",
                 "type": "lens"
             },
             {
@@ -715,7 +844,7 @@
                     "y": 15
                 },
                 "panelIndex": "50cf0039-1485-47e8-bf02-595b3675389b",
-                "title": "Audit Events by Category [Logs Zscaler ZIA]",
+                "title": "Audit Events by Category",
                 "type": "lens"
             },
             {
@@ -881,7 +1010,7 @@
                     "y": 30
                 },
                 "panelIndex": "aa9d8b16-4300-43ee-9df0-b0d4df7f2171",
-                "title": "Audit Events by Subcategory [Logs Zscaler ZIA]",
+                "title": "Audit Events by Subcategory",
                 "type": "lens"
             },
             {
@@ -1023,7 +1152,7 @@
                     "y": 30
                 },
                 "panelIndex": "e54ca3c7-88bc-4ced-9544-313f694b2306",
-                "title": "Top 10 Source IP [Logs Zscaler ZIA]",
+                "title": "Top 10 Source IP",
                 "type": "lens"
             },
             {
@@ -1205,7 +1334,7 @@
                     "y": 45
                 },
                 "panelIndex": "15f7c044-e348-47e0-a28a-bbc3cda04d65",
-                "title": "Actions Over Time [Logs Zscaler ZIA]",
+                "title": "Actions Over Time",
                 "type": "lens"
             },
             {
@@ -1435,7 +1564,7 @@
                     "y": 45
                 },
                 "panelIndex": "3a187f81-2d2b-4561-a9bd-571cec00f05a",
-                "title": "Login Attempts Over Time [Logs Zscaler ZIA]",
+                "title": "Login Attempts Over Time",
                 "type": "lens"
             },
             {
@@ -1643,7 +1772,7 @@
                     "y": 60
                 },
                 "panelIndex": "d68bdb4c-0321-4b7d-be7a-daef3f048966",
-                "title": "Interface Over Time [Logs Zscaler ZIA]",
+                "title": "Interface Over Time",
                 "type": "lens"
             },
             {
@@ -1903,7 +2032,7 @@
                     "y": 60
                 },
                 "panelIndex": "22e4039c-2e2d-44a9-82fb-d8e1daef71dc",
-                "title": "Failed Actions Over Time [Logs Zscaler ZIA]",
+                "title": "Failed Actions Over Time",
                 "type": "lens"
             },
             {
@@ -2035,6 +2164,51 @@
             "id": "zscaler_zia-security-solution-default",
             "name": "tag-ref-security-solution-default",
             "type": "tag"
+        },
+        {
+            "name": "634126cc-38ec-44ef-8d41-5284634071eb:link_zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e"
+        },
+        {
+            "name": "634126cc-38ec-44ef-8d41-5284634071eb:link_zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635"
+        },
+        {
+            "name": "634126cc-38ec-44ef-8d41-5284634071eb:link_zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "634126cc-38ec-44ef-8d41-5284634071eb:link_zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42"
+        },
+        {
+            "name": "634126cc-38ec-44ef-8d41-5284634071eb:link_zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "634126cc-38ec-44ef-8d41-5284634071eb:link_zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416"
+        },
+        {
+            "name": "634126cc-38ec-44ef-8d41-5284634071eb:link_zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "634126cc-38ec-44ef-8d41-5284634071eb:link_zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "634126cc-38ec-44ef-8d41-5284634071eb:link_zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6"
         }
     ],
     "type": "dashboard",

--- a/packages/zscaler_zia/kibana/dashboard/zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e.json
+++ b/packages/zscaler_zia/kibana/dashboard/zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e.json
@@ -214,6 +214,135 @@
             {
                 "embeddableConfig": {
                     "enhancements": {},
+                    "attributes": {
+                        "title": "links",
+                        "layout": "vertical",
+                        "links": [
+                            {
+                                "label": "Overview",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e",
+                                "order": 0,
+                                "destinationRefName": "link_zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e_dashboard"
+                            },
+                            {
+                                "label": "Audit",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635",
+                                "order": 1,
+                                "destinationRefName": "link_zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635_dashboard"
+                            },
+                            {
+                                "label": "DNS",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84",
+                                "order": 2,
+                                "destinationRefName": "link_zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Endpoint DLP",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42",
+                                "order": 3,
+                                "destinationRefName": "link_zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42_dashboard"
+                            },
+                            {
+                                "label": "Firewall",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84",
+                                "order": 4,
+                                "destinationRefName": "link_zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Sandbox Report",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416",
+                                "order": 5,
+                                "destinationRefName": "link_zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416_dashboard"
+                            },
+                            {
+                                "label": "Tunnel",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84",
+                                "order": 6,
+                                "destinationRefName": "link_zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Web Overview",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84",
+                                "order": 7,
+                                "destinationRefName": "link_zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Web Access Control",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6",
+                                "order": 8,
+                                "destinationRefName": "link_zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6_dashboard"
+                            }
+                        ]
+                    }
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "4d7cd002-7737-4bd2-916f-9a481ed43584",
+                    "w": 24,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "4d7cd002-7737-4bd2-916f-9a481ed43584",
+                "title": "Table of Contents",
+                "type": "links"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
                     "savedVis": {
                         "data": {
                             "aggs": [],
@@ -229,7 +358,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**Zscaler ZIA**\n\n[**Overview (This Page)**](#/dashboard/zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e)\n- [Audit](#/dashboard/zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635)\n- [DNS](#/dashboard/zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84)\n- [Endpoint DLP](#/dashboard/zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42)\n- [Firewall](#/dashboard/zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84)\n- [Sandbox Report](#/dashboard/zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416)\n- [Tunnel](#/dashboard/zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84)\n- Web\n  - [Web Overview](#/dashboard/zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84)\n  - [Web Access Control](#/dashboard/zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6)\n\n**Overview**\n\nThis dashboard shows Overview related to the Zscaler ZIA Integration.\n\nThe dashboard is made to provide general statistics and show the ingested Overview  logs from Zscaler ZIA.\n\nIt shows the breakdown  by Users. It presents the User over Time. The dashboard also includes the Events by Data Source. In addition, it illustrates the Host Information.\n\n[**Integrations Page**](/app/integrations/detail/zscaler_zia/overview)",
+                            "markdown": "**Zscaler ZIA**\n\nThis dashboard shows Overview related to the Zscaler ZIA Integration.\n\nThe dashboard is made to provide general statistics and show the ingested Overview  logs from Zscaler ZIA.\n\nIt shows the breakdown  by Users. It presents the User over Time. The dashboard also includes the Events by Data Source. In addition, it illustrates the Host Information.\n\n[**Integrations Page**](/app/integrations/detail/zscaler_zia/overview)",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -238,14 +367,14 @@
                     }
                 },
                 "gridData": {
-                    "h": 29,
+                    "h": 14,
                     "i": "4d7cd002-7737-4bd2-916f-9a481ed43584",
                     "w": 24,
                     "x": 0,
-                    "y": 0
+                    "y": 15
                 },
-                "panelIndex": "4d7cd002-7737-4bd2-916f-9a481ed43584",
-                "title": "Table of Content",
+                "panelIndex": "4d7cd002-7737-4bd2-916f-9a481ed43584_1",
+                "title": "Overview",
                 "type": "visualization"
             },
             {
@@ -881,7 +1010,7 @@
                     "y": 6
                 },
                 "panelIndex": "3bb0e1a1-8450-4012-967e-731513e0f3c6",
-                "title": "User over Time [Logs Zscaler ZIA]",
+                "title": "User over Time",
                 "type": "lens"
             },
             {
@@ -1186,7 +1315,7 @@
                     "y": 18
                 },
                 "panelIndex": "799fba12-6aec-49fb-b98e-276a34d0c02b",
-                "title": "Events by Data Source [Logs Zscaler ZIA]",
+                "title": "Events by Data Source",
                 "type": "lens"
             },
             {
@@ -1263,6 +1392,51 @@
             "id": "zscaler_zia-security-solution-default",
             "name": "tag-ref-security-solution-default",
             "type": "tag"
+        },
+        {
+            "name": "4d7cd002-7737-4bd2-916f-9a481ed43584:link_zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e"
+        },
+        {
+            "name": "4d7cd002-7737-4bd2-916f-9a481ed43584:link_zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635"
+        },
+        {
+            "name": "4d7cd002-7737-4bd2-916f-9a481ed43584:link_zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "4d7cd002-7737-4bd2-916f-9a481ed43584:link_zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42"
+        },
+        {
+            "name": "4d7cd002-7737-4bd2-916f-9a481ed43584:link_zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "4d7cd002-7737-4bd2-916f-9a481ed43584:link_zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416"
+        },
+        {
+            "name": "4d7cd002-7737-4bd2-916f-9a481ed43584:link_zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "4d7cd002-7737-4bd2-916f-9a481ed43584:link_zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "4d7cd002-7737-4bd2-916f-9a481ed43584:link_zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6"
         }
     ],
     "type": "dashboard",

--- a/packages/zscaler_zia/kibana/dashboard/zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84.json
+++ b/packages/zscaler_zia/kibana/dashboard/zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84.json
@@ -49,6 +49,135 @@
             {
                 "embeddableConfig": {
                     "enhancements": {},
+                    "attributes": {
+                        "title": "links",
+                        "layout": "vertical",
+                        "links": [
+                            {
+                                "label": "Overview",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e",
+                                "order": 0,
+                                "destinationRefName": "link_zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e_dashboard"
+                            },
+                            {
+                                "label": "Audit",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635",
+                                "order": 1,
+                                "destinationRefName": "link_zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635_dashboard"
+                            },
+                            {
+                                "label": "DNS",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84",
+                                "order": 2,
+                                "destinationRefName": "link_zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Endpoint DLP",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42",
+                                "order": 3,
+                                "destinationRefName": "link_zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42_dashboard"
+                            },
+                            {
+                                "label": "Firewall",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84",
+                                "order": 4,
+                                "destinationRefName": "link_zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Sandbox Report",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416",
+                                "order": 5,
+                                "destinationRefName": "link_zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416_dashboard"
+                            },
+                            {
+                                "label": "Tunnel",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84",
+                                "order": 6,
+                                "destinationRefName": "link_zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Web Overview",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84",
+                                "order": 7,
+                                "destinationRefName": "link_zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Web Access Control",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6",
+                                "order": 8,
+                                "destinationRefName": "link_zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6_dashboard"
+                            }
+                        ]
+                    }
+                },
+                "gridData": {
+                    "h": 17,
+                    "i": "421d0606-6aa7-40e4-95ef-aebdf7908419",
+                    "w": 19,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "421d0606-6aa7-40e4-95ef-aebdf7908419",
+                "title": "Table of Contents",
+                "type": "links"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
                     "savedVis": {
                         "data": {
                             "aggs": [],
@@ -64,7 +193,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**Zscaler ZIA**\n\n[Overview](#/dashboard/zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e)\n- [Audit](#/dashboard/zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635)\n- [DNS](#/dashboard/zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84)\n- [Endpoint DLP](#/dashboard/zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42)\n- [Firewall](#/dashboard/zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84)\n- [Sandbox Report](#/dashboard/zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416)\n- [Tunnel](#/dashboard/zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84)\n- Web\n  - [**Web Overview (This Page)**](#/dashboard/zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84)\n  - [Web Access Control](#/dashboard/zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6)\n\n**Overview**\n\nThis dashboard shows Web Overview  related to the Zscaler ZIA Integration.\n\nThe dashboard is made to provide general statistics and show the ingested Web Overview  logs from Zscaler ZIA.\n\nIt shows the breakdown  by Top 10 Rule Type, Top 10 Rule Name, Malware Events by Location, Malware Events by User Name, Inline DLP Events by Action and Events by Malware Category. It presents the  Protocol of Web Events over Time. The dashboard also includes the Top 10 Threats by name, Top 10 Failed URL, Top 10 Cloud App, Top 10 User Impacted by Threat Name and Inline DLP Events by Dictionary Name. In addition, it illustrates the Total Threats Blocked, Total Inline DLP Event, Distribution of Web Events and Threat Activity.\n\n[**Integrations Page**](/app/integrations/detail/zscaler_zia/overview)",
+                            "markdown": "**Zscaler ZIA**\n\nThis dashboard shows Web Overview  related to the Zscaler ZIA Integration.\n\nThe dashboard is made to provide general statistics and show the ingested Web Overview  logs from Zscaler ZIA.\n\nIt shows the breakdown  by Top 10 Rule Type, Top 10 Rule Name, Malware Events by Location, Malware Events by User Name, Inline DLP Events by Action and Events by Malware Category. It presents the  Protocol of Web Events over Time. The dashboard also includes the Top 10 Threats by name, Top 10 Failed URL, Top 10 Cloud App, Top 10 User Impacted by Threat Name and Inline DLP Events by Dictionary Name. In addition, it illustrates the Total Threats Blocked, Total Inline DLP Event, Distribution of Web Events and Threat Activity.\n\n[**Integrations Page**](/app/integrations/detail/zscaler_zia/overview)",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -73,14 +202,14 @@
                     }
                 },
                 "gridData": {
-                    "h": 33,
+                    "h": 16,
                     "i": "421d0606-6aa7-40e4-95ef-aebdf7908419",
                     "w": 19,
                     "x": 0,
-                    "y": 0
+                    "y": 17
                 },
-                "panelIndex": "421d0606-6aa7-40e4-95ef-aebdf7908419",
-                "title": "Table of Content",
+                "panelIndex": "421d0606-6aa7-40e4-95ef-aebdf7908419_1",
+                "title": "Overview",
                 "type": "visualization"
             },
             {
@@ -484,7 +613,7 @@
                     "y": 6
                 },
                 "panelIndex": "50bf15e9-d0a2-4499-ae00-75a9a0797465",
-                "title": "Protocol of Web Events over Time [Logs Zscaler ZIA]",
+                "title": "Protocol of Web Events over Time",
                 "type": "lens"
             },
             {
@@ -671,7 +800,7 @@
                     "y": 20
                 },
                 "panelIndex": "c89ca12e-08c2-4b3a-a0f5-5597066851ca",
-                "title": "Inline DLP Events by Action [Logs Zscaler ZIA]",
+                "title": "Inline DLP Events by Action",
                 "type": "lens"
             },
             {
@@ -920,7 +1049,7 @@
                     "y": 33
                 },
                 "panelIndex": "b81e5c0f-9add-4e87-a293-9587f2d3b3b7",
-                "title": "Web Events by Malware Category [Logs Zscaler ZIA]",
+                "title": "Web Events by Malware Category",
                 "type": "lens"
             },
             {
@@ -1083,7 +1212,7 @@
                     "y": 33
                 },
                 "panelIndex": "0b8c4807-869a-4289-a858-dca1bba9eba5",
-                "title": "Top 10 Rule Type [Logs Zscaler ZIA]",
+                "title": "Top 10 Rule Type",
                 "type": "lens"
             },
             {
@@ -1267,7 +1396,7 @@
                     "y": 45
                 },
                 "panelIndex": "613656f2-744a-4fff-86ce-788ac9d677b6",
-                "title": "Top 10 Rule Name [Logs Zscaler ZIA]",
+                "title": "Top 10 Rule Name",
                 "type": "lens"
             },
             {
@@ -1564,7 +1693,7 @@
                     "y": 45
                 },
                 "panelIndex": "2987c1b4-edc4-4b14-8fcb-5ac66223929c",
-                "title": "Malware Events by User Name [Logs  Zscaler ZIA]",
+                "title": "Malware Events by User Name",
                 "type": "lens"
             },
             {
@@ -1834,7 +1963,7 @@
                     "y": 57
                 },
                 "panelIndex": "2990768f-50cb-459c-85fd-0ebcb4200d56",
-                "title": "Malware Events by Location [Logs Zscaler ZIA]",
+                "title": "Malware Events by Location",
                 "type": "lens"
             },
             {
@@ -1940,7 +2069,7 @@
                     "y": 57
                 },
                 "panelIndex": "d9b43834-6aa8-4e92-be38-1e923e0678f3",
-                "title": "Top 10 Cloud App [Logs Zscaler ZIA]",
+                "title": "Top 10 Cloud App",
                 "type": "lens"
             },
             {
@@ -2099,7 +2228,7 @@
                     "y": 69
                 },
                 "panelIndex": "8ba8c72c-fcb5-4300-b753-4b432d28368a",
-                "title": "Top 10 Failed URL [Logs Zscaler ZIA]",
+                "title": "Top 10 Failed URL",
                 "type": "lens"
             },
             {
@@ -2228,7 +2357,7 @@
                     "y": 69
                 },
                 "panelIndex": "ce01899f-5e71-464c-b021-eb641cc4254f",
-                "title": "Top 10 Threats by Name [Logs Zscaler ZIA]",
+                "title": "Top 10 Threats by Name",
                 "type": "lens"
             },
             {
@@ -2422,7 +2551,7 @@
                     "y": 81
                 },
                 "panelIndex": "dc11ae90-1633-4f9a-840f-cdc844d0d999",
-                "title": "Top 10 User Impacted by Threat Name [Logs Zscaler ZIA]",
+                "title": "Top 10 User Impacted by Threat Name",
                 "type": "lens"
             },
             {
@@ -2566,7 +2695,7 @@
                     "y": 81
                 },
                 "panelIndex": "3e189bc2-d37f-4b6a-9319-fcc7522d2178",
-                "title": "Inline DLP Events by Dictionary Name [Logs Zscaler ZIA]",
+                "title": "Inline DLP Events by Dictionary Name",
                 "type": "lens"
             },
             {
@@ -2768,6 +2897,51 @@
             "id": "zscaler_zia-security-solution-default",
             "name": "tag-ref-security-solution-default",
             "type": "tag"
+        },
+        {
+            "name": "421d0606-6aa7-40e4-95ef-aebdf7908419:link_zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e"
+        },
+        {
+            "name": "421d0606-6aa7-40e4-95ef-aebdf7908419:link_zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635"
+        },
+        {
+            "name": "421d0606-6aa7-40e4-95ef-aebdf7908419:link_zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "421d0606-6aa7-40e4-95ef-aebdf7908419:link_zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42"
+        },
+        {
+            "name": "421d0606-6aa7-40e4-95ef-aebdf7908419:link_zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "421d0606-6aa7-40e4-95ef-aebdf7908419:link_zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416"
+        },
+        {
+            "name": "421d0606-6aa7-40e4-95ef-aebdf7908419:link_zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "421d0606-6aa7-40e4-95ef-aebdf7908419:link_zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "421d0606-6aa7-40e4-95ef-aebdf7908419:link_zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6"
         }
     ],
     "type": "dashboard",

--- a/packages/zscaler_zia/kibana/dashboard/zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416.json
+++ b/packages/zscaler_zia/kibana/dashboard/zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416.json
@@ -101,6 +101,135 @@
             {
                 "embeddableConfig": {
                     "enhancements": {},
+                    "attributes": {
+                        "title": "links",
+                        "layout": "vertical",
+                        "links": [
+                            {
+                                "label": "Overview",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e",
+                                "order": 0,
+                                "destinationRefName": "link_zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e_dashboard"
+                            },
+                            {
+                                "label": "Audit",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635",
+                                "order": 1,
+                                "destinationRefName": "link_zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635_dashboard"
+                            },
+                            {
+                                "label": "DNS",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84",
+                                "order": 2,
+                                "destinationRefName": "link_zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Endpoint DLP",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42",
+                                "order": 3,
+                                "destinationRefName": "link_zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42_dashboard"
+                            },
+                            {
+                                "label": "Firewall",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84",
+                                "order": 4,
+                                "destinationRefName": "link_zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Sandbox Report",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416",
+                                "order": 5,
+                                "destinationRefName": "link_zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416_dashboard"
+                            },
+                            {
+                                "label": "Tunnel",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84",
+                                "order": 6,
+                                "destinationRefName": "link_zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Web Overview",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84",
+                                "order": 7,
+                                "destinationRefName": "link_zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Web Access Control",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6",
+                                "order": 8,
+                                "destinationRefName": "link_zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6_dashboard"
+                            }
+                        ]
+                    }
+                },
+                "gridData": {
+                    "h": 13,
+                    "i": "963139c9-87c9-44ca-927f-c822ac1a2bcc",
+                    "w": 12,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "963139c9-87c9-44ca-927f-c822ac1a2bcc",
+                "title": "Table of Contents",
+                "type": "links"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
                     "hidePanelTitles": false,
                     "savedVis": {
                         "data": {
@@ -117,7 +246,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**Zscaler ZIA**\n\n[Overview](#/dashboard/zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e)\n- [Audit](#/dashboard/zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635)\n- [DNS](#/dashboard/zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84)\n- [Endpoint DLP](#/dashboard/zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42)\n- [Firewall](#/dashboard/zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84)\n- [**Sandbox Report (This Page)**](#/dashboard/zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416)\n- [Tunnel](#/dashboard/zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84)\n- Web\n  - [Web Overview](#/dashboard/zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84)\n  - [Web Access Control](#/dashboard/zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6)\n\n**Overview**\n\nThis dashboard provides a detailed analysis of sandbox reports, featuring pie charts for status, risk and classification types, and bar charts for file categories, file types, and classification categories. It includes a table of the top 10 detected malware and metrics for denotation times. Additionally, a saved search displays essential details of sandbox reports. These visualizations enable effective monitoring and analysis of sandbox activities and threats.\n\n[**Integrations Page**](/app/integrations/detail/zscaler_zia/overview)",
+                            "markdown": "**Zscaler ZIA**\n\nThis dashboard provides a detailed analysis of sandbox reports, featuring pie charts for status, risk and classification types, and bar charts for file categories, file types, and classification categories. It includes a table of the top 10 detected malware and metrics for denotation times. Additionally, a saved search displays essential details of sandbox reports. These visualizations enable effective monitoring and analysis of sandbox activities and threats.\n\n[**Integrations Page**](/app/integrations/detail/zscaler_zia/overview)",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -126,14 +255,14 @@
                     }
                 },
                 "gridData": {
-                    "h": 26,
+                    "h": 13,
                     "i": "963139c9-87c9-44ca-927f-c822ac1a2bcc",
                     "w": 12,
                     "x": 0,
-                    "y": 0
+                    "y": 13
                 },
-                "panelIndex": "963139c9-87c9-44ca-927f-c822ac1a2bcc",
-                "title": "Table of Contents",
+                "panelIndex": "963139c9-87c9-44ca-927f-c822ac1a2bcc_1",
+                "title": "Overview",
                 "type": "visualization"
             },
             {
@@ -218,7 +347,7 @@
                     "y": 0
                 },
                 "panelIndex": "0a6d4f4c-f9e3-4417-b0f9-4eedaac6ab27",
-                "title": "Denotation Average Time [Logs Zscaler ZIA]",
+                "title": "Denotation Average Time",
                 "type": "lens"
             },
             {
@@ -303,7 +432,7 @@
                     "y": 0
                 },
                 "panelIndex": "2c417b5b-32ba-4192-8681-dc0e08cf64e9",
-                "title": "Denotation Minimum Time [Logs Zscaler ZIA]",
+                "title": "Denotation Minimum Time",
                 "type": "lens"
             },
             {
@@ -388,7 +517,7 @@
                     "y": 0
                 },
                 "panelIndex": "50432df8-22cc-4a9d-8bf3-97d6caa8bfe9",
-                "title": "Denotation Maximum Time [Logs Zscaler ZIA]",
+                "title": "Denotation Maximum Time",
                 "type": "lens"
             },
             {
@@ -528,7 +657,7 @@
                     "y": 11
                 },
                 "panelIndex": "19515a7e-4d20-4ecd-b726-6ec19eaa7f81",
-                "title": "Sandbox Reports by Classification Type [Logs Zscaler ZIA]",
+                "title": "Sandbox Reports by Classification Type",
                 "type": "lens"
             },
             {
@@ -670,7 +799,7 @@
                     "y": 11
                 },
                 "panelIndex": "58e38488-6179-495f-b73b-eb21e9aaf4ed",
-                "title": "Sandbox Reports by Status [Logs Zscaler ZIA]",
+                "title": "Sandbox Reports by Status",
                 "type": "lens"
             },
             {
@@ -812,7 +941,7 @@
                     "y": 26
                 },
                 "panelIndex": "6b5251ad-094e-4438-8331-bbe15bd09d5c",
-                "title": "Sandbox Reports System Summary Report by Risk [Logs Zscaler ZIA]",
+                "title": "Sandbox Reports System Summary Report by Risk",
                 "type": "lens"
             },
             {
@@ -977,7 +1106,7 @@
                     "y": 26
                 },
                 "panelIndex": "48c0c0bc-d772-458e-bbc3-64ea25fd68f1",
-                "title": "Sandbox Reports by Classification Category [Logs Zscaler ZIA]",
+                "title": "Sandbox Reports by Classification Category",
                 "type": "lens"
             },
             {
@@ -1142,7 +1271,7 @@
                     "y": 41
                 },
                 "panelIndex": "3436bd15-34d0-4b39-894d-1764bf7ef7a4",
-                "title": "Sandbox Reports by File Category [Logs Zscaler ZIA]",
+                "title": "Sandbox Reports by File Category",
                 "type": "lens"
             },
             {
@@ -1258,7 +1387,7 @@
                     "y": 41
                 },
                 "panelIndex": "ecaba547-236d-4881-ab65-619f7f72fd14",
-                "title": "Top 10 Detected Malware [Logs Zscaler ZIA]",
+                "title": "Top 10 Detected Malware",
                 "type": "lens"
             },
             {
@@ -1423,7 +1552,7 @@
                     "y": 56
                 },
                 "panelIndex": "39827b38-1482-42bb-8176-8c003d9366e8",
-                "title": "Sandbox Reports by File Type [Logs Zscaler ZIA]",
+                "title": "Sandbox Reports by File Type",
                 "type": "lens"
             },
             {
@@ -1535,6 +1664,51 @@
             "id": "zscaler_zia-security-solution-default",
             "name": "tag-ref-security-solution-default",
             "type": "tag"
+        },
+        {
+            "name": "963139c9-87c9-44ca-927f-c822ac1a2bcc:link_zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e"
+        },
+        {
+            "name": "963139c9-87c9-44ca-927f-c822ac1a2bcc:link_zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635"
+        },
+        {
+            "name": "963139c9-87c9-44ca-927f-c822ac1a2bcc:link_zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "963139c9-87c9-44ca-927f-c822ac1a2bcc:link_zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42"
+        },
+        {
+            "name": "963139c9-87c9-44ca-927f-c822ac1a2bcc:link_zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "963139c9-87c9-44ca-927f-c822ac1a2bcc:link_zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416"
+        },
+        {
+            "name": "963139c9-87c9-44ca-927f-c822ac1a2bcc:link_zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "963139c9-87c9-44ca-927f-c822ac1a2bcc:link_zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "963139c9-87c9-44ca-927f-c822ac1a2bcc:link_zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6"
         }
     ],
     "type": "dashboard",

--- a/packages/zscaler_zia/kibana/dashboard/zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84.json
+++ b/packages/zscaler_zia/kibana/dashboard/zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84.json
@@ -49,6 +49,135 @@
             {
                 "embeddableConfig": {
                     "enhancements": {},
+                    "attributes": {
+                        "title": "links",
+                        "layout": "vertical",
+                        "links": [
+                            {
+                                "label": "Overview",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e",
+                                "order": 0,
+                                "destinationRefName": "link_zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e_dashboard"
+                            },
+                            {
+                                "label": "Audit",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635",
+                                "order": 1,
+                                "destinationRefName": "link_zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635_dashboard"
+                            },
+                            {
+                                "label": "DNS",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84",
+                                "order": 2,
+                                "destinationRefName": "link_zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Endpoint DLP",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42",
+                                "order": 3,
+                                "destinationRefName": "link_zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42_dashboard"
+                            },
+                            {
+                                "label": "Firewall",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84",
+                                "order": 4,
+                                "destinationRefName": "link_zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Sandbox Report",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416",
+                                "order": 5,
+                                "destinationRefName": "link_zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416_dashboard"
+                            },
+                            {
+                                "label": "Tunnel",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84",
+                                "order": 6,
+                                "destinationRefName": "link_zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Web Overview",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84",
+                                "order": 7,
+                                "destinationRefName": "link_zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Web Access Control",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6",
+                                "order": 8,
+                                "destinationRefName": "link_zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6_dashboard"
+                            }
+                        ]
+                    }
+                },
+                "gridData": {
+                    "h": 14,
+                    "i": "527862de-e8ad-4553-bdb6-fe8adaa80944",
+                    "w": 23,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "527862de-e8ad-4553-bdb6-fe8adaa80944",
+                "title": "Table of Contents",
+                "type": "links"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
                     "savedVis": {
                         "data": {
                             "aggs": [],
@@ -64,7 +193,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**Zscaler ZIA**\n\n[Overview](#/dashboard/zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e)\n- [Audit](#/dashboard/zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635)\n- [DNS](#/dashboard/zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84)\n- [Endpoint DLP](#/dashboard/zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42)\n- [**Firewall (This Page)**](#/dashboard/zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84)\n- [Sandbox Report](#/dashboard/zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416)\n- [Tunnel](#/dashboard/zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84)\n- Web\n  - [Web Overview](#/dashboard/zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84)\n  - [Web Access Control](#/dashboard/zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6)\n\n**Overview**\n\nThis dashboard shows Firewall  related to the Zscaler ZIA Integration.\n\nThe dashboard is made to provide general statistics and show the ingested Firewall  logs from Zscaler ZIA.\n\nIt shows the breakdown  by Top 10 Threats Detected by Firewall, Top 10 Destination Country, Top 10 Rule, Events by Flow Type, Events by Network Application, Events by Protocol, Events by Threat Category and Events by Threat Name. It presents the  Events by Network Application over Time. The dashboard also includes the Top 10 Tunnel IP, Top 10 Server Source IP, Top 10 Server Destination IP, Top 10 Client Source IP, Top 10 Client Destination IP and Top 10 User Impacted by Threat Name. In addition, it illustrates the Total Request in Second Total Threats Blocked and Distribution of Firewall Event.\n\n[**Integrations Page**](/app/integrations/detail/zscaler_zia/overview)",
+                            "markdown": "**Zscaler ZIA**\n\nThis dashboard shows Firewall  related to the Zscaler ZIA Integration.\n\nThe dashboard is made to provide general statistics and show the ingested Firewall  logs from Zscaler ZIA.\n\nIt shows the breakdown  by Top 10 Threats Detected by Firewall, Top 10 Destination Country, Top 10 Rule, Events by Flow Type, Events by Network Application, Events by Protocol, Events by Threat Category and Events by Threat Name. It presents the  Events by Network Application over Time. The dashboard also includes the Top 10 Tunnel IP, Top 10 Server Source IP, Top 10 Server Destination IP, Top 10 Client Source IP, Top 10 Client Destination IP and Top 10 User Impacted by Threat Name. In addition, it illustrates the Total Request in Second Total Threats Blocked and Distribution of Firewall Event.\n\n[**Integrations Page**](/app/integrations/detail/zscaler_zia/overview)",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -73,14 +202,14 @@
                     }
                 },
                 "gridData": {
-                    "h": 28,
+                    "h": 14,
                     "i": "527862de-e8ad-4553-bdb6-fe8adaa80944",
                     "w": 23,
                     "x": 0,
-                    "y": 0
+                    "y": 14
                 },
-                "panelIndex": "527862de-e8ad-4553-bdb6-fe8adaa80944",
-                "title": "Table of Content",
+                "panelIndex": "527862de-e8ad-4553-bdb6-fe8adaa80944_1",
+                "title": "Overview",
                 "type": "visualization"
             },
             {
@@ -527,7 +656,7 @@
                     "y": 12
                 },
                 "panelIndex": "2147c38e-2f9d-4f89-a3ef-8fa1f13e53ee",
-                "title": "Firewall Events  by Network Application over Time [Logs Zscaler ZIA]",
+                "title": "Firewall Events  by Network Application over Time",
                 "type": "lens"
             },
             {
@@ -696,7 +825,7 @@
                     "y": 28
                 },
                 "panelIndex": "edf17888-cb90-4aba-9d8c-701e468ddac8",
-                "title": "Firewall Events  by Network Application [Logs Zscaler ZIA]",
+                "title": "Firewall Events  by Network Application",
                 "type": "lens"
             },
             {
@@ -864,7 +993,7 @@
                     "y": 28
                 },
                 "panelIndex": "e6cfec2c-607e-4def-9cf6-74e67db415ed",
-                "title": "Firewall Events  by Threat Name [Logs Zscaler ZIA]",
+                "title": "Firewall Events  by Threat Name",
                 "type": "lens"
             },
             {
@@ -1059,7 +1188,7 @@
                     "y": 40
                 },
                 "panelIndex": "2d4d2e8f-8b59-43b5-9765-e8e915bcba9b",
-                "title": "Firewall Events  by Protocol [Logs Zscaler ZIA]",
+                "title": "Firewall Events  by Protocol",
                 "type": "lens"
             },
             {
@@ -1227,7 +1356,7 @@
                     "y": 40
                 },
                 "panelIndex": "586da8f2-8e41-4982-9438-052b320fc11f",
-                "title": "Firewall Events  by Threat Category [Logs Zscaler ZIA]",
+                "title": "Firewall Events  by Threat Category",
                 "type": "lens"
             },
             {
@@ -1392,7 +1521,7 @@
                     "y": 53
                 },
                 "panelIndex": "b5f9516d-e13c-44a8-a871-d77b85818f76",
-                "title": "Top 10 Destination Country [Logs Zscaler ZIA]",
+                "title": "Top 10 Destination Country",
                 "type": "lens"
             },
             {
@@ -1598,7 +1727,7 @@
                     "y": 53
                 },
                 "panelIndex": "3a34ad56-d3c0-4edb-92bb-be96329c197f",
-                "title": "Top 10 Rule [Logs Zscaler ZIA]",
+                "title": "Top 10 Rule",
                 "type": "lens"
             },
             {
@@ -1759,7 +1888,7 @@
                     "y": 66
                 },
                 "panelIndex": "2b8839f5-a3c5-4984-8c2e-7760e1934b1f",
-                "title": "Firewall Events  by Flow Type [Logs Zscaler ZIA]",
+                "title": "Firewall Events  by Flow Type",
                 "type": "lens"
             },
             {
@@ -1917,7 +2046,7 @@
                     "y": 66
                 },
                 "panelIndex": "73033209-06cc-4c50-8730-f2671a847672",
-                "title": "Top 10 Threats Detected by Firewall [Logs Zscaler ZIA]",
+                "title": "Top 10 Threats Detected by Firewall",
                 "type": "lens"
             },
             {
@@ -2022,7 +2151,7 @@
                     "y": 79
                 },
                 "panelIndex": "39c93b5b-510d-4347-bd03-b2a57cdedd23",
-                "title": "Top 10 Server Source IP [Logs Zscaler ZIA]",
+                "title": "Top 10 Server Source IP",
                 "type": "lens"
             },
             {
@@ -2128,7 +2257,7 @@
                     "y": 79
                 },
                 "panelIndex": "a85898a7-4588-445f-bb32-ab355bd47bdf",
-                "title": "Top 10 Tunnel IP [Logs Zscaler ZIA]",
+                "title": "Top 10 Tunnel IP",
                 "type": "lens"
             },
             {
@@ -2233,7 +2362,7 @@
                     "y": 91
                 },
                 "panelIndex": "bee21887-58f2-434f-9bf8-2df3cce27e5f",
-                "title": "Top 10 Server Destination IP [Logs Zscaler ZIA]",
+                "title": "Top 10 Server Destination IP",
                 "type": "lens"
             },
             {
@@ -2340,7 +2469,7 @@
                     "y": 91
                 },
                 "panelIndex": "4292e6fc-3afa-474f-953d-a385713e29ac",
-                "title": "Top 10 Client Destination IP [Logs Zscaler ZIA]",
+                "title": "Top 10 Client Destination IP",
                 "type": "lens"
             },
             {
@@ -2512,7 +2641,7 @@
                     "y": 106
                 },
                 "panelIndex": "45666e9e-fe55-4979-bff2-e68b6feef53c",
-                "title": "Top 10 User Impacted by Threat Name [Logs Zscaler ZIA]",
+                "title": "Top 10 User Impacted by Threat Name",
                 "type": "lens"
             },
             {
@@ -2617,7 +2746,7 @@
                     "y": 106
                 },
                 "panelIndex": "c466689d-2023-4bf9-a97a-b5b4cb6fa45c",
-                "title": "Top 10 Client Source IP [Logs Zscaler ZIA]",
+                "title": "Top 10 Client Source IP",
                 "type": "lens"
             },
             {
@@ -2633,7 +2762,7 @@
                 },
                 "panelIndex": "93615be2-0759-41b9-a1f5-babcb7587d31",
                 "panelRefName": "panel_93615be2-0759-41b9-a1f5-babcb7587d31",
-                "title": "Distribution of Firewall Events [Logs Zscaler ZIA]",
+                "title": "Distribution of Firewall Events",
                 "type": "search"
             }
         ],
@@ -2805,6 +2934,51 @@
             "id": "zscaler_zia-security-solution-default",
             "name": "tag-ref-security-solution-default",
             "type": "tag"
+        },
+        {
+            "name": "527862de-e8ad-4553-bdb6-fe8adaa80944:link_zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e"
+        },
+        {
+            "name": "527862de-e8ad-4553-bdb6-fe8adaa80944:link_zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635"
+        },
+        {
+            "name": "527862de-e8ad-4553-bdb6-fe8adaa80944:link_zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "527862de-e8ad-4553-bdb6-fe8adaa80944:link_zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42"
+        },
+        {
+            "name": "527862de-e8ad-4553-bdb6-fe8adaa80944:link_zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "527862de-e8ad-4553-bdb6-fe8adaa80944:link_zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416"
+        },
+        {
+            "name": "527862de-e8ad-4553-bdb6-fe8adaa80944:link_zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "527862de-e8ad-4553-bdb6-fe8adaa80944:link_zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "527862de-e8ad-4553-bdb6-fe8adaa80944:link_zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6"
         }
     ],
     "type": "dashboard",

--- a/packages/zscaler_zia/kibana/dashboard/zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84.json
+++ b/packages/zscaler_zia/kibana/dashboard/zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84.json
@@ -49,6 +49,135 @@
             {
                 "embeddableConfig": {
                     "enhancements": {},
+                    "attributes": {
+                        "title": "links",
+                        "layout": "vertical",
+                        "links": [
+                            {
+                                "label": "Overview",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e",
+                                "order": 0,
+                                "destinationRefName": "link_zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e_dashboard"
+                            },
+                            {
+                                "label": "Audit",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635",
+                                "order": 1,
+                                "destinationRefName": "link_zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635_dashboard"
+                            },
+                            {
+                                "label": "DNS",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84",
+                                "order": 2,
+                                "destinationRefName": "link_zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Endpoint DLP",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42",
+                                "order": 3,
+                                "destinationRefName": "link_zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42_dashboard"
+                            },
+                            {
+                                "label": "Firewall",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84",
+                                "order": 4,
+                                "destinationRefName": "link_zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Sandbox Report",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416",
+                                "order": 5,
+                                "destinationRefName": "link_zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416_dashboard"
+                            },
+                            {
+                                "label": "Tunnel",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84",
+                                "order": 6,
+                                "destinationRefName": "link_zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Web Overview",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84",
+                                "order": 7,
+                                "destinationRefName": "link_zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Web Access Control",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6",
+                                "order": 8,
+                                "destinationRefName": "link_zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6_dashboard"
+                            }
+                        ]
+                    }
+                },
+                "gridData": {
+                    "h": 13,
+                    "i": "23a6dda5-1f58-4fcc-82ee-5003730ce8c8",
+                    "w": 24,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "23a6dda5-1f58-4fcc-82ee-5003730ce8c8",
+                "title": "Table of Contents",
+                "type": "links"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
                     "savedVis": {
                         "data": {
                             "aggs": [],
@@ -64,7 +193,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**Zscaler ZIA**\n\n[Overview](#/dashboard/zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e)\n- [Audit](#/dashboard/zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635)\n- [DNS](#/dashboard/zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84)\n- [Endpoint DLP](#/dashboard/zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42)\n- [Firewall](#/dashboard/zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84)\n- [Sandbox Report](#/dashboard/zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416)\n- [**Tunnel (This Page)**](#/dashboard/zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84)\n- Web\n  - [Web Overview](#/dashboard/zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84)\n  - [Web Access Control](#/dashboard/zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6)\n\n**Overview**\n\nThis dashboard shows Tunnel  related to the Zscaler ZIA Integration.\n\nThe dashboard is made to provide general statistics and show the ingested Tunnel  logs from Zscaler ZIA.\n\nIt shows the breakdown  by Top 10 Events by Encryption Algorithm, Top 10 Events by Authentication Algorithm, Top 10 Events by Authentication Type, Events by Tunnel Type, Events by location and Events by Vendor Name of Edge Device. The dashboard also includes the Top 10 Tunnel Action Name, Top 10 Source IP and Top 10 Destination IP. In addition, it illustrates the Distribution of Tunnel Event.\n\n[**Integrations Page**](/app/integrations/detail/zscaler_zia/overview)",
+                            "markdown": "**Zscaler ZIA**\n\nThis dashboard shows Tunnel  related to the Zscaler ZIA Integration.\n\nThe dashboard is made to provide general statistics and show the ingested Tunnel  logs from Zscaler ZIA.\n\nIt shows the breakdown  by Top 10 Events by Encryption Algorithm, Top 10 Events by Authentication Algorithm, Top 10 Events by Authentication Type, Events by Tunnel Type, Events by location and Events by Vendor Name of Edge Device. The dashboard also includes the Top 10 Tunnel Action Name, Top 10 Source IP and Top 10 Destination IP. In addition, it illustrates the Distribution of Tunnel Event.\n\n[**Integrations Page**](/app/integrations/detail/zscaler_zia/overview)",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -73,14 +202,14 @@
                     }
                 },
                 "gridData": {
-                    "h": 25,
+                    "h": 12,
                     "i": "23a6dda5-1f58-4fcc-82ee-5003730ce8c8",
                     "w": 24,
                     "x": 0,
-                    "y": 0
+                    "y": 13
                 },
-                "panelIndex": "23a6dda5-1f58-4fcc-82ee-5003730ce8c8",
-                "title": "Table of Content",
+                "panelIndex": "23a6dda5-1f58-4fcc-82ee-5003730ce8c8_1",
+                "title": "Overview",
                 "type": "visualization"
             },
             {
@@ -192,7 +321,7 @@
                     "y": 0
                 },
                 "panelIndex": "51e71d8f-9652-4c47-91b1-2db2401ac3c6",
-                "title": "Tunnel Events  by Vendor Name of Edge Device [Logs Zscaler ZIA]",
+                "title": "Tunnel Events  by Vendor Name of Edge Device",
                 "type": "lens"
             },
             {
@@ -304,7 +433,7 @@
                     "y": 12
                 },
                 "panelIndex": "da0b8f17-5d81-4887-91e7-a6117cc09f6e",
-                "title": "Tunnel Events  by Location [Logs Zscaler ZIA]",
+                "title": "Tunnel Events  by Location",
                 "type": "lens"
             },
             {
@@ -416,7 +545,7 @@
                     "y": 25
                 },
                 "panelIndex": "8f694796-f63c-4f70-ad44-f91bbd11f23b",
-                "title": "Tunnel Events  by Tunnel Type [Logs Zscaler ZIA] ",
+                "title": "Tunnel Events  by Tunnel Type",
                 "type": "lens"
             },
             {
@@ -581,7 +710,7 @@
                     "y": 25
                 },
                 "panelIndex": "82aaad4b-a14b-4f9f-baca-1e19862e0c17",
-                "title": "Top 10 Events by Authentication Algorithm [Logs Zscaler ZIA]",
+                "title": "Top 10 Events by Authentication Algorithm",
                 "type": "lens"
             },
             {
@@ -746,7 +875,7 @@
                     "y": 38
                 },
                 "panelIndex": "30d96000-b5bd-4f60-9ebb-c5b6157aa32a",
-                "title": "Top 10 Events by Encryption Algorithm [Logs Zscaler ZIA]",
+                "title": "Top 10 Events by Encryption Algorithm",
                 "type": "lens"
             },
             {
@@ -909,7 +1038,7 @@
                     "y": 38
                 },
                 "panelIndex": "0bfafe62-44cd-4b10-8c96-3f9ccf0ebd23",
-                "title": "Top 10 Events by Authentication Type [Logs Zscaler ZIA]",
+                "title": "Top 10 Events by Authentication Type",
                 "type": "lens"
             },
             {
@@ -1041,7 +1170,7 @@
                     "y": 51
                 },
                 "panelIndex": "ee9ebe7d-4aca-484c-be0f-27c073756cb7",
-                "title": "Top 10 Source IP [Logs Zscaler ZIA]",
+                "title": "Top 10 Source IP",
                 "type": "lens"
             },
             {
@@ -1147,7 +1276,7 @@
                     "y": 51
                 },
                 "panelIndex": "d5a053a8-abd7-46e8-9787-da0171a8361b",
-                "title": "Top 10 Tunnel Action Name [Logs Zscaler ZIA]",
+                "title": "Top 10 Tunnel Action Name",
                 "type": "lens"
             },
             {
@@ -1279,7 +1408,7 @@
                     "y": 63
                 },
                 "panelIndex": "2f7e566b-253c-44ca-abb3-97846b112636",
-                "title": "Top 10 Destination IP [Logs Zscaler ZIA]",
+                "title": "Top 10 Destination IP",
                 "type": "lens"
             },
             {
@@ -1391,6 +1520,51 @@
             "id": "zscaler_zia-security-solution-default",
             "name": "tag-ref-security-solution-default",
             "type": "tag"
+        },
+        {
+            "name": "23a6dda5-1f58-4fcc-82ee-5003730ce8c8:link_zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e"
+        },
+        {
+            "name": "23a6dda5-1f58-4fcc-82ee-5003730ce8c8:link_zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635"
+        },
+        {
+            "name": "23a6dda5-1f58-4fcc-82ee-5003730ce8c8:link_zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "23a6dda5-1f58-4fcc-82ee-5003730ce8c8:link_zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42"
+        },
+        {
+            "name": "23a6dda5-1f58-4fcc-82ee-5003730ce8c8:link_zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "23a6dda5-1f58-4fcc-82ee-5003730ce8c8:link_zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416"
+        },
+        {
+            "name": "23a6dda5-1f58-4fcc-82ee-5003730ce8c8:link_zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "23a6dda5-1f58-4fcc-82ee-5003730ce8c8:link_zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "23a6dda5-1f58-4fcc-82ee-5003730ce8c8:link_zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6"
         }
     ],
     "type": "dashboard",

--- a/packages/zscaler_zia/kibana/dashboard/zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84.json
+++ b/packages/zscaler_zia/kibana/dashboard/zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84.json
@@ -49,6 +49,135 @@
             {
                 "embeddableConfig": {
                     "enhancements": {},
+                    "attributes": {
+                        "title": "links",
+                        "layout": "vertical",
+                        "links": [
+                            {
+                                "label": "Overview",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e",
+                                "order": 0,
+                                "destinationRefName": "link_zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e_dashboard"
+                            },
+                            {
+                                "label": "Audit",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635",
+                                "order": 1,
+                                "destinationRefName": "link_zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635_dashboard"
+                            },
+                            {
+                                "label": "DNS",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84",
+                                "order": 2,
+                                "destinationRefName": "link_zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Endpoint DLP",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42",
+                                "order": 3,
+                                "destinationRefName": "link_zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42_dashboard"
+                            },
+                            {
+                                "label": "Firewall",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84",
+                                "order": 4,
+                                "destinationRefName": "link_zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Sandbox Report",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416",
+                                "order": 5,
+                                "destinationRefName": "link_zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416_dashboard"
+                            },
+                            {
+                                "label": "Tunnel",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84",
+                                "order": 6,
+                                "destinationRefName": "link_zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Web Overview",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84",
+                                "order": 7,
+                                "destinationRefName": "link_zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Web Access Control",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6",
+                                "order": 8,
+                                "destinationRefName": "link_zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6_dashboard"
+                            }
+                        ]
+                    }
+                },
+                "gridData": {
+                    "h": 11,
+                    "i": "353110e0-92bd-4481-8180-85d79cc22e2f",
+                    "w": 27,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "353110e0-92bd-4481-8180-85d79cc22e2f",
+                "title": "Table of Contents",
+                "type": "links"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
                     "savedVis": {
                         "data": {
                             "aggs": [],
@@ -64,7 +193,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**Zscaler ZIA**\n\n[Overview](#/dashboard/zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e)\n- [Audit](#/dashboard/zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635)\n- [**DNS (This Page)**](#/dashboard/zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84)\n- [Endpoint DLP](#/dashboard/zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42)\n- [Firewall](#/dashboard/zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84)\n- [Sandbox Report](#/dashboard/zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416)\n- [Tunnel](#/dashboard/zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84)\n- Web\n  - [Web Overview](#/dashboard/zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84)\n  - [Web Access Control](#/dashboard/zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6)\n\n**Overview**\n\nThis dashboard shows DNS  related to the Zscaler ZIA Integration.\n\nThe dashboard is made to provide general statistics and show the ingested DNS  logs from Zscaler ZIA.\n\nIt shows the breakdown  by Top 10 Rule, Top 10 Events by Error Code, Top 10 Events by Status Code, Events by Department and Events by Request Action .It presents the Events by Region.In addition, it illustrates the Total Request in Second.\n\n[**Integrations Page**](/app/integrations/detail/zscaler_zia/overview)",
+                            "markdown": "**Zscaler ZIA**\n\nThis dashboard shows DNS  related to the Zscaler ZIA Integration.\n\nThe dashboard is made to provide general statistics and show the ingested DNS  logs from Zscaler ZIA.\n\nIt shows the breakdown  by Top 10 Rule, Top 10 Events by Error Code, Top 10 Events by Status Code, Events by Department and Events by Request Action. It presents the Events by Region. In addition, it illustrates the Total Request in Second.\n\n[**Integrations Page**](/app/integrations/detail/zscaler_zia/overview)",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -73,14 +202,14 @@
                     }
                 },
                 "gridData": {
-                    "h": 21,
+                    "h": 10,
                     "i": "353110e0-92bd-4481-8180-85d79cc22e2f",
                     "w": 27,
                     "x": 0,
-                    "y": 0
+                    "y": 11
                 },
-                "panelIndex": "353110e0-92bd-4481-8180-85d79cc22e2f",
-                "title": "Table of Content",
+                "panelIndex": "353110e0-92bd-4481-8180-85d79cc22e2f_1",
+                "title": "Overview",
                 "type": "visualization"
             },
             {
@@ -314,7 +443,7 @@
                     "y": 7
                 },
                 "panelIndex": "50e3bd5d-abe2-4854-b6e2-b48dffd37623",
-                "title": "DNS Events by Request Action [Logs Zscaler ZIA]",
+                "title": "DNS Events by Request Action",
                 "type": "lens"
             },
             {
@@ -429,7 +558,7 @@
                     "y": 21
                 },
                 "panelIndex": "aa01aea8-7564-4425-af91-9b5183e7a93f",
-                "title": "DNS Events by Department [Logs Zscaler ZIA]",
+                "title": "DNS Events by Department",
                 "type": "lens"
             },
             {
@@ -620,7 +749,7 @@
                     "y": 21
                 },
                 "panelIndex": "50daad8a-58ab-4e87-a714-25a8078bcec1",
-                "title": "Top 10 Events by Error Code [Logs Zscaler ZIA]",
+                "title": "Top 10 Events by Error Code",
                 "type": "lens"
             },
             {
@@ -811,7 +940,7 @@
                     "y": 36
                 },
                 "panelIndex": "05581c9f-e24f-4d9f-b027-c7ff3d79ccb5",
-                "title": "Top 10 Rule [Logs Zscaler ZIA]",
+                "title": "Top 10 Rule",
                 "type": "lens"
             },
             {
@@ -976,7 +1105,7 @@
                     "y": 36
                 },
                 "panelIndex": "42e76c82-1915-48b0-bb92-99210f1e84bf",
-                "title": "Top 10 Events by Status Code [Logs Zscaler ZIA]",
+                "title": "Top 10 Events by Status Code",
                 "type": "lens"
             },
             {
@@ -1123,7 +1252,7 @@
                     "y": 53
                 },
                 "panelIndex": "7ba9b3df-0cb5-4151-9526-ad504c923a4d",
-                "title": "Top 10 Source IP [Logs Zscaler ZIA]",
+                "title": "Top 10 Source IP",
                 "type": "lens"
             },
             {
@@ -1258,7 +1387,7 @@
                     "y": 67
                 },
                 "panelIndex": "0d8d442a-ae5b-4a1d-b2ef-985c59dce792",
-                "title": "DNS Events by Region [Logs Zscaler ZIA]",
+                "title": "DNS Events by Region",
                 "type": "lens"
             }
         ],
@@ -1370,6 +1499,51 @@
             "id": "zscaler_zia-security-solution-default",
             "name": "tag-ref-security-solution-default",
             "type": "tag"
+        },
+        {
+            "name": "353110e0-92bd-4481-8180-85d79cc22e2f:link_zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e"
+        },
+        {
+            "name": "353110e0-92bd-4481-8180-85d79cc22e2f:link_zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635"
+        },
+        {
+            "name": "353110e0-92bd-4481-8180-85d79cc22e2f:link_zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "353110e0-92bd-4481-8180-85d79cc22e2f:link_zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42"
+        },
+        {
+            "name": "353110e0-92bd-4481-8180-85d79cc22e2f:link_zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "353110e0-92bd-4481-8180-85d79cc22e2f:link_zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416"
+        },
+        {
+            "name": "353110e0-92bd-4481-8180-85d79cc22e2f:link_zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "353110e0-92bd-4481-8180-85d79cc22e2f:link_zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "353110e0-92bd-4481-8180-85d79cc22e2f:link_zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6"
         }
     ],
     "type": "dashboard",

--- a/packages/zscaler_zia/kibana/dashboard/zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6.json
+++ b/packages/zscaler_zia/kibana/dashboard/zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6.json
@@ -50,6 +50,135 @@
             {
                 "embeddableConfig": {
                     "enhancements": {},
+                    "attributes": {
+                        "title": "links",
+                        "layout": "vertical",
+                        "links": [
+                            {
+                                "label": "Overview",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e",
+                                "order": 0,
+                                "destinationRefName": "link_zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e_dashboard"
+                            },
+                            {
+                                "label": "Audit",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635",
+                                "order": 1,
+                                "destinationRefName": "link_zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635_dashboard"
+                            },
+                            {
+                                "label": "DNS",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84",
+                                "order": 2,
+                                "destinationRefName": "link_zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Endpoint DLP",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42",
+                                "order": 3,
+                                "destinationRefName": "link_zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42_dashboard"
+                            },
+                            {
+                                "label": "Firewall",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84",
+                                "order": 4,
+                                "destinationRefName": "link_zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Sandbox Report",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416",
+                                "order": 5,
+                                "destinationRefName": "link_zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416_dashboard"
+                            },
+                            {
+                                "label": "Tunnel",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84",
+                                "order": 6,
+                                "destinationRefName": "link_zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Web Overview",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84",
+                                "order": 7,
+                                "destinationRefName": "link_zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Web Access Control",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6",
+                                "order": 8,
+                                "destinationRefName": "link_zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6_dashboard"
+                            }
+                        ]
+                    }
+                },
+                "gridData": {
+                    "h": 16,
+                    "i": "ede900a0-3876-4eb2-819f-f319a79b9c85",
+                    "w": 17,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "ede900a0-3876-4eb2-819f-f319a79b9c85",
+                "title": "Table of Contents",
+                "type": "links"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
                     "savedVis": {
                         "data": {
                             "aggs": [],
@@ -65,7 +194,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**Zscaler ZIA**\n\n[Overview](#/dashboard/zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e)\n- [Audit](#/dashboard/zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635)\n- [DNS](#/dashboard/zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84)\n- [Endpoint DLP](#/dashboard/zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42)\n- [Firewall](#/dashboard/zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84)\n- [Sandbox Report](#/dashboard/zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416)\n- [Tunnel](#/dashboard/zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84)\n- Web\n  - [Web Overview](#/dashboard/zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84)\n  - [**Web Access Control (This Page)**](#/dashboard/zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6)\n\n**Overview**\n\nThis dashboard shows Web Access Control  related to the Zscaler ZIA Integration.\n\nThe dashboard is made to provide general statistics and show the ingested Web Access Control  logs from Zscaler ZIA.\n\nIt shows the breakdown  by Top 10 Location, Top 10 URL Categories, Events by Protocol, SSL non-Decrypted Events by Protocol, Events by File Type, Events by Blocked Reason and Allowed vs Blocked Event. It presents the  Events over Time, User Uploading over Time, User Downloading over Time and User Uploading into Cloud App over Time. In addition, it illustrates the Total SSL Decrypted Events and Top 10 User and URL.\n\n[**Integrations Page**](/app/integrations/detail/zscaler_zia/overview)",
+                            "markdown": "**Zscaler ZIA**\n\nThis dashboard shows Web Access Control  related to the Zscaler ZIA Integration.\n\nThe dashboard is made to provide general statistics and show the ingested Web Access Control  logs from Zscaler ZIA.\n\nIt shows the breakdown  by Top 10 Location, Top 10 URL Categories, Events by Protocol, SSL non-Decrypted Events by Protocol, Events by File Type, Events by Blocked Reason and Allowed vs Blocked Event. It presents the  Events over Time, User Uploading over Time, User Downloading over Time and User Uploading into Cloud App over Time. In addition, it illustrates the Total SSL Decrypted Events and Top 10 User and URL.\n\n[**Integrations Page**](/app/integrations/detail/zscaler_zia/overview)",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -74,14 +203,14 @@
                     }
                 },
                 "gridData": {
-                    "h": 31,
+                    "h": 15,
                     "i": "ede900a0-3876-4eb2-819f-f319a79b9c85",
                     "w": 17,
                     "x": 0,
-                    "y": 0
+                    "y": 16
                 },
-                "panelIndex": "ede900a0-3876-4eb2-819f-f319a79b9c85",
-                "title": "Table of Content",
+                "panelIndex": "ede900a0-3876-4eb2-819f-f319a79b9c85_1",
+                "title": "Overview",
                 "type": "visualization"
             },
             {
@@ -389,7 +518,7 @@
                     "y": 7
                 },
                 "panelIndex": "86ff83ce-81e1-41a0-88eb-fd8706a12554",
-                "title": "Web Events over Time [Logs Zscaler ZIA]",
+                "title": "Web Events over Time",
                 "type": "lens"
             },
             {
@@ -597,7 +726,7 @@
                     "y": 19
                 },
                 "panelIndex": "96a28436-ab84-4154-a860-1814df0a8436",
-                "title": "User Uploading into Cloud App over Time [Logs Zscaler ZIA]",
+                "title": "User Uploading into Cloud App over Time",
                 "type": "lens"
             },
             {
@@ -950,7 +1079,7 @@
                     "y": 31
                 },
                 "panelIndex": "1a3b3f52-f254-4983-876e-f72f93d34fc2",
-                "title": "User Uploading over Time [Logs Zscaler ZIA]",
+                "title": "User Uploading over Time",
                 "type": "lens"
             },
             {
@@ -1118,7 +1247,7 @@
                     "y": 46
                 },
                 "panelIndex": "b3fa4e8c-977f-4e6b-b992-a23c75d83c64",
-                "title": "Web Events by Protocol [Logs Zscaler ZIA]",
+                "title": "Web Events by Protocol",
                 "type": "lens"
             },
             {
@@ -1313,7 +1442,7 @@
                     "y": 46
                 },
                 "panelIndex": "f90076ab-4dbd-4160-988c-183431f71d80",
-                "title": "SSL non-Decrypted Events by Protocol [Logs Zscaler ZIA]",
+                "title": "SSL non-Decrypted Events by Protocol",
                 "type": "lens"
             },
             {
@@ -1453,7 +1582,7 @@
                     "y": 58
                 },
                 "panelIndex": "b0a6c87e-cb3c-4fe5-af98-b85154dd2fdc",
-                "title": "Web Events by File Type [Logs Zscaler ZIA]",
+                "title": "Web Events by File Type",
                 "type": "lens"
             },
             {
@@ -1680,7 +1809,7 @@
                     "y": 58
                 },
                 "panelIndex": "3f5a7883-1c1d-444d-a37d-ca7cb7cfec5d",
-                "title": "Allowed vs Blocked Events [Logs Zscaler ZIA]",
+                "title": "Allowed vs Blocked Events",
                 "type": "lens"
             },
             {
@@ -1843,7 +1972,7 @@
                     "y": 70
                 },
                 "panelIndex": "84ec0872-5c26-4e34-97c4-ca1ce0ea8d07",
-                "title": "Top 10 URL Categories [Logs Zscaler ZIA]",
+                "title": "Top 10 URL Categories",
                 "type": "lens"
             },
             {
@@ -2038,7 +2167,7 @@
                     "y": 70
                 },
                 "panelIndex": "84ff65a6-79ef-41c7-9d82-5eddf45ca91f",
-                "title": "Web Events by Blocked Reason [Logs Zscaler ZIA]",
+                "title": "Web Events by Blocked Reason",
                 "type": "lens"
             },
             {
@@ -2207,7 +2336,7 @@
                     "y": 85
                 },
                 "panelIndex": "6708d7cf-3fee-4f95-8c76-5775435f7ec3",
-                "title": "Top 10 User and URL [Logs Zscaler ZIA]",
+                "title": "Top 10 User and URL",
                 "type": "lens"
             },
             {
@@ -2372,7 +2501,7 @@
                     "y": 85
                 },
                 "panelIndex": "41feb1bc-d976-417d-8604-e30dd26678c3",
-                "title": "Top 10 Location [Logs Zscaler ZIA]",
+                "title": "Top 10 Location",
                 "type": "lens"
             }
         ],
@@ -2524,6 +2653,51 @@
             "id": "zscaler_zia-security-solution-default",
             "name": "tag-ref-security-solution-default",
             "type": "tag"
+        },
+        {
+            "name": "ede900a0-3876-4eb2-819f-f319a79b9c85:link_zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e"
+        },
+        {
+            "name": "ede900a0-3876-4eb2-819f-f319a79b9c85:link_zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635"
+        },
+        {
+            "name": "ede900a0-3876-4eb2-819f-f319a79b9c85:link_zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "ede900a0-3876-4eb2-819f-f319a79b9c85:link_zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42"
+        },
+        {
+            "name": "ede900a0-3876-4eb2-819f-f319a79b9c85:link_zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "ede900a0-3876-4eb2-819f-f319a79b9c85:link_zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416"
+        },
+        {
+            "name": "ede900a0-3876-4eb2-819f-f319a79b9c85:link_zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "ede900a0-3876-4eb2-819f-f319a79b9c85:link_zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "ede900a0-3876-4eb2-819f-f319a79b9c85:link_zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6"
         }
     ],
     "type": "dashboard",

--- a/packages/zscaler_zia/kibana/dashboard/zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42.json
+++ b/packages/zscaler_zia/kibana/dashboard/zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42.json
@@ -44,6 +44,135 @@
             {
                 "embeddableConfig": {
                     "enhancements": {},
+                    "attributes": {
+                        "title": "links",
+                        "layout": "vertical",
+                        "links": [
+                            {
+                                "label": "Overview",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e",
+                                "order": 0,
+                                "destinationRefName": "link_zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e_dashboard"
+                            },
+                            {
+                                "label": "Audit",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635",
+                                "order": 1,
+                                "destinationRefName": "link_zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635_dashboard"
+                            },
+                            {
+                                "label": "DNS",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84",
+                                "order": 2,
+                                "destinationRefName": "link_zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Endpoint DLP",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42",
+                                "order": 3,
+                                "destinationRefName": "link_zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42_dashboard"
+                            },
+                            {
+                                "label": "Firewall",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84",
+                                "order": 4,
+                                "destinationRefName": "link_zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Sandbox Report",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416",
+                                "order": 5,
+                                "destinationRefName": "link_zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416_dashboard"
+                            },
+                            {
+                                "label": "Tunnel",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84",
+                                "order": 6,
+                                "destinationRefName": "link_zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Web Overview",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84",
+                                "order": 7,
+                                "destinationRefName": "link_zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84_dashboard"
+                            },
+                            {
+                                "label": "Web Access Control",
+                                "type": "dashboardLink",
+                                "options": {
+                                    "openInNewTab": false,
+                                    "useCurrentDateRange": true,
+                                    "useCurrentFilters": false
+                                },
+                                "id": "zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6",
+                                "order": 8,
+                                "destinationRefName": "link_zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6_dashboard"
+                            }
+                        ]
+                    }
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "261532b6-e177-4e4e-a75d-3dee35edbb16",
+                    "w": 12,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "261532b6-e177-4e4e-a75d-3dee35edbb16",
+                "title": "Table of Contents",
+                "type": "links"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
                     "hidePanelTitles": false,
                     "savedVis": {
                         "data": {
@@ -60,7 +189,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**Zscaler ZIA**\n\n[Overview](#/dashboard/zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e)\n- [Audit](#/dashboard/zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635)\n- [DNS](#/dashboard/zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84)\n- [**Endpoint DLP (This Page)**](#/dashboard/zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42)\n- [Firewall](#/dashboard/zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84)\n- [Sandbox Report](#/dashboard/zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416)\n- [Tunnel](#/dashboard/zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84)\n- Web\n  - [Web Overview](#/dashboard/zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84)\n  - [Web Access Control](#/dashboard/zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6)\n\n**Overview**\n\nThis dashboard provides an insightful analysis of Endpoint Data Loss Prevention (DLP) events. It features bar charts for actions, file types, severity, and channels, pie charts for device types, and metrics for total DLP dictionary and engine hits. It also includes a line chart for tracking DLP events over time and a table listing the top 10 rule names. These visualizations help monitor, analyze, and respond to potential data loss incidents effectively.\n\n[**Integrations Page**](/app/integrations/detail/zscaler_zia/overview)",
+                            "markdown": "**Zscaler ZIA**\n\nThis dashboard provides an insightful analysis of Endpoint Data Loss Prevention (DLP) events. It features bar charts for actions, file types, severity, and channels, pie charts for device types, and metrics for total DLP dictionary and engine hits. It also includes a line chart for tracking DLP events over time and a table listing the top 10 rule names. These visualizations help monitor, analyze, and respond to potential data loss incidents effectively.\n\n[**Integrations Page**](/app/integrations/detail/zscaler_zia/overview)",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -69,14 +198,14 @@
                     }
                 },
                 "gridData": {
-                    "h": 30,
+                    "h": 15,
                     "i": "261532b6-e177-4e4e-a75d-3dee35edbb16",
                     "w": 12,
                     "x": 0,
-                    "y": 0
+                    "y": 15
                 },
-                "panelIndex": "261532b6-e177-4e4e-a75d-3dee35edbb16",
-                "title": "Table of Contents",
+                "panelIndex": "261532b6-e177-4e4e-a75d-3dee35edbb16_1",
+                "title": "Overview",
                 "type": "visualization"
             },
             {
@@ -159,7 +288,7 @@
                     "y": 0
                 },
                 "panelIndex": "8cd05283-18d5-4c41-98fb-9477ad5e2cd2",
-                "title": "Total DLP Dictionary Hits [Logs Zscaler ZIA]",
+                "title": "Total DLP Dictionary Hits",
                 "type": "lens"
             },
             {
@@ -242,7 +371,7 @@
                     "y": 0
                 },
                 "panelIndex": "b672cba7-08cc-496e-937e-650a0cb496ac",
-                "title": "Total DLP Engine Hits [Logs Zscaler ZIA]",
+                "title": "Total DLP Engine Hits",
                 "type": "lens"
             },
             {
@@ -411,7 +540,7 @@
                     "y": 0
                 },
                 "panelIndex": "41bde4a6-d680-4b32-aedf-c8a94927ea8d",
-                "title": "Endpoint DLP by Device Type [Logs Zscaler ZIA]",
+                "title": "Endpoint DLP by Device Type",
                 "type": "lens"
             },
             {
@@ -575,7 +704,7 @@
                     "y": 15
                 },
                 "panelIndex": "81c2cac3-a3e0-41f9-8983-c5e972f4fe2c",
-                "title": "Endpoint DLP by File Type [Logs Zscaler ZIA]",
+                "title": "Endpoint DLP by File Type",
                 "type": "lens"
             },
             {
@@ -740,7 +869,7 @@
                     "y": 15
                 },
                 "panelIndex": "adea9ac5-3363-493a-a605-059d00f75721",
-                "title": "Endpoint DLP by Severity [Logs Zscaler ZIA]",
+                "title": "Endpoint DLP by Severity",
                 "type": "lens"
             },
             {
@@ -933,7 +1062,7 @@
                     "y": 30
                 },
                 "panelIndex": "925defee-8fb0-4f43-be63-06d3bc6eac13",
-                "title": "Endpoint DLP by Action [Logs Zscaler ZIA]",
+                "title": "Endpoint DLP by Action",
                 "type": "lens"
             },
             {
@@ -1096,7 +1225,7 @@
                     "y": 30
                 },
                 "panelIndex": "5001a720-4d3c-41d3-8142-69f7775b3f10",
-                "title": "Endpoint DLP by Channel [Logs Zscaler ZIA]",
+                "title": "Endpoint DLP by Channel",
                 "type": "lens"
             },
             {
@@ -1241,7 +1370,7 @@
                     "y": 45
                 },
                 "panelIndex": "af957edf-7df9-4dbf-a4da-1c762771fb4b",
-                "title": "Top 10 Rule Name [Logs Zscaler ZIA]",
+                "title": "Top 10 Rule Name",
                 "type": "lens"
             },
             {
@@ -1401,7 +1530,7 @@
                     "y": 45
                 },
                 "panelIndex": "c3899457-30e7-4736-bfe4-17d7c8617ace",
-                "title": "DLP Events Over Time [Logs Zscaler ZIA]",
+                "title": "DLP Events Over Time",
                 "type": "lens"
             }
         ],
@@ -1493,6 +1622,51 @@
             "id": "zscaler_zia-security-solution-default",
             "name": "tag-ref-security-solution-default",
             "type": "tag"
+        },
+        {
+            "name": "261532b6-e177-4e4e-a75d-3dee35edbb16:link_zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-44e6d836-f55d-495d-93e0-79da0637042e"
+        },
+        {
+            "name": "261532b6-e177-4e4e-a75d-3dee35edbb16:link_zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-03b699de-70f6-4ef0-9fa9-49c035b62635"
+        },
+        {
+            "name": "261532b6-e177-4e4e-a75d-3dee35edbb16:link_zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-b335cb40-3811-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "261532b6-e177-4e4e-a75d-3dee35edbb16:link_zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-eec7265e-2cd3-422a-924a-c3db6f5d0a42"
+        },
+        {
+            "name": "261532b6-e177-4e4e-a75d-3dee35edbb16:link_zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-78eeb3f0-381d-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "261532b6-e177-4e4e-a75d-3dee35edbb16:link_zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-5de5ab5a-fd15-40bf-8f4c-5206f0ed7416"
+        },
+        {
+            "name": "261532b6-e177-4e4e-a75d-3dee35edbb16:link_zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-7b9f74b0-3820-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "261532b6-e177-4e4e-a75d-3dee35edbb16:link_zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-579d9380-382a-11ed-aa11-3bf35d6f0a84"
+        },
+        {
+            "name": "261532b6-e177-4e4e-a75d-3dee35edbb16:link_zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6_dashboard",
+            "type": "dashboard",
+            "id": "zscaler_zia-c12fb7c5-0f5c-4341-98fb-12dd197f00a6"
         }
     ],
     "type": "dashboard",

--- a/packages/zscaler_zia/manifest.yml
+++ b/packages/zscaler_zia/manifest.yml
@@ -4,7 +4,7 @@ title: Zscaler Internet Access
 # When updating version, make sure the pkg_version parameter in
 # the check_template_version script in ingest pipelines is
 # updated to match.
-version: "3.15.1"
+version: "3.15.2"
 description: Collect logs from Zscaler Internet Access (ZIA) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

The Zscarer ZIA uses Markdown to link to other dashboards. But this is not ideal, as it either doesn't work in serverless or it doesn't work in a different space. That is why here we are replacing the markdown links with a Links panel.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [X] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

closes #[11199](https://github.com/elastic/integrations/issues/11199)

## Screenshots

After the update:
<img width="763" height="993" alt="Screenshot 2025-09-19 at 09 54 01" src="https://github.com/user-attachments/assets/639fe7a3-4880-4e53-b41c-ec0229625aba" />
