### PR TITLE
[fortinet_fortigate] Generate processor tags and normalize error handler

### DIFF
--- a/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -4,17 +4,21 @@ processors:
   - set:
       field: ecs.version
       value: '8.17.0'
+      tag: set_f5923549
   - set:
       field: event.original
       copy_from: message
+      tag: set_b9758751
   - remove:
       field: message
+      tag: remove_7144efd2
   - grok:
       field: event.original
       ecs_compatibility: v1
       patterns:
         - "^(?:%{SYSLOG5424PRI}%{NONNEGINT} )+(?:%{TIMESTAMP_ISO8601}|-) +(?:%{HOSTNAME:syslog5424_host}|-) +(-|%{SYSLOG5424PRINTASCII}) +(-|%{SYSLOG5424PRINTASCII}) +(-|%{SYSLOG5424PRINTASCII}) +(-|%{SYSLOG5424PRINTASCII}) +(?:%{GREEDYDATA:syslog5424_msg}|-|)"
         - "^(?:%{SYSLOG5424PRI} *)?%{GREEDYDATA:syslog5424_msg}$"
+      tag: grok_995e7c66
   - script:
       lang: painless
       source: |
@@ -26,10 +30,12 @@ processors:
           facility['code'] = ctx.log.syslog.priority>>3;
           ctx.log.syslog['facility'] = facility;
         }
+      tag: script_4a9d0c10
   - gsub:
       field: syslog5424_msg
       pattern: "[\u0000-\u001F\u007F]"
       replacement: ""
+      tag: gsub_b526c35d
   - script:
       lang: painless
       if: ctx.syslog5424_msg != null
@@ -96,6 +102,7 @@ processors:
           ctx.fortinet = new HashMap();
         }
         ctx.fortinet.firewall = map;
+      tag: script_2073fe5f
   - script:
       lang: painless
       source: |
@@ -105,24 +112,30 @@ processors:
             def pat = /\W+/; 
             fw.entrySet().removeIf(entry -> entry.getValue() == "N/A" || pat.matcher(entry.getKey()).find());
         }
+      tag: script_dc02f280
   - set:
       field: observer.vendor
       value: Fortinet
+      tag: set_7e57c221
   - set:
       field: observer.product
       value: Fortigate
+      tag: set_19a6a908
   - set:
       field: observer.type
       value: firewall
+      tag: set_5dddf3ba
   # Fortigate may set two timezones for an event. Use the first.
   - set:
       if: ctx.fortinet?.firewall?.tz != null && !(ctx.fortinet.firewall.tz instanceof List)
       field: event.timezone
       copy_from: fortinet.firewall.tz
+      tag: set_5c5e1e41
   - set:
       if: ctx.fortinet?.firewall?.tz instanceof List && ctx.fortinet.firewall.tz.length != 0
       field: event.timezone
       copy_from: fortinet.firewall.tz.0
+      tag: set_1f1c0600
   # The timezone may be formatted for human consumption, so fix that too.
   - gsub:
       field: event.timezone
@@ -130,20 +143,24 @@ processors:
       replacement: $10$2$3
       ignore_missing: true
       ignore_failure: true
+      tag: gsub_1ce50a02
   - gsub:
       field: event.timezone
       pattern: ^(?:[A-Z]{1,4})([+-][0-9]{2}):?([0-9]{2})$
       replacement: $1$2
       ignore_missing: true
       ignore_failure: true
+      tag: gsub_46d548b8
   - set:
       field: _temp.time
       value: "{{{fortinet.firewall.date}}} {{{fortinet.firewall.time}}} {{{event.timezone}}}"
       if: ctx.fortinet?.firewall?.date != null && ctx.fortinet?.firewall?.time != null && ctx.event?.timezone != null
+      tag: set_2240d59c
   - set:
       field: _temp.time
       value: "{{{fortinet.firewall.date}}} {{{fortinet.firewall.time}}}"
       if: ctx.fortinet?.firewall?.date != null && ctx.fortinet?.firewall?.time != null && ctx.event?.timezone == null
+      tag: set_41a88693
   - date:
       field: _temp.time
       target_field: "@timestamp"
@@ -154,6 +171,7 @@ processors:
         - ISO8601
       timezone: "{{{event.timezone}}}"
       if: ctx._temp?.time != null && ctx.event?.timezone != null
+      tag: date_745b440f
   - date:
       field: _temp.time
       target_field: "@timestamp"
@@ -163,11 +181,13 @@ processors:
         - yyyy-MM-dd HH:mm:ss z
         - ISO8601
       if: ctx._temp?.time != null && ctx.event?.timezone == null
+      tag: date_978d46f3
   - gsub:
       field: fortinet.firewall.eventtime
       pattern: "\\d{6}$"
       replacement: ""
       if: ctx.fortinet?.firewall?.eventtime != null && (ctx.fortinet?.firewall?.eventtime).length() > 18
+      tag: gsub_7a46875e
   - date:
       field: fortinet.firewall.eventtime
       target_field: event.start
@@ -175,6 +195,7 @@ processors:
         - UNIX_MS
       timezone: "{{{event.timezone}}}"
       if: ctx.fortinet?.firewall?.eventtime != null && ctx.event?.timezone != null && (ctx.fortinet?.firewall?.eventtime).length() > 11
+      tag: date_2c86beef
   - date:
       field: fortinet.firewall.eventtime
       target_field: event.start
@@ -182,97 +203,119 @@ processors:
         - UNIX
       timezone: "{{{event.timezone}}}"
       if: ctx.fortinet?.firewall?.eventtime != null && ctx.event?.timezone != null && (ctx.fortinet?.firewall?.eventtime).length() <= 11
+      tag: date_5c1ae327
   - date:
       field: fortinet.firewall.eventtime
       target_field: event.start
       formats:
         - UNIX_MS
       if: ctx.fortinet?.firewall?.eventtime != null && ctx.event?.timezone == null && (ctx.fortinet?.firewall?.eventtime).length() > 11
+      tag: date_d17d3bd3
   - date:
       field: fortinet.firewall.eventtime
       target_field: event.start
       formats:
         - UNIX
       if: ctx.fortinet?.firewall?.eventtime != null && ctx.event?.timezone == null && (ctx.fortinet?.firewall?.eventtime).length() <= 11
+      tag: date_c49d753b
   - rename:
       field: fortinet.firewall.devname
       target_field: observer.name
       ignore_missing: true
+      tag: rename_81fc9d96
   - rename:
       field: syslog5424_host
       target_field: observer.name
       if: ctx.observer?.name == null && ctx.syslog5424_host !== null
       ignore_missing: true
+      tag: rename_193d2ffb
   - remove:
       field:
         - syslog5424_host
         - syslog5424_msg
       ignore_missing: true
+      tag: remove_c1748a95
   - script:
       lang: painless
       source: "ctx.event.duration = Long.parseLong(ctx.fortinet.firewall.duration) * 1000000000"
       if: ctx.fortinet?.firewall?.duration != null
+      tag: script_587fe567
   - rename:
       field: fortinet.firewall.devid
       target_field: observer.serial_number
       ignore_missing: true
+      tag: rename_60129b13
   - rename:
       field: fortinet.firewall.dstintf
       target_field: observer.egress.interface.name
       ignore_missing: true
       if: ctx.observer?.egress?.interface?.name == null
+      tag: rename_340a1617
   - rename:
       field: fortinet.firewall.srcintf
       target_field: observer.ingress.interface.name
       ignore_missing: true
       if: ctx.observer?.ingress?.interface?.name == null
+      tag: rename_2eb05d40
   - rename:
       field: fortinet.firewall.dst_int
       target_field: observer.egress.interface.name
       ignore_missing: true
