### PR TITLE
feat: Preserve event.original when pipeline errors in integration-experience integrations (part 4)

### DIFF
--- a/packages/sophos/changelog.yml
+++ b/packages/sophos/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.16.0"
+  changes:
+    - description: Preserve event.original on pipeline error.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/15806
 - version: "3.15.4"
   changes:
     - description: Generate processor tags and normalize error handler.

--- a/packages/sophos/data_stream/utm/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sophos/data_stream/utm/elasticsearch/ingest_pipeline/default.yml
@@ -226,6 +226,12 @@ processors:
           return false;
         }
         dropEmptyFields(ctx);
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - append:
       field: error.message
@@ -237,3 +243,7 @@ on_failure:
   - set:
       field: event.kind
       value: pipeline_error
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/sophos/data_stream/utm/elasticsearch/ingest_pipeline/dhcp.yml
+++ b/packages/sophos/data_stream/utm/elasticsearch/ingest_pipeline/dhcp.yml
@@ -169,3 +169,7 @@ on_failure:
   - set:
       field: event.kind
       value: pipeline_error
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/sophos/data_stream/utm/elasticsearch/ingest_pipeline/dns.yml
+++ b/packages/sophos/data_stream/utm/elasticsearch/ingest_pipeline/dns.yml
@@ -97,3 +97,7 @@ on_failure:
   - set:
       field: event.kind
       value: pipeline_error
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/sophos/data_stream/utm/elasticsearch/ingest_pipeline/http.yml
+++ b/packages/sophos/data_stream/utm/elasticsearch/ingest_pipeline/http.yml
@@ -324,3 +324,7 @@ on_failure:
   - set:
       field: event.kind
       value: pipeline_error
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/sophos/data_stream/utm/elasticsearch/ingest_pipeline/packetfilter.yml
+++ b/packages/sophos/data_stream/utm/elasticsearch/ingest_pipeline/packetfilter.yml
@@ -276,3 +276,7 @@ on_failure:
   - set:
       field: event.kind
       value: pipeline_error
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/antispam.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/antispam.yml
@@ -163,3 +163,7 @@ on_failure:
       {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
       {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
       failed with message '{{{ _ingest.on_failure_message }}}'
+- append:
+    field: tags
+    value: preserve_original_event
+    allow_duplicates: false

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/antivirus.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/antivirus.yml
@@ -263,3 +263,7 @@ on_failure:
       {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
       {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
       failed with message '{{{ _ingest.on_failure_message }}}'
+- append:
+    field: tags
+    value: preserve_original_event
+    allow_duplicates: false

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/atp.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/atp.yml
@@ -144,3 +144,7 @@ on_failure:
       {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
       {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
       failed with message '{{{ _ingest.on_failure_message }}}'
+- append:
+    field: tags
+    value: preserve_original_event
+    allow_duplicates: false

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/cfilter.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/cfilter.yml
@@ -200,3 +200,7 @@ on_failure:
       {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
       {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
       failed with message '{{{ _ingest.on_failure_message }}}'
+- append:
+    field: tags
+    value: preserve_original_event
+    allow_duplicates: false

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/default.yml
@@ -869,6 +869,12 @@ processors:
       - sophos.xg.severity
       - sophos.xg.src_country
     ignore_missing: true
+- append:
+    tag: append_preserve_original_event_on_error
+    field: tags
+    value: preserve_original_event
+    allow_duplicates: false
+    if: ctx.error?.message != null
 on_failure:
 - set:
     field: event.kind
@@ -880,3 +886,7 @@ on_failure:
       {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
       {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
       failed with message '{{{ _ingest.on_failure_message }}}'
+- append:
+    field: tags
+    value: preserve_original_event
+    allow_duplicates: false

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/event.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/event.yml
@@ -151,3 +151,7 @@ on_failure:
       {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
       {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
       failed with message '{{{ _ingest.on_failure_message }}}'
+- append:
+    field: tags
+    value: preserve_original_event
+    allow_duplicates: false

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/firewall.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/firewall.yml
@@ -276,3 +276,7 @@ on_failure:
       {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
       {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
       failed with message '{{{ _ingest.on_failure_message }}}'
+- append:
+    field: tags
+    value: preserve_original_event
+    allow_duplicates: false

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/idp.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/idp.yml
@@ -138,3 +138,7 @@ on_failure:
       {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
       {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
       failed with message '{{{ _ingest.on_failure_message }}}'
+- append:
+    field: tags
+    value: preserve_original_event
+    allow_duplicates: false

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/sandstorm.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/sandstorm.yml
@@ -159,3 +159,7 @@ on_failure:
       {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
       {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
       failed with message '{{{ _ingest.on_failure_message }}}'
+- append:
+    field: tags
+    value: preserve_original_event
+    allow_duplicates: false

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/systemhealth.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/systemhealth.yml
@@ -230,3 +230,7 @@ on_failure:
       {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
       {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
       failed with message '{{{ _ingest.on_failure_message }}}'
+- append:
+    field: tags
+    value: preserve_original_event
+    allow_duplicates: false

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/waf.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/waf.yml
@@ -207,3 +207,7 @@ on_failure:
       {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
       {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
       failed with message '{{{ _ingest.on_failure_message }}}'
+- append:
+    field: tags
+    value: preserve_original_event
+    allow_duplicates: false

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/wifi.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/wifi.yml
@@ -36,3 +36,7 @@ on_failure:
       {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
       {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
       failed with message '{{{ _ingest.on_failure_message }}}'
+- append:
+    field: tags
+    value: preserve_original_event
+    allow_duplicates: false

--- a/packages/sophos/manifest.yml
+++ b/packages/sophos/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: sophos
 title: Sophos
-version: "3.15.4"
+version: "3.16.0"
 description: Collect logs from Sophos with Elastic Agent.
 categories:
   - security

--- a/packages/squid/changelog.yml
+++ b/packages/squid/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Preserve event.original on pipeline error.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/15806
 - version: "1.3.2"
   changes:
     - description: Generate processor tags and normalize error handler.

--- a/packages/squid/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/squid/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -248,6 +248,12 @@ processors:
       field:
         - _tmp
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 
 on_failure:
   - remove:
@@ -265,3 +271,7 @@ on_failure:
   - set:
       field: event.kind
       value: pipeline_error
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/squid/manifest.yml
+++ b/packages/squid/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: squid
 title: Squid Proxy
-version: "1.3.2"
+version: "1.4.0"
 description: Collect and parse logs from Squid devices with Elastic Agent.
 categories:
   # Observability is a parent category for web

--- a/packages/stormshield/changelog.yml
+++ b/packages/stormshield/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Preserve event.original on pipeline error.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/15806
 - version: "1.3.2"
   changes:
     - description: Generate processor tags and normalize error handler.

--- a/packages/stormshield/data_stream/log/elasticsearch/ingest_pipeline/count.yml
+++ b/packages/stormshield/data_stream/log/elasticsearch/ingest_pipeline/count.yml
@@ -56,3 +56,7 @@ on_failure:
   - set:
       field: event.kind
       value: pipeline_error
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/stormshield/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/stormshield/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -556,6 +556,12 @@ processors:
       field: _temp_
       ignore_missing: true
       ignore_failure: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 
 on_failure:
 - append:
@@ -568,3 +574,7 @@ on_failure:
 - set:
     field: event.kind
     value: pipeline_error
+- append:
+    field: tags
+    value: preserve_original_event
+    allow_duplicates: false

--- a/packages/stormshield/data_stream/log/elasticsearch/ingest_pipeline/filterstat.yml
+++ b/packages/stormshield/data_stream/log/elasticsearch/ingest_pipeline/filterstat.yml
@@ -62,3 +62,7 @@ on_failure:
   - set:
       field: event.kind
       value: pipeline_error
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/stormshield/data_stream/log/elasticsearch/ingest_pipeline/monitor.yml
+++ b/packages/stormshield/data_stream/log/elasticsearch/ingest_pipeline/monitor.yml
@@ -158,3 +158,7 @@ on_failure:
   - set:
       field: event.kind
       value: pipeline_error
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/stormshield/manifest.yml
+++ b/packages/stormshield/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.1
 name: stormshield
 title: "StormShield SNS"
-version: "1.3.2"
+version: "1.4.0"
 source:
   license: "Elastic-2.0"
 description: "Stormshield SNS integration."

--- a/packages/suricata/changelog.yml
+++ b/packages/suricata/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.26.0"
+  changes:
+    - description: Preserve event.original on pipeline error.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/15806
 - version: "2.25.2"
   changes:
     - description: Generate processor tags and normalize error handler.

--- a/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/default.yml
@@ -788,6 +788,12 @@ processors:
         - dns.question.domain
         - _tmp_
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -799,3 +805,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/dns-answer-v1.yml
+++ b/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/dns-answer-v1.yml
@@ -44,3 +44,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/dns-answer-v2.yml
+++ b/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/dns-answer-v2.yml
@@ -48,3 +48,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/dns.yml
+++ b/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/dns.yml
@@ -111,3 +111,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/tls.yml
+++ b/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/tls.yml
@@ -294,3 +294,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/suricata/manifest.yml
+++ b/packages/suricata/manifest.yml
@@ -1,6 +1,6 @@
 name: suricata
 title: Suricata
-version: "2.25.2"
+version: "2.26.0"
 description: Collect logs from Suricata with Elastic Agent.
 type: integration
 icons:

--- a/packages/syslog_router/changelog.yml
+++ b/packages/syslog_router/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: Preserve event.original on pipeline error.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/15806
 - version: "0.3.1"
   changes:
     - description: Generate processor tags and normalize error handler.

--- a/packages/syslog_router/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/syslog_router/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -5,6 +5,12 @@ processors:
       tag: set_ecs_version_135371bc
       field: ecs.version
       value: 8.16.0
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 
 on_failure:
   - append:
@@ -17,3 +23,7 @@ on_failure:
   - set:
       field: event.kind
       value: pipeline_error
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/syslog_router/manifest.yml
+++ b/packages/syslog_router/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: syslog_router
 title: "Syslog Router"
-version: 0.3.1
+version: 0.4.0
 description: "Route syslog events to integrations with Elastic Agent."
 type: integration
 categories:

--- a/packages/tetragon/changelog.yml
+++ b/packages/tetragon/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Preserve event.original on pipeline error.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/15806
 - version: "0.2.2"
   changes:
     - description: Generate processor tags and normalize error handler.

--- a/packages/tetragon/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/tetragon/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -286,6 +286,12 @@ processors:
           return false;
         }
         dropEmptyFields(ctx);
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - append:
       field: error.message
@@ -299,3 +305,7 @@ on_failure:
       value: pipeline_error
   - remove:
       field: "_tmp_"
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/tetragon/manifest.yml
+++ b/packages/tetragon/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.4
 name: cilium_tetragon
 title: Cilium Tetragon
-version: 0.2.2
+version: 0.3.0
 description: >-
   Collect Cilium Tetragon logs from Kubernetes environments.
 type: integration
@@ -23,9 +23,7 @@ policy_templates:
   - name: cilium_tetragon
     title: Cilium Tetragon
     description: >-
-      Cilium Tetragon is an open-source security observability tool that
-      leverages eBPF technology to provide real-time visibility and monitoring
-      for containerized applications.
+      Cilium Tetragon is an open-source security observability tool that leverages eBPF technology to provide real-time visibility and monitoring for containerized applications.
     inputs:
       - type: filestream
         title: 'log : filestream'

--- a/packages/watchguard_firebox/changelog.yml
+++ b/packages/watchguard_firebox/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Preserve event.original on pipeline error.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/15806
 - version: "1.4.2"
   changes:
     - description: Generate processor tags and normalize error handler.

--- a/packages/watchguard_firebox/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/watchguard_firebox/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -4712,6 +4712,12 @@ processors:
       value: pipeline_error
       tag: set_pipeline_error_into_event_kind
       if: ctx.error?.message != null
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - append:
       field: error.message
@@ -4723,3 +4729,7 @@ on_failure:
   - set:
       field: event.kind
       value: pipeline_error
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/watchguard_firebox/data_stream/log/elasticsearch/ingest_pipeline/pipeline_alarm.yml
+++ b/packages/watchguard_firebox/data_stream/log/elasticsearch/ingest_pipeline/pipeline_alarm.yml
@@ -274,3 +274,7 @@ on_failure:
   - set:
       field: event.kind
       value: pipeline_error
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/watchguard_firebox/data_stream/log/elasticsearch/ingest_pipeline/pipeline_diagnostic.yml
+++ b/packages/watchguard_firebox/data_stream/log/elasticsearch/ingest_pipeline/pipeline_diagnostic.yml
@@ -1428,3 +1428,7 @@ on_failure:
   - set:
       field: event.kind
       value: pipeline_error
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/watchguard_firebox/data_stream/log/elasticsearch/ingest_pipeline/pipeline_event.yml
+++ b/packages/watchguard_firebox/data_stream/log/elasticsearch/ingest_pipeline/pipeline_event.yml
@@ -1175,3 +1175,7 @@ on_failure:
   - set:
       field: event.kind
       value: pipeline_error
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/watchguard_firebox/data_stream/log/elasticsearch/ingest_pipeline/pipeline_traffic.yml
+++ b/packages/watchguard_firebox/data_stream/log/elasticsearch/ingest_pipeline/pipeline_traffic.yml
@@ -1266,3 +1266,7 @@ on_failure:
   - set:
       field: event.kind
       value: pipeline_error
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/watchguard_firebox/manifest.yml
+++ b/packages/watchguard_firebox/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.4
 name: watchguard_firebox
 title: WatchGuard Firebox
-version: "1.4.2"
+version: "1.5.0"
 description: Collect logs from WatchGuard Firebox with Elastic Agent.
 type: integration
 categories:

--- a/packages/zeek/changelog.yml
+++ b/packages/zeek/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.1.0"
+  changes:
+    - description: Preserve event.original on pipeline error.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/15806
 - version: "3.0.3"
   changes:
     - description: Generate processor tags and normalize error handler.

--- a/packages/zeek/data_stream/capture_loss/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/capture_loss/elasticsearch/ingest_pipeline/default.yml
@@ -56,6 +56,12 @@ processors:
       field:
         - zeek.capture_loss.ts
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -67,3 +73,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/capture_loss/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/capture_loss/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/connection/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/connection/elasticsearch/ingest_pipeline/default.yml
@@ -384,6 +384,12 @@ processors:
         - json
         - temp
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -395,3 +401,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/connection/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/connection/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/dce_rpc/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/dce_rpc/elasticsearch/ingest_pipeline/default.yml
@@ -200,6 +200,12 @@ processors:
       field:
         - zeek.dce_rpc.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -211,3 +217,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/dce_rpc/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/dce_rpc/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/dhcp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/dhcp/elasticsearch/ingest_pipeline/default.yml
@@ -224,6 +224,12 @@ processors:
   - community_id:
       tag: community_id_612651e3
       target_field: network.community_id
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -235,3 +241,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/dhcp/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/dhcp/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/dnp3/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/dnp3/elasticsearch/ingest_pipeline/default.yml
@@ -224,6 +224,12 @@ processors:
       field:
         - zeek.dnp3.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -235,3 +241,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/dnp3/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/dnp3/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
@@ -356,6 +356,12 @@ processors:
         - zeek.dns.addl
         - zeek.dns.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -367,3 +373,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/dns/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/dns/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/dpd/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/dpd/elasticsearch/ingest_pipeline/default.yml
@@ -190,6 +190,12 @@ processors:
       field:
         - zeek.dpd.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -201,3 +207,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/dpd/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/dpd/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/files/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/files/elasticsearch/ingest_pipeline/default.yml
@@ -158,6 +158,12 @@ processors:
       field:
         - zeek.files.x509
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -169,3 +175,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/files/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/files/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/ftp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/ftp/elasticsearch/ingest_pipeline/default.yml
@@ -280,6 +280,12 @@ processors:
       field:
         - zeek.ftp.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -291,3 +297,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/ftp/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/ftp/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/http/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/http/elasticsearch/ingest_pipeline/default.yml
@@ -309,6 +309,12 @@ processors:
       field:
         - zeek.http.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -320,3 +326,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/http/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/http/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/intel/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/intel/elasticsearch/ingest_pipeline/default.yml
@@ -347,6 +347,12 @@ processors:
       field:
         - zeek.intel.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -358,3 +364,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/intel/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/intel/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/irc/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/irc/elasticsearch/ingest_pipeline/default.yml
@@ -226,6 +226,12 @@ processors:
       field:
         - zeek.irc.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -237,3 +243,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/irc/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/irc/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/kerberos/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/kerberos/elasticsearch/ingest_pipeline/default.yml
@@ -440,6 +440,12 @@ processors:
         - json
         - zeek.kerberos.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -451,3 +457,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/kerberos/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/kerberos/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/known_certs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/known_certs/elasticsearch/ingest_pipeline/default.yml
@@ -163,6 +163,12 @@ processors:
       field:
         - json
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -174,3 +180,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/known_hosts/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/known_hosts/elasticsearch/ingest_pipeline/default.yml
@@ -81,6 +81,12 @@ processors:
       field:
         - json
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -92,3 +98,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/known_services/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/known_services/elasticsearch/ingest_pipeline/default.yml
@@ -119,6 +119,12 @@ processors:
       field:
         - json
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -130,3 +136,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/modbus/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/modbus/elasticsearch/ingest_pipeline/default.yml
@@ -213,6 +213,12 @@ processors:
       field:
         - zeek.modbus.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -224,3 +230,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/modbus/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/modbus/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/mysql/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/mysql/elasticsearch/ingest_pipeline/default.yml
@@ -242,6 +242,12 @@ processors:
       field:
         - zeek.mysql.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -253,3 +259,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/mysql/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/mysql/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/notice/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/notice/elasticsearch/ingest_pipeline/default.yml
@@ -326,6 +326,12 @@ processors:
         - zeek.notice.remote_location
         - zeek.notice.f
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -337,3 +343,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/notice/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/notice/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/ntlm/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/ntlm/elasticsearch/ingest_pipeline/default.yml
@@ -245,6 +245,12 @@ processors:
         - json
         - zeek.ntlm.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -256,3 +262,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/ntlm/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/ntlm/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/ntp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/ntp/elasticsearch/ingest_pipeline/default.yml
@@ -231,6 +231,12 @@ processors:
         - zeek.ntp.id
         - zeek.ntp.ts
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -242,3 +248,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/ntp/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/ntp/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/ocsp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/ocsp/elasticsearch/ingest_pipeline/default.yml
@@ -135,6 +135,12 @@ processors:
       value: "{{{zeek.ocsp.issuerKeyHash}}}"
       if: "ctx.zeek?.ocsp?.issuerKeyHash != null"
       allow_duplicates: false
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -146,3 +152,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/ocsp/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/ocsp/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/pe/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/pe/elasticsearch/ingest_pipeline/default.yml
@@ -66,6 +66,12 @@ processors:
         - UNIX
         - ISO8601
       if: ctx.zeek.pe.compile_time != null
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -77,3 +83,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/pe/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/pe/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/radius/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/radius/elasticsearch/ingest_pipeline/default.yml
@@ -213,6 +213,12 @@ processors:
       field:
         - zeek.radius.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -224,3 +230,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/radius/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/radius/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/rdp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/rdp/elasticsearch/ingest_pipeline/default.yml
@@ -254,6 +254,12 @@ processors:
       field:
         - zeek.rdp.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -265,3 +271,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/rdp/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/rdp/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/rfb/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/rfb/elasticsearch/ingest_pipeline/default.yml
@@ -223,6 +223,12 @@ processors:
       field:
         - zeek.rfb.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -234,3 +240,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/rfb/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/rfb/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/signature/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/signature/elasticsearch/ingest_pipeline/default.yml
@@ -172,6 +172,12 @@ processors:
       field:
         - zeek.signature.ts
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -183,3 +189,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/signature/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/signature/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/sip/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/sip/elasticsearch/ingest_pipeline/default.yml
@@ -283,6 +283,12 @@ processors:
       field:
         - zeek.sip.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -294,3 +300,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/sip/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/sip/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/smb_cmd/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/smb_cmd/elasticsearch/ingest_pipeline/default.yml
@@ -348,6 +348,12 @@ processors:
       field:
         - zeek.smb_cmd.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -359,3 +365,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/smb_cmd/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/smb_cmd/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/smb_files/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/smb_files/elasticsearch/ingest_pipeline/default.yml
@@ -306,6 +306,12 @@ processors:
       field:
         - zeek.smb_files.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -317,3 +323,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/smb_files/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/smb_files/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/smb_mapping/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/smb_mapping/elasticsearch/ingest_pipeline/default.yml
@@ -193,6 +193,12 @@ processors:
       field:
         - zeek.smb_mapping.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -204,3 +210,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/smb_mapping/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/smb_mapping/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/smtp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/smtp/elasticsearch/ingest_pipeline/default.yml
@@ -228,6 +228,12 @@ processors:
       field:
         - zeek.smtp.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -239,3 +245,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/smtp/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/smtp/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/snmp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/snmp/elasticsearch/ingest_pipeline/default.yml
@@ -221,6 +221,12 @@ processors:
       field:
         - zeek.snmp.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -232,3 +238,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/snmp/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/snmp/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/socks/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/socks/elasticsearch/ingest_pipeline/default.yml
@@ -243,6 +243,12 @@ processors:
       field:
         - zeek.socks.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -254,3 +260,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/socks/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/socks/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/software/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/software/elasticsearch/ingest_pipeline/default.yml
@@ -121,6 +121,12 @@ processors:
       field:
         - zeek.software.ts
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -132,3 +138,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/ssh/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/ssh/elasticsearch/ingest_pipeline/default.yml
@@ -238,6 +238,12 @@ processors:
       field:
         - zeek.ssh.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -249,3 +255,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/ssh/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/ssh/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/ssl/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/ssl/elasticsearch/ingest_pipeline/default.yml
@@ -649,6 +649,12 @@ processors:
       field:
         - zeek.ssl.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -660,3 +666,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/ssl/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/ssl/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/stats/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/stats/elasticsearch/ingest_pipeline/default.yml
@@ -169,6 +169,12 @@ processors:
       tag: set_event_kind_495d69f0
       field: event.kind
       value: metric
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -180,3 +186,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/stats/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/stats/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/syslog/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/syslog/elasticsearch/ingest_pipeline/default.yml
@@ -197,6 +197,12 @@ processors:
   - community_id:
       tag: community_id_612651e3
       target_field: network.community_id
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -208,3 +214,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/syslog/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/syslog/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/traceroute/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/traceroute/elasticsearch/ingest_pipeline/default.yml
@@ -144,6 +144,12 @@ processors:
         - zeek.traceroute
       ignore_missing: true
       if: 'ctx.zeek?.traceroute == null || ctx.zeek?.traceroute.isEmpty()'
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -155,3 +161,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/traceroute/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/traceroute/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/tunnel/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/tunnel/elasticsearch/ingest_pipeline/default.yml
@@ -191,6 +191,12 @@ processors:
       field:
         - zeek.tunnel.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -202,3 +208,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/tunnel/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/tunnel/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/weird/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/weird/elasticsearch/ingest_pipeline/default.yml
@@ -188,6 +188,12 @@ processors:
       field:
         - zeek.weird.id
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -199,3 +205,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/weird/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/weird/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/x509/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/x509/elasticsearch/ingest_pipeline/default.yml
@@ -501,6 +501,12 @@ processors:
       field: zeek.x509.certificate.subject.ST
       target_field: zeek.x509.certificate.subject.state
       ignore_missing: true
+  - append:
+      tag: append_preserve_original_event_on_error
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false
+      if: ctx.error?.message != null
 on_failure:
   - set:
       field: event.kind
@@ -512,3 +518,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/data_stream/x509/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/x509/elasticsearch/ingest_pipeline/third-party.yml
@@ -46,3 +46,7 @@ on_failure:
         {{#_ingest.on_failure_processor_tag}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/zeek/manifest.yml
+++ b/packages/zeek/manifest.yml
@@ -1,6 +1,6 @@
 name: zeek
 title: Zeek
-version: "3.0.3"
+version: "3.1.0"
 description: Collect logs from Zeek with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## Proposed commit message

- Add append processor to pipeline on_failure handlers to preserve `event.original`.
- Add append processor to pipeline to preserve event.original if `error.message` is set.

### Integrations

- sophos
- squid
- stormshield
- suricata
- syslog_router
- tetragon
- watchguard_firebox
- zeek

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

## Related issues

- Relates #12045
- Relates elastic/integration-experience#292
