### PR TITLE
[cisco_aironet]: enhance CLIENT_ADDED_TO_RUN_STATE log parsing

### DIFF
--- a/packages/cisco_aironet/changelog.yml
+++ b/packages/cisco_aironet/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.17.0"
+  changes:
+    - description: Parse 'CLIENT_ORCH_LOG-6-CLIENT_ADDED_TO_RUN_STATE' log messages with more fields
+      type: enhancement
+      link:
 - version: "1.16.1"
   changes:
     - description: Changed owners.

--- a/packages/cisco_aironet/changelog.yml
+++ b/packages/cisco_aironet/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Parse 'CLIENT_ORCH_LOG-6-CLIENT_ADDED_TO_RUN_STATE' log messages with more fields
       type: enhancement
-      link:
+      link: https://github.com/elastic/integrations/pull/15517
 - version: "1.16.1"
   changes:
     - description: Changed owners.

--- a/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log
+++ b/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log
@@ -31,6 +31,7 @@
 <132>WLC001: *apfReceiveTask: Aug 22 10:24:20.959: %APF-4-MOBILESTATION_NOT_FOUND: apf_ms.c:8467 Could not find the mobile cc:73:14:61:b0:8f in internal database
 <190>201477: Jan 4 17:25:42.866: %CLIENT_ORCH_LOG-6-CLIENT_ADDED_TO_RUN_STATE: Chassis 2 R0/0: wncd: Username entry (00-00-00-00-00-00) joined with ssid (System-110) for device with MAC: 0000.0000.0000
 <190>201477: Jan 4 17:25:42.866: %CLIENT_ORCH_LOG-6-CLIENT_ADDED_TO_RUN_STATE: Chassis 1 R0/0: wncd: Username entry (RND-UN) joined with ssid (System-110) for device with MAC: abcd.ef12.3456
+<190>2371599: Jul 23 2024 14:31:54.468 UTC: %CLIENT_ORCH_LOG-6-CLIENT_ADDED_TO_RUN_STATE: Chassis 1 R0/3: wncd: Username entry (musterm8) joined with ssid (COMAPNY) for device with MAC: 1234.abcd.5678 on channel (1)
 <132>WLC001: *spamReceiveTask: Dec 17 19:59:10.223: %LOG-3-Q_IND: mm_aplist.c:734 Could not delete an AP from the AP list.
 <132>WLC001: *spamApTask4: Jun 08 04:26:43.773: %LOG-3-Q_IND: spam_lrad.c:11366 Country code (CN ) not configured for AP 6c:99:89:b0:XX:XX[…It occurred 2 times.!]
 <132>WLC001: *emWeb: Jan 22 11:42:50.501: %LOG-3-Q_IND: spam_lrad.c:52448 The system is unable to find WLAN 1 to be deleted; AP XX:XX:XX:XX:XX:XX[...It occurred 3 times.!]