+      tag: rename_247e22bb
   - rename:
       field: fortinet.firewall.src_int
       target_field: observer.ingress.interface.name
       ignore_missing: true
+      tag: rename_a72a5c7a
   - rename:
       field: fortinet.firewall.level
       target_field: log.level
       ignore_missing: true
+      tag: rename_0e7843bb
   - append:
       field: email.cc.address
       value: "{{{fortinet.firewall.cc}}}"
       if: ctx.fortinet?.cc?.address != null
+      tag: append_4d235e7f
   - set:
       field: email.subject
       copy_from: fortinet.firewall.subject
       if: ctx.fortinet?.firewall?.subject != null
+      tag: set_5cfd5faa
   - lowercase:
       target_field: host.name
       field: fortinet.firewall.srcname
       if: ctx.fortinet?.firewall?.srcname != null
+      tag: lowercase_bae14896
   - set:
       field: user.name
       copy_from: source.user.name
       if: ctx.source?.user?.name != null && ctx.user?.name == null
+      tag: set_4fd1694d
   - rename:
       field: fortinet.firewall.msg
       target_field: message
       ignore_missing: true
+      tag: rename_18251f47
   - rename:
       field: fortinet.firewall.dstmac
       target_field: destination.mac
       ignore_missing: true
+      tag: rename_f4450c6e
   - gsub:
       field: destination.mac
       pattern: ':'
       replacement: '-'
       ignore_missing: true
+      tag: gsub_52ddb47b
   - uppercase:
       field: destination.mac
       ignore_missing: true
+      tag: uppercase_04de3657
   - pipeline:
       name: '{{ IngestPipeline "event" }}'
       if: ctx.fortinet?.firewall?.type == 'event'
+      tag: pipeline_0b88bd91
   - pipeline:
       name: '{{ IngestPipeline "login" }}'
       if: >-
@@ -281,41 +324,50 @@ processors:
           return (normalizedMessage.contains('login') || normalizedMessage.contains('logged in'));
         }
         return false;
+      tag: pipeline_4025c313
   - pipeline:
       name: '{{ IngestPipeline "traffic" }}'
       if: ctx.fortinet?.firewall?.type == 'traffic'
+      tag: pipeline_6d53bc4d
   - pipeline:
       name: '{{ IngestPipeline "utm" }}'
       if: ctx.fortinet?.firewall?.type == 'utm' || ctx.fortinet?.firewall?.type == 'dns'
+      tag: pipeline_461401ce
   - rename:
       field: fortinet.firewall.eventtype
       target_field: event.action
       ignore_missing: true
       if: ctx.event?.action == null
+      tag: rename_d051663b
   - rename:
       field: fortinet.firewall.reason
       target_field: event.reason
       ignore_missing: true
       if: ctx.event?.reason == null
+      tag: rename_86432253
   - rename:
       field: fortinet.firewall.eventsubtype
       target_field: event.reason
       ignore_missing: true
       if: ctx.event?.reason == null
+      tag: rename_7e989cdd
   - rename:
       field: fortinet.firewall.dir
       target_field: network.direction
       ignore_missing: true
       if: ctx.network?.direction == null
+      tag: rename_9bc88a5a
   - rename:
       field: fortinet.firewall.direction
       target_field: network.direction
       ignore_missing: true
       if: ctx.network?.direction == null
+      tag: rename_a0716d1c
   - network_direction:
       internal_networks_field: _temp.internal_networks
       ignore_missing: true
       if: ctx.network?.direction == null
+      tag: network_direction_af8b6e3d
   # Handle interface-based network directionality
   - set:
       field: network.direction
@@ -327,6 +379,7 @@ processors:
         ctx.observer?.egress?.interface?.name != null &&
         ctx._temp.external_interfaces.contains(ctx.observer.ingress.interface.name) &&
         ctx._temp.internal_interfaces.contains(ctx.observer.egress.interface.name)
+      tag: set_0fbdc385
   - set:
       field: network.direction
       value: outbound
@@ -337,6 +390,7 @@ processors:
         ctx.observer?.egress?.interface?.name != null &&
         ctx._temp.external_interfaces.contains(ctx.observer.egress.interface.name) &&
         ctx._temp.internal_interfaces.contains(ctx.observer.ingress.interface.name)
+      tag: set_1f1faa3e
   - set:
       field: network.direction
       value: internal
@@ -347,6 +401,7 @@ processors:
         ctx.observer?.egress?.interface?.name != null &&
         ctx._temp.internal_interfaces.contains(ctx.observer.egress.interface.name) &&
         ctx._temp.internal_interfaces.contains(ctx.observer.ingress.interface.name)
+      tag: set_fd72b4eb
   - set:
       field: network.direction
       value: external
@@ -357,6 +412,7 @@ processors:
         ctx.observer?.egress?.interface?.name != null &&
         ctx._temp.external_interfaces.contains(ctx.observer.egress.interface.name) &&
         ctx._temp.external_interfaces.contains(ctx.observer.ingress.interface.name)
+      tag: set_707f3fa1
   - set:
       field: network.direction
       value: unknown
@@ -375,6 +431,7 @@ processors:
             !ctx._temp.internal_interfaces.contains(ctx.observer.ingress.interface.name)
           )
         )
+      tag: set_fdc5ffc3
   # Normalize the network direction
   - script:
       lang: painless
@@ -391,79 +448,97 @@ processors:
         }
         ctx.network.direction = k;
       if: ctx.network?.direction instanceof String
+      tag: script_2ad0e621
   # Fix up network direction field to match ECS-allowable values.
   - set:
       field: network.direction
       value: unknown
       if: ctx.network?.direction != null && !(['ingress', 'egress', 'inbound', 'outbound', 'internal', 'external'].contains(ctx.network.direction))
+      tag: set_8fd7edc5
   - rename:
       field: fortinet.firewall.interface
       target_field: observer.ingress.interface.name
       ignore_missing: true
       if: ctx.observer?.ingress?.interface?.name == null && (['ingress', 'inbound', 'internal'].contains(ctx.network?.direction))
+      tag: rename_26e89051
   - rename:
       field: fortinet.firewall.interface
       target_field: observer.egress.interface.name
       ignore_missing: true
       if: ctx.observer?.egress?.interface?.name == null && (['egress', 'outbound', 'external'].contains(ctx.network?.direction))
+      tag: rename_4a104736
   - convert:
       field: fortinet.firewall.auditid
       type: long
       ignore_missing: true
+      tag: convert_ec0373ea
   - convert:
       field: fortinet.firewall.audittime
       type: long
       ignore_missing: true
+      tag: convert_0d65ad6e
   - convert:
       field: fortinet.firewall.quotamax
       type: long
       ignore_missing: true
+      tag: convert_a2257e1c
   - convert:
       field: fortinet.firewall.quotaused
       type: long
       ignore_missing: true
+      tag: convert_6a99b037
   - convert:
       field: fortinet.firewall.size
       type: long
       ignore_missing: true
+      tag: convert_4d138169
   - convert:
       field: fortinet.firewall.disklograte
       type: long
       ignore_missing: true
+      tag: convert_cc8fa1f9
   - convert:
       field: fortinet.firewall.fazlograte
       type: long
       ignore_missing: true
+      tag: convert_0b3f0dbb
   - convert:
       field: fortinet.firewall.lanin
       type: long
       ignore_missing: true
+      tag: convert_7938bde0
   - convert:
       field: fortinet.firewall.lanout
       type: long
       ignore_missing: true
+      tag: convert_826341f9
   - convert:
       field: fortinet.firewall.setuprate
       type: long
       ignore_missing: true
+      tag: convert_a6988fbd
   - convert:
       field: fortinet.firewall.wanin
       type: long
       ignore_missing: true
