### PR TITLE
[elastic_agent] document Open Handles dashboard is Linux only

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.6.9"
+  changes:
+    - description: Document that Open Handles dashboards are Linux only
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/15770
 - version: "2.6.8"
   changes:
     - description: Adds processor for health_status field to status change logs data stream

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -4438,7 +4438,7 @@
                     },
                     "enhancements": {},
                     "hidePanelTitles": false,
-                    "title": "[Elastic Agent] Open Handles"
+                    "title": "[Elastic Agent] Open Handles (Linux Only)"
                 },
                 "gridData": {
                     "h": 9,
@@ -4640,7 +4640,7 @@
                     },
                     "enhancements": {},
                     "hidePanelTitles": false,
-                    "title": "[Elastic Agent] Open Handles"
+                    "title": "[Elastic Agent] Open Handles (Linux Only)"
                 },
                 "gridData": {
                     "h": 9,

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 2.6.8
+version: 2.6.9
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 3.5.0


### PR DESCRIPTION
## Proposed commit message

document that the "Open Handles" dashboards are Linux only in elastic-agent, at least until https://github.com/elastic/elastic-agent-system-metrics/issues/268 is addressed

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

``` shell
elastic-package build
elastic-package stack up -d
elastic-package install --zip <repo>/build/packages/elastic_agent-2.6.5.zip
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/elastic-agent-system-metrics/issues/268

## Screenshots

<img width="1713" height="262" alt="Screenshot 2025-10-27 at 3 08 40 PM" src="https://github.com/user-attachments/assets/b62b54aa-cc2c-4ca4-b319-07d3fe406f73" />

