### PR TITLE
[fortinet_fortimanager] Generate processor tags and normalize error handler

### DIFF
--- a/packages/fortinet_fortimanager/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet_fortimanager/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -4,26 +4,32 @@ processors:
   - set:
       field: ecs.version
       value: 8.17.0
+      tag: set_f5923549
   - set:
       field: event.kind
       value: event
+      tag: set_de80643c
   - set:
       field: event.type
       value: [info]
+      tag: set_ec95f7f2
   - rename:
       field: message
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+      tag: rename_56a77271
   - grok:
       field: event.original
       ecs_compatibility: v1
       patterns:
         - "^(?:<%{NUMBER:fortimanager.log.priority_number:long}>)?%{GREEDYDATA:syslog5424_sd}$"
+      tag: grok_d813f65a
   - gsub:
       field: syslog5424_sd
       pattern: "[\u0000-\u001F\u007F]"
       replacement: ""
+      tag: gsub_756bcbdd
   - script:
       lang: painless
       if: ctx.syslog5424_sd != null
@@ -69,6 +75,7 @@ processors:
           ctx.fortinet = new HashMap();
         }
         ctx._temp = map;
+      tag: script_da23a97d
   - script:
       lang: painless
       source: |
@@ -78,118 +85,147 @@ processors:
             def pat = /\W+/; 
             fw.entrySet().removeIf(entry -> entry.getValue() == "N/A" || pat.matcher(entry.getKey()).find());
         }
+      tag: script_39b078f1
   - rename:
       field: _temp.changes
       target_field: fortimanager.log.changes
       ignore_missing: true
+      tag: rename_e2c4b352
   - rename:
       field: _temp.pri
       target_field: fortimanager.log.pri
       ignore_missing: true
+      tag: rename_9f5f7a6a
   - rename:
       field: _temp.intfname
       target_field: fortimanager.log.intfname
       ignore_missing: true
+      tag: rename_fb41e0b6
   - rename:
       field: _temp.importance
       target_field: fortimanager.log.importance
       ignore_missing: true
+      tag: rename_ea6e492a
   - rename:
       field: _temp.function
       target_field: fortimanager.log.function
       ignore_missing: true
+      tag: rename_6c1c1fa2
   - rename:
       field: _temp.detail
       target_field: fortimanager.log.detail
       ignore_missing: true
+      tag: rename_98343360
   - rename:
       field: _temp.desc
       target_field: fortimanager.log.desc
       ignore_missing: true
+      tag: rename_3e7ff1f4
   - rename:
       field: _temp.dbver
       target_field: fortimanager.log.db.ver
       ignore_missing: true
+      tag: rename_ea239a4a
   - rename:
       field: _temp.app
       target_field: fortimanager.log.app
       ignore_missing: true
+      tag: rename_9351428e
   - rename:
       field: _temp.bid
       target_field: fortimanager.log.bid
       ignore_missing: true
+      tag: rename_a16f0ada
   - rename:
       field: _temp.profname
       target_field: fortimanager.log.prof_name
       ignore_missing: true
+      tag: rename_b3c4a00f
   - rename:
       field: _temp.epid
       target_field: fortimanager.log.epid
       ignore_missing: true
+      tag: rename_f77bc522
   - rename:
       field: _temp.dstepid
       target_field: fortimanager.log.dste.pid
       ignore_missing: true
+      tag: rename_7db969ca
   - rename:
       field: _temp.dsteuid
       target_field: fortimanager.log.dste.uid
       ignore_missing: true
+      tag: rename_18ed0b60
   - rename:
       field: _temp.id
       target_field: fortimanager.log.event.id
       ignore_missing: true
+      tag: rename_0e020bc6
   - rename:
       field: _temp.event_type
       target_field: fortimanager.log.event.type
       ignore_missing: true
+      tag: rename_32df04b5
   - set:
       field: event.id
       copy_from: fortimanager.log.event.id
       ignore_empty_value: true
+      tag: set_cc760d10
   - rename:
       field: _temp.userid
       target_field: fortimanager.log.user.id
       ignore_missing: true
+      tag: rename_163a612e
   - rename:
       field: _temp.user
       target_field: fortimanager.log.user.name
       ignore_missing: true
+      tag: rename_e16f2fc3
   - rename:
       field: _temp.user_type
       target_field: fortimanager.log.user.type
       ignore_missing: true
