### PR TITLE
[CI] Update GVM version

### DIFF
--- a/.buildkite/pipeline.publish.yml
+++ b/.buildkite/pipeline.publish.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 
 env:
-  SETUP_GVM_VERSION: "v0.5.2"
+  SETUP_GVM_VERSION: "v0.6.0"
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
   DOCKER_COMPOSE_VERSION: "v2.24.1"
   DOCKER_VERSION: "false"

--- a/.buildkite/pipeline.schedule-daily.yml
+++ b/.buildkite/pipeline.schedule-daily.yml
@@ -2,7 +2,7 @@
 name: integrations-schedule-daily
 
 env:
-  SETUP_GVM_VERSION: "v0.5.2"
+  SETUP_GVM_VERSION: "v0.6.0"
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
 
 # The pipeline is triggered by the scheduler every day

--- a/.buildkite/pipeline.schedule-weekly.yml
+++ b/.buildkite/pipeline.schedule-weekly.yml
@@ -2,7 +2,7 @@
 name: integrations-schedule-weekly
 
 env:
-  SETUP_GVM_VERSION: "v0.5.2"
+  SETUP_GVM_VERSION: "v0.6.0"
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
 
 # The pipeline is triggered by the scheduler every week

--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 
 env:
-  SETUP_GVM_VERSION: "v0.5.2"
+  SETUP_GVM_VERSION: "v0.6.0"
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
   DOCKER_COMPOSE_VERSION: "v2.24.1"
   DOCKER_VERSION: "false" # not required to set since system tests are not running yet

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 env:
-  SETUP_GVM_VERSION: "v0.5.2"
+  SETUP_GVM_VERSION: "v0.6.0"
   DOCKER_COMPOSE_VERSION: "v2.24.1"
   DOCKER_VERSION: "26.1.2"
   KIND_VERSION: 'v0.27.0'

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -114,7 +114,7 @@ with_go() {
   echo "GVM ${SETUP_GVM_VERSION} (platform ${platform_type_lowercase} arch ${arch_type}"
   retry 5 curl -sL -o "${BIN_FOLDER}/gvm" "https://github.com/andrewkroh/gvm/releases/download/${SETUP_GVM_VERSION}/gvm-${platform_type_lowercase}-${arch_type}"
   chmod +x "${BIN_FOLDER}/gvm"
-  eval "$(gvm --url=https://go.dev/dl "$(cat .go-version)")"
+  eval "$(gvm "$(cat .go-version)")"
   go version
   which go
   PATH="${PATH}:$(go env GOPATH):$(go env GOPATH)/bin"


### PR DESCRIPTION
Follows #15675

Update to the latest GVM version ([v0.6.0](https://github.com/andrewkroh/gvm/releases/tag/v0.6.0)) to avoid issues downloading Golang versions