--- a/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log-expected.json
+++ b/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log-expected.json
@@ -1218,7 +1218,11 @@
         {
             "@timestamp": "2025-01-04T17:25:42.866Z",
             "cisco": {
-                "ssid": "System-110"
+                "ssid": "System-110",
+                "wps": {
+                    "radio": "0",
+                    "slot": "0"
+                }
             },
             "client": {
                 "mac": "00-00-00-00-00-00"
@@ -1255,7 +1259,11 @@
         {
             "@timestamp": "2025-01-04T17:25:42.866Z",
             "cisco": {
-                "ssid": "System-110"
+                "ssid": "System-110",
+                "wps": {
+                    "radio": "0",
+                    "slot": "0"
+                }
             },
             "client": {
                 "mac": "AB-CD-EF-12-34-56"
@@ -1287,6 +1295,48 @@
             ],
             "user": {
                 "name": "RND-UN"
+            }
+        },
+        {
+            "@timestamp": "2024-07-23T14:31:54.468Z",
+            "cisco": {
+                "ssid": "COMAPNY",
+                "wps": {
+                    "channel": 1,
+                    "radio": "3",
+                    "slot": "0"
+                }
+            },
+            "client": {
+                "mac": "12-34-AB-CD-56-78"
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "CLIENT_ADDED_TO_RUN_STATE",
+                "original": "<190>2371599: Jul 23 2024 14:31:54.468 UTC: %CLIENT_ORCH_LOG-6-CLIENT_ADDED_TO_RUN_STATE: Chassis 1 R0/3: wncd: Username entry (musterm8) joined with ssid (COMAPNY) for device with MAC: 1234.abcd.5678 on channel (1)",
+                "provider": "CLIENT_ORCH_LOG",
+                "severity": 6
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 23
+                    },
+                    "priority": 190,
+                    "severity": {
+                        "code": 6
+                    }
+                }
+            },
+            "message": "Chassis 1 R0/3: wncd: Username entry (musterm8) joined with ssid (COMAPNY) for device with MAC: 1234.abcd.5678 on channel (1)",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "musterm8"
             }
         },
         {

--- a/packages/cisco_aironet/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_aironet/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -20,7 +20,7 @@ processors:
       pattern_definitions:
         SYSLOG_HEADER: "%{SYSLOGFACILITY}%{DATA:host.name}:\\s\\*%{DATA:process.name}:\\s%{AIRONET_DATE}"
         SYSLOGFACILITY: "<%{NONNEGINT:log.syslog.priority:int}>"
-        AIRONET_DATE: "%{MONTH:_temp_.raw_date_month}\\s+%{MONTHDAY:_temp_.raw_date_monthday} %{TIME:_temp_.raw_date_time}"
+        AIRONET_DATE: "%{MONTH:_temp_.raw_date_month}\\s+%{MONTHDAY:_temp_.raw_date_monthday}(\\s+%{YEAR:_temp_.raw_date_year})? %{TIME:_temp_.raw_date_time}( %{TZ:_temp_.raw_date_timezone})?"
   - script:
       lang: painless
       source: |
@@ -80,7 +80,18 @@ processors:
   # Parse the date included in logs
   - set:
       field: _conf.tz_offset
+      if: "ctx._temp_?.raw_date_timezone != null"
+      value: "{{{_temp_.raw_date_timezone}}}"
+      override: false
+  - set:
+      field: _conf.tz_offset
       value: UTC
+      override: false
+  - set:
+      field: _temp_.raw_date
+      if: "ctx._temp_?.raw_date_month != null && ctx._temp_?.raw_date_monthday != null && ctx._temp_?.raw_date_time != null && ctx._temp_?.raw_date_year != null"
+      value: "{{{_temp_.raw_date_month}}} {{{_temp_.raw_date_monthday}}} {{{_temp_.raw_date_year}}} {{{_temp_.raw_date_time}}}"
+      tag: "set_raw_date_with_year"
       override: false
   - set:
       field: _temp_.raw_date
@@ -94,6 +105,7 @@ processors:
       target_field: "@timestamp"
       tag: "raw_date_processor"
       formats:
+        - "MMM d yyyy HH:mm:ss.SSS"
         - "MMM d HH:mm:ss.SSS"
       timezone: '{{{_conf.tz_offset}}}'
 
@@ -222,7 +234,7 @@ processors:
       field: message
       if: ctx._temp_?.reason == 'CLIENT_ORCH_LOG-6-CLIENT_ADDED_TO_RUN_STATE'
       patterns:
-        - "R0/0: wncd: Username entry \\(%{DATA:user.name}\\) joined with ssid \\(%{DATA:cisco.ssid}\\) for device with MAC: %{MAC:client.mac}"
+        - "R%{INT:cisco.wps.slot}/%{INT:cisco.wps.radio}: wncd: Username entry \\(%{DATA:user.name}\\) joined with ssid \\(%{DATA:cisco.ssid}\\) for device with MAC: %{MAC:client.mac}(\\s+on channel \\(%{INT:cisco.wps.channel:int}\\))?"
       ignore_failure: false
   ###
   # Client MAC

--- a/packages/cisco_aironet/data_stream/log/fields/aironet-fields.yml
+++ b/packages/cisco_aironet/data_stream/log/fields/aironet-fields.yml
@@ -13,6 +13,9 @@
 - name: cisco.wps.slot
   type: short
   description: Cisco WPS slot
+- name: cisco.wps.radio
+  type: short
+  description: The radio interface number within a slot
 - name: cisco.wps.track
   type: keyword
   description: Cisco WPS track

--- a/packages/cisco_aironet/docs/README.md
+++ b/packages/cisco_aironet/docs/README.md
@@ -101,6 +101,7 @@ An example event for `log` looks as following:
 | cisco.wps.channel | Cisco WPS channel | short |
 | cisco.wps.hits | Cisco WPS hits | short |
 | cisco.wps.preced | Cisco WPS precedence | short |
+| cisco.wps.radio | The radio interface number within a slot | short |
 | cisco.wps.slot | Cisco WPS slot | short |
 | cisco.wps.track | Cisco WPS track | keyword |
 | client.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |

--- a/packages/cisco_aironet/manifest.yml
+++ b/packages/cisco_aironet/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_aironet
 title: "Cisco Aironet"
-version: "1.16.1"
+version: "1.17.0"
 description: "Integration for Cisco Aironet WLC Logs"
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Parse extended `CLIENT_ORCH_LOG-6-CLIENT_ADDED_TO_RUN_STATE` messages including:
- Slot number (`cisco.wps.slot` – existing field)
- Radio interface number (`cisco.wps.radio` - new field added)
- Channel number (`cisco.wps.channel`  – existing field)
- Support for timestamps with year and timezone

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have added an entry to my package's `changelog.yml` file.

## Related issues

- Closes #14666

## Note

- [Claude Code](https://claude.com/claude-code) using Sonnet 4.5 with commands from [ilyannn/claude-commands](https://github.com/ilyannn/claude-commands) was used to create the commit descriptions (which were used to draft the PR description).
- Gemini 2.5 Pro and Google AI summary were used to explore the meaning of numbers in the `R??/??`, `Chassis ??` and `Channel ??` verbiage.
-  This PR has otherwise not been assisted with GenAI-based developer tooling.
