### PR TITLE
[sophos] Fix add_locale handling in xg data stream

### DIFF
--- a/packages/sophos/changelog.yml
+++ b/packages/sophos/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.15.3"
+  changes:
+    - description: Fix add_locale time zone handling
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.15.2"
   changes:
     - description: Add conditions to GeoIP processors to prevent failure on empty strings

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-time-zone.json
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-time-zone.json
@@ -1,0 +1,10 @@
+{
+  "events": [
+    {
+      "message": "<30>device=\"SFW\" date=2020-05-18 time=14:38:48 timezone=\"CEST\" device_name=\"XG230\" device_id=1234567890123456 log_id=041101618035 log_type=\"Anti-Spam\" log_component=\"SMTP\" log_subtype=\"Allowed\" status=\"\" priority=Information fw_rule_id=0 user_name=\"\" av_policy_name=\"None\" from_email_address=\"firewall@firewallgate.com\" to_email_address=\"Sysadmin@elasticuser.com\" email_subject=\"*ALERT* Sophos XG Firewall\" mailid=\"qkW2Y6-LxBk6U-vH-1590055245\" mailsize=19728 spamaction=\"QUEUED\" reason=\"Email has been accepted by Device and queued for scanning.\" src_domainname=\"elasticuser.com\" dst_domainname=\"\" src_ip=\"\" src_country_code=\"\" dst_ip=\"\" dst_country_code=\"\" protocol=\"TCP\" src_port=0 dst_port=0 sent_bytes=0 recv_bytes=0 quarantine_reason=\"Other\"\n",
+      "event": {
+        "timezone": "-05:00"
+      }
+    }
+  ]
+}

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-time-zone.json-expected.json
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-time-zone.json-expected.json
@@ -1,0 +1,106 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2020-05-18T14:38:48.000+02:00",
+            "destination": {
+                "bytes": 0,
+                "port": 0,
+                "user": {
+                    "email": "Sysadmin@elasticuser.com"
+                }
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "email": {
+                "from": {
+                    "address": [
+                        "firewall@firewallgate.com"
+                    ]
+                },
+                "subject": "*ALERT* Sophos XG Firewall",
+                "to": {
+                    "address": [
+                        "Sysadmin@elasticuser.com"
+                    ]
+                }
+            },
+            "event": {
+                "action": "Allowed",
+                "category": [
+                    "network"
+                ],
+                "code": "18035",
+                "kind": "event",
+                "original": "<30>device=\"SFW\" date=2020-05-18 time=14:38:48 timezone=\"CEST\" device_name=\"XG230\" device_id=1234567890123456 log_id=041101618035 log_type=\"Anti-Spam\" log_component=\"SMTP\" log_subtype=\"Allowed\" status=\"\" priority=Information fw_rule_id=0 user_name=\"\" av_policy_name=\"None\" from_email_address=\"firewall@firewallgate.com\" to_email_address=\"Sysadmin@elasticuser.com\" email_subject=\"*ALERT* Sophos XG Firewall\" mailid=\"qkW2Y6-LxBk6U-vH-1590055245\" mailsize=19728 spamaction=\"QUEUED\" reason=\"Email has been accepted by Device and queued for scanning.\" src_domainname=\"elasticuser.com\" dst_domainname=\"\" src_ip=\"\" src_country_code=\"\" dst_ip=\"\" dst_country_code=\"\" protocol=\"TCP\" src_port=0 dst_port=0 sent_bytes=0 recv_bytes=0 quarantine_reason=\"Other\"\n",
+                "outcome": "success",
+                "reason": "Email has been accepted by Device and queued for scanning.",
+                "severity": 6,
+                "timezone": "Etc/GMT-2",
+                "type": [
+                    "allowed",
+                    "connection"
+                ]
+            },
+            "host": {
+                "name": "testhost.local"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "network": {
+                "bytes": 0,
+                "protocol": "smtp",
+                "transport": "tcp"
+            },
+            "observer": {
+                "product": "XG",
+                "serial_number": "1234567890123456",
+                "type": "firewall",
+                "vendor": "Sophos"
+            },
+            "related": {
+                "hosts": [
+                    "testhost.local",
+                    "elasticuser.com"
+                ],
+                "user": [
+                    "firewall",
+                    "firewall@firewallgate.com"
+                ]
+            },
+            "sophos": {
+                "xg": {
+                    "av_policy_name": "None",
+                    "device": "SFW",
+                    "device_name": "XG230",
+                    "email_subject": "*ALERT* Sophos XG Firewall",
+                    "fw_rule_id": "0",
+                    "log_component": "SMTP",
+                    "log_id": "041101618035",
+                    "log_subtype": "Allowed",
+                    "log_type": "Anti-Spam",
+                    "mailid": "qkW2Y6-LxBk6U-vH-1590055245",
+                    "mailsize": "19728",
+                    "priority": "Information",
+                    "quarantine_reason": "Other",
+                    "spamaction": "QUEUED",
+                    "timezone": "CEST"
+                }
+            },
+            "source": {
+                "bytes": 0,
+                "domain": "elasticuser.com",
+                "port": 0,
+                "user": {
+                    "domain": "firewallgate.com",
+                    "email": "firewall@firewallgate.com",
+                    "name": "firewall"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/default.yml
@@ -52,22 +52,33 @@ processors:
 - set:
     description: "Set timezone from log timezone"
     field: _temp_.tz
+    tag: set_tz_from_log
     copy_from: sophos.xg.timezone
     override: false
     if: ctx.sophos?.xg?.timezone != null
 - set:
     description: Convert "Z" timezone to "UTC"
+    tag: convert_z_to_utc
     field: _temp_.tz
     value: UTC
     if: ctx._temp_?.tz == 'Z'
 - set:
-    description: "Set timezone from config tz_offset"
+    description: "Set timezone from config (tz_offset)"
+    tag: set_tz_from_conf_offset
     field: _temp_.tz
     copy_from: _conf.tz_offset
     override: false
     if: ctx._conf?.tz_offset != null && ctx._conf?.tz_offset != 'local'
 - set:
+    description: "Set time zone from event.timezone (locale)"
+    tag: set_tz_from_locale
+    field: _temp_.tz
+    copy_from: event.timezone
+    override: false
+    if: ctx.event?.timezone != null
+- set:
     description: "If timezone is not set from any previous source, default to UTC"
+    tag: set_tz_default_utc
     field: _temp_.tz
     value: UTC
     override: false
@@ -98,7 +109,6 @@ processors:
 - set:
     field: event.timezone
     copy_from: _temp_.tz
-    if: ctx.event?.timezone == null
 
 # Convert numeric based timezones to the standard time format
 # i.e. "-530" to "-5:30"

--- a/packages/sophos/manifest.yml
+++ b/packages/sophos/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: sophos
 title: Sophos
-version: "3.15.2"
+version: "3.15.3"
 description: Collect logs from Sophos with Elastic Agent.
 categories:
   - security


### PR DESCRIPTION
## Proposed commit message

- Fixed handling of time zones added by add_locale (which sets event.timezone) in the Sophos XG data stream. As add_locale will set the local timezone of the agent in event.timezone, this prevented the real time zone in the log from being set as there was a check to prevent event.timezone from being overridden.
- Added a pipeline test to test this scenario

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

## How to test this PR locally

```
cd packages/sophos
elastic-package test
```