+      tag: rename_4d030b7b
   - rename:
       field: _temp.userfrom
       target_field: fortimanager.log.user.from
       ignore_missing: true
+      tag: rename_33519492
   - set:
       field: user.name
       copy_from: fortimanager.log.user.name
       ignore_empty_value: true
+      tag: set_f1afb3f2
   - set:
       field: user.id
       copy_from: fortimanager.log.user.id
       ignore_empty_value: true
+      tag: set_10fbfb46
   - rename:
       field: _temp.dmstate
       target_field: fortimanager.log.dm_state
       ignore_missing: true
+      tag: rename_146325cd
   - rename:
       field: _temp.dvid
       target_field: fortimanager.log.dvid
       ignore_missing: true
+      tag: rename_7a64e4cc
   - rename:
       field: _temp.dvmdb_obj
       target_field: fortimanager.log.dvmdb_obj
       ignore_missing: true
+      tag: rename_317c6b6a
   - rename:
       field: _temp.fips_err
       target_field: fortimanager.log.fips.err
       ignore_missing: true
+      tag: rename_a0904599
   - rename:
       field: _temp.fips_method
       target_field: fortimanager.log.fips.method
       ignore_missing: true
+      tag: rename_81a0d477
   - convert:
       field: _temp.module
       tag: 'convert_module_to_long'
@@ -205,10 +241,12 @@ processors:
       field: _temp.metafield
       target_field: fortimanager.log.meta_field.name
       ignore_missing: true
+      tag: rename_e50e3112
   - rename:
       field: _temp.metafield_stat
       target_field: fortimanager.log.meta_field.stat
       ignore_missing: true
+      tag: rename_08a4b1ba
   - convert:
       field: _temp.metafield_leng
       tag: 'convert_metafield_leng_to_long'
@@ -224,14 +262,17 @@ processors:
       field: _temp.pkg
       target_field: fortimanager.log.pkg.name
       ignore_missing: true
+      tag: rename_93026ff1
   - rename:
       field: _temp.pkgadom
       target_field: fortimanager.log.pkg.adom
       ignore_missing: true
+      tag: rename_d63658ce
   - rename:
       field: _temp.pkgname
       target_field: fortimanager.log.pkg.name
       ignore_missing: true
+      tag: rename_b38a6532
   - convert:
       field: _temp.pkg_oid
       tag: 'convert_pkg_oid_to_string'
@@ -247,26 +288,32 @@ processors:
       field: _temp.ppkgname
       target_field: fortimanager.log.pkg.gname
       ignore_missing: true
+      tag: rename_203419fb
   - rename:
       field: _temp.vd
       target_field: fortimanager.log.vdom
       ignore_missing: true
+      tag: rename_6acbac72
   - rename:
       field: _temp.adminprof
       target_field: fortimanager.log.admin_prof
       ignore_missing: true
+      tag: rename_e3699f87
   - rename:
       field: _temp.oper_stat
       target_field: fortimanager.log.operstat
       ignore_missing: true
+      tag: rename_2a06f12f
   - rename:
       field: _temp.uploading_oper
       target_field: fortimanager.log.uploading.oper
       ignore_missing: true
+      tag: rename_e5bc745f
   - rename:
       field: _temp.uploading_server_type
       target_field: fortimanager.log.uploading.server_type
       ignore_missing: true
+      tag: rename_9f03a639
   - convert:
       field: _temp.uploading_pid
       tag: 'convert_uploading_pid_to_string'
@@ -304,10 +351,12 @@ processors:
       field: _temp.adom
       target_field: fortimanager.log.adom.name
       ignore_missing: true
+      tag: rename_9bdbb657
   - set:
       field: user.domain
       copy_from: fortimanager.log.adom.name
       ignore_empty_value: true
+      tag: set_dcca61c9
   - convert:
       field: _temp.adom_oid
       tag: 'convert_adom_oid_to_string'
@@ -323,18 +372,22 @@ processors:
       field: _temp.adomlock
       target_field: fortimanager.log.adom.lock
       ignore_missing: true
+      tag: rename_92abd4fe
   - rename:
       field: _temp.dbstatus
       target_field: fortimanager.log.db.status
       ignore_missing: true
+      tag: rename_1d6d5184
   - rename:
       field: _temp.disk_stat_before
       target_field: fortimanager.log.disk.status.before
       ignore_missing: true
+      tag: rename_6da8f40c
   - rename:
       field: _temp.disk_stat_current
       target_field: fortimanager.log.disk.status.current
       ignore_missing: true
