### PR TITLE
[cisco_nexus] Fix whitespace issue with grok pattern

### DIFF
--- a/packages/cisco_nexus/changelog.yml
+++ b/packages/cisco_nexus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.3"
+  changes:
+    - description: Fix whitespace issue with grok pattern.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.4.2"
   changes:
     - description: Changed owners.

--- a/packages/cisco_nexus/data_stream/log/_dev/test/pipeline/test-nexus-fix.log
+++ b/packages/cisco_nexus/data_stream/log/_dev/test/pipeline/test-nexus-fix.log
@@ -1,0 +1,1 @@
+<187>: 2025 Sep 25 08:49:23 UTC : %LOG_LOCAL7-3-SYSTEM_MSG: [F1547][soaking][packets-dropped][major][dbgs/ac/sdvpcpath-1109-1110-to-1303-1304/fault-F1547] 6% of packets were received in excess during the last collection interval

--- a/packages/cisco_nexus/data_stream/log/_dev/test/pipeline/test-nexus-fix.log-expected.json
+++ b/packages/cisco_nexus/data_stream/log/_dev/test/pipeline/test-nexus-fix.log-expected.json
@@ -1,0 +1,50 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2025-09-25T08:49:23.000Z",
+            "cisco_nexus": {
+                "log": {
+                    "description": "[F1547][soaking][packets-dropped][major][dbgs/ac/sdvpcpath-1109-1110-to-1303-1304/fault-F1547] 6% of packets were received in excess during the last collection interval",
+                    "facility": "LOG_LOCAL7",
+                    "priority_number": 187,
+                    "severity": 3,
+                    "time": "2025-09-25T08:49:23.000Z",
+                    "timezone": "UTC",
+                    "type": "SYSTEM_MSG"
+                }
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "code": "SYSTEM_MSG",
+                "kind": "event",
+                "original": "<187>: 2025 Sep 25 08:49:23 UTC : %LOG_LOCAL7-3-SYSTEM_MSG: [F1547][soaking][packets-dropped][major][dbgs/ac/sdvpcpath-1109-1110-to-1303-1304/fault-F1547] 6% of packets were received in excess during the last collection interval",
+                "severity": 3,
+                "timezone": "UTC"
+            },
+            "log": {
+                "level": "error",
+                "syslog": {
+                    "facility": {
+                        "code": 23
+                    },
+                    "priority": 187,
+                    "severity": {
+                        "code": 3
+                    }
+                }
+            },
+            "message": "[F1547][soaking][packets-dropped][major][dbgs/ac/sdvpcpath-1109-1110-to-1303-1304/fault-F1547] 6% of packets were received in excess during the last collection interval",
+            "observer": {
+                "product": "Nexus",
+                "type": "switches",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ]
+        }
+    ]
+}

--- a/packages/cisco_nexus/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_nexus/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -47,7 +47,7 @@ processors:
         - "^<%{NUMBER:cisco_nexus.log.priority_number:long}>%{SYSLOGTIMESTAMP:cisco_nexus.log.syslog_time}%{SPACE}(%{IP:cisco_nexus.log.ip_address}|%{NOTSPACE:cisco_nexus.log.switch_name})%{SPACE}(?::)?%{SPACE}%{NEXUS_TIMESTAMP_TIMEZONE}:%{SPACE}%{NEXUS_BODY}$"
         - "^<%{NUMBER:cisco_nexus.log.priority_number:long}>%{SYSLOGTIMESTAMP:cisco_nexus.log.syslog_time}%{SPACE}(%{IP:cisco_nexus.log.ip_address}|%{NOTSPACE:cisco_nexus.log.switch_name})%{SPACE}(?::)?%{SPACE}%{WORD:temp.timezone}:%{SPACE}%{NEXUS_BODY}$"
         - "^<%{NUMBER:cisco_nexus.log.priority_number:long}>(%{IP:cisco_nexus.log.ip_address}|%{NOTSPACE:cisco_nexus.log.switch_name}):%{SPACE}%{NEXUS_TIMESTAMP_TIMEZONE}:%{SPACE}%{NEXUS_BODY}$"
-        - "^<%{NUMBER:cisco_nexus.log.priority_number:long}>:%{SPACE}%{NEXUS_TIMESTAMP_TIMEZONE}:%{SPACE}%{NEXUS_BODY}$"
+        - "^<%{NUMBER:cisco_nexus.log.priority_number:long}>:%{SPACE}%{NEXUS_TIMESTAMP_TIMEZONE}%{SPACE}:%{SPACE}%{NEXUS_BODY}$"
         - "^%{NEXUS_TIMESTAMP:temp.timestamp}%{SPACE}(%{IP:cisco_nexus.log.ip_address}|%{NOTSPACE:cisco_nexus.log.switch_name})%{SPACE}%{NEXUS_BODY}$"
       on_failure:
         - append:

--- a/packages/cisco_nexus/manifest.yml
+++ b/packages/cisco_nexus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_nexus
 title: Cisco Nexus
-version: "1.4.2"
+version: "1.4.3"
 description: Collect logs from Cisco Nexus with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- Fix issue with syslog grok pattern where whitespace is introduced after the timestamp and before the next colon.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

## How to test this PR locally

```
cd packages/cisco_nexus
elastic-package test
```

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