+      tag: convert_754b2213
   - convert:
       field: fortinet.firewall.wanout
       type: long
       ignore_missing: true
+      tag: convert_2bbe180c
   - geoip:
       field: source.ip
       target_field: source.geo
       ignore_missing: true
       if: ctx.source?.geo == null
+      tag: geoip_0e79e8a4
   - geoip:
       field: destination.ip
       target_field: destination.geo
       ignore_missing: true
       if: ctx.destination?.geo == null
+      tag: geoip_2f67bd6f
   - geoip:
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
@@ -472,6 +547,7 @@ processors:
       - asn
       - organization_name
       ignore_missing: true
+      tag: geoip_28d69883
   - geoip:
       database_file: GeoLite2-ASN.mmdb
       field: destination.ip
@@ -480,16 +556,19 @@ processors:
       - asn
       - organization_name
       ignore_missing: true
+      tag: geoip_8a007787
   - geoip:
       field: source.nat.ip
       target_field: source.geo
       ignore_missing: true
       if: ctx.source?.geo == null
+      tag: geoip_9fb0fcc3
   - geoip:
       field: destination.nat.ip
       target_field: destination.geo
       ignore_missing: true
       if: ctx.destination?.geo == null
+      tag: geoip_b429ceb4
   - geoip:
       database_file: GeoLite2-ASN.mmdb
       field: source.nat.ip
@@ -499,6 +578,7 @@ processors:
       - organization_name
       ignore_missing: true
       if: ctx.source?.as == null
+      tag: geoip_d9d3c7d1
   - geoip:
       database_file: GeoLite2-ASN.mmdb
       field: destination.nat.ip
@@ -508,32 +588,39 @@ processors:
       - organization_name
       ignore_missing: true
       if: ctx.destination?.as == null
+      tag: geoip_dcccb906
   - rename:
       field: source.as.asn
       target_field: source.as.number
       ignore_missing: true
+      tag: rename_a917047d
   - rename:
       field: source.as.organization_name
       target_field: source.as.organization.name
       ignore_missing: true
+      tag: rename_f1362d0b
   - rename:
       field: destination.as.asn
       target_field: destination.as.number
       ignore_missing: true
+      tag: rename_3b459fcd
   - rename:
       field: destination.as.organization_name
       target_field: destination.as.organization.name
       ignore_missing: true
+      tag: rename_814bd459
   - script:
       lang: painless
       source: "ctx.network.bytes = ctx.source.bytes + ctx.destination.bytes"
       if: ctx.source?.bytes != null && ctx.destination?.bytes != null
       ignore_failure: true
+      tag: script_7a41cd50
   - script:
       lang: painless
       source: "ctx.network.packets = ctx.source.packets + ctx.destination.packets"
       if: ctx.source?.packets != null && ctx.destination?.packets != null
       ignore_failure: true
+      tag: script_8baeb286
   - script:
       lang: painless
       ignore_failure: true
@@ -563,89 +650,107 @@ processors:
         } else if (iana_number == '132') {
             ctx.network.transport = 'sctp';
         }
+      tag: script_c5ddceda
   - uppercase:
       field: source.mac
       ignore_missing: true
+      tag: uppercase_5b4e7be2
   - gsub:
       field: source.mac
       pattern: '[:.]'
       replacement: '-'
       ignore_missing: true
+      tag: gsub_3ceae5bc
   - append:
       field: related.ip
       value: "{{{source.ip}}}"
       if: ctx.source?.ip != null
       allow_duplicates: false
+      tag: append_8121c591
   - append:
       field: related.ip
       value: "{{{destination.ip}}}"
       if: ctx.destination?.ip != null
       allow_duplicates: false
+      tag: append_c1a6356b
   - append:
       field: related.ip
       value: "{{{source.nat.ip}}}"
       if: ctx.source?.nat?.ip != null
       allow_duplicates: false
+      tag: append_53b62ed8
   - append:
       field: related.ip
       value: "{{{destination.nat.ip}}}"
       if: ctx.destination?.nat?.ip != null
       allow_duplicates: false
+      tag: append_6a388074
   - append:
       field: related.ip
       value: "{{{source.nat.ip}}}"
       allow_duplicates: false
       if: ctx.source?.nat?.ip != null
+      tag: append_53b62ed8
   - append:
       field: related.ip
       value: "{{{destination.nat.ip}}}"
       allow_duplicates: false
       if: ctx.destination?.nat?.ip != null
+      tag: append_6a388074
   - append:
       field: related.ip
       value: "{{{fortinet.firewall.ip}}}"
       allow_duplicates: false
       if: ctx.fortinet?.firewall?.ip != null
+      tag: append_1ccb183c
   - append:
       field: related.ip
       value: "{{{fortinet.firewall.assignip}}}"
       allow_duplicates: false
       if: ctx.fortinet?.firewall?.assignip != null
+      tag: append_45cc2958
   - append:
       field: related.ip
       value: "{{{fortinet.firewall.tunnelip}}}"
       allow_duplicates: false
       if: ctx.fortinet?.firewall?.tunnelip != null
+      tag: append_a5b82964
   - append:
       field: related.user
       value: "{{{source.user.name}}}"
       if: ctx.source?.user?.name != null
       allow_duplicates: false
+      tag: append_f745a124
   - append:
       field: related.user
       value: "{{{destination.user.name}}}"
       if: ctx.destination?.user?.name != null
       allow_duplicates: false
+      tag: append_8f37bc82
   - append:
       field: related.hosts
       value: "{{{destination.address}}}"
       if: ctx.destination?.address != null
       allow_duplicates: false
+      tag: append_aa05bed9
   - append:
       field: related.hosts
       value: "{{{source.address}}}"
       if: ctx.source?.address != null
       allow_duplicates: false
+      tag: append_439b2767
   - append:
       field: related.hosts
       value: "{{{host.name}}}"
       if: ctx.host?.name != null
       allow_duplicates: false
+      tag: append_452ef445
   - append:
       field: related.hosts
       value: "{{{dns.question.name}}}"
       if: ctx.dns?.question?.name != null
       allow_duplicates: false
+      tag: append_c4ad0d16
 
   - script:
       lang: painless
@@ -661,6 +766,7 @@ processors:
             }
           }
         }
+      tag: script_b4f88753
   - script:
       description: Drops null/empty values recursively
       tag: drop_empty_fields
@@ -689,10 +795,15 @@ processors:
         - fortinet.firewall.time
         - fortinet.firewall.duration
       ignore_missing: true
+      tag: remove_c87f67c3
 on_failure:
   - set:
       field: event.kind
       value: pipeline_error
   - append:
       field: error.message
-      value: '{{{ _ingest.on_failure_message }}}'
+      value: >-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{/_ingest.on_failure_processor_tag}}failed with message '{{{ _ingest.on_failure_message }}}'
+

--- a/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/event.yml
+++ b/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/event.yml
@@ -4,69 +4,84 @@ processors:
   - set:
       field: event.kind
       value: event
+      tag: set_de80643c
   - set:
       field: event.outcome
       value: failure
       if: ctx.fortinet?.firewall?.result == 'ERROR' || ctx.fortinet?.firewall?.status == 'negotiate_error'
+      tag: set_102f0bb5
   - set:
       field: event.outcome
       value: success
       if: ctx.fortinet?.firewall?.result == 'OK' || ['FSSO-logon', 'auth-logon', 'FSSO-logoff', 'auth-logout'].contains(ctx.fortinet?.firewall?.action)
+      tag: set_bac8ed90
   - append:
       field: event.type
       value:
         - start
       if: "['FSSO-logon', 'auth-logon'].contains(ctx.fortinet?.firewall?.action)"
