### PR TITLE
[Contextual Security][CNVM] change vulnerability.published_date field type from keyword to date

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,6 +1,7 @@
 # newer versions go on top
 # version map:
 # IMPORTANT: this map doesn't apply to serverless where package availability depends on the spec version https://github.com/elastic/kibana/blob/main/config/serverless.yml#L14-L15
+# 4.0.x - 9.2.x
 # 3.1.x - 9.2.x
 # 3.0.x - 9.1.x
 # 2.0.x - 8.19.x
@@ -16,6 +17,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "4.0.0"
+  changes:
+    - description: Change mapping of field `vulnerability.published_date` from `keyword` to `date`.
+      type: breaking-change
+      link: https://github.com/elastic/integrations/pull/15819
 - version: "3.1.1"
   changes:
     - description: Update transform to filter out documents containing an error message from latest vulnerability and misconfiguration indexes.

--- a/packages/cloud_security_posture/data_stream/vulnerabilities/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloud_security_posture/data_stream/vulnerabilities/elasticsearch/ingest_pipeline/default.yml
@@ -28,6 +28,17 @@ processors:
       field: host.name
       tag: set_host_name_lowercase
       ignore_missing: true
+  - date:
+      field: vulnerability.published_date
+      target_field: vulnerability.published_date
+      tag: parse_vulnerability_published_date
+      formats:
+        - ISO8601
+      if: ctx.vulnerability?.published_date != null && ctx.vulnerability.published_date != ''
+      on_failure:
+        - append:
+            field: error.message
+            value: 'Failed to parse vulnerability.published_date: {{{_ingest.on_failure_message}}}'
 on_failure:
   - set:
       field: event.kind

--- a/packages/cloud_security_posture/data_stream/vulnerabilities/fields/vulnerability.yml
+++ b/packages/cloud_security_posture/data_stream/vulnerabilities/fields/vulnerability.yml
@@ -23,4 +23,4 @@
     - name: scanner.version
       type: keyword
     - name: published_date
-      type: keyword
+      type: date

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "3.1.1"
+version: "4.0.0"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
This is a BREAKING CHANGE that updates the field mapping that aligns cnvm with other integrations - tenable_io, m365 etc.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Summary

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

This PR updates the vulnerability.published_date field mapping from keyword to date type in the Cloud Native Vulnerability Management (CNVM) integration. The change includes:

1. modifying the field definition in `fields/vulnerability.yml` to use the date type
2. adding a date processor to the ingest pipeline (default.yml) that parses the published_date field using ISO8601 format with proper error handling.
3. bumping the package version from 3.1.1 to 4.0.0 following semantic versioning for breaking changes
4. documenting the breaking change in changelog.yml. The ingest pipeline processor includes conditional logic to only parse the field when it exists and is not empty, with on_failure handling to append error messages without breaking the entire pipeline. 

change was made to address this [issue](https://github.com/elastic/security-team/issues/12860).

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

### Breaking Change Impact
⚠️ Important: This is a breaking change that will result in mapping conflicts within the data stream during the upgrade process:
- Existing indices will retain the old keyword mapping for vulnerability.published_date
- New indices (created after rollover) will use the new date mapping
- Multiple backing indices with different mappings will coexist under the same logs-cloud_security_posture.vulnerabilities-* data stream
- 
**User Impact:**
- Queries spanning both old and new indices may produce inconsistent results or errors due to field type conflicts
- Sorting by vulnerability.published_date will work correctly only for data in new indices
- Data views and dashboards may show mapping conflicts


## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 
https://github.com/elastic/sdh-security-team/issues/1477
## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->

**Screenshots**
<img width="1918" height="933" alt="image" src="https://github.com/user-attachments/assets/71e475c8-a791-4492-9139-551d0f9c653a" />

**Screen recording**
https://github.com/user-attachments/assets/75a01ab4-c48a-4e5e-8fdb-c85b260eb229


