### PR TITLE
[PANW] Fix broken link

### DIFF
--- a/packages/panw/_dev/build/docs/README.md
+++ b/packages/panw/_dev/build/docs/README.md
@@ -50,7 +50,7 @@ Elastic Agent is required to stream data from the syslog or log file receiver an
 
 ### Collect logs via syslog
 
-To configure syslog monitoring, follow the steps described in the [Configure Syslog Monitoring](https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-admin/monitoring/use-syslog-for-monitoring/configure-syslog-monitoring) documentation.
+To configure syslog monitoring, follow the steps described in the [Configure Syslog Monitoring](https://docs.paloaltonetworks.com/ngfw/administration/monitoring/use-syslog-for-monitoring/configure-syslog-monitoring) documentation.
 
 ### Collect logs via log file
 

--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -2,7 +2,7 @@
 - version: "5.3.4"
   changes:
     - description: Fix broken link on the Palo Alto Network Integration page.
-      type: bug
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/15504
 - version: "5.3.3"
   changes:

--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "5.3.4"
+  changes:
+    - description: Fix broken link on the Palo Alto Network Integration page.
+      type: bug
+      link: https://github.com/elastic/integrations/pull/15504
 - version: "5.3.3"
   changes:
     - description: Changed owners.

--- a/packages/panw/docs/README.md
+++ b/packages/panw/docs/README.md
@@ -50,7 +50,7 @@ Elastic Agent is required to stream data from the syslog or log file receiver an
 
 ### Collect logs via syslog
 
-To configure syslog monitoring, follow the steps described in the [Configure Syslog Monitoring](https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-admin/monitoring/use-syslog-for-monitoring/configure-syslog-monitoring) documentation.
+To configure syslog monitoring, follow the steps described in the [Configure Syslog Monitoring](https://docs.paloaltonetworks.com/ngfw/administration/monitoring/use-syslog-for-monitoring/configure-syslog-monitoring) documentation.
 
 ### Collect logs via log file
 

--- a/packages/panw/manifest.yml
+++ b/packages/panw/manifest.yml
@@ -1,6 +1,6 @@
 name: panw
 title: Palo Alto Next-Gen Firewall
-version: "5.3.3"
+version: "5.3.4"
 description: Collect logs from Palo Alto next-gen firewalls with Elastic Agent.
 type: integration
 format_version: "3.0.3"


### PR DESCRIPTION
This PR fixes a broken link on the https://www.elastic.co/docs/reference/integrations/panw page.

Fixes https://github.com/elastic/docs-content/issues/3232