### PR TITLE
[fortinet_fortimail] Generate processor tags and normalize error handler

### DIFF
--- a/packages/fortinet_fortimail/changelog.yml
+++ b/packages/fortinet_fortimail/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.16.1"
+  changes:
+    - description: Generate processor tags and normalize error handler.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/15541
 - version: "2.16.0"
   changes:
     - description: Replace navigation with links panels. Updated support for kibana version to 8.11.0 and above.

--- a/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -2,23 +2,29 @@
 description: Pipeline for processing Fortinet FortiMail logs.
 processors:
   - set:
+      tag: set_ecs_version_f5923549
       field: ecs.version
       value: '8.17.0'
   - set:
+      tag: set_observer_vendor_7e57c221
       field: observer.vendor
       value: Fortinet
   - set:
+      tag: set_observer_product_7580a600
       field: observer.product
       value: FortiMail
   - set:
+      tag: set_observer_type_5dddf3ba
       field: observer.type
       value: firewall
   - rename:
+      tag: rename_message_to_event_original_56a77271
       field: message
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - grok:
@@ -30,6 +36,7 @@ processors:
         - '^<%{NUMBER:fortinet_fortimail.log.priority_number:long}>%{GREEDYDATA:temp.message}$'
       on_failure:
         - append:
+            tag: append_error_message_2c4a457a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - gsub:
@@ -40,6 +47,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_fd68155b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - kv:
@@ -53,22 +61,27 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0e8855ca
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_event_timezone_656ca26d
       field: event.timezone
       copy_from: _conf.tz_offset
       if: ctx._conf?.tz_offset != null && ctx._conf.tz_offset != 'local'
       ignore_empty_value: true
   - rename:
+      tag: rename_temp_date_to_fortinet_fortimail_log_date_791b1e7f
       field: temp.date
       target_field: fortinet_fortimail.log.date
       ignore_missing: true
   - rename:
+      tag: rename_temp_time_to_fortinet_fortimail_log_time_28b7e7b1
       field: temp.time
       target_field: fortinet_fortimail.log.time
       ignore_missing: true
   - set:
+      tag: set_temp_timestamp_3a851ed4
       field: temp.timestamp
       value: '{{{fortinet_fortimail.log.date}}}T{{{fortinet_fortimail.log.time}}}'
       if: ctx.fortinet_fortimail?.log?.date != null && ctx.fortinet_fortimail.log.date != '' && ctx.fortinet_fortimail.log.time != null && ctx.fortinet_fortimail.log.time != ''
@@ -82,24 +95,28 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss
       on_failure:
         - append:
+            tag: append_error_message_7393d9f9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: temp.timestamp
-      tag: 'date_set_timestamp'
+      tag: date_temp_timestamp_0ab6aaa4
       if: ctx.temp?.timestamp != null && ctx.temp.timestamp != '' && ctx.event?.timezone == null
       formats:
         - yyyy-MM-dd'T'HH:mm:ss.SSS
         - yyyy-MM-dd'T'HH:mm:ss
       on_failure:
         - append:
+            tag: append_error_message_8ab178d9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_temp_device_id_to_fortinet_fortimail_log_device_id_ad7319b7
       field: temp.device_id
       target_field: fortinet_fortimail.log.device_id
       ignore_missing: true
   - set:
+      tag: set_observer_serial_number_af8a006c
       field: observer.serial_number
       copy_from: fortinet_fortimail.log.device_id
       ignore_empty_value: true
@@ -111,41 +128,51 @@ processors:
       if: ctx.fortinet_fortimail?.log?.priority_number != ''
       on_failure:
         - append:
+            tag: append_error_message_e4e1f474
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_log_syslog_priority_5bba7139
       field: log.syslog.priority
       copy_from: fortinet_fortimail.log.priority_number
       ignore_empty_value: true
   - rename:
+      tag: rename_temp_log_id_to_fortinet_fortimail_log_id_c4838ad6
       field: temp.log_id
       target_field: fortinet_fortimail.log.id
       ignore_missing: true
   - set:
+      tag: set_event_code_fd86fb7a
       field: event.code
       copy_from: fortinet_fortimail.log.id
       ignore_empty_value: true
   - rename:
+      tag: rename_temp_type_to_fortinet_fortimail_log_type_7498bbf7
       field: temp.type
       target_field: fortinet_fortimail.log.type
       ignore_missing: true
   - rename:
+      tag: rename_temp_subtype_to_fortinet_fortimail_log_sub_type_50405a6e
       field: temp.subtype
       target_field: fortinet_fortimail.log.sub_type
       ignore_missing: true
   - rename:
+      tag: rename_temp_pri_to_fortinet_fortimail_log_priority_a6f312b4
       field: temp.pri
       target_field: fortinet_fortimail.log.priority
       ignore_missing: true
   - set:
+      tag: set_log_level_e6bfdefc
       field: log.level
       copy_from: fortinet_fortimail.log.priority
       ignore_empty_value: true
   - rename:
+      tag: rename_temp_subject_to_fortinet_fortimail_log_subject_798cf6cf
       field: temp.subject
       target_field: fortinet_fortimail.log.subject
       ignore_missing: true
   - set:
+      tag: set_email_subject_a26859b4
       field: email.subject
       copy_from: fortinet_fortimail.log.subject
       ignore_empty_value: true
@@ -171,40 +198,51 @@ processors:
         }
       on_failure:
         - append:
+            tag: append_error_message_a08d2f23
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_temp_msg_to_fortinet_fortimail_log_message_09e20425
       field: temp.msg
       target_field: fortinet_fortimail.log.message
       ignore_missing: true
   - set:
+      tag: set_message_4828486a
       field: message
       copy_from: fortinet_fortimail.log.message
       ignore_empty_value: true
   - pipeline:
+      tag: pipeline_c9fec8bf
       name: '{{ IngestPipeline "pipeline_history" }}'
       if: ctx.fortinet_fortimail?.log?.type != null && ctx.fortinet_fortimail.log.type.toLowerCase() == 'statistics'
   - pipeline:
+      tag: pipeline_eb9d81a8
       name: '{{ IngestPipeline "pipeline_system" }}'
       if: ctx.fortinet_fortimail?.log?.type != null && ctx.fortinet_fortimail.log.type.toLowerCase() == 'kevent'
   - pipeline:
+      tag: pipeline_fe700e77
       name: '{{ IngestPipeline "pipeline_mail" }}'
       if: ctx.fortinet_fortimail?.log?.type != null && ctx.fortinet_fortimail.log.type.toLowerCase() == 'event'
   - pipeline:
+      tag: pipeline_f4d2fc92
       name: '{{ IngestPipeline "pipeline_antivirus" }}'
       if: ctx.fortinet_fortimail?.log?.type != null && ctx.fortinet_fortimail.log.type.toLowerCase() == 'virus'
   - pipeline:
+      tag: pipeline_6b2edc66
       name: '{{ IngestPipeline "pipeline_antispam" }}'
       if: ctx.fortinet_fortimail?.log?.type != null && ctx.fortinet_fortimail.log.type.toLowerCase() == 'spam'
   - pipeline:
+      tag: pipeline_70a3c98c
       name: '{{ IngestPipeline "pipeline_encryption" }}'
       if: ctx.fortinet_fortimail?.log?.type != null && ctx.fortinet_fortimail.log.type.toLowerCase() == 'encrypt'
   - remove:
+      tag: remove_c9ff360d
       field:
         - _conf
         - temp
       ignore_missing: true
   - remove:
+      tag: remove_017c4e84
       field:
         - fortinet_fortimail.log.action
         - fortinet_fortimail.log.client.ip
@@ -229,11 +267,13 @@ processors:
       ignore_missing: true
       if: ctx.tags == null || !(ctx.tags.contains('preserve_duplicate_custom_fields'))
   - remove:
+      tag: remove_779d3744
       field:
         - event.original
       ignore_missing: true
       if: ctx.tags == null || !(ctx.tags.contains('preserve_original_event'))
   - script:
