### PR TITLE
trend_micro_vision_one: relocate common required options

### DIFF
--- a/packages/trend_micro_vision_one/data_stream/alert/_dev/test/system/test-default-config.yml
+++ b/packages/trend_micro_vision_one/data_stream/alert/_dev/test/system/test-default-config.yml
@@ -3,11 +3,11 @@ service: trend_micro_vision_one
 vars:
   hostname: http://{{Hostname}}:{{Port}}
   api_token: xxxx
-  enable_request_tracer: true
 data_stream:
   vars:
     preserve_original_event: true
     preserve_duplicate_custom_fields: true
+    enable_request_tracer: true
 numeric_keyword_fields:
   - trend_micro_vision_one.alert.indicators.id
   - trend_micro_vision_one.alert.impact_scope.entities.related_indicator_id

--- a/packages/trend_micro_vision_one/data_stream/alert/manifest.yml
+++ b/packages/trend_micro_vision_one/data_stream/alert/manifest.yml
@@ -71,3 +71,11 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        default: false
+        multi: false
+        required: false
+        show_user: false
+        description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.

--- a/packages/trend_micro_vision_one/data_stream/audit/_dev/test/system/test-default-config.yml
+++ b/packages/trend_micro_vision_one/data_stream/audit/_dev/test/system/test-default-config.yml
@@ -3,8 +3,8 @@ service: trend_micro_vision_one
 vars:
   hostname: http://{{Hostname}}:{{Port}}
   api_token: xxxx
-  enable_request_tracer: true
 data_stream:
   vars:
     preserve_original_event: true
     preserve_duplicate_custom_fields: true
+    enable_request_tracer: true

--- a/packages/trend_micro_vision_one/data_stream/audit/manifest.yml
+++ b/packages/trend_micro_vision_one/data_stream/audit/manifest.yml
@@ -79,3 +79,11 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        default: false
+        multi: false
+        required: false
+        show_user: false
+        description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.

--- a/packages/trend_micro_vision_one/data_stream/detection/_dev/test/system/test-default-config.yml
+++ b/packages/trend_micro_vision_one/data_stream/detection/_dev/test/system/test-default-config.yml
@@ -3,10 +3,10 @@ service: trend_micro_vision_one
 vars:
   hostname: http://{{Hostname}}:{{Port}}
   api_token: xxxx
-  enable_request_tracer: true
 data_stream:
   vars:
     preserve_original_event: true
     preserve_duplicate_custom_fields: true
+    enable_request_tracer: true
 assert:
   hit_count: 3

--- a/packages/trend_micro_vision_one/data_stream/detection/manifest.yml
+++ b/packages/trend_micro_vision_one/data_stream/detection/manifest.yml
@@ -79,3 +79,11 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        default: false
+        multi: false
+        required: false
+        show_user: false
+        description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.

--- a/packages/trend_micro_vision_one/data_stream/telemetry/_dev/test/system/test-default-config.yml
+++ b/packages/trend_micro_vision_one/data_stream/telemetry/_dev/test/system/test-default-config.yml
@@ -3,13 +3,13 @@ service: trend_micro_vision_one
 vars:
   hostname: http://{{Hostname}}:{{Port}}
   api_token: xxxx
-  enable_request_tracer: true
 data_stream:
   vars:
     initial_interval: 2h
     min_time_range: 10m
     preserve_original_event: true
     preserve_duplicate_custom_fields: true
+    enable_request_tracer: true
 numeric_keyword_fields:
   - trend_micro_vision_one.telemetry.event_id
   - trend_micro_vision_one.telemetry.event_sub_id

--- a/packages/trend_micro_vision_one/data_stream/telemetry/manifest.yml
+++ b/packages/trend_micro_vision_one/data_stream/telemetry/manifest.yml
@@ -110,3 +110,11 @@ streams:
         required: true
         show_user: false
         default: managed-by-elastic-integrations-trend_micro_vision_one-telemetry
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        default: false
+        multi: false
+        required: false
+        show_user: false
+        description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.

--- a/packages/trend_micro_vision_one/manifest.yml
+++ b/packages/trend_micro_vision_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: trend_micro_vision_one
 title: Trend Micro Vision One
-version: "2.3.0"
+version: "2.4.0"
 description: Collect logs from Trend Micro Vision One with Elastic Agent.
 type: integration
 categories:
@@ -26,62 +26,6 @@ icons:
     title: Trend Micro Vision One Logo
     size: 32x32
     type: image/svg+xml
-vars:
-  - name: hostname
-    type: text
-    title: Regional Domain URL
-    description: "Trend Micro Vision One URL to connect to the API. The URL domain used for this configuration is the domain for the region where your service endpoint is hosted. See the [Trend Vision One documentation](https://automation.trendmicro.com/xdr/Guides/Regional-domains) for the domain for your region. Enter the the HTTPS URL for your domain, `https://<your-regional-domain` without any trailing slash. "
-    required: true
-  - name: enable_request_tracer
-    type: bool
-    title: Enable request tracing
-    default: false
-    multi: false
-    required: false
-    show_user: false
-    description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
-  - name: api_token
-    type: password
-    title: API Token
-    description: API Token with API Access Level type.
-    required: true
-    secret: true
-  - name: proxy_url
-    type: text
-    title: Proxy URL
-    multi: false
-    required: false
-    show_user: false
-    description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>. Please ensure your username and password are in URL encoded format.
-  - name: ssl
-    type: yaml
-    title: SSL Configuration
-    description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
-    multi: false
-    required: false
-    show_user: false
-    default: |
-      #certificate_authorities:
-      #  - |
-      #    -----BEGIN CERTIFICATE-----
-      #    MIIDCjCCAfKgAwIBAgITJ706Mu2wJlKckpIvkWxEHvEyijANBgkqhkiG9w0BAQsF
-      #    ADAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwIBcNMTkwNzIyMTkyOTA0WhgPMjExOTA2
-      #    MjgxOTI5MDRaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEB
-      #    BQADggEPADCCAQoCggEBANce58Y/JykI58iyOXpxGfw0/gMvF0hUQAcUrSMxEO6n
-      #    fZRA49b4OV4SwWmA3395uL2eB2NB8y8qdQ9muXUdPBWE4l9rMZ6gmfu90N5B5uEl
-      #    94NcfBfYOKi1fJQ9i7WKhTjlRkMCgBkWPkUokvBZFRt8RtF7zI77BSEorHGQCk9t
-      #    /D7BS0GJyfVEhftbWcFEAG3VRcoMhF7kUzYwp+qESoriFRYLeDWv68ZOvG7eoWnP
-      #    PsvZStEVEimjvK5NSESEQa9xWyJOmlOKXhkdymtcUd/nXnx6UTCFgnkgzSdTWV41
-      #    CI6B6aJ9svCTI2QuoIq2HxX/ix7OvW1huVmcyHVxyUECAwEAAaNTMFEwHQYDVR0O
-      #    BBYEFPwN1OceFGm9v6ux8G+DZ3TUDYxqMB8GA1UdIwQYMBaAFPwN1OceFGm9v6ux
-      #    8G+DZ3TUDYxqMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAG5D
-      #    874A4YI7YUwOVsVAdbWtgp1d0zKcPRR+r2OdSbTAV5/gcS3jgBJ3i1BN34JuDVFw
-      #    3DeJSYT3nxy2Y56lLnxDeF8CUTUtVQx3CuGkRg1ouGAHpO/6OqOhwLLorEmxi7tA
-      #    H2O8mtT0poX5AnOAhzVy7QW0D/k4WaoLyckM5hUa6RtvgvLxOwA0U+VGurCDoctu
-      #    8F4QOgTAWyh8EZIwaKCliFRSynDpv3JTUwtfZkxo6K6nce1RhCWFAsMvDZL8Dgc0
-      #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
-      #    sxSmbIUfc2SGJGCJD4I=
-      #    -----END CERTIFICATE-----
 policy_templates:
   - name: trend_micro_vision_one
     title: Trend Micro Vision One
@@ -90,9 +34,105 @@ policy_templates:
       - type: httpjson
         title: Collect Trend Micro Vision One logs via API
         description: Collecting Trend Micro Vision One logs via API.