+      tag: rename_9b47d0ac
   - convert:
       field: _temp.disk_label
       tag: 'convert_disk_label_to_long'
@@ -350,86 +403,107 @@ processors:
       field: _temp.log_id
       target_field: fortimanager.log.id
       ignore_missing: true
+      tag: rename_89bfcd0f
   - rename:
       field: _temp.peer
       target_field: fortimanager.log.peer
       ignore_missing: true
+      tag: rename_e2dcbab2
   - rename:
       field: _temp.performed_on
       target_field: fortimanager.log.performed_on
       ignore_missing: true
+      tag: rename_e6b5840a
   - rename:
       field: _temp.log_path
       target_field: fortimanager.log.path
       ignore_missing: true
+      tag: rename_f97e903b
   - rename:
       field: _temp.logdev_id
       target_field: fortimanager.log.device_log.id
       ignore_missing: true
+      tag: rename_c75ddc61
   - rename:
       field: _temp.logdev_last_logging
       target_field: fortimanager.log.device_log.last_logging
       ignore_missing: true
+      tag: rename_c5925051
   - rename:
       field: _temp.logdev_name
       target_field: fortimanager.log.device_log.name
       ignore_missing: true
+      tag: rename_39014d2d
   - rename:
       field: _temp.logdev_offline_duration
       target_field: fortimanager.log.device_log.offline_duration
       ignore_missing: true
+      tag: rename_176c8a9d
   - rename:
       field: _temp.package
       target_field: fortimanager.log.package.name
       ignore_missing: true
+      tag: rename_c2f56ecd
   - rename:
       field: _temp.package_desc
       target_field: fortimanager.log.package.desc
       ignore_missing: true
+      tag: rename_8773affb
   - rename:
       field: _temp.package_type
       target_field: fortimanager.log.package.type
       ignore_missing: true
+      tag: rename_476bf86d
   - rename:
       field: _temp.logid
       target_field: fortimanager.log.id
       ignore_missing: true
+      tag: rename_1016c252
   - rename:
       field: _temp.pty_err
       target_field: fortimanager.log.pty.err
       ignore_missing: true
+      tag: rename_ce716ea1
   - rename:
       field: _temp.pty_oper
       target_field: fortimanager.log.pty.oper
       ignore_missing: true
+      tag: rename_767499df
   - rename:
       field: _temp.pty_sess
       target_field: fortimanager.log.pty.sess
       ignore_missing: true
+      tag: rename_437c4b3b
   - rename:
       field: _temp.pty_step
       target_field: fortimanager.log.pty.step
       ignore_missing: true
+      tag: rename_2aa6849f
   - rename:
       field: _temp.raid_stat_before
       target_field: fortimanager.log.raid_state.before
       ignore_missing: true
+      tag: rename_584d14c2
   - rename:
       field: _temp.raid_stat_current
       target_field: fortimanager.log.raid_state.current
       ignore_missing: true
+      tag: rename_eea04798
   - rename:
       field: _temp.remote_filename
       target_field: fortimanager.log.remote.filename
       ignore_missing: true
+      tag: rename_32f59a07
   - rename:
       field: _temp.remote_host
       target_field: fortimanager.log.remote.host
       ignore_missing: true
+      tag: rename_e1d0a787
   - rename:
       field: _temp.remote_path
       target_field: fortimanager.log.remote.path
       ignore_missing: true
+      tag: rename_2123dddb
   - convert:
       field: _temp.remote_ip
       tag: 'convert_remote_ip_to_ip'
@@ -446,10 +520,12 @@ processors:
       value: '{{{fortimanager.log.remote.ip}}}'
       if: ctx._temp?.remote?.ip != null
       allow_duplicates: false
+      tag: append_ce53e544
   - set:
       field: source.ip
       copy_from: fortimanager.log.remote.ip
       ignore_empty_value: true
+      tag: set_78e33e51
   - convert:
       field: _temp.remote_port
       tag: 'convert_remote_port_to_long'
@@ -465,46 +541,57 @@ processors:
       field: source.port
       copy_from: fortimanager.log.remote.port
       ignore_empty_value: true
+      tag: set_2aa16f31
   - rename:
       field: _temp.sensor_name
       target_field: fortimanager.log.sensor.name
       ignore_missing: true
+      tag: rename_f0fdeb53
   - rename:
       field: _temp.sensor_st
       target_field: fortimanager.log.sensor.st
       ignore_missing: true
