### PR TITLE
[CI] Update maximum tests reported in daily Serverless jobs

### DIFF
--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -109,6 +109,8 @@ steps:
   - label: ":github: Report failed tests"
     key: report-failed-tests
     command: ".buildkite/scripts/report_issues.sh"
+    env:
+      CI_MAX_TESTS_REPORTED: 30
     agents:
       image: "${LINUX_AGENT_IMAGE}"
       cpu: "8"


### PR DESCRIPTION
## Proposed commit message

Set the same maximum number of tests (30) to be reported for Serverless daily jobs as other daily jobs:
https://github.com/elastic/integrations/blob/8477eb1b11bab0333c21323ec416f1217f153d34/.buildkite/pipeline.yml#L118-L126

By default, this limit is 20:
https://github.com/elastic/integrations/blob/8477eb1b11bab0333c21323ec416f1217f153d34/magefile.go#L31

Relates https://github.com/elastic/integrations/pull/12296