+      tag: script_69e302b9
       lang: painless
       source: |-
         boolean drop(Object o) {
@@ -251,13 +291,18 @@ processors:
         drop(ctx);
       description: Drops null/empty values recursively.
   - set:
+      tag: set_event_kind_92954dfa
       field: event.kind
       value: pipeline_error
       if: ctx.error?.message != null
 on_failure:
   - append:
       field: error.message
-      value: '{{{_ingest.on_failure_message}}}'
+      value: >-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
+        failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       value: pipeline_error

--- a/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_antispam.yml
+++ b/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_antispam.yml
@@ -10,31 +10,38 @@ processors:
       if: ctx.temp?.client_ip != ''
       on_failure:
         - append:
+            tag: append_error_message_ac99aa3d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
+      tag: append_related_ip_5387e179
       field: related.ip
       value: '{{{fortinet_fortimail.log.client.ip}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.client?.ip != null
   - set:
+      tag: set_source_ip_f6f51834
       field: source.ip
       copy_from: fortinet_fortimail.log.client.ip
       ignore_empty_value: true
   - geoip:
+      tag: geoip_source_ip_to_source_geo_bace2435
       if: ctx.source?.ip != null
       field: source.ip
       target_field: source.geo
   - rename:
+      tag: rename_temp_client_name_to_fortinet_fortimail_log_client_name_629e2e1e
       field: temp.client_name
       target_field: fortinet_fortimail.log.client.name
       ignore_missing: true
   - append:
+      tag: append_related_user_5d80ed0f
       field: related.user
       value: '{{{fortinet_fortimail.log.client.name}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.client?.name != null
   - set:
+      tag: set_source_user_name_818409d3
       field: source.user.name
       copy_from: fortinet_fortimail.log.client.name
       ignore_empty_value: true
@@ -47,58 +54,71 @@ processors:
       if: ctx.temp?.dst_ip != ''
       on_failure:
         - append:
+            tag: append_error_message_228d93f7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
+      tag: append_related_ip_bb6cbf32
       field: related.ip
       value: '{{{fortinet_fortimail.log.destination_ip}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.destination_ip != null
   - set:
+      tag: set_destination_ip_7ada744f
       field: destination.ip
       copy_from: fortinet_fortimail.log.destination_ip
       ignore_empty_value: true
   - rename:
+      tag: rename_temp_from_to_fortinet_fortimail_log_from_5b70ec4b
       field: temp.from
       target_field: fortinet_fortimail.log.from
       ignore_missing: true
   - append:
+      tag: append_related_user_d0753b7c
       field: related.user
       value: '{{{fortinet_fortimail.log.from}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.from != null
   - append:
+      tag: append_email_from_address_7f1e9688
       field: email.from.address
       value: '{{{fortinet_fortimail.log.from}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.from != null
   - rename:
+      tag: rename_temp_subject_to_fortinet_fortimail_log_subject_798cf6cf
       field: temp.subject
       target_field: fortinet_fortimail.log.subject
       ignore_missing: true
   - set:
+      tag: set_email_subject_a26859b4
       field: email.subject
       copy_from: fortinet_fortimail.log.subject
       ignore_empty_value: true
   - rename:
+      tag: rename_temp_to_to_fortinet_fortimail_log_to_45dc2e79
       field: temp.to
       target_field: fortinet_fortimail.log.to
       ignore_missing: true
   - append:
+      tag: append_related_user_b1d2b872
       field: related.user
       value: '{{{fortinet_fortimail.log.to}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.to != null
   - append:
+      tag: append_email_to_address_3c4f03db
       field: email.to.address
       value: '{{{fortinet_fortimail.log.to}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.to != null
   - rename:
+      tag: rename_temp_session_id_to_fortinet_fortimail_log_session_id_c4b20db7
       field: temp.session_id
       target_field: fortinet_fortimail.log.session_id
       ignore_missing: true
   - rename:
+      tag: rename_temp_endpoint_to_fortinet_fortimail_log_endpoint_dbd671e1
       field: temp.endpoint
       target_field: fortinet_fortimail.log.endpoint
       ignore_missing: true
@@ -108,4 +128,8 @@ on_failure:
       value: pipeline_error
   - append:
       field: error.message
-      value: '{{{ _ingest.on_failure_message }}}'
+      value: >-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
+        failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_antivirus.yml
+++ b/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_antivirus.yml
@@ -2,29 +2,35 @@
 description: Pipeline for processing Antivirus logs.
 processors:
   - rename:
+      tag: rename_temp_from_to_fortinet_fortimail_log_from_5b70ec4b
       field: temp.from
       target_field: fortinet_fortimail.log.from
       ignore_missing: true
   - append:
+      tag: append_related_user_d0753b7c
       field: related.user
       value: '{{{fortinet_fortimail.log.from}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.from != null
   - append:
+      tag: append_email_from_address_7f1e9688
       field: email.from.address
       value: '{{{fortinet_fortimail.log.from}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.from != null
   - rename:
+      tag: rename_temp_to_to_fortinet_fortimail_log_to_45dc2e79
       field: temp.to
       target_field: fortinet_fortimail.log.to
       ignore_missing: true
   - append:
+      tag: append_related_user_b1d2b872
       field: related.user
       value: '{{{fortinet_fortimail.log.to}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.to != null
   - append:
+      tag: append_email_to_address_3c4f03db
       field: email.to.address
       value: '{{{fortinet_fortimail.log.to}}}'
       allow_duplicates: false
@@ -38,22 +44,27 @@ processors:
       if: ctx.temp?.src != ''
       on_failure:
         - append:
+            tag: append_error_message_8dbfd71c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
+      tag: append_related_ip_4c0d9a15
       field: related.ip
       value: '{{{fortinet_fortimail.log.source.ip}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.source?.ip != null
   - set:
+      tag: set_source_ip_23e0a7ba
       field: source.ip
       copy_from: fortinet_fortimail.log.source.ip
       ignore_empty_value: true
   - geoip:
+      tag: geoip_source_ip_to_source_geo_bace2435
       if: ctx.source?.ip != null
       field: source.ip
       target_field: source.geo
   - rename:
+      tag: rename_temp_session_id_to_fortinet_fortimail_log_session_id_c4b20db7
       field: temp.session_id
       target_field: fortinet_fortimail.log.session_id
       ignore_missing: true
@@ -63,4 +74,8 @@ on_failure:
       value: pipeline_error
   - append:
       field: error.message
-      value: '{{{ _ingest.on_failure_message }}}'
+      value: >-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
+        failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_encryption.yml
+++ b/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_encryption.yml
@@ -2,10 +2,12 @@
 description: Pipeline for processing Encryption logs.
 processors:
   - rename:
+      tag: rename_temp_session_id_to_fortinet_fortimail_log_session_id_c4b20db7
       field: temp.session_id
       target_field: fortinet_fortimail.log.session_id
       ignore_missing: true
   - grok:
+      tag: grok_message_2eb49cca
       field: message
       patterns:
         - '^%{DATA}(?i)user %{NOTSPACE:temp.user} %{DATA}%{IP:fortinet_fortimail.log.ip}%{GREEDYDATA:temp.msg}$'
@@ -14,41 +16,49 @@ processors:
       ignore_missing: true
       ignore_failure: true
   - append:
+      tag: append_related_ip_bf78f00c
       field: related.ip
       value: '{{{fortinet_fortimail.log.ip}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.ip != null
   - append:
+      tag: append_fortinet_fortimail_log_user_2f9ddf13
       field: fortinet_fortimail.log.user
       value: '{{{temp.user}}}'
       allow_duplicates: false
       if: ctx.temp?.user != null
   - append:
+      tag: append_user_name_9b60aa7f
       field: user.name
       value: '{{{temp.user}}}'
       allow_duplicates: false
       if: ctx.temp?.user != null
   - append:
+      tag: append_related_user_4554486f
       field: related.user
       value: '{{{temp.user}}}'
       allow_duplicates: false
       if: ctx.temp?.user != null
   - append:
+      tag: append_related_user_0e980ca0
       field: related.user
       value: '{{{fortinet_fortimail.log.sent_from}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.sent_from != null
   - append:
+      tag: append_email_from_address_d2cf608c
       field: email.from.address
       value: '{{{fortinet_fortimail.log.sent_from}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.sent_from != null
   - append:
+      tag: append_fortinet_fortimail_log_subject_cc39b1e0
       field: fortinet_fortimail.log.subject
       value: '{{{temp.subject}}}'
       allow_duplicates: false
       if: ctx.temp?.subject != null
   - append:
+      tag: append_email_subject_4ee59141
       field: email.subject
       value: '{{{temp.subject}}}'
       allow_duplicates: false
@@ -59,4 +69,8 @@ on_failure:
       value: pipeline_error
   - append:
       field: error.message
-      value: '{{{ _ingest.on_failure_message }}}'
+      value: >-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
+        failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_history.yml
+++ b/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_history.yml
@@ -10,31 +10,38 @@ processors:
       if: ctx.temp?.client_ip != ''
       on_failure:
         - append:
+            tag: append_error_message_ac99aa3d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
+      tag: append_related_ip_5387e179
       field: related.ip
       value: '{{{fortinet_fortimail.log.client.ip}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.client?.ip != null
   - set:
+      tag: set_source_ip_f6f51834
       field: source.ip
       copy_from: fortinet_fortimail.log.client.ip
       ignore_empty_value: true
   - geoip:
+      tag: geoip_source_ip_to_source_geo_bace2435
       if: ctx.source?.ip != null
       field: source.ip
       target_field: source.geo
   - rename:
+      tag: rename_temp_client_name_to_fortinet_fortimail_log_client_name_629e2e1e
       field: temp.client_name
       target_field: fortinet_fortimail.log.client.name
       ignore_missing: true
   - append:
+      tag: append_related_user_5d80ed0f
       field: related.user
       value: '{{{fortinet_fortimail.log.client.name}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.client?.name != null
   - set:
+      tag: set_source_user_name_818409d3
       field: source.user.name
       copy_from: fortinet_fortimail.log.client.name
       ignore_empty_value: true
@@ -47,82 +54,101 @@ processors:
       if: ctx.temp?.dst_ip != ''
       on_failure:
         - append:
+            tag: append_error_message_228d93f7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
+      tag: append_related_ip_bb6cbf32
       field: related.ip
       value: '{{{fortinet_fortimail.log.destination_ip}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.destination_ip != null
   - set:
+      tag: set_destination_ip_7ada744f
       field: destination.ip
       copy_from: fortinet_fortimail.log.destination_ip
       ignore_empty_value: true
   - rename:
+      tag: rename_temp_direction_to_fortinet_fortimail_log_direction_0c74ea2f
       field: temp.direction
       target_field: fortinet_fortimail.log.direction
       ignore_missing: true
   - set:
+      tag: set_email_direction_a0a27af4
       field: email.direction
       copy_from: fortinet_fortimail.log.direction
       ignore_empty_value: true
   - rename:
+      tag: rename_temp_from_to_fortinet_fortimail_log_from_5b70ec4b
       field: temp.from
       target_field: fortinet_fortimail.log.from
       ignore_missing: true
   - append:
+      tag: append_related_user_d0753b7c
       field: related.user
       value: '{{{fortinet_fortimail.log.from}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.from != null
   - append:
+      tag: append_email_from_address_7f1e9688
       field: email.from.address
       value: '{{{fortinet_fortimail.log.from}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.from != null
   - rename:
+      tag: rename_temp_subject_to_fortinet_fortimail_log_subject_798cf6cf
       field: temp.subject
       target_field: fortinet_fortimail.log.subject
       ignore_missing: true
   - set:
+      tag: set_email_subject_a26859b4
       field: email.subject
       copy_from: fortinet_fortimail.log.subject
       ignore_empty_value: true
   - rename:
+      tag: rename_temp_to_to_fortinet_fortimail_log_to_45dc2e79
       field: temp.to
       target_field: fortinet_fortimail.log.to
       ignore_missing: true
   - append:
+      tag: append_related_user_b1d2b872
       field: related.user
       value: '{{{fortinet_fortimail.log.to}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.to != null
   - append:
+      tag: append_email_to_address_3c4f03db
       field: email.to.address
       value: '{{{fortinet_fortimail.log.to}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.to != null
   - rename:
+      tag: rename_temp_mailer_to_fortinet_fortimail_log_mailer_352ef303
       field: temp.mailer
       target_field: fortinet_fortimail.log.mailer
       ignore_missing: true
   - set:
+      tag: set_email_x_mailer_9ee3219f
       field: email.x_mailer
       copy_from: fortinet_fortimail.log.mailer
       ignore_empty_value: true
   - rename:
+      tag: rename_temp_session_id_to_fortinet_fortimail_log_session_id_c4b20db7
       field: temp.session_id
       target_field: fortinet_fortimail.log.session_id
       ignore_missing: true
   - rename:
+      tag: rename_temp_endpoint_to_fortinet_fortimail_log_endpoint_dbd671e1
       field: temp.endpoint
       target_field: fortinet_fortimail.log.endpoint
       ignore_missing: true
   - rename:
+      tag: rename_temp_polid_to_fortinet_fortimail_log_policy_id_f1846b83
       field: temp.polid
       target_field: fortinet_fortimail.log.policy_id
       ignore_missing: true
   - rename:
+      tag: rename_temp_domain_to_fortinet_fortimail_log_domain_86dbca07
       field: temp.domain
       target_field: fortinet_fortimail.log.domain
       ignore_missing: true
@@ -133,41 +159,51 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_875edc31
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_temp_resolved_to_fortinet_fortimail_log_resolved_94f3801f
       field: temp.resolved
       target_field: fortinet_fortimail.log.resolved
       ignore_missing: true
   - set:
+      tag: set_event_outcome_73905c42
       field: event.outcome
       value: 'success'
       if: ctx.fortinet_fortimail?.log?.resolved?.toLowerCase() == 'ok'
   - set:
+      tag: set_event_outcome_a34432c7
       field: event.outcome
       value: 'failure'
       if: ctx.fortinet_fortimail?.log?.resolved?.toLowerCase() == 'fail'
   - set:
+      tag: set_event_outcome_6f947b7c
       field: event.outcome
       value: 'unknown'
       if: ctx.event?.outcome == null
   - rename:
+      tag: rename_temp_virus_to_fortinet_fortimail_log_virus_96d68353
       field: temp.virus
       target_field: fortinet_fortimail.log.virus
       ignore_missing: true
   - rename:
+      tag: rename_temp_disposition_to_fortinet_fortimail_log_disposition_879ef12f
       field: temp.disposition
       target_field: fortinet_fortimail.log.disposition
       ignore_missing: true
   - rename:
+      tag: rename_temp_classifier_to_fortinet_fortimail_log_classifier_8fcd3ce5
       field: temp.classifier
       target_field: fortinet_fortimail.log.classifier
       ignore_missing: true
   - rename:
+      tag: rename_temp_hfrom_to_fortinet_fortimail_log_hfrom_0d5aa52f
       field: temp.hfrom
       target_field: fortinet_fortimail.log.hfrom
       ignore_missing: true
   - rename:
+      tag: rename_temp_src_type_to_fortinet_fortimail_log_source_type_8d293373
       field: temp.src_type
       target_field: fortinet_fortimail.log.source.type
       ignore_missing: true
@@ -180,25 +216,31 @@ processors:
       if: ctx.temp?.message_length != ''
       on_failure:
         - append:
+            tag: append_error_message_7dc7598c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_temp_client_cc_to_fortinet_fortimail_log_client_cc_aa4598ce
       field: temp.client_cc
       target_field: fortinet_fortimail.log.client.cc
       ignore_missing: true
   - rename:
+      tag: rename_temp_detail_to_fortinet_fortimail_log_detail_a92c18d9
       field: temp.detail
       target_field: fortinet_fortimail.log.detail
       ignore_missing: true
   - rename:
+      tag: rename_temp_message_id_to_fortinet_fortimail_log_message_id_2a15e1cd
       field: temp.message_id
       target_field: fortinet_fortimail.log.message_id
       ignore_missing: true
   - rename:
+      tag: rename_temp_recv_time_to_fortinet_fortimail_log_recv_time_f206036f
       field: temp.recv_time
       target_field: fortinet_fortimail.log.recv_time
       ignore_missing: true
   - rename:
+      tag: rename_temp_notif_delay_to_fortinet_fortimail_log_notif_delay_60f502bb
       field: temp.notif_delay
       target_field: fortinet_fortimail.log.notif_delay
       ignore_missing: true
@@ -211,6 +253,7 @@ processors:
       if: ctx.temp?.scan_time != ''
       on_failure:
         - append:
+            tag: append_error_message_8aabfee8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -222,13 +265,16 @@ processors:
       if: ctx.temp?.xfer_time != ''
       on_failure:
         - append:
+            tag: append_error_message_fbef5dec
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_temp_srcfolder_to_fortinet_fortimail_log_source_folder_0e0d2066
       field: temp.srcfolder
       target_field: fortinet_fortimail.log.source.folder
       ignore_missing: true
   - rename:
+      tag: rename_temp_read_status_to_fortinet_fortimail_log_read_status_9fff5b87
       field: temp.read_status
       target_field: fortinet_fortimail.log.read_status
       ignore_missing: true
@@ -238,4 +284,8 @@ on_failure:
       value: pipeline_error
   - append:
       field: error.message
-      value: '{{{ _ingest.on_failure_message }}}'
+      value: >-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
+        failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_mail.yml
+++ b/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_mail.yml
@@ -2,45 +2,55 @@
 description: Pipeline for processing Mail logs.
 processors:
   - set:
+      tag: set_event_category_98057b5a
       field: event.category
       value: [email]
       override: true
   - set:
+      tag: set_event_outcome_bc82a5f8
       field: event.outcome
       value: success
       if: ctx.fortinet_fortimail?.log?.sub_type == 'webmail' && ctx.temp?.status.toLowerCase() == 'success'
   - set:
+      tag: set_event_outcome_4d7fed36
       field: event.outcome
       value: failure
       if: ctx.fortinet_fortimail?.log?.sub_type == 'webmail' && ctx.temp?.status.toLowerCase() == 'failure'
   - append:
+      tag: append_event_category_4b6ee264
       field: event.category
       value: 'authentication'
       if: ctx.fortinet_fortimail?.log?.sub_type == 'webmail'
       allow_duplicates: false
   - set:
+      tag: set_event_type_ec95f7f2
       field: event.type
       value: [info]
   - append:
+      tag: append_event_type_2ff73bea
       field: event.type
       value: 'end'
       if: ctx.fortinet_fortimail?.log?.sub_type == 'webmail'
   - append:
+      tag: append_fortinet_fortimail_log_user_2f9ddf12
       field: fortinet_fortimail.log.user
       value: '{{{temp.user}}}'
       allow_duplicates: false
       if: ctx.temp?.user != null
   - append:
+      tag: append_user_name_9b60aa7e
       field: user.name
       value: '{{{temp.user}}}'
       allow_duplicates: false
       if: ctx.temp?.user != null
   - append:
+      tag: append_related_user_4554486e
       field: related.user
       value: '{{{temp.user}}}'
       allow_duplicates: false
       if: ctx.temp?.user != null
   - grok:
+      tag: grok_message_affe3e37
       field: message
       if: ctx.fortinet_fortimail?.log?.sub_type == 'webmail'
       patterns:
@@ -51,58 +61,71 @@ processors:
       ignore_missing: true
       ignore_failure: true
   - append:
+      tag: append_related_ip_bf78f00c
       field: related.ip
       value: '{{{fortinet_fortimail.log.ip}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.ip != null
   - append:
+      tag: append_fortinet_fortimail_log_user_2f9ddf13
       field: fortinet_fortimail.log.user
       value: '{{{temp.user}}}'
       allow_duplicates: false
       if: ctx.temp?.user != null
   - append:
+      tag: append_user_name_9b60aa7f
       field: user.name
       value: '{{{temp.user}}}'
       allow_duplicates: false
       if: ctx.temp?.user != null
   - append:
+      tag: append_related_user_4554486f
       field: related.user
       value: '{{{temp.user}}}'
       allow_duplicates: false
       if: ctx.temp?.user != null
   - rename:
+      tag: rename_temp_action_to_fortinet_fortimail_log_action_d1d0a68f
       field: temp.action
       target_field: fortinet_fortimail.log.action
       ignore_missing: true
   - set:
+      tag: set_event_action_fac205d4
       field: event.action
       copy_from: fortinet_fortimail.log.action
       ignore_empty_value: true
   - rename:
+      tag: rename_temp_module_to_fortinet_fortimail_log_module_fb389af3
       field: temp.module
       target_field: fortinet_fortimail.log.module
       ignore_missing: true
   - rename:
+      tag: rename_temp_reason_to_fortinet_fortimail_log_reason_a448343f
       field: temp.reason
       target_field: fortinet_fortimail.log.reason
       ignore_missing: true
   - rename:
+      tag: rename_temp_session_id_to_fortinet_fortimail_log_session_id_c4b20db7
       field: temp.session_id
       target_field: fortinet_fortimail.log.session_id
       ignore_missing: true
   - rename:
+      tag: rename_temp_status_to_fortinet_fortimail_log_status_b34786cf
       field: temp.status
       target_field: fortinet_fortimail.log.status
       ignore_missing: true
   - rename:
+      tag: rename_temp_submodule_to_fortinet_fortimail_log_sub_module_b2295dde
       field: temp.submodule
       target_field: fortinet_fortimail.log.sub_module
       ignore_missing: true
   - rename:
+      tag: rename_temp_ui_to_fortinet_fortimail_log_ui_ecc5d28f
       field: temp.ui
       target_field: fortinet_fortimail.log.ui
       ignore_missing: true
   - grok:
+      tag: grok_fortinet_fortimail_log_ui_cfbad394
       field: fortinet_fortimail.log.ui
       ignore_missing: true
       patterns:
@@ -113,23 +136,28 @@ processors:
         PROTOCOL: SSH|telnet|ssh|http|HTTP
       ignore_failure: true
   - set:
+      tag: set_source_ip_a1237bd8
       field: source.ip
       copy_from: fortinet_fortimail.log.ui_ip
       ignore_empty_value: true
   - geoip:
+      tag: geoip_source_ip_to_source_geo_bace2435
       if: ctx.source?.ip != null
       field: source.ip
       target_field: source.geo
   - append:
+      tag: append_related_ip_f8ea089a
       field: related.ip
       value: '{{{fortinet_fortimail.log.ui_ip}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.ui_ip != null
   - set:
+      tag: set_network_protocol_5da2dd0c
       field: network.protocol
       copy_from: fortinet_fortimail.log.network
       ignore_empty_value: true
   - lowercase:
+      tag: lowercase_network_protocol_49872259
       field: network.protocol
       ignore_missing: true
 on_failure:
@@ -138,4 +166,8 @@ on_failure:
       value: pipeline_error
   - append:
       field: error.message
-      value: '{{{ _ingest.on_failure_message }}}'
+      value: >-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
+        failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_system.yml
+++ b/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_system.yml
@@ -2,83 +2,101 @@
 description: Pipeline for processing System logs.
 processors:
   - set:
+      tag: set_event_outcome_82c7155e
       field: event.outcome
       value: unknown
   - set:
+      tag: set_event_outcome_a02366c2
       field: event.outcome
       value: success
       if: ctx.fortinet_fortimail?.log?.sub_type == 'admin' && ctx.temp?.status.toLowerCase() == 'success'
   - set:
+      tag: set_event_outcome_ab2ec938
       field: event.outcome
       value: failure
       if: ctx.fortinet_fortimail?.log?.sub_type == 'admin' && ctx.temp?.status.toLowerCase() == 'failure'
   - set:
+      tag: set_event_category_08028495
       field: event.category
       value: [authentication]
       if: ctx.fortinet_fortimail?.log?.sub_type == 'admin' && (ctx.fortinet_fortimail.log.message.toLowerCase().contains('login') || ctx.fortinet_fortimail.log.message.toLowerCase().contains('logged'))
   - append:
+      tag: append_event_type_88871742
       field: event.type
       value: end
       if: ctx.fortinet_fortimail?.log?.sub_type == 'admin' && (ctx.fortinet_fortimail.log.message.toLowerCase().contains('login successfully') || ctx.fortinet_fortimail.log.message.toLowerCase().contains('logged in') || ctx.fortinet_fortimail.log.message.toLowerCase().contains('login'))
       allow_duplicates: false
   - append:
+      tag: append_event_type_e03135e5
       field: event.type
       value: info
       if: ctx.fortinet_fortimail?.log?.sub_type == 'admin' && ctx.event?.category != null
       allow_duplicates: false
   - append:
+      tag: append_event_category_37b01657
       field: event.category
       value: configuration
       if: ctx.fortinet_fortimail?.log?.sub_type == 'config'
       allow_duplicates: false
   - set:
+      tag: set_event_type_63c98742
       field: event.type
       value: [change]
       if: ctx.fortinet_fortimail?.log?.sub_type == 'config'
   - set:
+      tag: set_event_type_3d393468
       field: event.type
       value: [deletion]
       if: ctx.fortinet_fortimail?.log?.sub_type == 'config' && ctx.fortinet_fortimail.log.message.toLowerCase().contains('delet')
       override: true
   - set:
+      tag: set_event_category_139ba01e
       field: event.category
       value: [host]
       if: ctx.fortinet_fortimail?.log?.sub_type == 'system' && ctx.fortinet_fortimail.log.message.toLowerCase().contains('system')
   - set:
+      tag: set_event_category_e21a3544
       field: event.category
       value: [configuration]
       if: (ctx.fortinet_fortimail?.log?.sub_type == 'system' && ctx.fortinet_fortimail.log.message.toLowerCase().contains('change')) || (ctx.fortinet_fortimail?.log?.sub_type == 'update' && ctx.fortinet_fortimail.log.message.toLowerCase().contains('update'))
       override: true
   - set:
+      tag: set_event_type_0f6f6e93
       field: event.type
       value: [info]
       if: ctx.fortinet_fortimail?.log?.sub_type == 'system'
   - set:
+      tag: set_event_type_e33a537c
       field: event.type
       value: [end]
       if: ctx.fortinet_fortimail?.log?.sub_type == 'system' && ctx.fortinet_fortimail.log.message.toLowerCase().contains('shutdown')
       override: true
   - set:
+      tag: set_event_type_c5fda874
       field: event.type
       value: [change]
       if: (ctx.fortinet_fortimail?.log?.sub_type == 'system' && ctx.fortinet_fortimail.log.message.toLowerCase().contains('change')) || (ctx.fortinet_fortimail?.log?.sub_type == 'update' && ctx.fortinet_fortimail.log.message.toLowerCase().contains('update'))
       override: true
   - append:
+      tag: append_fortinet_fortimail_log_user_2f9ddf12
       field: fortinet_fortimail.log.user
       value: '{{{temp.user}}}'
       allow_duplicates: false
       if: ctx.temp?.user != null
   - append:
+      tag: append_user_name_9b60aa7e
       field: user.name
       value: '{{{temp.user}}}'
       allow_duplicates: false
       if: ctx.temp?.user != null
   - append:
+      tag: append_related_user_4554486e
       field: related.user
       value: '{{{temp.user}}}'
       allow_duplicates: false
       if: ctx.temp?.user != null
   - grok:
+      tag: grok_message_0070248e
       field: message
       ignore_missing: true
       ignore_failure: true
@@ -94,73 +112,89 @@ processors:
         USER: '(?i)user %{NOTSPACE:temp.user}'
         BLOCK_ACTION: '(?:added|removed)'
   - set:
+      tag: set_source_port_2d5659fd
       field: source.port
       copy_from: fortinet_fortimail.log.port
       ignore_empty_value: true
   - append:
+      tag: append_related_ip_bf78f00c
       field: related.ip
       value: '{{{fortinet_fortimail.log.ip}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.ip != null
   - append:
+      tag: append_related_ip_c9493339
       field: related.ip
       value: '{{{temp.block_ip}}}'
       allow_duplicates: false
       if: ctx.temp?.block_ip != null
   - append:
+      tag: append_client_ip_e1408be5
       field: client.ip
       value: '{{{temp.block_ip}}}'
       allow_duplicates: false
       if: ctx.temp?.block_ip != null
   - set:
+      tag: set_event_action_bd6b62e4
       field: event.action
       value: '{{{temp.block_action}}}_block_rule'
       if: ctx.temp?.block_ip != null
   - append:
+      tag: append_fortinet_fortimail_log_user_2f9ddf13
       field: fortinet_fortimail.log.user
       value: '{{{temp.user}}}'
       allow_duplicates: false
       if: ctx.temp?.user != null
   - append:
+      tag: append_user_name_9b60aa7f
       field: user.name
       value: '{{{temp.user}}}'
       allow_duplicates: false
       if: ctx.temp?.user != null
   - append:
+      tag: append_related_user_4554486f
       field: related.user
       value: '{{{temp.user}}}'
       allow_duplicates: false
       if: ctx.temp?.user != null
   - rename:
+      tag: rename_temp_action_to_fortinet_fortimail_log_action_d1d0a68f
       field: temp.action
       target_field: fortinet_fortimail.log.action
       ignore_missing: true
   - set:
+      tag: set_event_action_6c0a2415
       field: event.action
       copy_from: fortinet_fortimail.log.action
       ignore_empty_value: true
       override: false
   - rename:
+      tag: rename_temp_module_to_fortinet_fortimail_log_module_fb389af3
       field: temp.module
       target_field: fortinet_fortimail.log.module
       ignore_missing: true
   - rename:
+      tag: rename_temp_submodule_to_fortinet_fortimail_log_sub_module_b2295dde
       field: temp.submodule
       target_field: fortinet_fortimail.log.sub_module
       ignore_missing: true
   - rename:
+      tag: rename_temp_ui_to_fortinet_fortimail_log_ui_ecc5d28f
       field: temp.ui
       target_field: fortinet_fortimail.log.ui
       ignore_missing: true
   - rename:
+      tag: rename_temp_reason_to_fortinet_fortimail_log_reason_a448343f
       field: temp.reason
       target_field: fortinet_fortimail.log.reason
       ignore_missing: true
   - rename:
+      tag: rename_temp_status_to_fortinet_fortimail_log_status_b34786cf
       field: temp.status
       target_field: fortinet_fortimail.log.status
       ignore_missing: true
   - grok:
+      tag: grok_fortinet_fortimail_log_ui_1434bd57
       field: fortinet_fortimail.log.ui
       ignore_missing: true
       patterns:
@@ -171,23 +205,28 @@ processors:
         PROTOCOL: '(?i)(?:telnet|ssh|http)'
       ignore_failure: true
   - set:
+      tag: set_source_ip_a1237bd8
       field: source.ip
       copy_from: fortinet_fortimail.log.ui_ip
       ignore_empty_value: true
   - geoip:
+      tag: geoip_source_ip_to_source_geo_bace2435
       if: ctx.source?.ip != null
       field: source.ip
       target_field: source.geo
   - append:
+      tag: append_related_ip_f8ea089a
       field: related.ip
       value: '{{{fortinet_fortimail.log.ui_ip}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.ui_ip != null
   - set:
+      tag: set_network_protocol_5da2dd0c
       field: network.protocol
       copy_from: fortinet_fortimail.log.network
       ignore_empty_value: true
   - lowercase:
+      tag: lowercase_network_protocol_49872259
       field: network.protocol
       ignore_missing: true
 on_failure:
@@ -196,4 +235,8 @@ on_failure:
       value: pipeline_error
   - append:
       field: error.message
-      value: '{{{ _ingest.on_failure_message }}}'
+      value: >-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
+        failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/fortinet_fortimail/manifest.yml
+++ b/packages/fortinet_fortimail/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_fortimail
 title: Fortinet FortiMail
-version: "2.16.0"
+version: "2.16.1"
 description: Collect logs from Fortinet FortiMail instances with Elastic Agent.
 type: integration
 format_version: "3.0.3"


### PR DESCRIPTION
## Proposed commit message

- Generate tags for processors missing tags
- Normalize the pipeline error handler

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~