+      tag: rename_59601413
   - rename:
       field: _temp.sensor_val
       target_field: fortimanager.log.sensor.val
       ignore_missing: true
+      tag: rename_366e50e1
   - rename:
       field: _temp.upgrade_adom
       target_field: fortimanager.log.upgrade.adom
       ignore_missing: true
+      tag: rename_14f5ec5f
   - rename:
       field: _temp.upgrade_from
       target_field: fortimanager.log.upgrade.from
       ignore_missing: true
+      tag: rename_23039871
   - rename:
       field: _temp.upgrade_to
       target_field: fortimanager.log.upgrade.to
       ignore_missing: true
+      tag: rename_bca638b3
   - rename:
       field: _temp.runfrom
       target_field: fortimanager.log.run_from
       ignore_missing: true
+      tag: rename_1092f471
   - rename:
       field: _temp.devname
       target_field: fortimanager.log.dev.name
       ignore_missing: true
+      tag: rename_f8bd7326
   - set:
       field: host.hostname
       copy_from: fortimanager.log.dev.name
       ignore_empty_value: true
+      tag: set_c61492f5
   - rename:
       field: _temp.devid
       target_field: fortimanager.log.dev.id
       ignore_missing: true
+      tag: rename_172e9e26
   - convert:
       field: _temp.dev_oid
       tag: 'convert_dev_oid_to_string'
@@ -520,10 +607,12 @@ processors:
       field: _temp.devlog
       target_field: fortimanager.log.dev.log
       ignore_missing: true
+      tag: rename_bc47b43a
   - rename:
       field: _temp.devgrps
       target_field: fortimanager.log.dev.grps
       ignore_missing: true
+      tag: rename_7925fb58
   - convert:
       field: _temp.session_id
       tag: 'convert_session_id_to_string'
@@ -616,43 +705,53 @@ processors:
       field: _temp.device
       target_field: fortimanager.log.device.name
       ignore_missing: true
+      tag: rename_f9b0aa85
   - set:
       field: observer.name
       copy_from: fortimanager.log.device.name
       ignore_empty_value: true
+      tag: set_7f80cb7e
   - rename:
       field: _temp.device_id
       target_field: fortimanager.log.device.id
       ignore_missing: true
+      tag: rename_cdcc4c67
   - set:
       field: device.id
       copy_from: fortimanager.log.device.id
       ignore_empty_value: true
+      tag: set_dca5453a
   - rename:
       field: _temp.action
       target_field: fortimanager.log.action
       ignore_missing: true
+      tag: rename_3335dfde
   - set:
       field: event.action
       copy_from: fortimanager.log.action
       ignore_empty_value: true
+      tag: set_79378658
   - set:
       field: event.timezone
       copy_from: _temp.tz
       ignore_empty_value: true
+      tag: set_85841de5
   - append:
       field: related.hosts
       value: '{{{host.hostname}}}'
       if: ctx.host?.hostname != null
       allow_duplicates: false
+      tag: append_ca923905
   - rename:
       field: _temp.msg
       target_field: fortimanager.log.msg
       ignore_missing: true
+      tag: rename_1c77d2fa
   - set:
       field: message
       copy_from: fortimanager.log.msg
       ignore_empty_value: true
+      tag: set_4a89d190
   - convert:
       field: _temp.pid
       tag: 'convert_pid_to_long'
@@ -668,6 +767,7 @@ processors:
       field: process.pid
       copy_from: fortimanager.log.pid
       ignore_empty_value: true
+      tag: set_f5a88df7
   - script:
       lang: painless
       description: Combines date, time, and timezone fields together.
@@ -675,6 +775,7 @@ processors:
         if (ctx._temp?.time != null && ctx._temp?.date != null && ctx._temp?.tz != null) {
           ctx._temp.date = ctx._temp.date + 'T' + ctx._temp.time + ctx._temp.tz;
         }
+      tag: script_3e7401ef
   - date:
       field: _temp.date
       tag: 'date_set_timestamp'
@@ -700,114 +801,142 @@ processors:
       field: _temp.extrainfo
       target_field: fortimanager.log.extra_info
       ignore_missing: true
+      tag: rename_30ed9ebd
   - rename:
       field: _temp.newname
       target_field: fortimanager.log.new.name
       ignore_missing: true
+      tag: rename_a15f039e
   - rename:
       field: _temp.new_version
       target_field: fortimanager.log.new.version
       ignore_missing: true
