### PR TITLE
Add missing information on the HAProxy Integration documentation

### DIFF
--- a/packages/haproxy/_dev/build/docs/README.md
+++ b/packages/haproxy/_dev/build/docs/README.md
@@ -2,7 +2,7 @@
 
 This integration periodically fetches logs and metrics from [HAProxy](https://www.haproxy.org/) servers.
 
-Metricbeat can collect two metricsets from HAProxy: `info` and `stat`. `info` is not available when using the stats page. For more information, refer to the [HAProxy module](https://www.elastic.co/docs/reference/beats/metricbeat/metricbeat-module-haproxy).
+The Integration can collect metrics in two datastreams from HAProxy: `info` and `stat`. `info` is not available when using the stats page. For more information, refer to the [HAProxy module](https://www.elastic.co/docs/reference/beats/metricbeat/metricbeat-module-haproxy).
 
 ## Compatibility
 

--- a/packages/haproxy/_dev/build/docs/README.md
+++ b/packages/haproxy/_dev/build/docs/README.md
@@ -2,17 +2,19 @@
 
 This integration periodically fetches logs and metrics from [HAProxy](https://www.haproxy.org/) servers.
 
+Metricbeat can collect two metricsets from HAProxy: `info` and `stat`. `info` is not available when using the stats page. For more information, refer to the [HAProxy module](https://www.elastic.co/docs/reference/beats/metricbeat/metricbeat-module-haproxy).
+
 ## Compatibility
 
-The `log` dataset was tested with logs from HAProxy 1.8, 1.9 and 2.0, 2.6 running on a Debian. It is not available on Windows. 
-The integration supports the default log patterns below:
+The `log` dataset was tested with logs from HAProxy `1.8`, `1.9` and `2.0`, `2.6` running on a Debian. It is not available on Windows. 
+The integration supports the following default log patterns:
 * [Default log format](https://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.1)
 * [TCP log format](https://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.2)
 * [HTTP log format](https://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.3)
 * [HTTPS log format](https://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.4)
 * [Error log format](https://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.5)
 
-The `info` and `stat` datasets were tested with tested with HAProxy versions from 1.6, 1.7, 1.8 to 2.0. 
+The `info` and `stat` datasets were tested with HAProxy versions from `1.6`, `1.7`, `1.8` to `2.0`. 
 
 ## Troubleshooting
 
@@ -28,7 +30,7 @@ The `log` dataset collects the HAProxy application logs.
 
 **ECS Field Reference**
 
-Please refer to the following [document](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) for detailed information on ECS fields.
+Refer to the following [document](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) for detailed information on ECS fields.
 
 {{fields "log"}}
 
@@ -45,7 +47,7 @@ The fields reported are:
 
 **ECS Field Reference**
 
-Please refer to the following [document](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) for detailed information on ECS fields.
+Refer to the following [document](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) for detailed information on ECS fields.
 
 {{fields "info"}}
 
@@ -61,6 +63,6 @@ The fields reported are:
 
 **ECS Field Reference**
 
-Please refer to the following [document](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) for detailed information on ECS fields.
+Refer to the following [document](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) for detailed information on ECS fields.
 
 {{fields "stat"}}

--- a/packages/haproxy/changelog.yml
+++ b/packages/haproxy/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.17.1"
+  changes:
+    - description: Add missing information on the HAProxy Integration documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/15550
 - version: "1.17.0"
   changes:
     - description: Allow @custom pipeline access to event.original without setting preserve_original_event.

--- a/packages/haproxy/docs/README.md
+++ b/packages/haproxy/docs/README.md
@@ -2,7 +2,7 @@
 
 This integration periodically fetches logs and metrics from [HAProxy](https://www.haproxy.org/) servers.
 
-Metricbeat can collect two metricsets from HAProxy: `info` and `stat`. `info` is not available when using the stats page. For more information, refer to the [HAProxy module](https://www.elastic.co/docs/reference/beats/metricbeat/metricbeat-module-haproxy).
+The Integration can collect metrics in two datastreams from HAProxy: `info` and `stat`. `info` is not available when using the stats page. For more information, refer to the [HAProxy module](https://www.elastic.co/docs/reference/beats/metricbeat/metricbeat-module-haproxy).
 
 ## Compatibility
 

--- a/packages/haproxy/docs/README.md
+++ b/packages/haproxy/docs/README.md
@@ -2,17 +2,19 @@
 
 This integration periodically fetches logs and metrics from [HAProxy](https://www.haproxy.org/) servers.
 
+Metricbeat can collect two metricsets from HAProxy: `info` and `stat`. `info` is not available when using the stats page. For more information, refer to the [HAProxy module](https://www.elastic.co/docs/reference/beats/metricbeat/metricbeat-module-haproxy).
+
 ## Compatibility
 
-The `log` dataset was tested with logs from HAProxy 1.8, 1.9 and 2.0, 2.6 running on a Debian. It is not available on Windows. 
-The integration supports the default log patterns below:
+The `log` dataset was tested with logs from HAProxy `1.8`, `1.9` and `2.0`, `2.6` running on a Debian. It is not available on Windows. 
+The integration supports the following default log patterns:
 * [Default log format](https://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.1)
 * [TCP log format](https://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.2)
 * [HTTP log format](https://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.3)
 * [HTTPS log format](https://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.4)
 * [Error log format](https://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.5)
 
-The `info` and `stat` datasets were tested with tested with HAProxy versions from 1.6, 1.7, 1.8 to 2.0. 
+The `info` and `stat` datasets were tested with HAProxy versions from `1.6`, `1.7`, `1.8` to `2.0`. 
 
 ## Troubleshooting
 
@@ -175,7 +177,7 @@ An example event for `log` looks as following:
 
 **ECS Field Reference**
 
-Please refer to the following [document](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) for detailed information on ECS fields.
+Refer to the following [document](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) for detailed information on ECS fields.
 
 **Exported fields**
 
@@ -354,7 +356,7 @@ The fields reported are:
 
 **ECS Field Reference**
 
-Please refer to the following [document](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) for detailed information on ECS fields.
+Refer to the following [document](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) for detailed information on ECS fields.
 
 **Exported fields**
 
@@ -537,7 +539,7 @@ The fields reported are:
 
 **ECS Field Reference**
 
-Please refer to the following [document](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) for detailed information on ECS fields.
+Refer to the following [document](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) for detailed information on ECS fields.
 
 **Exported fields**
 

--- a/packages/haproxy/manifest.yml
+++ b/packages/haproxy/manifest.yml
@@ -1,6 +1,6 @@
 name: haproxy
 title: HAProxy
-version: "1.17.0"
+version: "1.17.1"
 description: Collect logs and metrics from HAProxy servers with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
This PR:
- adds missing information about metricsets that can be collected from HAProxy
- suggests some edits

Closes https://github.com/elastic/docs-content/issues/3204.