### PR TITLE
[imperva] Generate processor tags and normalize error handler

### DIFF
--- a/packages/imperva/changelog.yml
+++ b/packages/imperva/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.2"
+  changes:
+    - description: Generate processor tags and normalize error handler.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/15560
 - version: "1.8.1"
   changes:
     - description: Fixed H1s for SEO purpose.

--- a/packages/imperva/data_stream/securesphere/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/imperva/data_stream/securesphere/elasticsearch/ingest_pipeline/default.yml
@@ -29,6 +29,7 @@ processors:
       if: ctx.cef?.extensions?.deviceReceiptTime != null && ctx.cef.extensions.deviceReceiptTime != ''
       on_failure:
         - append:
+            tag: append_error_message_41c96989
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -40,6 +41,7 @@ processors:
       if: ctx.cef?.extensions?.deviceReceiptTime != null && ctx.cef.extensions.deviceReceiptTime != '' && ctx.event?.timezone != null
       on_failure:
         - append:
+            tag: append_error_message_f70204ac
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -51,6 +53,7 @@ processors:
       if: ctx.cef?.extensions?.deviceReceiptTime != null && ctx.cef.extensions.deviceReceiptTime != ''
       on_failure:
         - append:
+            tag: append_error_message_9311b514
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -63,6 +66,7 @@ processors:
       if: ctx.cef?.extensions?.deviceReceiptTime != null && ctx.cef.extensions.deviceReceiptTime != '' && ctx.event?.timezone != null
       on_failure:
         - append:
+            tag: append_error_message_985ef094
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -74,6 +78,7 @@ processors:
       if: ctx.cef?.extensions?.destinationAddress != ''
       on_failure:
         - append:
+            tag: append_error_message_2b116b24
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
@@ -90,6 +95,7 @@ processors:
       if: ctx.cef?.extensions?.destinationPort != ''
       on_failure:
         - append:
+            tag: append_error_message_3c76337c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -156,6 +162,7 @@ processors:
       if: ctx.cef?.extensions?.sourceAddress != ''
       on_failure:
         - append:
+            tag: append_error_message_438925ec
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
@@ -172,6 +179,7 @@ processors:
       if: ctx.cef?.extensions?.sourcePort != ''
       on_failure:
         - append:
+            tag: append_error_message_fc978a99
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -331,7 +339,11 @@ processors:
 on_failure:
   - append:
       field: error.message
-      value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+      value: >-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
+        failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       value: pipeline_error

--- a/packages/imperva/manifest.yml
+++ b/packages/imperva/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: imperva
 title: Imperva
-version: "1.8.1"
+version: "1.8.2"
 description: Collect logs from Imperva devices with Elastic Agent.
 categories: ["network", "security"]
 type: integration


### PR DESCRIPTION
## Proposed commit message

- Generate tags for processors missing tags
- Normalize the pipeline error handler

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~
