### PR TITLE
feat(okta): add rate_limit_early_limit configuration

### DIFF
--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.11.0"
+  changes:
+    - description: Added support for rate_limit_early_limit configuration to start rate-limiting before reaching the API response limit.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/15835
 - version: "3.10.3"
   changes:
     - description: Optimize API pagination to prevent unnecessary requests when fewer logs than the limit are returned, reducing rate limit token consumption.

--- a/packages/okta/data_stream/system/agent/stream/httpjson.yml.hbs
+++ b/packages/okta/data_stream/system/agent/stream/httpjson.yml.hbs
@@ -13,6 +13,9 @@ request.rate_limit:
   limit: '[[.last_response.header.Get "X-Rate-Limit-Limit"]]'
   remaining: '[[.last_response.header.Get "X-Rate-Limit-Remaining"]]'
   reset: '[[.last_response.header.Get "X-Rate-Limit-Reset"]]'
+{{#if rate_limit_early_limit}}
+  early_limit: {{rate_limit_early_limit}}
+{{/if}}
 
 {{#if ssl}}
 request.ssl: {{ssl}}

--- a/packages/okta/data_stream/system/manifest.yml
+++ b/packages/okta/data_stream/system/manifest.yml
@@ -54,6 +54,13 @@ streams:
           # This works around system tests not allowing an assert.hit_count > 500.
           - default
           - agentless
+      - name: rate_limit_early_limit
+        title: Rate Limit Early Limit
+        description: Start rate-limiting before reaching the limit specified in the response. Values less than 1 are treated as a percentage of the limit (e.g. 0.9 means 90%). Values greater than or equal to 1 are treated as the target remaining value.
+        type: text
+        required: false
+        show_user: false
+        secret: false
 
     template_path: httpjson.yml.hbs
     title: Okta system logs

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -1,6 +1,6 @@
 name: okta
 title: Okta
-version: "3.10.3"
+version: "3.11.0"
 description: Collect and parse event logs from Okta API with Elastic Agent.
 type: integration
 format_version: "3.2.3"
@@ -149,11 +149,7 @@ policy_templates:
             required: false
             show_user: false
             description: >-
-              The request tracer logs requests and responses to the agent's local file-system for debugging configurations.
-              Enabling this request tracing compromises security and should only be used for debugging. Disabling the request
-              tracer will delete any stored traces.
-              See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename)
-              for details.
+              The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. Disabling the request tracer will delete any stored traces. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
           - name: ssl
             type: yaml
             title: SSL


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
Add support for the rate_limit_early_limit parameter to enable starting
rate-limiting before reaching the API response limit.  Values less than
1 are treated as a percentage of the limit, while values greater than or
equal to 1 are treated as the target remaining value.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
