### PR TITLE
[citrix_waf] Generate processor tags and normalize error handler

### DIFF
--- a/packages/citrix_waf/data_stream/log/elasticsearch/ingest_pipeline/cef.yml
+++ b/packages/citrix_waf/data_stream/log/elasticsearch/ingest_pipeline/cef.yml
@@ -4,20 +4,24 @@ processors:
   - set:
       field: citrix.cef_format
       value: true
+      tag: set_41a175e5
   # https://docs.citrix.com/en-us/citrix-adc/downloads/cef-log-components.pdf
   - dissect:
       field: citrix.detail
       pattern: "CEF:%{citrix.cef_version}|%{citrix.device_vendor}|%{citrix.device_product}|%{citrix.device_version}|%{citrix.device_event_class_id}|%{citrix.name}|%{event.severity}|%{citrix.extended.message}"
+      tag: dissect_51e6b372
   - kv:
       field: citrix.extended.message
       target_field: citrix.extended_kv
       field_split: ' (?=[a-zA-Z][a-zA-Z0-9]*=)'
       value_split: '='
       ignore_missing: true
+      tag: kv_93498010
   - remove:
       field: citrix.extended
       if: ctx.citrix?.extended_kv != null
-  
+      tag: remove_9f808877
+
   # https://docs.citrix.com/en-us/citrix-adc/current-release/application-firewall/logs.html#common-event-format-cef-logs
   - convert:
       # src – source IP address
@@ -25,83 +29,100 @@ processors:
       target_field: source.ip
       type: ip
       ignore_missing: true
+      tag: convert_1ed5ca12
   - remove:
       field: citrix.extended_kv.src
       ignore_missing: true
+      tag: remove_4cf6d8b4
   - convert:
       # spt – source port number
       field: citrix.extended_kv.spt
       target_field: source.port
       type: long
       ignore_missing: true
+      tag: convert_c3c90d76
   - remove:
       field: citrix.extended_kv.spt
       ignore_missing: true
+      tag: remove_e2e36761
   - rename:
       # method – Method (for example GET/POST)
       field: citrix.extended_kv.method
       target_field: http.request.method
       ignore_missing: true
+      tag: rename_58f6232d
   - rename:
       # request – request URL
       field: citrix.extended_kv.request
       target_field: url.original
       ignore_missing: true
+      tag: rename_e21816b5
   - rename:
       # action (for example blocked, transformed)
       field: citrix.extended_kv.act
       target_field: event.action
       ignore_missing: true
+      tag: rename_13c00860
   - rename:
       # message (Message regarding the observed security check violation)
       field: citrix.extended_kv.msg
       target_field: message
       ignore_missing: true
+      tag: rename_5eef7c54
   - rename:
       # event ID
       field: citrix.extended_kv.cn1
       target_field: event.id
       ignore_missing: true
+      tag: rename_32caf115
   - rename:
       # HTTP Transaction ID
       field: citrix.extended_kv.cn2
       target_field: http.request.id
       ignore_missing: true
+      tag: rename_1f5832ff
   - rename:
       # profile name
       field: citrix.extended_kv.cs1
       target_field: citrix.profile_name
       ignore_missing: true
+      tag: rename_328b1267
   - rename:
       # PPE ID (for example PPE1)
       field: citrix.extended_kv.cs2
       target_field: citrix.ppe_id
       ignore_missing: true
+      tag: rename_35020cfe
   - rename:
       # Session ID
       field: citrix.extended_kv.cs3
       target_field: citrix.session_id
       ignore_missing: true
+      tag: rename_d998f936
   - rename:
       # Severity (for example INFO, ALERT)
       field: citrix.extended_kv.cs4
       target_field: citrix.severity
       ignore_missing: true
+      tag: rename_e4f324aa
   - rename:
       # event year
       field: citrix.extended_kv.cs5
       target_field: citrix.event_year
       ignore_missing: true
