### PR TITLE
[CI] Set url parameter in gvm command

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -114,7 +114,7 @@ with_go() {
   echo "GVM ${SETUP_GVM_VERSION} (platform ${platform_type_lowercase} arch ${arch_type}"
   retry 5 curl -sL -o "${BIN_FOLDER}/gvm" "https://github.com/andrewkroh/gvm/releases/download/${SETUP_GVM_VERSION}/gvm-${platform_type_lowercase}-${arch_type}"
   chmod +x "${BIN_FOLDER}/gvm"
-  eval "$(gvm "$(cat .go-version)")"
+  eval "$(gvm --url=https://go.dev/dl "$(cat .go-version)")"
   go version
   which go
   PATH="${PATH}:$(go env GOPATH):$(go env GOPATH)/bin"


### PR DESCRIPTION
## Proposed commit message

https://storage.googleapis.com/golang/ is not working, see https://storage.googleapis.com/golang/go1.24.2.linux-amd64.tar.gz

```
GVM v0.5.2 (platform linux arch amd64
gvm: error: failed downloading from https://storage.googleapis.com/golang/go1.24.2.linux-amd64.tar.gz: download failed with http status 403: %!w(<nil>)
.buildkite/scripts/common.sh: line 118: go: command not found
```

Example build: https://buildkite.com/elastic/integrations/builds/32819#0199f313-c9a5-4f33-9588-6995391205bb