+      tag: rename_e829b779
   - rename:
       field: _temp.new_value
       target_field: fortimanager.log.new.value
       ignore_missing: true
+      tag: rename_cdb48e39
   - rename:
       field: _temp.instpkg
       target_field: fortimanager.log.inst.pkg
       ignore_missing: true
+      tag: rename_8171e9ac
   - rename:
       field: _temp.inst_dev
       target_field: fortimanager.log.inst.dev
       ignore_missing: true
+      tag: rename_873e9895
   - rename:
       field: _temp.inst_adom
       target_field: fortimanager.log.inst.adom
       ignore_missing: true
+      tag: rename_ca91765f
   - rename:
       field: _temp.certname
       target_field: fortimanager.log.cert.name
       ignore_missing: true
+      tag: rename_013c122c
   - rename:
       field: _temp.certtype
       target_field: fortimanager.log.cert.type
       ignore_missing: true
+      tag: rename_2b2e55d4
   - rename:
       field: _temp.attrname
       target_field: fortimanager.log.attribute_name
       ignore_missing: true
+      tag: rename_a5541390
   - rename:
       field: _temp.authmsg
       target_field: fortimanager.log.auth_msg
       ignore_missing: true
+      tag: rename_db5e9601
   - rename:
       field: _temp.object
       target_field: fortimanager.log.object
       ignore_missing: true
+      tag: rename_6b4a27f8
   - rename:
       field: _temp.offline_stat
       target_field: fortimanager.log.offline_stat
       ignore_missing: true
+      tag: rename_0f862662
   - rename:
       field: _temp.old_value
       target_field: fortimanager.log.old_value
       ignore_missing: true
+      tag: rename_3dbf2b46
   - rename:
       field: _temp.pre_version
       target_field: fortimanager.log.pre_version
       ignore_missing: true
+      tag: rename_19cc1f4a
   - rename:
       field: _temp.operation
       target_field: fortimanager.log.operation
       ignore_missing: true
+      tag: rename_49d6c27e
   - rename:
       field: _temp.objattr
       target_field: fortimanager.log.obj.attr
       ignore_missing: true
+      tag: rename_7f16c0c2
   - rename:
       field: _temp.objname
       target_field: fortimanager.log.obj.name
       ignore_missing: true
+      tag: rename_0ff1e5d2
   - rename:
       field: _temp.objtype
       target_field: fortimanager.log.obj.type
       ignore_missing: true
+      tag: rename_ac245dd4
   - rename:
       field: _temp.path
       target_field: fortimanager.log.obj.path
       ignore_missing: true
+      tag: rename_a5467d67
   - rename:
       field: _temp.level
       target_field: fortimanager.log.level
       ignore_missing: true
+      tag: rename_28444a22
   - set:
       field: log.level
       copy_from: fortimanager.log.level
       ignore_empty_value: true
+      tag: set_7f0b6a32
   - rename:
       field: _temp.file
       target_field: fortimanager.log.file
       ignore_missing: true
+      tag: rename_2d332cde
   - set:
       field: file.name
       copy_from: fortimanager.log.file
       ignore_empty_value: true
+      tag: set_771a82d9
   - rename:
       field: _temp.confstatus
       target_field: fortimanager.log.conf_status
       ignore_missing: true
+      tag: rename_773aaeb5
   - rename:
       field: _temp.constmsg
       target_field: fortimanager.log.const_msg
       ignore_missing: true
+      tag: rename_8cc0cfd1
   - rename:
       field: _temp.euid
       target_field: fortimanager.log.euid
       ignore_missing: true
+      tag: rename_ecc91c3c
   - rename:
       field: _temp.error
       target_field: fortimanager.log.error
       ignore_missing: true
+      tag: rename_1041cebe
   - convert:
       field: _temp.errcode
       tag: 'convert_errcode_to_string'
@@ -823,158 +952,197 @@ processors:
       field: error.code
       copy_from: fortimanager.log.err_code
       ignore_empty_value: true
+      tag: set_1f3fbc74
   - rename:
       field: _temp.connect_status
       target_field: fortimanager.log.connect_status
       ignore_missing: true
+      tag: rename_c24239e4
   - rename:
       field: _temp.condition
       target_field: fortimanager.log.condition
       ignore_missing: true
+      tag: rename_b151cc4e
   - rename:
       field: _temp.comment
       target_field: fortimanager.log.comment
       ignore_missing: true
