### PR TITLE
Remove promote and publish commands

### DIFF
--- a/docs/extend/elastic-package.md
+++ b/docs/extend/elastic-package.md
@@ -247,25 +247,6 @@ Use this command to add, remove, and manage multiple config profiles.
 Individual user profiles appear in ~/.elastic-package/stack and contain all the config files needed by the "stack" subcommand. Once a new profile is created, it can be specified with the -p flag, or the ELASTIC_PACKAGE_PROFILE environment variable. User profiles are not overwritten on an upgrade of elastic-stack and can be freely modified to allow for different stack configs.
 
 
-### `elastic-package promote` [_elastic_package_promote]
-
-*Context: global*
-
-Use this command to move packages between the {{package-registry}} snapshot, staging, and production stages.
-
-This command is intended primarily for use by administrators.
-
-It allows for selecting packages for promotion and opens new pull requests to review changes. However, please be aware that the tool checks out an in-memory Git repository and switches over branches (snapshot, staging and production), so it may take longer to promote a larger number of packages.
-
-
-### `elastic-package publish` [_elastic_package_publish]
-
-*Context: package*
-
-Use this command to publish a new package revision.
-
-The command checks if the package has already been published (whether it’s present in the snapshot/staging/production branch or open as pull request). If the package revision hasn’t been published, it will open a new pull request.
-
 ### `elastic-package report` [_elastic_package_report]
 
 *Context: package*


### PR DESCRIPTION
The promote and publish commands do not exist anymore. When running the latest elastic-package with v0.115.0, there is no `promote` and `publish` command available anymore.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