+        vars:
+          - name: hostname
+            type: text
+            title: Regional Domain URL
+            description: "Trend Micro Vision One URL to connect to the API. The URL domain used for this configuration is the domain for the region where your service endpoint is hosted. See the [Trend Vision One documentation](https://automation.trendmicro.com/xdr/Guides/Regional-domains) for the domain for your region. Enter the the HTTPS URL for your domain, `https://<your-regional-domain>` without any trailing slash. "
+            required: true
+          - name: api_token
+            type: password
+            title: API Token
+            description: API Token with API Access Level type.
+            required: true
+            secret: true
+          - name: proxy_url
+            type: text
+            title: Proxy URL
+            multi: false
+            required: false
+            show_user: false
+            description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>. Please ensure your username and password are in URL encoded format.
+          - name: ssl
+            type: yaml
+            title: SSL Configuration
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
+            multi: false
+            required: false
+            show_user: false
+            default: |
+              #certificate_authorities:
+              #  - |
+              #    -----BEGIN CERTIFICATE-----
+              #    MIIDCjCCAfKgAwIBAgITJ706Mu2wJlKckpIvkWxEHvEyijANBgkqhkiG9w0BAQsF
+              #    ADAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwIBcNMTkwNzIyMTkyOTA0WhgPMjExOTA2
+              #    MjgxOTI5MDRaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEB
+              #    BQADggEPADCCAQoCggEBANce58Y/JykI58iyOXpxGfw0/gMvF0hUQAcUrSMxEO6n
+              #    fZRA49b4OV4SwWmA3395uL2eB2NB8y8qdQ9muXUdPBWE4l9rMZ6gmfu90N5B5uEl
+              #    94NcfBfYOKi1fJQ9i7WKhTjlRkMCgBkWPkUokvBZFRt8RtF7zI77BSEorHGQCk9t
+              #    /D7BS0GJyfVEhftbWcFEAG3VRcoMhF7kUzYwp+qESoriFRYLeDWv68ZOvG7eoWnP
+              #    PsvZStEVEimjvK5NSESEQa9xWyJOmlOKXhkdymtcUd/nXnx6UTCFgnkgzSdTWV41
+              #    CI6B6aJ9svCTI2QuoIq2HxX/ix7OvW1huVmcyHVxyUECAwEAAaNTMFEwHQYDVR0O
+              #    BBYEFPwN1OceFGm9v6ux8G+DZ3TUDYxqMB8GA1UdIwQYMBaAFPwN1OceFGm9v6ux
+              #    8G+DZ3TUDYxqMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAG5D
+              #    874A4YI7YUwOVsVAdbWtgp1d0zKcPRR+r2OdSbTAV5/gcS3jgBJ3i1BN34JuDVFw
+              #    3DeJSYT3nxy2Y56lLnxDeF8CUTUtVQx3CuGkRg1ouGAHpO/6OqOhwLLorEmxi7tA
+              #    H2O8mtT0poX5AnOAhzVy7QW0D/k4WaoLyckM5hUa6RtvgvLxOwA0U+VGurCDoctu
+              #    8F4QOgTAWyh8EZIwaKCliFRSynDpv3JTUwtfZkxo6K6nce1RhCWFAsMvDZL8Dgc0
+              #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
+              #    sxSmbIUfc2SGJGCJD4I=
+              #    -----END CERTIFICATE-----
       - type: cel
         title: Collect Trend Micro Vision One data via the Datalake Pipeline API
         description: Collecting Trend Micro Vision One data via the Datalake Pipeline API.
