### PR TITLE
feat(elastic_agent): parse Elastic Defend log level

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,10 @@
 # newer versions go on top
+- version: "2.6.5"
+  changes:
+    - description: >-
+        Parse log level from Elastic Defend installation command output to address incorrect labeling where all stderr output appears as `log.level: error`.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/15769
 - version: "2.6.4"
   changes:
     - description: Adds alerting rule templates

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/_dev/test/pipeline/test-endpoint-security-install.json
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/_dev/test/pipeline/test-endpoint-security-install.json
@@ -1,0 +1,88 @@
+{
+  "events": [
+    {
+      "agent": {
+        "name": "test-host-12345",
+        "id": "a4461838-ba9e-4221-852e-16606e179b58",
+        "type": "filebeat",
+        "ephemeral_id": "aa707259-bbdf-4fe3-a097-c41689db6e78",
+        "version": "9.2.0"
+      },
+      "log": {
+        "file": {
+          "path": "C:\\Program Files\\Elastic\\Agent\\data\\elastic-agent-9.2.0-e7bf31\\logs\\elastic-agent-20251027-1.ndjson"
+        }
+      },
+      "elastic_agent": {
+        "id": "a4461838-ba9e-4221-852e-16606e179b58",
+        "version": "9.2.0",
+        "snapshot": false
+      },
+      "message": "2025-10-27 16:09:04: debug: Util.cpp:520 Setting up minifilter registry keys successful.",
+      "log.logger": "component.runtime.endpoint-default.service_runtime",
+      "cloud": {
+        "image": {
+          "id": "ami-021158f59b67638f2"
+        },
+        "availability_zone": "us-east-2b",
+        "instance": {
+          "id": "i-1111111111111111a"
+        },
+        "provider": "aws",
+        "service": {
+          "name": "EC2"
+        },
+        "machine": {
+          "type": "t2.micro"
+        },
+        "region": "us-east-2",
+        "account": {
+          "id": "111111111111"
+        }
+      },
+      "log.origin": {
+        "file.line": 68,
+        "function": "github.com/elastic/elastic-agent/pkg/component/runtime.executeCommand.func2",
+        "file.name": "runtime/service_command.go"
+      },
+      "@timestamp": "2025-10-27T16:09:04.525Z",
+      "ecs": {
+        "version": "8.0.0"
+      },
+      "data_stream": {
+        "namespace": "default",
+        "type": "logs",
+        "dataset": "elastic_agent"
+      },
+      "host": {
+        "hostname": "test-host-12345",
+        "os": {
+          "build": "20348.4294",
+          "kernel": "10.0.20348.4294 (WinBuild.160101.0800)",
+          "name": "Windows Server 2022 Datacenter",
+          "family": "windows",
+          "type": "windows",
+          "version": "10.0",
+          "platform": "windows"
+        },
+        "ip": [
+          "fe80::9d46:c45c:a144:b134",
+          "172.31.31.13"
+        ],
+        "name": "test-host-12345",
+        "id": "df8784f0-bc0e-48f2-b0bf-e934002587fd",
+        "mac": [
+          "06-E8-B3-CB-66-F1"
+        ],
+        "architecture": "x86_64"
+      },
+      "context": "command output",
+      "log.level": "error",
+      "event": {
+        "agent_id_status": "verified",
+        "ingested": "2025-10-27T16:09:08Z",
+        "dataset": "elastic_agent"
+      }
+    }
+  ]
+}

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/_dev/test/pipeline/test-endpoint-security-install.json-expected.json
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/_dev/test/pipeline/test-endpoint-security-install.json-expected.json
@@ -1,0 +1,88 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2025-10-27T16:09:04.525Z",
+            "agent": {
+                "ephemeral_id": "aa707259-bbdf-4fe3-a097-c41689db6e78",
+                "id": "a4461838-ba9e-4221-852e-16606e179b58",
+                "name": "test-host-12345",
+                "type": "filebeat",
+                "version": "9.2.0"
+            },
+            "cloud": {
+                "account": {
+                    "id": "111111111111"
+                },
+                "availability_zone": "us-east-2b",
+                "image": {
+                    "id": "ami-021158f59b67638f2"
+                },
+                "instance": {
+                    "id": "i-1111111111111111a"
+                },
+                "machine": {
+                    "type": "t2.micro"
+                },
+                "provider": "aws",
+                "region": "us-east-2",
+                "service": {
+                    "name": "EC2"
+                }
+            },
+            "context": "command output",
+            "data_stream": {
+                "dataset": "elastic_agent",
+                "namespace": "default",
+                "type": "logs"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "elastic_agent": {
+                "id": "a4461838-ba9e-4221-852e-16606e179b58",
+                "snapshot": false,
+                "version": "9.2.0"
+            },
+            "event": {
+                "agent_id_status": "verified",
+                "dataset": "elastic_agent",
+                "ingested": "2025-10-27T16:09:08Z"
+            },
+            "host": {
+                "architecture": "x86_64",
+                "hostname": "test-host-12345",
+                "id": "df8784f0-bc0e-48f2-b0bf-e934002587fd",
+                "ip": [
+                    "fe80::9d46:c45c:a144:b134",
+                    "172.31.31.13"
+                ],
+                "mac": [
+                    "06-E8-B3-CB-66-F1"
+                ],
+                "name": "test-host-12345",
+                "os": {
+                    "build": "20348.4294",
+                    "family": "windows",
+                    "kernel": "10.0.20348.4294 (WinBuild.160101.0800)",
+                    "name": "Windows Server 2022 Datacenter",
+                    "platform": "windows",
+                    "type": "windows",
+                    "version": "10.0"
+                }
+            },
+            "log": {
+                "file": {
+                    "path": "C:\\Program Files\\Elastic\\Agent\\data\\elastic-agent-9.2.0-e7bf31\\logs\\elastic-agent-20251027-1.ndjson"
+                },
+                "level": "debug"
+            },
+            "log.logger": "component.runtime.endpoint-default.service_runtime",
+            "log.origin": {
+                "file.line": 68,
+                "file.name": "runtime/service_command.go",
+                "function": "github.com/elastic/elastic-agent/pkg/component/runtime.executeCommand.func2"
+            },
+            "message": "2025-10-27 16:09:04: debug: Util.cpp:520 Setting up minifilter registry keys successful."
+        }
+    ]
+}

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/_dev/test/pipeline/test-unit-state-change.json
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/_dev/test/pipeline/test-unit-state-change.json
@@ -1,0 +1,96 @@
+{
+  "events": [
+    {
+      "agent": {
+        "name": "test-host-12345",
+        "id": "a4461838-ba9e-4221-852e-16606e179b58",
+        "ephemeral_id": "aa707259-bbdf-4fe3-a097-c41689db6e78",
+        "type": "filebeat",
+        "version": "9.2.0"
+      },
+      "log": {
+        "file": {
+          "path": "C:\\Program Files\\Elastic\\Agent\\data\\elastic-agent-9.2.0-e7bf31\\logs\\elastic-agent-20251027-1.ndjson"
+        }
+      },
+      "elastic_agent": {
+        "id": "a4461838-ba9e-4221-852e-16606e179b58",
+        "version": "9.2.0",
+        "snapshot": false
+      },
+      "message": "Unit state changed endpoint-default (STARTING->CONFIGURING): ",
+      "cloud": {
+        "availability_zone": "us-east-2b",
+        "image": {
+          "id": "ami-021158f59b67638f2"
+        },
+        "instance": {
+          "id": "i-1111111111111111a"
+        },
+        "provider": "aws",
+        "machine": {
+          "type": "t2.micro"
+        },
+        "service": {
+          "name": "EC2"
+        },
+        "region": "us-east-2",
+        "account": {
+          "id": "111111111111"
+        }
+      },
+      "log.origin": {
+        "file.line": 1024,
+        "function": "github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator.logComponentStateChange",
+        "file.name": "coordinator/coordinator.go"
+      },
+      "unit": {
+        "old_state": "STARTING",
+        "id": "endpoint-default",
+        "state": "CONFIGURING",
+        "type": "output"
+      },
+      "component": {
+        "state": "HEALTHY",
+        "id": "endpoint-default"
+      },
+      "@timestamp": "2025-10-27T16:09:33.495Z",
+      "ecs": {
+        "version": "8.0.0"
+      },
+      "data_stream": {
+        "namespace": "default",
+        "type": "logs",
+        "dataset": "elastic_agent"
+      },
+      "host": {
+        "hostname": "test-host-12345",
+        "os": {
+          "build": "20348.4294",
+          "kernel": "10.0.20348.4294 (WinBuild.160101.0800)",
+          "name": "Windows Server 2022 Datacenter",
+          "type": "windows",
+          "family": "windows",
+          "version": "10.0",
+          "platform": "windows"
+        },
+        "ip": [
+          "fe80::9d46:c45c:a144:b134",
+          "172.31.31.13"
+        ],
+        "name": "test-host-12345",
+        "id": "df8784f0-bc0e-48f2-b0bf-e934002587fd",
+        "mac": [
+          "06-E8-B3-CB-66-F1"
+        ],
+        "architecture": "x86_64"
+      },
+      "log.level": "info",
+      "event": {
+        "agent_id_status": "verified",
+        "ingested": "2025-10-27T16:09:45Z",
+        "dataset": "elastic_agent"
+      }
+    }
+  ]
+}

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/_dev/test/pipeline/test-unit-state-change.json-expected.json
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/_dev/test/pipeline/test-unit-state-change.json-expected.json
@@ -1,0 +1,96 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2025-10-27T16:09:33.495Z",
+            "agent": {
+                "ephemeral_id": "aa707259-bbdf-4fe3-a097-c41689db6e78",
+                "id": "a4461838-ba9e-4221-852e-16606e179b58",
+                "name": "test-host-12345",
+                "type": "filebeat",
+                "version": "9.2.0"
+            },
+            "cloud": {
+                "account": {
+                    "id": "111111111111"
+                },
+                "availability_zone": "us-east-2b",
+                "image": {
+                    "id": "ami-021158f59b67638f2"
+                },
+                "instance": {
+                    "id": "i-1111111111111111a"
+                },
+                "machine": {
+                    "type": "t2.micro"
+                },
+                "provider": "aws",
+                "region": "us-east-2",
+                "service": {
+                    "name": "EC2"
+                }
+            },
+            "component": {
+                "id": "endpoint-default",
+                "state": "HEALTHY"
+            },
+            "data_stream": {
+                "dataset": "elastic_agent",
+                "namespace": "default",
+                "type": "logs"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "elastic_agent": {
+                "id": "a4461838-ba9e-4221-852e-16606e179b58",
+                "snapshot": false,
+                "version": "9.2.0"
+            },
+            "event": {
+                "agent_id_status": "verified",
+                "dataset": "elastic_agent",
+                "ingested": "2025-10-27T16:09:45Z"
+            },
+            "host": {
+                "architecture": "x86_64",
+                "hostname": "test-host-12345",
+                "id": "df8784f0-bc0e-48f2-b0bf-e934002587fd",
+                "ip": [
+                    "fe80::9d46:c45c:a144:b134",
+                    "172.31.31.13"
+                ],
+                "mac": [
+                    "06-E8-B3-CB-66-F1"
+                ],
+                "name": "test-host-12345",
+                "os": {
+                    "build": "20348.4294",
+                    "family": "windows",
+                    "kernel": "10.0.20348.4294 (WinBuild.160101.0800)",
+                    "name": "Windows Server 2022 Datacenter",
+                    "platform": "windows",
+                    "type": "windows",
+                    "version": "10.0"
+                }
+            },
+            "log": {
+                "file": {
+                    "path": "C:\\Program Files\\Elastic\\Agent\\data\\elastic-agent-9.2.0-e7bf31\\logs\\elastic-agent-20251027-1.ndjson"
+                },
+                "level": "info"
+            },
+            "log.origin": {
+                "file.line": 1024,
+                "file.name": "coordinator/coordinator.go",
+                "function": "github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator.logComponentStateChange"
+            },
+            "message": "Unit state changed endpoint-default (STARTING->CONFIGURING): ",
+            "unit": {
+                "id": "endpoint-default",
+                "old_state": "STARTING",
+                "state": "CONFIGURING",
+                "type": "output"
+            }
+        }
+    ]
+}

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,26 @@
+---
+description: Pipeline for Elastic Agent logs.
+processors:
+  - dot_expander:
+      if: ctx['log.level'] != null
+      field: 'log.level'
+  - grok:
+      description: Parse the log level from Elastic Defend service installation log messages.
+      if: ctx.context == "command output" && ctx['log.logger'] instanceof String && ctx['log.logger'].startsWith('component.runtime.endpoint-')
+      tag: grok_parse_endpoint_log_level
+      field: message
+      patterns:
+        - '^%{TIMESTAMP_ISO8601}: %{LOGLEVEL:log.level}: '
+      ignore_missing: true
+      ignore_failure: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: >-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
+        failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/fields/fields.yml
@@ -70,3 +70,9 @@
       type: keyword
       ignore_above: 1024
       description: Previous unit health