+      tag: rename_5cd62f04
   - rename:
       # Signature Violation Category
       field: citrix.extended_kv.cs6
       target_field: citrix.signature_violation_category
       ignore_missing: true
-  
+      tag: rename_9f949ebc
+
   - rename:
       field: citrix.extended_kv
       target_field: citrix.extended
       ignore_missing: true
+      tag: rename_2223d100
 
 on_failure:
   - set:
@@ -109,4 +130,8 @@ on_failure:
       value: pipeline_error
   - append:
       field: error.message
-      value: '{{{ _ingest.on_failure_message }}}'
+      value: >-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{/_ingest.on_failure_processor_tag}}failed with message '{{{ _ingest.on_failure_message }}}'
+

--- a/packages/citrix_waf/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/citrix_waf/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -4,11 +4,13 @@ processors:
   - set:
       field: ecs.version
       value: '8.17.0'
+      tag: set_f5923549
   - rename:
       field: message
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+      tag: rename_56a77271
   - grok:
       description: Extract header details and message from log line.
       field: event.original
@@ -20,34 +22,42 @@ processors:
         IDENT: '[a-zA-Z][a-zA-Z0-9]*'
         SYSLOG_TIMESTAMP: '(?:%{SYSLOGTIMESTAMP:_tmp.timestamp}|%{TIMESTAMP_ISO8601:_tmp.timestamp8601})'
         TIMESTAMP_ISO8601: '%{YEAR}-%{MONTHNUM}-%{MONTHDAY}[T ]%{HOUR}:?%{MINUTE}(?::?%{SECOND})?%{ISO8601_TIMEZONE:event.timezone}?'
+      tag: grok_022385c2
   - pipeline:
       name: '{{ IngestPipeline "cef" }}'
       if: ctx.citrix?.detail != null && ctx.citrix?.detail.startsWith("CEF:")
+      tag: pipeline_89a9f5e0
   - pipeline:
       name: '{{ IngestPipeline "native" }}'
       if: ctx.citrix?.detail != null && !ctx.citrix?.detail.startsWith("CEF:")
+      tag: pipeline_57c774a2
   - convert:
       field: event.severity
       type: long
       ignore_missing: true
+      tag: convert_5f837ce4
   - set:
       field: _conf.tz_offset
       value: UTC
       override: false
+      tag: set_473d581a
   - set:
       field: event.timezone
       copy_from: _conf.tz_offset
       if: ctx.event?.timezone == null || ctx.event?.timezone == ""
+      tag: set_66df15c5
   - date:
       if: ctx?._tmp?.timestamp8601 != null
       field: _tmp.timestamp8601
       timezone: '{{{event.timezone}}}'
       formats:
         - ISO8601
+      tag: date_39f0e89a
   - set:
       field: _tmp.timestamp
       if: ctx._tmp?.timestamp != null && ctx.citrix?.event_year != null
       value: "{{{citrix.event_year}}} {{{_tmp.timestamp}}}"
+      tag: set_90c8795d
   - date:
       if: ctx?._tmp?.timestamp != null
       field: _tmp.timestamp
@@ -65,6 +75,7 @@ processors:
         - yyyy MMMM d HH:mm:ss
         - yyyy MMMM  d HH:mm:ss
         - yyyy MMMM dd HH:mm:ss
+      tag: date_e583edfc
   - date:
       if: ctx?._tmp?.timestamp_native != null
       field: _tmp.timestamp_native
@@ -72,17 +83,21 @@ processors:
         - MM/dd/yyyy:HH:mm:ss
         - yyyy/MM/dd:HH:mm:ss
       timezone: '{{{event.timezone}}}'
+      tag: date_ab5976b2
   - remove:
       field: citrix.event_year
       ignore_failure: true
+      tag: remove_5bf03913
   - geoip:
       field: client.ip
       target_field: client.geo
       ignore_missing: true
+      tag: geoip_90831252
   - geoip:
       field: source.ip
       target_field: source.geo
       ignore_missing: true
