### PR TITLE
openai: Update dashboard to remove internal regex filters

### DIFF
--- a/packages/openai/changelog.yml
+++ b/packages/openai/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Relax internal filters for image, audio transcription and audio speech charts
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/15740
 - version: "1.2.0"
   changes:
     - description: Update OpenAI dashboard screenshots.

--- a/packages/openai/kibana/dashboard/openai-651bb059-f606-44fc-b704-2078d0af26da.json
+++ b/packages/openai/kibana/dashboard/openai-651bb059-f606-44fc-b704-2078d0af26da.json
@@ -2573,17 +2573,13 @@
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-0d76c878-9134-41d9-a09e-d2dab922806f",
                                 "type": "index-pattern"
-                            },
-                            {
-                                "id": "logs-*",
-                                "name": "27dea502-7bcb-466b-8d50-4dea78307b9b",
-                                "type": "index-pattern"
                             }
                         ],
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
+                                    "currentIndexPatternId": "logs-*",
                                     "layers": {
                                         "0d76c878-9134-41d9-a09e-d2dab922806f": {
                                             "columnOrder": [
@@ -2600,10 +2596,8 @@
                                                     "params": {
                                                         "exclude": [],
                                                         "excludeIsRegex": false,
-                                                        "include": [
-                                                            "dall-e.*"
-                                                        ],
-                                                        "includeIsRegex": true,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
                                                             "columnId": "c94dd296-dd60-473a-adbb-89e5b2376d81",
@@ -2656,6 +2650,7 @@
                                                 }
                                             },
                                             "incompleteColumns": {},
+                                            "indexPatternId": "logs-*",
                                             "sampling": 1
                                         }
                                     }
@@ -3066,17 +3061,13 @@
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-0d76c878-9134-41d9-a09e-d2dab922806f",
                                 "type": "index-pattern"
-                            },
-                            {
-                                "id": "logs-*",
-                                "name": "1e0f9983-9110-4925-a91c-e17b3dd5d87d",
-                                "type": "index-pattern"
                             }
                         ],
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
+                                    "currentIndexPatternId": "logs-*",
                                     "layers": {
                                         "0d76c878-9134-41d9-a09e-d2dab922806f": {
                                             "columnOrder": [
@@ -3093,10 +3084,8 @@
                                                     "params": {
                                                         "exclude": [],
                                                         "excludeIsRegex": false,
-                                                        "include": [
-                                                            "whisper.*"
-                                                        ],
-                                                        "includeIsRegex": true,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
                                                             "columnId": "d85b18e7-10ac-4b0b-8c4d-3d5dd3709809",
@@ -3149,6 +3138,7 @@
                                                 }
                                             },
                                             "incompleteColumns": {},
+                                            "indexPatternId": "logs-*",
                                             "sampling": 1
                                         }
                                     }
@@ -3292,17 +3282,13 @@
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-d3c5bffd-6606-48cd-aac8-70e02b9e9313",
                                 "type": "index-pattern"
-                            },
-                            {
-                                "id": "logs-*",
-                                "name": "788b915a-9a0c-46ea-a4ca-d24b6393c356",
-                                "type": "index-pattern"
                             }
                         ],
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
+                                    "currentIndexPatternId": "logs-*",
                                     "layers": {
                                         "d3c5bffd-6606-48cd-aac8-70e02b9e9313": {
                                             "columnOrder": [
@@ -3332,10 +3318,8 @@
                                                     "params": {
                                                         "exclude": [],
                                                         "excludeIsRegex": false,
-                                                        "include": [
-                                                            "whisper.*"
-                                                        ],
-                                                        "includeIsRegex": true,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
                                                             "columnId": "89cb498b-8b47-433f-bbd6-313505aa5fd4",
@@ -3375,6 +3359,7 @@
                                                 }
                                             },
                                             "incompleteColumns": {},
+                                            "indexPatternId": "logs-*",
                                             "sampling": 1
                                         }
                                     }
@@ -3565,17 +3550,13 @@
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-37156e1a-3437-42ab-8db3-c832eefff967",
                                 "type": "index-pattern"