+      tag: rename_0aecce36
   - rename:
       field: _temp.cmd_from
       target_field: fortimanager.log.cmd_from
       ignore_missing: true
+      tag: rename_e1b21590
   - rename:
       field: _temp.cli_act
       target_field: fortimanager.log.cli_act
       ignore_missing: true
+      tag: rename_472b132e
   - rename:
       field: _temp.cause
       target_field: fortimanager.log.cause
       ignore_missing: true
+      tag: rename_9bd04f62
   - rename:
       field: _temp.category
       target_field: fortimanager.log.category
       ignore_missing: true
+      tag: rename_26e0ae32
   - rename:
       field: _temp.zip_path
       target_field: fortimanager.log.zip_path
       ignore_missing: true
+      tag: rename_70406240
   - rename:
        field: _temp.whitelist_size
        target_field: fortimanager.log.whitelist_size
        ignore_missing: true
+       tag: rename_14c6c360
   - rename:
        field: _temp.zip_path
        target_field: fortimanager.log.zip_path
        ignore_missing: true
+       tag: rename_70406240
   - rename:
        field: _temp.version
        target_field: fortimanager.log.version
        ignore_missing: true
+       tag: rename_0541ac12
   - rename:
        field: _temp.version
        target_field: fortimanager.log.version
        ignore_missing: true
+       tag: rename_0541ac12
   - rename:
        field: _temp.vdoms
        target_field: fortimanager.log.vdoms
        ignore_missing: true
+       tag: rename_8daf78c2
   - rename:
        field: _temp.vdom
        target_field: fortimanager.log.vdom
        ignore_missing: true
+       tag: rename_492a7c02
   - rename:
        field: _temp.ustr
        target_field: fortimanager.log.ustr
        ignore_missing: true
+       tag: rename_91d5f202
   - rename:
        field: _temp.type
        target_field: fortimanager.log.type
        ignore_missing: true
+       tag: rename_2be45ae2
   - rename:
        field: _temp.type
        target_field: fortimanager.log.type
        ignore_missing: true
+       tag: rename_2be45ae2
   - rename:
        field: _temp.url
        target_field: fortimanager.log.url
        ignore_missing: true
+       tag: rename_cfaa73ba
   - rename:
        field: _temp.upg_act
        target_field: fortimanager.log.upg_act
        ignore_missing: true
+       tag: rename_ca1e9dee
   - rename:
        field: _temp.uid
        target_field: fortimanager.log.uid
        ignore_missing: true
+       tag: rename_856f1896
   - rename:
        field: _temp.upddb_ver
        target_field: fortimanager.log.upddb_ver
        ignore_missing: true
+       tag: rename_ee7f8dda
   - rename:
        field: _temp.to_version
        target_field: fortimanager.log.to_version
        ignore_missing: true
+       tag: rename_e1fe6746
   - rename:
        field: _temp.to_release
        target_field: fortimanager.log.to_release
        ignore_missing: true
+       tag: rename_26e23174
   - rename:
        field: _temp.title
        target_field: fortimanager.log.title
        ignore_missing: true
+       tag: rename_e36c6bce
   - rename:
        field: _temp.title
        target_field: fortimanager.log.title
        ignore_missing: true
+       tag: rename_e36c6bce
   - rename:
        field: _temp.sw_version
        target_field: fortimanager.log.sw_version
        ignore_missing: true
+       tag: rename_67311968
   - rename:
        field: _temp.subtype
        target_field: fortimanager.log.subtype
        ignore_missing: true
+       tag: rename_36bf99ae
   - rename:
        field: _temp.status
        target_field: fortimanager.log.status
        ignore_missing: true
+       tag: rename_917bb32a
   - rename:
        field: _temp.state
        target_field: fortimanager.log.state
        ignore_missing: true
+       tag: rename_0a94e36e
   - rename:
        field: _temp.shutdown_reason
        target_field: fortimanager.log.shutdown_reason
        ignore_missing: true
+       tag: rename_df162872
   - rename:
        field: _temp.state
        target_field: fortimanager.log.state
        ignore_missing: true
+       tag: rename_0a94e36e
   - rename:
        field: _temp.service
        target_field: fortimanager.log.service
        ignore_missing: true
+       tag: rename_df95468e
   - rename:
        field: _temp.serial
        target_field: fortimanager.log.serial
        ignore_missing: true
+       tag: rename_f1e966a2
   - rename:
        field: _temp.script
        target_field: fortimanager.log.script
        ignore_missing: true