+      tag: geoip_da2e41b2
   # IP Autonomous System (AS) Lookup
   - geoip:
       database_file: GeoLite2-ASN.mmdb
@@ -92,6 +107,7 @@ processors:
         - asn
         - organization_name
       ignore_missing: true
+      tag: geoip_28d69883
   - geoip:
       database_file: GeoLite2-ASN.mmdb
       field: client.ip
@@ -100,26 +116,32 @@ processors:
         - asn
         - organization_name
       ignore_missing: true
+      tag: geoip_f17fb2b3
   - rename:
       field: source.as.asn
       target_field: source.as.number
       ignore_missing: true
+      tag: rename_a917047d
   - rename:
       field: source.as.organization_name
       target_field: source.as.organization.name
       ignore_missing: true
+      tag: rename_f1362d0b
   - rename:
       field: client.as.asn
       target_field: client.as.number
       ignore_missing: true
+      tag: rename_a6e30d01
   - rename:
       field: client.as.organization_name
       target_field: client.as.organization.name
       ignore_missing: true
+      tag: rename_817a526f
   - uri_parts:
       field: url.original
       target_field: url
       if: ctx.url?.original != null && ctx.url?.original != ""
+      tag: uri_parts_2956d625
   - script:
       description: Drops null/empty values recursively
       lang: painless
@@ -137,11 +159,13 @@ processors:
           return false;
         }
         dropEmptyFields(ctx);
+      tag: script_74b2bac3
   - remove:
       field:
         - _tmp
         - _conf
       ignore_missing: true
+      tag: remove_3f586893
 on_failure:
   - remove:
       field:
@@ -153,4 +177,8 @@ on_failure:
       value: pipeline_error
   - append:
       field: error.message
-      value: "{{{ _ingest.on_failure_message }}}"
+      value: >-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{/_ingest.on_failure_processor_tag}}failed with message '{{{ _ingest.on_failure_message }}}'
+

--- a/packages/citrix_waf/data_stream/log/elasticsearch/ingest_pipeline/native.yml
+++ b/packages/citrix_waf/data_stream/log/elasticsearch/ingest_pipeline/native.yml
@@ -4,6 +4,7 @@ processors:
   - set:
       field: citrix.cef_format
       value: false
+      tag: set_647109bc
   - grok:
       description: Extract native header and message.
       field: citrix.detail
@@ -13,6 +14,7 @@ processors:
       pattern_definitions:
         HEADER: '(?:<%{NUMBER}>%{SPACE})?%{NATIVE_TIMESTAMP:_tmp.timestamp_native} %{WORD:event.timezone} (?:%{SYSLOGHOST:citrix.host} )?%{INT}-PPE-%{INT}'
         NATIVE_TIMESTAMP: '(?:%{MONTHNUM}/%{MONTHDAY}/%{YEAR}|%{YEAR}/%{MONTHNUM}/%{MONTHDAY}):%{HOUR}:%{MINUTE}:%{SECOND}'
+      tag: grok_21fa0653
   - grok:
       description: Parse out details.
       field: _tmp.details
@@ -20,14 +22,20 @@ processors:
         - '^%{DEFAULT:_tmp.default}?%{WORD:citrix.device_event_class_id} %{GREEDYDATA:citrix.name} %{INT:event.id} %{INT:event.severity}$'
       pattern_definitions:
         DEFAULT: 'default '
+      tag: grok_7fe39004
   - set:
       field: citrix.default_class
       value: true
       if: ctx._tmp?.default == 'default ' # The trailing space is intended.
+      tag: set_7414b158
 on_failure:
   - set:
       field: event.kind
       value: pipeline_error
   - append:
       field: error.message
-      value: '{{{ _ingest.on_failure_message }}}'
+      value: >-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{/_ingest.on_failure_processor_tag}}failed with message '{{{ _ingest.on_failure_message }}}'
+


### PR DESCRIPTION
## Proposed commit message

- Generate tags for processors missing tags
- Normalize the pipeline error handler

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~