+      tag: append_41eb50c6
   - append:
       field: event.type
       value:
         - end
       if: "['FSSO-logoff', 'auth-logout'].contains(ctx.fortinet?.firewall?.action)"
+      tag: append_a0b70a82
   - append:
       field: event.type
       value: connection
       if: ctx.fortinet?.firewall?.subtype == 'vpn'
+      tag: append_7df30e03
   - append:
       field: event.category
       value: network
       if: ctx.fortinet?.firewall?.subtype == 'vpn'
+      tag: append_75e66583
   - append:
       field: event.type
       value: info
       if: ctx.fortinet?.firewall?.action == 'perf-stats'
+      tag: append_d9e5777e
   - append:
       field: event.category
       value: host
       if: ctx.fortinet?.firewall?.action == 'perf-stats'
+      tag: append_c9e00984
   - append:
       field: event.type
       value: info
       if: ctx.fortinet?.firewall?.subtype == 'update'
+      tag: append_0b9b5f72
   - append:
       field: event.category
       value:
         - host
         - malware
       if: ctx.fortinet?.firewall?.subtype == 'update'
+      tag: append_61d5b2cf
   - append:
       field: event.category
       value: authentication
       if: ctx.fortinet?.firewall?.subtype == 'user'
+      tag: append_975470e4
   - rename:
       field: fortinet.firewall.dstip
       target_field: destination.ip
       ignore_missing: true
+      tag: rename_72bf25a6
   - rename:
       field: fortinet.firewall.remip
       target_field: destination.ip
       ignore_missing: true
       if: ctx.destination?.ip == null
+      tag: rename_971a6fc2
   - convert:
       field: fortinet.firewall.dstport
       target_field: destination.port
       type: long
       ignore_failure: true
       ignore_missing: true
+      tag: convert_37791676
   - convert:
       field: fortinet.firewall.remport
       target_field: destination.port
@@ -74,60 +89,72 @@ processors:
       ignore_failure: true
       ignore_missing: true
       if: ctx.destination?.port == null
+      tag: convert_763b849e
   - convert:
       field: fortinet.firewall.rcvdbyte
       target_field: destination.bytes
       type: long
       ignore_failure: true
       ignore_missing: true
+      tag: convert_65439a41
   - rename:
       field: fortinet.firewall.daddr
       target_field: destination.address
       ignore_missing: true
+      tag: rename_b6978056
   - rename:
       field: fortinet.firewall.dst_host
       target_field: destination.address
       ignore_missing: true
       if: ctx.destination?.address == null
+      tag: rename_8323a9e5
   - rename:
       field: fortinet.firewall.dst_host
       target_field: destination.domain
       ignore_missing: true
       if: ctx.destination?.address == null
+      tag: rename_f63213f3
   - rename:
       field: fortinet.firewall.group
       target_field: source.user.group.name
       ignore_missing: true
+      tag: rename_8ef934c4
   - convert:
       field: fortinet.firewall.sentbyte
       target_field: source.bytes
       type: long
       ignore_failure: true
       ignore_missing: true
+      tag: convert_fe52ad03
   - rename:
       field: fortinet.firewall.srcip
       target_field: source.ip
       ignore_missing: true
+      tag: rename_79344114
   - rename:
       field: fortinet.firewall.locip
       target_field: source.ip
       ignore_missing: true
       if: ctx.source?.ip == null
+      tag: rename_47ccd6f8
   - rename:
       field: fortinet.firewall.srcmac
       target_field: source.mac
       ignore_missing: true
+      tag: rename_bfde8f82
   - rename:
       field: fortinet.firewall.source_mac
       target_field: source.mac
       ignore_missing: true
       if: ctx.source?.mac == null
+      tag: rename_e364b602
   - convert:
       field: fortinet.firewall.srcport
       target_field: source.port
       type: long
       ignore_failure: true
       ignore_missing: true
+      tag: convert_dbc962e4
   - convert:
       field: fortinet.firewall.locport
       target_field: source.port
@@ -135,64 +162,79 @@ processors:
       ignore_failure: true
       ignore_missing: true
       if: ctx.source?.port == null
+      tag: convert_ecd8b392
   - rename:
       field: fortinet.firewall.user
       target_field: source.user.name
       ignore_missing: true
+      tag: rename_ba3b5509
   - rename:
       field: fortinet.firewall.saddr
       target_field: source.address
       ignore_missing: true
+      tag: rename_036ff596
   - rename:
       field: fortinet.firewall.agent
       target_field: user_agent.original
       ignore_missing: true
+      tag: rename_c612b9cc
   - rename:
       field: fortinet.firewall.file
       target_field: file.name
       ignore_missing: true
+      tag: rename_a8d30898
   - convert:
       field: fortinet.firewall.filesize
       target_field: file.size
       type: long
       ignore_failure: true
       ignore_missing: true
+      tag: convert_2e69dd69
   - rename:
       field: fortinet.firewall.level
       target_field: log.level
       ignore_missing: true
+      tag: rename_0e7843bb
   - rename:
       field: fortinet.firewall.logid
       target_field: event.code
       ignore_missing: true
       if: ctx.event?.code == null
+      tag: rename_d1ce9848
   - rename:
       field: fortinet.firewall.msg
       target_field: message
       ignore_missing: true
+      tag: rename_18251f47
   - rename:
       field: fortinet.firewall.policyid
       target_field: rule.id
       ignore_missing: true
+      tag: rename_b85da627
   - rename:
       field: fortinet.firewall.proto
       target_field: network.iana_number
       ignore_missing: true
+      tag: rename_930125ae
   - rename:
       field: fortinet.firewall.service
       target_field: network.protocol
       ignore_missing: true
+      tag: rename_c028ec88
   - lowercase:
       field: network.protocol
       ignore_missing: true
+      tag: lowercase_49872259
   - rename:
       field: fortinet.firewall.error_num
       target_field: error.code
       ignore_missing: true
+      tag: rename_8e7c3151
   - rename:
       field: fortinet.firewall.logdesc
       target_field: rule.description
       ignore_missing: true
+      tag: rename_4783eec6
   - convert:
       field: fortinet.firewall.addr
       type: ip
@@ -201,6 +243,7 @@ processors:
         - rename:
             field: fortinet.firewall.addr
             target_field: fortinet.firewall.addrgrp
+      tag: convert_e65b2bfc
   - uri_parts:
       field: fortinet.firewall.url
       target_field: url
@@ -211,6 +254,7 @@ processors:
             tag: event_set_url_original_on_fail
             field: url.original
             copy_from: fortinet.firewall.url
+      tag: uri_parts_3a7b2d2e
   # Need to do a set, then remove since rename w/ override
   # is not supported in 8.3.0
   - set:
@@ -218,12 +262,15 @@ processors:
       copy_from: fortinet.firewall.hostname
       ignore_empty_value: true
       override: true
+      tag: set_e4ace8d8
   - remove:
       field: fortinet.firewall.hostname
       ignore_missing: true
+      tag: remove_161ef624
   - remove:
       field: fortinet.firewall.url
       ignore_missing: true
+      tag: remove_5d47c5fc
   - convert:
       field: fortinet.firewall.sess_duration
       type: long
@@ -231,23 +278,28 @@ processors:
       ignore_failure: true
       ignore_missing: true
       if: ctx.event?.duration == null
+      tag: convert_022af8e6
   - convert:
       field: fortinet.firewall.mem
       type: integer
       ignore_failure: true
       ignore_missing: true
+      tag: convert_4afb50de
   - convert:
       field: fortinet.firewall.jitter
       type: float
       ignore_missing: true
+      tag: convert_6cb67bbc
   - convert:
       field: fortinet.firewall.latency
       type: float
       ignore_missing: true