+       tag: rename_898e8e5c
   - rename:
        field: _temp.rundb_ver
        target_field: fortimanager.log.rundb_ver
        ignore_missing: true
+       tag: rename_9f174d12
   - rename:
        field: _temp.result
        target_field: fortimanager.log.result
        ignore_missing: true
+       tag: rename_50021d48
   - rename:
       field: _temp.reboot_reason
       target_field: fortimanager.log.reboot_reason
       ignore_missing: true
+      tag: rename_6ce329a2
   - rename:
       field: _temp.protocol
       target_field: fortimanager.log.protocol
       ignore_missing: true
+      tag: rename_60ff314a
   - convert:
       field: _temp.srcip
       tag: 'convert_srcip_to_ip'
@@ -990,14 +1158,17 @@ processors:
       field: source.ip
       copy_from: fortimanager.log.srcip
       ignore_empty_value: true
+      tag: set_85ff9577
   - rename:
       field: _temp.srcname
       target_field: fortimanager.log.srcname
       ignore_missing: true
+      tag: rename_b58cd27e
   - set:
       field: source.address
       copy_from: fortimanager.log.srcname
       ignore_empty_value: true
+      tag: set_4e544c26
   - convert:
       field: _temp.srcport
       tag: 'convert_srcport'
@@ -1013,6 +1184,7 @@ processors:
       field: source.port
       copy_from: fortimanager.log.srcport
       ignore_empty_value: true
+      tag: set_3089d4c7
   - convert:
       field: _temp.dstip
       tag: 'convert_dstip_to_ip'
@@ -1028,30 +1200,37 @@ processors:
       field: destination.ip
       copy_from: fortimanager.log.dstip
       ignore_empty_value: true
+      tag: set_68c319b5
   - rename:
       field: _temp.dstname
       target_field: fortimanager.log.dstname
       ignore_missing: true
+      tag: rename_1617ef22
   - set:
       field: destination.address
       copy_from: fortimanager.log.dstname
       ignore_empty_value: true
+      tag: set_70335e80
   - rename:
       field: _temp.dstcountry
       target_field: fortimanager.log.dstcountry
       ignore_missing: true
+      tag: rename_21dbef08
   - set:
       field: destination.geo.country_name
       copy_from: fortimanager.log.dstcountry
       ignore_empty_value: true
+      tag: set_61d4381c
   - rename:
       field: _temp.unauthuser
       target_field: fortimanager.log.unauthuser
       ignore_missing: true
+      tag: rename_67b40726
   - set:
       field: user.name
       copy_from: fortimanager.log.unauthuser
       ignore_empty_value: true
+      tag: set_4390f24c
   - convert:
       field: _temp.sentbyte
       tag: 'convert_sentbyte'
@@ -1067,6 +1246,7 @@ processors:
       field: source.bytes
       copy_from: fortimanager.log.sentbyte
       ignore_empty_value: true
+      tag: set_df8989a6
   - convert:
       field: _temp.rcvdbyte
       tag: 'convert_rcvdbyte'
@@ -1082,38 +1262,47 @@ processors:
       field: destination.bytes
       copy_from: fortimanager.log.rcvdbyte
       ignore_empty_value: true
+      tag: set_f80b7804
   - rename:
       field: _temp.osname
       target_field: fortimanager.log.osname
       ignore_missing: true
+      tag: rename_52f0e284
   - set:
       field: os.name
       copy_from: fortimanager.log.osname
       ignore_empty_value: true
+      tag: set_ea7f6724
   - rename:
       field: _temp.direction
       target_field: fortimanager.log.direction
       ignore_missing: true
+      tag: rename_f9cebeea
   - set:
       field: network.direction
       copy_from: fortimanager.log.direction
       ignore_empty_value: true
+      tag: set_77083bde
   - set:
       field: network.direction
       value: inbound
       if: ctx.network?.direction == "incoming"
+      tag: set_cd0a6b2a
   - set:
       field: network.direction
       value: outbound
       if: ctx.network?.direction == "outgoing"
+      tag: set_a3958939
   - rename:
       field: _temp.crlevel
       target_field: fortimanager.log.crlevel
       ignore_missing: true
+      tag: rename_b1ad410a
   - set:
       field: risk.static_level
       copy_from: fortimanager.log.crlevel
       ignore_empty_value: true