-                            },
-                            {
-                                "id": "logs-*",
-                                "name": "473ddac7-366a-4baf-bb6e-7e1c68a290c6",
-                                "type": "index-pattern"
                             }
                         ],
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
+                                    "currentIndexPatternId": "logs-*",
                                     "layers": {
                                         "37156e1a-3437-42ab-8db3-c832eefff967": {
                                             "columnOrder": [
@@ -3605,10 +3586,8 @@
                                                     "params": {
                                                         "exclude": [],
                                                         "excludeIsRegex": false,
-                                                        "include": [
-                                                            "tts.*"
-                                                        ],
-                                                        "includeIsRegex": true,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
                                                             "columnId": "96a6212b-f493-43d3-8925-4d2539ee2f4a",
@@ -3648,6 +3627,7 @@
                                                 }
                                             },
                                             "incompleteColumns": {},
+                                            "indexPatternId": "logs-*",
                                             "sampling": 1
                                         }
                                     }
@@ -3791,17 +3771,13 @@
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-bb4d07a4-2a14-4a28-bfb9-ccda92c07342",
                                 "type": "index-pattern"
-                            },
-                            {
-                                "id": "logs-*",
-                                "name": "9e78dce0-718f-41c9-95ae-c030b9acd33a",
-                                "type": "index-pattern"
                             }
                         ],
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
+                                    "currentIndexPatternId": "logs-*",
                                     "layers": {
                                         "bb4d07a4-2a14-4a28-bfb9-ccda92c07342": {
                                             "columnOrder": [
@@ -3854,10 +3830,8 @@
                                                     "params": {
                                                         "exclude": [],
                                                         "excludeIsRegex": false,
-                                                        "include": [
-                                                            "tts.*"
-                                                        ],
-                                                        "includeIsRegex": true,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
                                                             "columnId": "480e26d3-381b-49c1-a245-6e8eca2d2028",
@@ -3875,6 +3849,7 @@
                                                 }
                                             },
                                             "incompleteColumns": {},
+                                            "indexPatternId": "logs-*",
                                             "sampling": 1
                                         }
                                     }
@@ -4014,9 +3989,8 @@
         "version": 2
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2025-02-02T15:41:14.743Z",
+    "created_at": "2025-10-23T19:58:51.586Z",
     "id": "openai-651bb059-f606-44fc-b704-2078d0af26da",
-    "managed": false,
     "references": [
         {
             "id": "logs-*",
@@ -4105,11 +4079,6 @@
         },
         {
             "id": "logs-*",
-            "name": "d7884746-198f-450b-90e4-6204de7c1634:27dea502-7bcb-466b-8d50-4dea78307b9b",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
             "name": "843baace-4ec5-4254-9e7f-39f7c7ea6d73:indexpattern-datasource-layer-1a91a845-9919-443d-aeea-025574284aff",
             "type": "index-pattern"
         },
@@ -4125,17 +4094,7 @@
         },
         {
             "id": "logs-*",
-            "name": "e6502014-2b10-45a2-8cc1-05f21556eb8e:1e0f9983-9110-4925-a91c-e17b3dd5d87d",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
             "name": "42f5b7f5-a9e2-42ab-91b0-f094bf6355a1:indexpattern-datasource-layer-d3c5bffd-6606-48cd-aac8-70e02b9e9313",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
-            "name": "42f5b7f5-a9e2-42ab-91b0-f094bf6355a1:788b915a-9a0c-46ea-a4ca-d24b6393c356",
             "type": "index-pattern"
         },
         {
@@ -4145,17 +4104,7 @@
         },
         {
             "id": "logs-*",
-            "name": "189f3a33-8ec3-4f8b-b65b-f84edfa63ad0:473ddac7-366a-4baf-bb6e-7e1c68a290c6",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
             "name": "5263c7c4-ddee-4f8b-b474-7c7c25cc8b3e:indexpattern-datasource-layer-bb4d07a4-2a14-4a28-bfb9-ccda92c07342",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
-            "name": "5263c7c4-ddee-4f8b-b474-7c7c25cc8b3e:9e78dce0-718f-41c9-95ae-c030b9acd33a",
             "type": "index-pattern"
         }
     ],

--- a/packages/openai/manifest.yml
+++ b/packages/openai/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.0
 name: openai
 title: OpenAI
-version: 1.2.0
+version: 1.2.1
 description: |
   Collect OpenAI usage metrics with Elastic Agent.
 type: integration


### PR DESCRIPTION
## Proposed commit message

No visual changes. So internally, OpenAI changed the name of their image model to `dall-e` to `unclip-029-dapi` and it is reflecting in the older data as well. So specifically in image and audio charts we were using regex filters like `dall-e.*`, `whisper.*`, etc. and hence this PR removes those filters so that because of any change in model name or new models, charts render as expected.

This issue was noticed when one of the charts that depended on it did not render although data was there because it was using `dall-e.*` regex and OpenAI changed the name and that model name isn't even there.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)