+        vars:
+          - name: hostname
+            type: text
+            title: Regional Domain URL
+            description: "Trend Micro Vision One URL to connect to the API. The URL domain used for this configuration is the domain for the region where your service endpoint is hosted. See the [Trend Vision One documentation](https://automation.trendmicro.com/xdr/Guides/Regional-domains) for the domain for your region. Enter the the HTTPS URL for your domain, `https://<your-regional-domain>` without any trailing slash. "
+            required: true
+          - name: api_token
+            type: password
+            title: API Token
+            description: API Token with API Access Level type.
+            required: true
+            secret: true
+          - name: proxy_url
+            type: text
+            title: Proxy URL
+            multi: false
+            required: false
+            show_user: false
+            description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>. Please ensure your username and password are in URL encoded format.
+          - name: ssl
+            type: yaml
+            title: SSL Configuration
+            description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
+            multi: false
+            required: false
+            show_user: false
+            default: |
+              #certificate_authorities:
+              #  - |
+              #    -----BEGIN CERTIFICATE-----
+              #    MIIDCjCCAfKgAwIBAgITJ706Mu2wJlKckpIvkWxEHvEyijANBgkqhkiG9w0BAQsF
+              #    ADAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwIBcNMTkwNzIyMTkyOTA0WhgPMjExOTA2
+              #    MjgxOTI5MDRaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEB
+              #    BQADggEPADCCAQoCggEBANce58Y/JykI58iyOXpxGfw0/gMvF0hUQAcUrSMxEO6n
+              #    fZRA49b4OV4SwWmA3395uL2eB2NB8y8qdQ9muXUdPBWE4l9rMZ6gmfu90N5B5uEl
+              #    94NcfBfYOKi1fJQ9i7WKhTjlRkMCgBkWPkUokvBZFRt8RtF7zI77BSEorHGQCk9t
+              #    /D7BS0GJyfVEhftbWcFEAG3VRcoMhF7kUzYwp+qESoriFRYLeDWv68ZOvG7eoWnP
+              #    PsvZStEVEimjvK5NSESEQa9xWyJOmlOKXhkdymtcUd/nXnx6UTCFgnkgzSdTWV41
+              #    CI6B6aJ9svCTI2QuoIq2HxX/ix7OvW1huVmcyHVxyUECAwEAAaNTMFEwHQYDVR0O
+              #    BBYEFPwN1OceFGm9v6ux8G+DZ3TUDYxqMB8GA1UdIwQYMBaAFPwN1OceFGm9v6ux
+              #    8G+DZ3TUDYxqMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAG5D
+              #    874A4YI7YUwOVsVAdbWtgp1d0zKcPRR+r2OdSbTAV5/gcS3jgBJ3i1BN34JuDVFw
+              #    3DeJSYT3nxy2Y56lLnxDeF8CUTUtVQx3CuGkRg1ouGAHpO/6OqOhwLLorEmxi7tA
+              #    H2O8mtT0poX5AnOAhzVy7QW0D/k4WaoLyckM5hUa6RtvgvLxOwA0U+VGurCDoctu
+              #    8F4QOgTAWyh8EZIwaKCliFRSynDpv3JTUwtfZkxo6K6nce1RhCWFAsMvDZL8Dgc0
+              #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
+              #    sxSmbIUfc2SGJGCJD4I=
+              #    -----END CERTIFICATE-----
 owner:
   github: elastic/security-service-integrations
   type: elastic


### PR DESCRIPTION
## Proposed commit message

```
To avoid bug described at https://github.com/elastic/kibana/issues/235242,
common required settings such as URL and API Token have been located
under input level, as they were in previous versions.

This forces users to solve conflicts in the integration configuration during
upgrades from any version, avoiding the integration to gets broken once upgraded.

Request tracing option has been moved to each data stream at the same time
to allow for more granular control of request tracing.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

### 2.4.0 fresh install

All options are shown as expected:

<img width="769" height="408" alt="image" src="https://github.com/user-attachments/assets/ce5b7dfb-312b-4cae-ab69-9ec63ac48d44" />

<img width="703" height="454" alt="image" src="https://github.com/user-attachments/assets/7709498e-7759-47a8-bb02-b5497abcf058" />


### Upgrade from < 2.2.0

When clicking on `Upgrade to latest version` the integration is upgraded but the policy upgrade fails due to conflicts.

<img width="690" height="197" alt="image" src="https://github.com/user-attachments/assets/9fbfeb1d-19f7-43e4-a514-517d4067c7d7" />

Once the policy is manually upgraded and conflicts are solved, the integration works as expected and all config options appear in the UI for future editions. This is expected in a breaking change according to [our docs](https://www.elastic.co/guide/en/fleet/8.18/upgrade-integration.html#resolve-conflicts).

<img width="636" height="811" alt="image" src="https://github.com/user-attachments/assets/6223d4d0-89f1-463d-a96b-431d99c6275b" />

### Upgrade from > 2.2.0

Same situation as for previous case. The breaking change forces users to update policies manually.

<img width="570" height="804" alt="image" src="https://github.com/user-attachments/assets/8203a945-cd79-4319-a9bc-2fdab4e62378" />

After the upgrade, everything works fine.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/integrations/issues/14094
- Relates https://github.com/elastic/kibana/issues/235242
