### PR TITLE
[syslog_router] Support Cisco IOS

### DIFF
--- a/packages/syslog_router/changelog.yml
+++ b/packages/syslog_router/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add support for Cisco IOS. Matches on the Cisco emblem header.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/15456
 - version: "0.2.1"
   changes:
     - description: Changed owners.

--- a/packages/syslog_router/changelog.yml
+++ b/packages/syslog_router/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Add support for Cisco IOS. Matches on the Cisco emblem header.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.2.1"
   changes:
     - description: Changed owners.

--- a/packages/syslog_router/data_stream/log/manifest.yml
+++ b/packages/syslog_router/data_stream/log/manifest.yml
@@ -94,6 +94,16 @@ streams:
           - if:
               and:
                 - not.has_fields: _conf.dataset
+                - regexp.message: "%\\S+-\\d-\\S+\\s?:"
+            then:
+              - add_fields:
+                  target: ''
+                  fields:
+                    _conf.dataset: "cisco_ios.log"
+                    _conf.tz_offset: "UTC"
+          - if:
+              and:
+                - not.has_fields: _conf.dataset
                 - regexp.message: "CISE_+"
             then:
               - add_fields:
@@ -391,6 +401,16 @@ streams:
           - if:
               and:
                 - not.has_fields: _conf.dataset
+                - regexp.message: "%\\S+-\\d-\\S+\\s?:"
+            then:
+              - add_fields:
+                  target: ''
+                  fields:
+                    _conf.dataset: "cisco_ios.log"
+                    _conf.tz_offset: "UTC"
+          - if:
+              and:
+                - not.has_fields: _conf.dataset
                 - regexp.message: "CISE_+"
             then:
               - add_fields:
@@ -675,6 +695,16 @@ streams:
                     _conf.tz_offset: "UTC"
                     _temp_.internal_zones: ['trust']
                     _temp_.external_zones: ['untrust']
+          - if:
+              and:
+                - not.has_fields: _conf.dataset
+                - regexp.message: "%\\S+-\\d-\\S+\\s?:"
+            then:
+              - add_fields:
+                  target: ''
+                  fields:
+                    _conf.dataset: "cisco_ios.log"
+                    _conf.tz_offset: "UTC"
           - if:
               and:
                 - not.has_fields: _conf.dataset

--- a/packages/syslog_router/manifest.yml
+++ b/packages/syslog_router/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: syslog_router
 title: "Syslog Router"
-version: 0.2.1
+version: 0.3.0
 description: "Route syslog events to integrations with Elastic Agent."
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Add support for Cisco IOS messages. Matches on the Cisco Emblem header in the log, and by default matches after Cisco ASA and FTD to avoid ambiguity.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

## How to test this PR locally

1. Install assets for Cisco ASA, Cisco FTD, and Cisco IOS
2. Configure the Syslog Router integration (no changes necessary to routing configs).
3. Send Cisco ASA, FTD, and IOS logs to agent running integration
4. Verify that logs have landed in the correct data streams

I manually verified that logs were routed to the correct data streams.

## Related issues

- Closes #15337