+      tag: convert_a02f5b8a
   - set:
       field: source.user.name
       copy_from: fortinet.firewall.xauthuser
       if: ctx.fortinet?.firewall?.subtype == 'vpn' && ctx.fortinet.firewall.xauthuser != null
+      tag: set_d0ef01fd
   - script:
       lang: painless
       tag: script_convert_advpnsc
@@ -266,6 +318,7 @@ processors:
         - fortinet.firewall.filesize
         - fortinet.firewall.sess_duration
       ignore_missing: true
+      tag: remove_79b94f58
   # For vpn subtype, remip(the client), is source, and locip(the firewall) is destination
   # https://docs.fortinet.com/document/fortigate/7.6.0/administration-guide/834425/understanding-vpn-related-logs
   - script:
@@ -279,10 +332,15 @@ processors:
             tmp.remove("user");
         }
         ctx.destination = tmp;
+      tag: script_345a587b
 on_failure:
   - set:
       field: event.kind
       value: pipeline_error
   - append:
       field: error.message
-      value: '{{{ _ingest.on_failure_message }}}'
+      value: >-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{/_ingest.on_failure_processor_tag}}failed with message '{{{ _ingest.on_failure_message }}}'
+

--- a/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/login.yml
+++ b/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/login.yml
@@ -4,26 +4,32 @@ processors:
 - set:
     field: "event.kind"
     value: "event"
+    tag: set_de80643c
 - set:
     field: "event.action"
     value: "login"
     override: false
+    tag: set_9396d084
 - append:
     field: "event.category"
     value:
     - "authentication"
+    tag: append_c182a53a
 - set:
     field: "user.name"
     value: "{{{ source.user.name }}}"
     if: ctx.source?.user?.name != null
+    tag: set_7ff007fb
 - append:
     field: "user.roles"
     value: "{{{ fortinet.firewall.adminprof }}}"
     if: ctx.fortinet?.firewall?.adminprof != null
+    tag: append_9f4ec36b
 - append:
     field: "source.user.roles"
     value: "{{{ fortinet.firewall.adminprof }}}"
     if: ctx.fortinet?.firewall?.adminprof != null
+    tag: append_fa50adf0
 - dissect:
     field: "fortinet.firewall.userfrom"
     tag: "userfrom"
@@ -79,32 +85,39 @@ processors:
     field: "event.outcome"
     value: "failure"
     if: "ctx.event?.outcome != null && ctx.event?.outcome.toLowerCase().startsWith('fail')"
+    tag: set_4b7c0079
 - set:
     field: "event.outcome"
     value: "success"
     if: "ctx.event?.outcome != null && ctx.event?.outcome.toLowerCase().startsWith('success')"
+    tag: set_bd391e8b
 - rename:
     field: "fortinet.firewall.log_id"
     target_field: "event.id"
     ignore_missing: true
+    tag: rename_14d08806
 - rename:
     field: "fortinet.firewall.pri"
     target_field: "log.level"
     ignore_missing: true
+    tag: rename_c2c890f0
 - rename:
     field: "fortinet.firewall.device_id"
     target_field: "observer.serial_number"
     ignore_missing: true
+    tag: rename_f8ed8afb
 - append:
     field: user.roles
     value: "{{{ _tmp.user.roles }}}"
     if: ctx._tmp?.user?.roles != null
     allow_duplicates: false
+    tag: append_217fc576
 - append:
     field: source.user.roles
     value: "{{{ _tmp.user.roles }}}"
     if: ctx._tmp?.user?.roles != null
     allow_duplicates: false
+    tag: append_a2c82efb
 - convert:
     field: source.port
     type: long
@@ -134,10 +147,15 @@ processors:
     - "_tmp.user.roles"
     ignore_missing: true
     ignore_failure: true
+    tag: remove_723f70cc
 on_failure:
 - set:
     field: "event.kind"
     value: "pipeline_error"
 - append:
-    field: "error.message"
-    value: "{{{ _ingest.on_failure_message }}}"
+    field: error.message
+    value: >-
+      Processor '{{{ _ingest.on_failure_processor_type }}}'
+      {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+      {{/_ingest.on_failure_processor_tag}}failed with message '{{{ _ingest.on_failure_message }}}'
+

--- a/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/traffic.yml
+++ b/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/traffic.yml
@@ -4,44 +4,55 @@ processors:
 - set:
     field: event.kind
     value: event
+    tag: set_de80643c
 - set:
     field: event.action
     value: "{{{fortinet.firewall.action}}}"
     ignore_empty_value: true
+    tag: set_d2842801
 - set:
     field: event.outcome
     value: success
     if: ctx.fortinet?.firewall?.action != null
+    tag: set_e219d8f1
 - append:
     field: event.category
     value: network
+    tag: append_7afdca3c
 - append:
     field: event.type
     value: connection
+    tag: append_ab8d9d0e
 - append:
     field: event.type
     value: start
     if: ctx.fortinet?.firewall?.action == 'start'
+    tag: append_7a3e52b1
 - append:
     field: event.type
     value: end
     if: ctx.fortinet?.firewall?.action != null && ctx.fortinet?.firewall?.action !='start'
+    tag: append_95005a3f
 - append:
     field: event.type
     value: protocol
     if: ctx.fortinet?.firewall?.app != null && ctx.fortinet?.firewall?.action != 'deny'
+    tag: append_a0c004ed
 - append:
     field: event.type
     value: allowed
     if: ctx.fortinet?.firewall?.utmaction == null && ctx.fortinet?.firewall?.action != 'deny'
+    tag: append_b0751c98
 - append:
     field: event.type
     value: denied
     if: ctx.fortinet?.firewall?.utmaction == 'block' || ctx.fortinet?.firewall?.action == 'deny'
+    tag: append_4099186f
 - rename:
     field: fortinet.firewall.dstip
     target_field: destination.ip
     ignore_missing: true
+    tag: rename_72bf25a6
 - convert:
     field: fortinet.firewall.tranip
     target_field: destination.nat.ip
@@ -53,99 +64,119 @@ processors:
       - append:
           field: error.message
           value: '{{{_ingest.on_failure_message}}}'
+    tag: convert_7b6fb54b
 - convert:
     field: fortinet.firewall.dstport
     target_field: destination.port
     type: long
     ignore_failure: true
     ignore_missing: true
+    tag: convert_37791676
 - convert:
     field: fortinet.firewall.tranport
     target_field: destination.nat.port
     type: long
     ignore_failure: true
     ignore_missing: true
+    tag: convert_0a1cdcdb
 - convert:
     field: fortinet.firewall.rcvddelta
     type: long
     ignore_failure: true
     ignore_missing: true
+    tag: convert_fbf14766
 - convert:
     field: fortinet.firewall.rcvdbyte
     target_field: destination.bytes
     type: long
     ignore_failure: true
     ignore_missing: true
+    tag: convert_65439a41
 - convert:
     field: fortinet.firewall.rcvdpkt
     target_field: destination.packets
     type: long
     ignore_failure: true
     ignore_missing: true
+    tag: convert_523a1dfa
 - append:
     field: email.to.address
     value: "{{{fortinet.firewall.dstcollectedemail}}}"
     if: ctx.fortinet?.firewall?.dstcollectedemail != null
+    tag: append_20a3bc20
 - rename:
     field: fortinet.firewall.dstname
     target_field: destination.address
     ignore_missing: true
+    tag: rename_55c832a1
 - rename:
     field: fortinet.firewall.dstunauthuser
     target_field: destination.user.name
     ignore_missing: true
+    tag: rename_379463a0
 - rename:
     field: fortinet.firewall.group
     target_field: source.user.group.name
     ignore_missing: true
+    tag: rename_8ef934c4
 - convert:
     field: fortinet.firewall.sentdelta
     type: long
     ignore_failure: true
     ignore_missing: true
+    tag: convert_5e362e81
 - convert:
     field: fortinet.firewall.sentbyte
     target_field: source.bytes
     type: long
     ignore_failure: true
     ignore_missing: true
+    tag: convert_fe52ad03
 - rename:
     field: fortinet.firewall.srcdomain
     target_field: source.domain
     ignore_missing: true
+    tag: rename_0f9ec89a
 - rename:
     field: fortinet.firewall.srcip
     target_field: source.ip
     ignore_missing: true
+    tag: rename_79344114
 - rename:
     field: fortinet.firewall.srcmac
     target_field: source.mac
     ignore_missing: true
+    tag: rename_bfde8f82
 - convert:
     field: fortinet.firewall.srcport
     target_field: source.port
     type: long
     ignore_failure: true
     ignore_missing: true
+    tag: convert_dbc962e4
 - rename:
     field: fortinet.firewall.unauthuser
     target_field: source.user.name
     ignore_missing: true
+    tag: rename_45077c3a
 - rename:
     field: fortinet.firewall.user
     target_field: source.user.name
     ignore_missing: true
     if: ctx.source?.user?.name == null
+    tag: rename_5bbf0229
 - append:
     field: email.from.address
     value: "{{{fortinet.firewall.collectedemail}}}"
     if: ctx.fortinet?.firewall?.collectedemail != null
+    tag: append_bc766c69
 - convert:
     field: fortinet.firewall.sentpkt
     target_field: source.packets
     type: long
     ignore_failure: true
     ignore_missing: true
+    tag: convert_ada35c44
 - convert:
     field: fortinet.firewall.transip
     target_field: source.nat.ip
@@ -157,74 +188,91 @@ processors:
       - append:
           field: error.message
           value: '{{{_ingest.on_failure_message}}}'
+    tag: convert_c36fcafa
 - convert:
     field: fortinet.firewall.transport
     target_field: source.nat.port
     type: long
     ignore_failure: true
     ignore_missing: true
+    tag: convert_06b4f995
 - rename:
     field: fortinet.firewall.app
     target_field: network.application
     ignore_missing: true
+    tag: rename_352bb492
 - rename:
     field: fortinet.firewall.filename
     target_field: file.name
     ignore_missing: true
+    tag: rename_d7a6e0d3
 - rename:
     field: fortinet.firewall.logid
     target_field: event.code
     ignore_missing: true
     if: ctx.event?.code == null
+    tag: rename_d1ce9848
 - rename:
     field: fortinet.firewall.msg
     target_field: message
     ignore_missing: true
+    tag: rename_18251f47
 - rename:
     field: fortinet.firewall.comment
     target_field: rule.description
     ignore_missing: true
+    tag: rename_09652b08
 - rename:
     field: fortinet.firewall.policyid
     target_field: rule.id
     ignore_missing: true
     if: ctx.rule?.id == null
+    tag: rename_220b73f8
 - rename:
     field: fortinet.firewall.poluuid
     target_field: rule.uuid
     ignore_missing: true
+    tag: rename_67e505b2
 - rename:
     field: fortinet.firewall.policytype
     target_field: rule.ruleset
     ignore_missing: true
+    tag: rename_1b162d39
 - rename:
     field: fortinet.firewall.policyname
     target_field: rule.name
     ignore_missing: true
+    tag: rename_d59c3713
 - rename:
     field: fortinet.firewall.appcat
     target_field: rule.category
     ignore_missing: true
+    tag: rename_89544502
 - gsub:
     field: rule.category
     pattern: "\\."
     replacement: "-"
     ignore_missing: true
+    tag: gsub_90e9a3c8
 - rename:
     field: fortinet.firewall.proto
     target_field: network.iana_number
     ignore_missing: true
+    tag: rename_930125ae
 - rename:
     field: fortinet.firewall.service
     target_field: network.protocol
     ignore_missing: true
+    tag: rename_c028ec88
 - rename:
     field: fortinet.firewall.srcthreatfeed
     target_field: threat.feed.name
     ignore_missing: true
+    tag: rename_9d1d1b8e
 - lowercase:
     field: network.protocol
     ignore_missing: true
+    tag: lowercase_49872259
 - uri_parts:
     field: fortinet.firewall.url
     target_field: url
@@ -235,6 +283,7 @@ processors:
             tag: traffic_set_url_original_on_fail
             field: url.original
             copy_from: fortinet.firewall.url
+    tag: uri_parts_e619068b
 - script:
     if: ctx.fortinet?.firewall?.rcvddelta instanceof Number && ctx.fortinet?.firewall?.sentdelta instanceof Number
     tag: script_sum_delta_bytes
@@ -243,6 +292,7 @@ processors:
 - remove:
     field: fortinet.firewall.url
     ignore_missing: true
+    tag: remove_5d47c5fc
 - remove:
     field:
     - fortinet.firewall.dstport
@@ -254,10 +304,15 @@ processors:
     - fortinet.firewall.sentpkt
     - fortinet.firewall.transport
     ignore_missing: true
+    tag: remove_11027338
 on_failure:
 - set:
     field: event.kind
     value: pipeline_error
 - append:
     field: error.message
-    value: '{{{ _ingest.on_failure_message }}}'
+    value: >-
+      Processor '{{{ _ingest.on_failure_processor_type }}}'
+      {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+      {{/_ingest.on_failure_processor_tag}}failed with message '{{{ _ingest.on_failure_message }}}'
+

--- a/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/utm.yml
+++ b/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/utm.yml
@@ -4,40 +4,49 @@ processors:
   - set:
       field: event.kind
       value: event
+      tag: set_de80643c
   - append:
       field: event.type
       value: denied
       if: "['block', 'blocked'].contains(ctx.fortinet?.firewall?.action)"
+      tag: append_b5f2b289
   - append:
       field: event.type
       value: info
       if: ctx.fortinet?.firewall?.subtype == 'dns'
+      tag: append_45c048ea
   - append:
       field: event.type
       value: allowed
       if: "['pass', 'passthrough'].contains(ctx.fortinet?.firewall?.action)"
+      tag: append_c8b37b6a
   - set:
       field: event.outcome
       value: success
       if: ctx.fortinet?.firewall?.action != null
+      tag: set_e219d8f1
   - append:
       field: event.category
       value: network
+      tag: append_7afdca3c
   - rename:
       field: fortinet.firewall.dstip
       target_field: destination.ip
       ignore_missing: true
+      tag: rename_72bf25a6
   - rename:
       field: fortinet.firewall.remip
       target_field: destination.ip
       ignore_missing: true
       if: ctx.destination?.ip == null
+      tag: rename_971a6fc2
   - convert:
       field: fortinet.firewall.dst_port
       target_field: destination.port
       type: long
       ignore_failure: true
       ignore_missing: true
+      tag: convert_5c36a431
   - convert:
       field: fortinet.firewall.remport
       target_field: destination.port
@@ -45,6 +54,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
       if: ctx.destination?.port == null
+      tag: convert_763b849e
   - convert:
       field: fortinet.firewall.dstport
       target_field: destination.port
@@ -52,34 +62,41 @@ processors:
       ignore_failure: true
       ignore_missing: true
       if: ctx.destination?.port == null
+      tag: convert_1215c57d
   - convert:
       field: fortinet.firewall.rcvdbyte
       target_field: destination.bytes
       type: long
       ignore_failure: true
       ignore_missing: true
+      tag: convert_65439a41
   - rename:
       field: fortinet.firewall.recipient
       target_field: email.to.address
       ignore_missing: true
+      tag: rename_e1ed6c6b
   - append:
       field: email.to.address
       value: "{{{fortinet.firewall.recipient}}}"
       if: ctx.fortinet?.firewall?.recipient != null
+      tag: append_78c2982a
   - rename:
       field: fortinet.firewall.group
       target_field: source.user.group.name
       ignore_missing: true
+      tag: rename_8ef934c4
   - rename:
       field: fortinet.firewall.locip
       target_field: source.ip
       ignore_missing: true
+      tag: rename_51dcb848
   - convert:
       field: fortinet.firewall.locport
       target_field: source.port
       type: long
       ignore_failure: true
       ignore_missing: true
+      tag: convert_6bc2e2d4
   - convert:
       field: fortinet.firewall.src_port
       target_field: source.port
@@ -87,6 +104,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
       if: ctx.source?.port == null
+      tag: convert_bf031661
   - convert:
       field: fortinet.firewall.srcport
       target_field: source.port
@@ -94,192 +112,235 @@ processors:
       ignore_failure: true
       ignore_missing: true
       if: ctx.source?.port == null
+      tag: convert_21df2082
   - convert:
       field: fortinet.firewall.sentbyte
       target_field: source.bytes
       type: long
       ignore_failure: true
       ignore_missing: true
+      tag: convert_fe52ad03
   - rename:
       field: fortinet.firewall.srcdomain
       target_field: source.domain
       ignore_missing: true
+      tag: rename_0f9ec89a
   - rename:
       field: fortinet.firewall.srcip
       target_field: source.ip
       ignore_missing: true
       if: ctx.source?.ip == null
+      tag: rename_3df192ac
   - rename:
       field: fortinet.firewall.httpmethod
       target_field: http.request.method
       ignore_missing: true
+      tag: rename_e47a5424
   - rename:
       field: fortinet.firewall.referralurl
       target_field: http.request.referrer
       ignore_missing: true
+      tag: rename_7efe6725
   - rename:
       field: fortinet.firewall.srcmac
       target_field: source.mac
       ignore_missing: true
+      tag: rename_bfde8f82
   - rename:
       field: fortinet.firewall.unauthuser
       target_field: source.user.name
       ignore_missing: true
+      tag: rename_45077c3a
   - rename:
       field: fortinet.firewall.user
       target_field: source.user.name
       ignore_missing: true
       if: ctx.source?.user?.name == null
+      tag: rename_5bbf0229
   - append:
       field: email.sender.address
       value: "{{{fortinet.firewall.sender}}}"
       if: ctx.fortinet?.firewall?.sender != null
+      tag: append_37ff254c
   - append:
       field: email.from.address
       value: "{{{fortinet.firewall.from}}}"
       if: ctx.fortinet?.firewall?.from != null
+      tag: append_868613c1
   - rename:
       field: fortinet.firewall.agent
       target_field: user_agent.original
       ignore_missing: true
+      tag: rename_c612b9cc
   - rename:
       field: fortinet.firewall.app
       target_field: network.application
       ignore_missing: true
+      tag: rename_352bb492
   - rename:
       field: fortinet.firewall.appcat
       target_field: rule.category
       ignore_missing: true
+      tag: rename_89544502
   - rename:
       field: fortinet.firewall.applist
       target_field: rule.ruleset
       ignore_missing: true
+      tag: rename_8752d1ee
   - rename:
       field: fortinet.firewall.catdesc
       target_field: rule.category
       ignore_missing: true
       if: ctx.rule?.category == null
+      tag: rename_863824c0
   - gsub:
       field: rule.category
       pattern: "\\."
       replacement: "-"
       ignore_missing: true
       if: ctx.rule?.category != null
+      tag: gsub_ea9c0116
   - rename:
       field: fortinet.firewall.error
       target_field: event.message
       ignore_missing: true
+      tag: rename_1eb40e8e
   - rename:
       field: fortinet.firewall.errorcode
       target_field: event.code
       ignore_missing: true
+      tag: rename_0c462b81
   - rename:
       field: fortinet.firewall.event_id
       target_field: event.id
       ignore_missing: true
+      tag: rename_ad65b8d8
   - rename:
       field: fortinet.firewall.eventid
       target_field: event.id
       ignore_missing: true
       if: ctx.event?.id == null
+      tag: rename_91348166
   - rename:
       field: fortinet.firewall.filename
       target_field: file.name
       ignore_missing: true
+      tag: rename_d7a6e0d3
   - convert:
       field: fortinet.firewall.filesize
       target_field: file.size
       type: long
       ignore_failure: true
       ignore_missing: true
+      tag: convert_2e69dd69
   - rename:
       field: fortinet.firewall.filetype
       target_field: file.extension
       ignore_missing: true
+      tag: rename_0d6978f4
   - rename:
       field: fortinet.firewall.infectedfilename
       target_field: file.name
       ignore_missing: true
       if: ctx.file?.name == null
+      tag: rename_470a39d2
   - rename:
       field: fortinet.firewall.infectedfilesize
       target_field: file.size
       ignore_missing: true
       if: ctx.file?.size == null
+      tag: rename_6190f68c
   - rename:
       field: fortinet.firewall.infectedfiletype
       target_field: file.extension
       ignore_missing: true
       if: ctx.file?.extension == null
+      tag: rename_c1ee548f
   - rename:
       field: fortinet.firewall.matchedfilename
       target_field: file.name
       ignore_missing: true
       if: ctx.file?.name == null
+      tag: rename_f9cea46a
   - rename:
       field: fortinet.firewall.matchedfiletype
       target_field: file.extension
       ignore_missing: true
       if: ctx.file?.extension == null
+      tag: rename_56d8df57
   - rename:
       field: fortinet.firewall.ipaddr
       target_field: dns.resolved_ip
       ignore_missing: true
+      tag: rename_3e7ee47e
   - split:
       field: dns.resolved_ip
       separator: ", "
       ignore_missing: true
+      tag: split_61a17abc
   - rename:
       field: fortinet.firewall.level
       target_field: log.level
       ignore_missing: true
+      tag: rename_0e7843bb
   - rename:
       field: fortinet.firewall.logid
       target_field: event.code
       ignore_missing: true
       if: ctx.event?.code == null
+      tag: rename_d1ce9848
   - rename:
       field: fortinet.firewall.msg
       target_field: message
       ignore_missing: true
+      tag: rename_18251f47
   - rename:
       field: fortinet.firewall.policy_id
       target_field: rule.id
       ignore_missing: true
       if: ctx.rule?.id == null
+      tag: rename_4b286d2d
   - rename:
       field: fortinet.firewall.policyid
       target_field: rule.id
       ignore_missing: true
       if: ctx.rule?.id == null
+      tag: rename_220b73f8
   - rename:
       field: fortinet.firewall.profile
       target_field: rule.ruleset
       ignore_missing: true
       if: ctx.rule?.ruleset == null
+      tag: rename_0715e7bc
   - rename:
       field: fortinet.firewall.proto
       target_field: network.iana_number
       ignore_missing: true
+      tag: rename_930125ae
   - rename:
       field: fortinet.firewall.qclass
       target_field: dns.question.class
       ignore_missing: true
+      tag: rename_dd343cd1
   - rename:
       field: fortinet.firewall.qname
       target_field: dns.question.name
       ignore_missing: true
+      tag: rename_ada7e477
   - rename:
       field: fortinet.firewall.qtype
       target_field: dns.question.type
       ignore_missing: true
+      tag: rename_3bfd2a8d
   - rename:
       field: fortinet.firewall.service
       target_field: network.protocol
       ignore_missing: true
+      tag: rename_c028ec88
   - lowercase:
       field: network.protocol
       ignore_missing: true
+      tag: lowercase_49872259
   - uri_parts:
       field: fortinet.firewall.url
       target_field: url
@@ -290,6 +351,7 @@ processors:
             tag: utm_set_url_original_on_fail
             field: url.original
             copy_from: fortinet.firewall.url
+      tag: uri_parts_bdb5970a
   # Need to do a set, then remove since rename w/ override
   # is not supported in 8.3.0
   - set:
@@ -297,131 +359,161 @@ processors:
       copy_from: fortinet.firewall.hostname
       ignore_empty_value: true
       override: true
+      tag: set_e4ace8d8
   - remove:
       field: fortinet.firewall.hostname
       ignore_missing: true
+      tag: remove_161ef624
   - remove:
       field: fortinet.firewall.url
       ignore_missing: true
+      tag: remove_5d47c5fc
   - rename:
       field: fortinet.firewall.xid
       target_field: dns.id
       ignore_missing: true
+      tag: rename_7c6ef4f8
   - append:
       field: tls.server.x509.subject.common_name
       value: "{{{fortinet.firewall.scertcname}}}"
       if: ctx.fortinet?.firewall?.scertcname != null
+      tag: append_822f6daa
   - rename:
       field: fortinet.firewall.scertissuer
       target_field: tls.server.issuer
       ignore_missing: true
+      tag: rename_65a8bad6
   - append:
       field: tls.server.x509.issuer.common_name
       value: "{{{tls.server.issuer}}}"
       if: ctx.tls?.server?.issuer != null
+      tag: append_e1391a8d
   - rename:
       field: fortinet.firewall.ccertissuer
       target_field: tls.client.issuer
       ignore_missing: true
+      tag: rename_5d819a7a
   - append:
       field: tls.client.x509.issuer.common_name
       value: "{{{tls.client.issuer}}}"
       if: ctx.tls?.client?.issuer != null
+      tag: append_3908abd9
   - rename:
       field: fortinet.firewall.sender
       target_field: tls.server.issuer
       ignore_missing: true
+      tag: rename_53552963
   - rename:
       field: fortinet.firewall.issuer
       target_field: tls.server.issuer
       ignore_missing: true
       if: ctx.tls?.server?.issuer == null
+      tag: rename_81110cbf
   - rename:
       field: fortinet.firewall.authalgo
       target_field: tls.server.x509.public_key_algorithm
       ignore_missing: true
+      tag: rename_a19bd0ed
   - rename:
       field: fortinet.firewall.keyalgo
       target_field: tls.server.x509.public_key_algorithm
       ignore_missing: true
       if: ctx.tls?.server?.x509?.public_key_algorithm == null
+      tag: rename_b7b7c24d
   - rename:
       field: fortinet.firewall.notbefore
       target_field: tls.server.not_before
       ignore_missing: true
       if: ctx.tls?.server?.not_before == null
+      tag: rename_e72d5bec
   - rename:
       field: fortinet.firewall.notafter
       target_field: tls.server.not_after
       ignore_missing: true
       if: ctx.tls?.server?.not_after == null
+      tag: rename_243506eb
   - rename:
       field: fortinet.firewall.keysize
       target_field: tls.server.x509.public_key_size
       ignore_missing: true
       if: ctx.tls?.server?.x509?.public_key_size == null
+      tag: rename_eb70b1c1
   - convert:
       field: tls.server.x509.public_key_size
       type: long
       ignore_missing: true
+      tag: convert_6513b5d4
   - rename:
       field: fortinet.firewall.sn
       target_field: tls.server.x509.serial_number
       ignore_missing: true
       if: ctx.tls?.server?.x509?.serial_number == null
+      tag: rename_74ef21d8
   - rename:
       field: fortinet.firewall.certhash
       target_field: tls.server.hash.sha1
       ignore_missing: true
       if: ctx.tls?.server?.hash?.sha1 == null
+      tag: rename_9490fc6f
   - append:
       field: related.hash
       value: "{{{tls.server.hash.sha1}}}"
       allow_duplicates: false
       if: ctx.tls?.server?.hash?.sha1 != null
+      tag: append_6b51007e
   - set:
       field: tls.server.x509.not_after
       copy_from: tls.server.not_after
       ignore_empty_value: true
+      tag: set_99449ca7
   - set:
       field: tls.server.x509.not_before
       copy_from: tls.server.not_before
       ignore_empty_value: true
+      tag: set_639ff489
   - split:
       field: fortinet.firewall.san
       separator: ";"
       target_field: tls.server.x509.alternative_names
       ignore_missing: true
+      tag: split_33c817cd
   - append:
       field: tls.server.x509.alternative_names
       value: "{{{fortinet.firewall.cn}}}"
       allow_duplicates: false
       if: ctx.fortinet?.firewall?.cn != null
+      tag: append_cb12c914
   - set:
       field: tls.client.x509.public_key_algorithm
       copy_from: tls.server.x509.public_key_algorithm
       ignore_empty_value: true
+      tag: set_c8e4b429
   - rename:
       field: fortinet.firewall.kxcurve
       target_field: tls.curve
       ignore_missing: true
+      tag: rename_4ba43a3d
   - rename:
       field: fortinet.firewall.cipher
       target_field: tls.cipher
       ignore_missing: true
+      tag: rename_2440d05e
   - rename:
       field: fortinet.firewall.sni
       target_field: tls.client.server_name
       ignore_missing: true
+      tag: rename_640d85d0
   - set:
       field: destination.domain
       copy_from: tls.client.server_name
       ignore_empty_value: true
       if: ctx.destination?.domain == null
+      tag: set_1ee4539a
   - set:
       field: tls.established
       value: true
       if: ctx.fortinet?.firewall?.handshake == "full"
+      tag: set_6ae896b6
   - script:
       lang: painless
       if: ctx.fortinet?.firewall?.tlsver instanceof String
@@ -440,32 +532,39 @@ processors:
         if (!ctx.tls.version.contains(".")) {
             ctx.tls.version += ".0";
         }
+      tag: script_55eb70c0
   - append:
       field: vulnerability.category
       value: "{{{fortinet.firewall.dtype}}}"
       allow_duplicates: false
       if: ctx.fortinet?.firewall?.dtype instanceof String
+      tag: append_e516aea2
   - rename:
       field: fortinet.firewall.ref
       target_field: event.reference
       ignore_missing: true
+      tag: rename_ac3e7de7
   - rename:
       field: fortinet.firewall.filehash
       target_field: fortinet.file.hash.crc32
       ignore_missing: true
+      tag: rename_b8cdcb97
   - append:
       field: related.hash
       value: "{{{fortinet.file.hash.crc32}}}"
       if: ctx.fortinet?.file?.hash?.crc32 != null
+      tag: append_af3ee53d
   # Populate ECS dns
   - registered_domain:
       field: dns.question.name
       target_field: dns.question
       ignore_missing: true
       ignore_failure: true
+      tag: registered_domain_24868ff9
   - remove:
       field: dns.question.domain
       ignore_missing: true
+      tag: remove_3403bb7d
   - remove:
       field:
         - fortinet.firewall.cn
@@ -483,10 +582,15 @@ processors:
         - fortinet.firewall.dtype
         - fortinet.firewall.tlsver
       ignore_missing: true
+      tag: remove_54bd5916
 on_failure:
   - set:
       field: event.kind
       value: pipeline_error
   - append:
       field: error.message
-      value: '{{{ _ingest.on_failure_message }}}'
+      value: >-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{/_ingest.on_failure_processor_tag}}failed with message '{{{ _ingest.on_failure_message }}}'
+


### PR DESCRIPTION
## Proposed commit message

- Generate tags for processors missing tags
- Normalize the pipeline error handler

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~