+# Define context to allow the pipeline tests to pass.
+# The index disables dynamic fields so this causes no behavior change.
+- name: context
+  index: false
+  type: keyword
+  description: Context of the log entry.

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 2.6.4
+version: 2.6.5
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 3.5.0


### PR DESCRIPTION
## Proposed commit message

```
Address incorrect log level labeling where all stderr output appears as
'log.level: error', reducing noise for users reviewing agent logs.

Add ingest pipeline to extract log level from Elastic Defend service
installation command output. The pipeline applies only to command output
logs from endpoint service commands.

Include pipeline tests covering both endpoint installation logs and
standard agent logs to ensure the parsing applies conditionally.

Define context field in fields.yml to address 'field "context" is
undefined' test errors. Modify sample logs to remove fields not defined
in fields.yml that caused test failures: input.type,
log.file.fingerprint, log.file.idxhi, log.file.idxlo, log.file.vol,
log.offset, and log.source.

Reference: https://github.com/elastic/elastic-agent/blob/03a81c005d38f8190053c73e9033c7a94cefb2ac/pkg/component/runtime/service_command.go#L25
```

## Related

- https://github.com/elastic/elastic-agent/blob/03a81c005d38f8190053c73e9033c7a94cefb2ac/pkg/component/runtime/service_command.go#L25
- (internal) https://elastic.slack.com/archives/CNW9Y42KV/p1761501624067169

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