+      tag: set_9d9bbe3d
   - convert:
       field: _temp.crscore
       tag: 'convert_crscore'
@@ -1129,25 +1318,31 @@ processors:
       field: risk.static_score_norm
       copy_from: fortimanager.log.crscore
       ignore_empty_value: true
+      tag: set_5cd21b42
   - rename:
       field: _temp.apprisk
       target_field: fortimanager.log.apprisk
       ignore_missing: true
+      tag: rename_1ee434a2
   - rename:
       field: _temp.appcat
       target_field: fortimanager.log.appcat
       ignore_missing: true
+      tag: rename_04c5a1d4
   - set:
       field: rule.category
       copy_from: fortimanager.log.appcat
       ignore_empty_value: true
+      tag: set_a59da295
   - set:
       field: network.transport
       copy_from: fortimanager.log.protocol
       ignore_empty_value: true
+      tag: set_d4ba446d
   - lowercase:
       field: network.transport
       ignore_missing: true
+      tag: lowercase_bc8c1c12
   - convert:
       field: _temp.address
       tag: 'convert_address_to_ip'
@@ -1164,25 +1359,30 @@ processors:
       value: '{{{fortimanager.log.address}}}'
       if: ctx._temp?.address != null
       allow_duplicates: false
+      tag: append_3e9017fb
   - append:
       field: related.user
       value: '{{{user.id}}}'
       if: ctx.user?.id != null
       allow_duplicates: false
+      tag: append_7f407fef
   - append:
       field: related.user
       value: '{{{user.name}}}'
       if: ctx.user?.name != null
       allow_duplicates: false
+      tag: append_837e080f
   - append:
       field: related.user
       value: '{{{user.domain}}}'
       if: ctx.user?.domain != null
       allow_duplicates: false
+      tag: append_45d9c089
   - set:
       field: observer.serial_number
       copy_from: fortimanager.log.serial
       ignore_empty_value: true
+      tag: set_08e7f996
   - date:
       field: _temp.end_time
       tag: 'date_end_time'
@@ -1199,6 +1399,7 @@ processors:
       field: event.end
       copy_from: fortimanager.log.end_time
       ignore_empty_value: true
+      tag: set_5548ecd6
   - date:
       field: _temp.start_time
       tag: 'date_start_time'
@@ -1214,6 +1415,7 @@ processors:
       field: event.start
       copy_from: fortimanager.log.start_time
       ignore_empty_value: true
+      tag: set_f496f724
   - date:
       field: _temp.itime
       tag: 'date_itime'
@@ -1253,14 +1455,17 @@ processors:
       field: _temp.lickey_type
       target_field: fortimanager.log.lickey_type
       ignore_missing: true
+      tag: rename_7ee3ba62
   - rename:
       field: _temp.lnk_path
       target_field: fortimanager.log.lnk_path
       ignore_missing: true
+      tag: rename_30db1c58
   - rename:
       field: _temp.local_file
       target_field: fortimanager.log.local_file
       ignore_missing: true
+      tag: rename_b3c02eea
   - convert:
       field: _temp.license_type
       tag: 'convert_license_type_to_long'
@@ -1406,12 +1611,14 @@ processors:
         if (fortianalyzer_product.contains(ctx.fortimanager.log.subtype)) {
           ctx.fortimanager.log.product = "fortianalyzer";
         }
+      tag: script_eec1c3ae
   - remove:
       field:
         - temp
         - _temp
         - syslog5424_sd
       ignore_missing: true
+      tag: remove_623dc767
   - remove:
       if: ctx.tags == null || !(ctx.tags.contains('preserve_duplicate_custom_fields'))
       field:
@@ -1449,6 +1656,7 @@ processors:
         - fortimanager.log.user.id
         - fortimanager.log.user.name
       ignore_missing: true
+      tag: remove_3460c02f
   - script:
       lang: painless
       source: |-
@@ -1466,14 +1674,19 @@ processors:
         }
         drop(ctx);
       description: Drops null/empty values recursively.
+      tag: script_06971239
   - set:
       field: event.kind
       value: pipeline_error
       if: ctx.error?.message != null
+      tag: set_92954dfa
 on_failure:
   - append:
       field: error.message
-      value: '{{{_ingest.on_failure_message}}}'
+      value: >-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{/_ingest.on_failure_processor_tag}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       value: pipeline_error


### PR DESCRIPTION
## Proposed commit message

- Generate tags for processors missing tags
- Normalize the pipeline error handler

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~
