### PR TITLE
[Osquery_manager] Add services artifact saved query

### DIFF
--- a/packages/osquery_manager/artifacts_matrix.md
+++ b/packages/osquery_manager/artifacts_matrix.md
@@ -1,0 +1,154 @@
+## Osquery Saved Queries - Forensic Artifact Coverage
+
+This document tracks the coverage of forensic artifacts in Osquery.
+
+**Last Updated**: 2025-11-06
+**Total Core Artifacts**: 1 completed + 11 in progress + 5 not available = 17 total
+**Total Queries**: 45 (18 core forensic variants + 27 additional)
+**Completion Rate**: 5.9% (1/17 core artifacts fully validated)
+
+---
+
+## Coverage Summary
+
+| Status | Count | Percentage |
+|--------|-------|------------|
+| ✅ Completed (Fully Validated) | 1 | 5.9% |
+| ⚠️ In Progress (Needs Validation) | 11 | 64.7% |
+| ❌ Not Available (Requires Extensions) | 5 | 29.4% |
+
+---
+
+## Core Forensic Artifacts Coverage
+
+| # | Artifact                | ✓ | OS | Query | File | Description |
+|:-:|-------------------------|:-:|:--:|-------|:----:|-------------|
+| 1 | Services                | ✅ | Win | suspicious_services | [003](kibana/osquery_saved_query/osquery_manager-892ee425-60e7-4eb6-ba25-6e97dc3e2ea0.json) | Detect suspicious services running from user-writable directories or with generic names commonly used by malware |
+| 1a | Services                | ✅ | Mac | suspicious_launchd_macos | [043](kibana/osquery_saved_query/osquery_manager-5823a22e-5add-416d-a142-de323400edb0.json) | Detect suspicious launch daemons and agents on macOS, excluding system paths but flagging user-writable directories |
+| 1b | Services                | ✅ | Linux | suspicious_systemd_linux | [044](kibana/osquery_saved_query/osquery_manager-f8b0894b-772d-4242-8e19-dbc5d7ae2e06.json) | Detect suspicious systemd units on Linux, excluding system paths but flagging user-writable directories and unusual locations |
+| 2 | Scheduled Tasks         | ⚠️ | Win | scheduled_tasks_persistence | - | Identify enabled scheduled tasks executing from suspicious locations or using LOLBins |
+| 2a | Scheduled Tasks         | ⚠️ | Mac+Linux | crontab_persistence | - | Detect suspicious crontab entries used for persistence (unified query for both platforms) |
+| 3 | Startup Items           | ⚠️ | Win | startup_items_persistence | - | Track startup items from registry and startup folders, focusing on non-Microsoft entries |
+| 4 | Process Listing         | ⚠️ | All | suspicious_processes | - | Detect suspicious running processes including fileless malware and processes from temp folders |
+| 5 | File Hashes             | ⚠️ | All | file_hashes_threat_intel | - | Enumerate recently modified executables with file hashes from suspicious locations |
+| 6 | ARP Cache               | ⚠️ | All | arp_cache_lateral_movement | - | Monitor ARP cache for lateral movement indicators |
+| 7 | Network Connections     | ⚠️ | All | network_connections_c2 | - | Identify active network connections to external IPs on common C2 and lateral movement ports |
+| 8 | Registry                | ⚠️ | Win | registry_persistence | - | Monitor Windows registry Run keys and startup locations for persistence mechanisms |
+| 8a | Startup / Persistence   | ⚠️ | Mac | startup_items_persistence_macos | - | Monitor macOS startup items for persistence mechanisms (equivalent to registry persistence) |
+| 8b | Autostart / Persistence | ⚠️ | Linux | autostart_persistence_linux | - | Monitor Linux autostart mechanisms via user systemd units (equivalent to registry persistence) |
+| 9 | LNK Files               | ⚠️ | Win | lnk_files_recent_activity | - | Analyze LNK shortcut files showing recently accessed documents and programs |
+| 10 | BITS Jobs               | ⚠️ | Win | bits_jobs_database | - | Detect suspicious BITS transfers by filtering out known-good domains (Microsoft, Google, Adobe, etc.) and internal networks - **Windows-only (no macOS/Linux equivalent)** |
+| 11 | Network Interfaces      | ⚠️ | All | network_interfaces_baseline | - | Document network configuration and identify anomalies like VPN or tunnel interfaces |
+| 12 | Disk Info               | ⚠️ | Win | disk_drives_removable_windows | - | Enumerate logical drives on Windows systems focusing on removable media and unusual volumes (uses logical_drives table) |
+| 12a | Disk Info               | ⚠️ | Mac+Linux | mounts_removable | - | Enumerate mounted volumes focusing on removable media and external drives (unified query for both platforms) |
+| 13 | AmCache                 | ❌ | Win | - | - | **Not Available** - Alternative: Use Prefetch + File Hashes + Registry uninstall keys |
+| 14 | Jumplists               | ❌ | Win | - | - | **Not Available** - Alternative: File enumeration + Shellbags + Office MRU |
+| 15 | Browser History         | ❌ | All | - | - | **Not Available** - Alternative: Downloads folder + cache analysis + ATC extension |
+| 16 | MFT                     | ❌ | Win | - | - | **Not Available** - Alternative: Trail of Bits extension + USN Journal + targeted queries |
+| 17 | File Handles            | ❌ | All | - | - | **Not Available** - Alternative: process_open_sockets + file table + eclecticiq extension |
+
+---
+
+## Additional Queries (Original Repository)
+
+These queries existed in the original repository and provide additional coverage beyond the core forensic artifacts listed above.
+
+| # | Query | ✓ | OS | File | Description |
+|:-:|-------|:-:|:--:|:----:|-------------|
+| 1 | listening_ports | ✅ | All | [0796](kibana/osquery_saved_query/osquery_manager-0796f890-b4a9-11ec-8f39-bf9c07530bbb.json) | Network listening ports enumeration |
+| 2 | processes | ✅ | All | [363d](kibana/osquery_saved_query/osquery_manager-363d6a30-b4a9-11ec-8f39-bf9c07530bbb.json) | General process listing (all processes) |
+| 3 | logged_in_users | ✅ | All | [ccd3](kibana/osquery_saved_query/osquery_manager-ccd3f850-b4a5-11ec-8f39-bf9c07530bbb.json) | Currently logged in users |
+| 4 | users | ✅ | All | [cebd](kibana/osquery_saved_query/osquery_manager-cebd7b00-b4b4-11ec-8f39-bf9c07530bbb.json) | System user accounts enumeration |
+| 5 | file_info | ✅ | All | [128b](kibana/osquery_saved_query/osquery_manager-128b90b0-b4a6-11ec-8f39-bf9c07530bbb.json) | File metadata queries by path |
+| 6 | file_info_by_type | ✅ | All | [fc4e](kibana/osquery_saved_query/osquery_manager-fc4e34b0-b4a5-11ec-8f39-bf9c07530bbb.json) | File information by extension type |
+| 7 | system_os | ✅ | All | [23af](kibana/osquery_saved_query/osquery_manager-23af51c0-d75f-11ec-879b-83915b27217e.json) | Operating system information |
+| 8 | system_info | ✅ | All | [47d9](kibana/osquery_saved_query/osquery_manager-47d96fe0-d75f-11ec-879b-83915b27217e.json) | System hardware information |
+| 9 | system_memory_linux | ✅ |Linux | [315b](kibana/osquery_saved_query/osquery_manager-315bfda0-d75f-11ec-879b-83915b27217e.json) | Memory information (Linux specific) |
+| 10 | applications_mac | ✅ | Mac | [5c14](kibana/osquery_saved_query/osquery_manager-5c144ac0-b4a5-11ec-8f39-bf9c07530bbb.json) | Installed applications enumeration |
+| 10a | applications_windows | ✅ | Win | [a887](kibana/osquery_saved_query/osquery_manager-a8870ff0-b4a5-11ec-8f39-bf9c07530bbb.json) | Installed applications enumeration |
+| 11 | usb_devices_mac_or_linux | ✅ | Mac+Linux | [7ee7](kibana/osquery_saved_query/osquery_manager-7ee71870-b4b4-11ec-8f39-bf9c07530bbb.json) | USB device enumeration (non-Windows) |
+| 12 | registry_windows | ✅ | Win | [6fc0](kibana/osquery_saved_query/osquery_manager-6fc00190-b4b4-11ec-8f39-bf9c07530bbb.json) | General registry queries |
+| 13 | persisted_apps | ✅ | Win | [2de2](kibana/osquery_saved_query/osquery_manager-2de24900-b4a9-11ec-8f39-bf9c07530bbb.json) | Persistence applications (non-executables) |
+| 14 | persisted_apps_executables_windows | ✅ | Win | [239d](kibana/osquery_saved_query/osquery_manager-239dce60-b4a9-11ec-8f39-bf9c07530bbb.json) | Persistence applications (executables) |
+| 15 | posh_logging_windows | ✅ | Win | [5595](kibana/osquery_saved_query/osquery_manager-55955db0-0c07-11ed-a49c-6b13b058b135.json) | PowerShell logging configuration status |
+| 16 | defender_exclusions_windows | ✅ | Win | [157d](kibana/osquery_saved_query/osquery_manager-157d5550-fd27-11ec-8645-83a23bc513b5.json) | Windows Defender exclusion paths |
+| 17 | firewall_rules_windows | ✅ | Win | [e640](kibana/osquery_saved_query/osquery_manager-e640e200-b4a8-11ec-8f39-bf9c07530bbb.json) | Windows Firewall rules enumeration |
+| 18 | loaded_drivers_windows | ✅ | Win | [f864](kibana/osquery_saved_query/osquery_manager-f8649710-b4a8-11ec-8f39-bf9c07530bbb.json) | Loaded kernel drivers |
+| 19 | services_running_on_user_accounts | ✅ | Win | [ee58](kibana/osquery_saved_query/osquery_manager-ee586dc0-1801-11ed-89c6-331eb0db6d01.json) | Services running under user accounts (not SYSTEM) |
+| 20 | wdigest_uselogoncredential | ✅ | Win | [a08d](kibana/osquery_saved_query/osquery_manager-a08d7320-1823-11ed-89c6-331eb0db6d01.json) | WDigest credential caching configuration |
+| 21 | winbaseobj_mutex_search | ✅ | Win | [0f61](kibana/osquery_saved_query/osquery_manager-0f61edf0-17e1-11ed-89c6-331eb0db6d01.json) | Mutex objects for malware IOC detection |
+| 22 | unsigned_processes_vt | ✅ | Win | [3e71](kibana/osquery_saved_query/osquery_manager-3e7155d0-0db5-11ed-a49c-6b13b058b135.json) | Unsigned running processes with VirusTotal integration |
+| 23 | unsigned_services_vt | ✅ | Win | [8386](kibana/osquery_saved_query/osquery_manager-83869f40-0dab-11ed-a49c-6b13b058b135.json) | Unsigned services with VirusTotal integration |
+| 24 | unsigned_startup_items_vt | ✅ | Win | [b068](kibana/osquery_saved_query/osquery_manager-b0683c20-0dbb-11ed-a49c-6b13b058b135.json) | Unsigned startup items with VirusTotal integration |
+| 25 | unsigned_dlls_on_system_folders_vt | ✅ | Win | [63c1](kibana/osquery_saved_query/osquery_manager-63c1fe20-176f-11ed-89c6-331eb0db6d01.json) | Unsigned DLLs in system folders with VirusTotal integration |
+| 26 | executables_in_temp_folder_vt | ✅ | Win | [3e55](kibana/osquery_saved_query/osquery_manager-3e553650-17fd-11ed-89c6-331eb0db6d01.json) | Executables/drivers in temp folders with VirusTotal integration |
+
+**Note**: Queries with VirusTotal integration require the VirusTotal extension configured in osquery.
+
+---
+
+## Not Available Artifacts
+
+The following artifacts cannot be queried with standard osquery and require extensions or are not yet supported:
+
+| # | Artifact | Status | Reason | Alternative Approach |
+|:-:|----------|:------:|--------|----------------------|
+| 1 | AmCache | ❌ | PR #7261 closed due to SQL constraint problems | Use combination of Prefetch analysis, file system queries for recent executables, and registry uninstall keys |
+| 2 | Jumplists | ❌ | PR #7260 closed due to OLE format complexity | File enumeration (list .automaticDestinations-ms files), manual offline analysis, or use Recent files from Shellbags/Office MRU |
+| 3 | Browser History | ❌ | No native table, databases locked while browser running | Downloads folder analysis, file system queries for browser cache, or ATC custom tables (if deployed) |
+| 4 | MFT | ❌ | Complex NTFS structure requires specialized parsing | Trail of Bits osquery extension (if deployed), USN Journal for recent activity, or targeted file system queries |
+| 5 | File Handles | ❌ | PR #7835 still open, not merged | Network connections via process_open_sockets, file table for static analysis, or eclecticiq-osq-ext-bin extension |
+
+### Alternative Coverage
+
+While these artifacts are not directly available, the existing queries provide strong coverage through related artifacts:
+
+**Execution Tracking**: Use Prefetch + File Hashes + Process Listing instead of AmCache
+**User Activity**: Use Shellbags + LNK Files + Office Documents instead of Jumplists/Browser History
+**File System Monitoring**: Use USN Journal + File Hashes instead of MFT
+**Resource Access**: Use Network Connections + Process Listing instead of File Handles
+
+---
+
+## Legend
+
+### Status Definitions
+
+- ✅ Available in standard osquery with production-ready queries
+- ⚠️ In Progress - Query exists but needs validation or refinement
+- ❌ Not Available - Requires osquery extensions or not yet supported
+
+---
+
+## Artifacts by Category
+
+### Persistence Mechanisms
+- ✅ Services
+- ⚠️ Scheduled Tasks
+- ⚠️ Startup Items
+- ⚠️ Registry
+
+### Network/C2 Indicators
+- ⚠️ BITS Jobs
+- ⚠️ ARP Cache
+- ⚠️ Network Interfaces
+- ⚠️ Network Connections
+
+### File Activity
+- ⚠️ File Hashes
+- ⚠️ LNK Files
+- ❌ Jumplists (Not Available)
+- ❌ MFT (Not Available)
+
+### System Information
+- ⚠️ Disk Info
+- ⚠️ Process Listing
+- ❌ File Handles (Not Available)
+
+### Execution Artifacts
+- ❌ AmCache (Not Available)
+
+### User Activity
+- ❌ Browser History (Not Available)
+
+---

--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.20.0"
+  changes:
+    - description: Add core forensics saved queries
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/15871
 - version: "1.19.1"
   changes:
     - description: Add root requirement for the integration

--- a/packages/osquery_manager/kibana/osquery_saved_query/osquery_manager-5823a22e-5add-416d-a142-de323400edb0.json
+++ b/packages/osquery_manager/kibana/osquery_saved_query/osquery_manager-5823a22e-5add-416d-a142-de323400edb0.json
@@ -1,0 +1,101 @@
+{
+  "attributes": {
+    "created_at": "2025-11-05T09:19:01.000Z",
+    "created_by": "elastic",
+    "description": "Detects suspicious launchd persistence on macOS with multi-factor risk scoring. Monitors all standard LaunchAgents/LaunchDaemons locations, analyzes program paths, detects label masquerading, and prioritizes high-risk entries. Returns entries with risk_score >= 30 (MEDIUM+) or created within last 7 days.",
+    "ecs_mapping": [
+      {
+        "key": "service.name",
+        "value": {
+          "field": "label"
+        }
+      },
+      {
+        "key": "service.state",
+        "value": {
+          "field": "disabled"
+        }
+      },
+      {
+        "key": "process.executable",
+        "value": {
+          "field": "program"
+        }
+      },
+      {
+        "key": "process.args",
+        "value": {
+          "field": "program_arguments"
+        }
+      },
+      {
+        "key": "user.name",
+        "value": {
+          "field": "username"
+        }
+      },
+      {
+        "key": "event.category",
+        "value": {
+          "value": [
+            "process"
+          ]
+        }
+      },
+      {
+        "key": "event.type",
+        "value": {
+          "value": [
+            "info"
+          ]
+        }
+      },
+      {
+        "key": "tags",
+        "value": {
+          "value": [
+            "persistence",
+            "launchd",
+            "macos"
+          ]
+        }
+      },
+      {
+        "key": "event.risk_score",
+        "value": {
+          "field": "risk_score"
+        }
+      },
+      {
+        "key": "event.risk_score_norm",
+        "value": {
+          "field": "risk_score"
+        }
+      },
+      {
+        "key": "file.created",
+        "value": {
+          "field": "created_time"
+        }
+      },
+      {
+        "key": "file.mtime",
+        "value": {
+          "field": "modified_time"
+        }
+      }
+    ],
+    "id": "suspicious_launchd_macos_elastic",
+    "interval": "3600",
+    "platform": "darwin",
+    "query": "WITH launchd_base AS (\n  SELECT\n    l.name,\n    l.label,\n    l.path,\n    -- Extract executable from program_arguments (NO l.program column exists!)\n    CASE\n      WHEN l.program_arguments LIKE '<%' THEN\n        -- Handle XML array format: <string>/path/to/exe</string>\n        RTRIM(LTRIM(SUBSTR(l.program_arguments, INSTR(l.program_arguments, '<string>') + 8, INSTR(l.program_arguments, '</string>') - INSTR(l.program_arguments, '<string>') - 8)))\n      WHEN l.program_arguments != '' THEN\n        -- Use program_arguments as-is (might be a simple string or first element)\n        l.program_arguments\n      ELSE NULL\n    END AS program,\n    l.program_arguments,\n    l.run_at_load,\n    l.keep_alive,\n    -- Infer username from plist location (NO l.username column exists!)\n    CASE\n      WHEN l.path LIKE '/Library/LaunchDaemons/%' THEN 'root'\n      WHEN l.path LIKE '/Users/%/Library/LaunchAgents/%' THEN\n        -- Extract username from path: /Users/USERNAME/Library/LaunchAgents/...\n        SUBSTR(l.path, 8, INSTR(SUBSTR(l.path, 8), '/') - 1)\n      WHEN l.path LIKE '/Users/%/Library/LaunchDaemons/%' THEN\n        -- Extract username from path: /Users/USERNAME/Library/LaunchDaemons/...\n        SUBSTR(l.path, 8, INSTR(SUBSTR(l.path, 8), '/') - 1)\n      WHEN l.path LIKE '/Library/LaunchAgents/%' THEN 'system'\n      ELSE NULL\n    END AS username,\n    l.disabled,\n    f.ctime AS file_created,\n    f.mtime AS file_modified,\n    CAST((strftime('%s', 'now') - COALESCE(f.ctime, strftime('%s', 'now'))) / 86400 AS INTEGER) AS age_days,\n    -- Program risk category (use program_arguments directly)\n    CASE\n      WHEN l.program_arguments LIKE '/tmp/%' OR l.program_arguments LIKE '/var/tmp/%' THEN 'TEMP_EXECUTION'\n      WHEN l.program_arguments LIKE '/Users/%/Downloads/%' OR l.program_arguments LIKE '/Users/%/Desktop/%' THEN 'USER_DOWNLOAD'\n      WHEN l.program_arguments LIKE '/dev/shm/%' THEN 'SHARED_MEMORY'\n      WHEN l.program_arguments LIKE '/Users/%/.%' OR l.program_arguments LIKE '%/.hidden/%' THEN 'HIDDEN_PROGRAM'\n      WHEN l.program_arguments NOT LIKE '/usr/%' AND l.program_arguments NOT LIKE '/bin/%' AND l.program_arguments NOT LIKE '/sbin/%' AND l.program_arguments NOT LIKE '/Applications/%.app/%' AND l.program_arguments NOT LIKE '/System/%' THEN 'NON_STANDARD_LOCATION'\n      WHEN l.program_arguments LIKE '/usr/bin/python%' OR l.program_arguments LIKE '/bin/sh' OR l.program_arguments LIKE '/bin/bash' OR l.program_arguments LIKE '/usr/bin/perl%' OR l.program_arguments LIKE '/usr/bin/ruby%' THEN 'INTERPRETER'\n      WHEN l.program_arguments LIKE '/Applications/%.app/%' THEN 'APPLICATION'\n      ELSE 'SYSTEM_BINARY'\n    END AS program_risk_category,\n    CASE\n      WHEN l.path LIKE '/Library/LaunchDaemons/%' THEN 'ROOT_DAEMON'\n      WHEN l.path LIKE '/Library/LaunchAgents/%' THEN 'SYSTEM_AGENT'\n      WHEN l.path LIKE '/Users/%/Library/LaunchAgents/%' THEN 'USER_AGENT'\n      WHEN l.path LIKE '/Users/%/Library/LaunchDaemons/%' THEN 'USER_DAEMON'\n      WHEN l.path LIKE '/tmp/%' OR l.path LIKE '/var/tmp/%' THEN 'TEMP_PLIST'\n      WHEN l.path LIKE '/Users/%/Downloads/%' THEN 'DOWNLOADS'\n      WHEN l.path LIKE '/Users/%/Desktop/%' THEN 'DESKTOP'\n      ELSE 'OTHER'\n    END AS plist_location_type\n  FROM launchd l\n  LEFT JOIN file f ON f.path = l.path\n  WHERE (\n    l.path LIKE '/Library/LaunchAgents/%'\n    OR l.path LIKE '/Library/LaunchDaemons/%'\n    OR l.path LIKE '/Users/%/Library/LaunchAgents/%'\n    OR l.path LIKE '/Users/%/Library/LaunchDaemons/%'\n    OR l.path LIKE '/tmp/%'\n    OR l.path LIKE '/var/tmp/%'\n    OR l.path LIKE '/Users/%/Downloads/%'\n    OR l.path LIKE '/Users/%/Desktop/%'\n  )\n  AND l.path NOT LIKE '/System/Library/%'\n  AND l.path NOT LIKE '/Library/Apple/%'\n  AND l.path NOT LIKE '/Applications/Xcode.app/%'\n),\nscored_launchd AS (\n  SELECT\n    *,\n    (\n      CASE\n        WHEN path LIKE '/Library/LaunchDaemons/%' THEN 30\n        WHEN path LIKE '/tmp/%' OR path LIKE '/var/tmp/%' THEN 30\n        WHEN path LIKE '/Users/%/Library/LaunchAgents/%' THEN 25\n        WHEN path LIKE '/Users/%/Library/LaunchDaemons/%' THEN 25\n        WHEN path LIKE '/Users/%/Downloads/%' OR path LIKE '/Users/%/Desktop/%' THEN 20\n        WHEN path LIKE '/Library/LaunchAgents/%' THEN 20\n        ELSE 0\n      END +\n      CASE\n        WHEN program_risk_category IN ('TEMP_EXECUTION', 'SHARED_MEMORY') THEN 30\n        WHEN program_risk_category IN ('USER_DOWNLOAD', 'HIDDEN_PROGRAM') THEN 25\n        WHEN program_risk_category = 'NON_STANDARD_LOCATION' THEN 20\n        WHEN program_risk_category = 'INTERPRETER' THEN 15\n        ELSE 0\n      END +\n      CASE\n        WHEN label LIKE 'com.apple.%' AND path NOT LIKE '/System/Library/%' AND path NOT LIKE '/Library/Apple/%' THEN 20\n        WHEN label LIKE 'com.google.%' AND program NOT LIKE '/Applications/Google%' AND program NOT LIKE '/Library/Google/%' THEN 20\n        WHEN label LIKE '%malware%' OR label LIKE '%trojan%' OR label LIKE '%backdoor%' OR label LIKE '%virus%' THEN 20\n        WHEN label LIKE '%update%' OR label LIKE '%check%' OR label LIKE '%sync%' OR label LIKE '%agent%' THEN 15\n        WHEN label NOT LIKE '%.%' THEN 10\n        ELSE 0\n      END +\n      CASE\n        WHEN run_at_load = 1 AND keep_alive = 1 THEN 20\n        WHEN keep_alive = 1 THEN 15\n        WHEN run_at_load = 1 THEN 10\n        ELSE 0\n      END\n    ) AS risk_score\n  FROM launchd_base\n)\nSELECT\n  name,\n  label,\n  path,\n  program,\n  program_arguments,\n  run_at_load,\n  keep_alive,\n  username,\n  disabled,\n  datetime(file_created, 'unixepoch', 'localtime') AS created_time,\n  datetime(file_modified, 'unixepoch', 'localtime') AS modified_time,\n  age_days,\n  plist_location_type,\n  program_risk_category,\n  risk_score,\n  CASE\n    WHEN risk_score >= 70 THEN 'CRITICAL'\n    WHEN risk_score >= 50 THEN 'HIGH'\n    WHEN risk_score >= 30 THEN 'MEDIUM'\n    ELSE 'LOW'\n  END AS risk_level\nFROM scored_launchd\nWHERE risk_score >= 30 OR age_days <= 7\nORDER BY risk_score DESC, age_days ASC, label\nLIMIT 200;",
+    "updated_at": "2025-11-06T13:00:00.000Z",
+    "updated_by": "elastic"
+  },
+  "coreMigrationVersion": "9.2.0",
+  "id": "osquery_manager-5823a22e-5add-416d-a142-de323400edb0",
+  "references": [],
+  "type": "osquery-saved-query",
+  "updated_at": "2025-11-05T09:19:01.000Z",
+  "version": "Wzk1LDJd"
+}

--- a/packages/osquery_manager/kibana/osquery_saved_query/osquery_manager-892ee425-60e7-4eb6-ba25-6e97dc3e2ea0.json
+++ b/packages/osquery_manager/kibana/osquery_saved_query/osquery_manager-892ee425-60e7-4eb6-ba25-6e97dc3e2ea0.json
@@ -1,0 +1,142 @@
+{
+  "attributes": {
+    "created_at": "2025-11-05T09:19:01.000Z",
+    "created_by": "elastic",
+    "description": "Detect suspicious Windows services with comprehensive risk scoring (0-100). Identifies: (1) Services in user-writable directories (Temp, AppData, Downloads), (2) Unsigned or untrusted binaries via code signature validation, (3) ServiceDLL hijacking (missing DLLs, unsigned DLLs, suspicious locations), (4) Failure command persistence mechanisms, (5) Privilege escalation (SYSTEM account with user-writable paths). Risk Scoring: CRITICAL (70-100) - Immediate investigation required, HIGH (50-69) - Review within 24 hours, MEDIUM (30-49) - Weekly review, LOW (0-29) - Baseline monitoring. Covers MITRE ATT&CK: T1543.003 (Create or Modify System Process: Windows Service), T1574.011 (Hijack Execution Flow: Services Registry Permissions Weakness)",
+    "ecs_mapping": [
+      {
+        "key": "service.name",
+        "value": {
+          "field": "name"
+        }
+      },
+      {
+        "key": "service.state",
+        "value": {
+          "field": "status"
+        }
+      },
+      {
+        "key": "process.executable",
+        "value": {
+          "field": "path"
+        }
+      },
+      {
+        "key": "user.name",
+        "value": {
+          "field": "user_account"
+        }
+      },
+      {
+        "key": "file.hash.md5",
+        "value": {
+          "field": "md5"
+        }
+      },
+      {
+        "key": "file.hash.sha256",
+        "value": {
+          "field": "sha256"
+        }
+      },
+      {
+        "key": "file.code_signature.subject_name",
+        "value": {
+          "field": "cert_subject"
+        }
+      },
+      {
+        "key": "file.code_signature.status",
+        "value": {
+          "field": "signature_status"
+        }
+      },
+      {
+        "key": "dll.hash.sha256",
+        "value": {
+          "field": "servicedll_sha256"
+        }
+      },
+      {
+        "key": "dll.hash.md5",
+        "value": {
+          "field": "servicedll_md5"
+        }
+      },
+      {
+        "key": "dll.code_signature.subject_name",
+        "value": {
+          "field": "servicedll_cert_subject"
+        }
+      },
+      {
+        "key": "dll.code_signature.status",
+        "value": {
+          "field": "servicedll_signature_status"
+        }
+      },
+      {
+        "key": "event.risk_score",
+        "value": {
+          "field": "risk_score"
+        }
+      },
+      {
+        "key": "event.severity",
+        "value": {
+          "field": "risk_level"
+        }
+      },
+      {
+        "key": "event.created",
+        "value": {
+          "field": "service_registry_mtime"
+        }
+      },
+      {
+        "key": "event.category",
+        "value": {
+          "value": [
+            "configuration"
+          ]
+        }
+      },
+      {
+        "key": "event.type",
+        "value": {
+          "value": [
+            "info"
+          ]
+        }
+      },
+      {
+        "key": "tags",
+        "value": {
+          "value": [
+            "persistence",
+            "services",
+            "backdoor_detection",
+            "service_dll",
+            "risk_scoring",
+            "servicedll_hijacking",
+            "privilege_escalation",
+            "code_signing"
+          ]
+        }
+      }
+    ],
+    "id": "suspicious_services_windows_elastic",
+    "interval": "3600",
+    "platform": "windows",
+    "query": "SELECT \n  s.name, \n  s.display_name, \n  s.status, \n  s.start_type, \n  s.path, \n  s.user_account,\n  r1.data AS service_dll,\n  r2.data AS failure_command,\n  h.sha256,\n  h.md5,\n  a.subject_name AS cert_subject,\n  a.issuer_name AS cert_issuer,\n  a.result AS signature_status,\n  h_dll.sha256 AS servicedll_sha256,\n  h_dll.md5 AS servicedll_md5,\n  a_dll.subject_name AS servicedll_cert_subject,\n  a_dll.result AS servicedll_signature_status,\n  r_service_key.mtime AS service_registry_mtime,\n  CAST((strftime('%s', 'now') - r_service_key.mtime) / 86400 AS INTEGER) AS days_since_creation,\n  (\n    (CASE\n      WHEN s.path LIKE '%\\\\Temp\\\\%' THEN 40\n      WHEN s.path LIKE '%\\\\Users\\\\%\\\\AppData\\\\Local\\\\Temp\\\\%' THEN 40\n      WHEN s.path LIKE '%\\\\Users\\\\%\\\\Downloads\\\\%' THEN 35\n      WHEN s.path LIKE '%\\\\AppData\\\\Local\\\\%' THEN 35\n      WHEN s.path LIKE '%\\\\AppData\\\\Roaming\\\\%' THEN 30\n      WHEN s.path LIKE '%\\\\Users\\\\%\\\\Documents\\\\%' THEN 30\n      WHEN s.path LIKE '%\\\\Users\\\\Public\\\\%' THEN 25\n      WHEN s.path LIKE '%\\\\ProgramData\\\\%' AND s.path NOT LIKE '%\\\\ProgramData\\\\Microsoft\\\\%' THEN 20\n      ELSE 5\n    END) +\n    (CASE\n      WHEN a.result IS NULL OR a.result = '' THEN 25\n      WHEN a.result != 'trusted' THEN 25\n      WHEN a.subject_name NOT LIKE '%Microsoft%' AND a.subject_name NOT LIKE '%Windows%' THEN 15\n      ELSE 0\n    END) +\n    (CASE\n      WHEN s.user_account IN ('LocalSystem', 'NT AUTHORITY\\\\SYSTEM', 'SYSTEM') AND\n           (s.path LIKE '%\\\\Temp\\\\%' OR s.path LIKE '%\\\\AppData\\\\%' OR s.path LIKE '%\\\\Users\\\\%') THEN 20\n      WHEN s.user_account IN ('LocalSystem', 'NT AUTHORITY\\\\SYSTEM', 'SYSTEM') THEN 10\n      WHEN s.user_account LIKE '%Administrator%' THEN 5\n      ELSE 0\n    END) +\n    (CASE\n      WHEN LOWER(s.name) IN ('service', 'svc', 'system', 'update', 'windows', 'microsoft', 'security', 'monitor', 'agent', 'helper') THEN 10\n      WHEN LENGTH(s.name) <= 5 THEN 8\n      WHEN s.display_name = s.name OR s.display_name IS NULL THEN 5\n      ELSE 0\n    END) +\n    (CASE\n      WHEN r1.data IS NOT NULL AND r1.data != '' AND h_dll.sha256 IS NULL THEN 5\n      WHEN r1.data LIKE '%\\\\Temp\\\\%' OR r1.data LIKE '%\\\\AppData\\\\%' THEN 5\n      WHEN a_dll.result IS NOT NULL AND a_dll.result != 'trusted' THEN 5\n      ELSE 0\n    END)\n  ) AS risk_score,\n  (CASE\n    WHEN (\n      (CASE\n        WHEN s.path LIKE '%\\\\Temp\\\\%' THEN 40\n        WHEN s.path LIKE '%\\\\Users\\\\%\\\\AppData\\\\Local\\\\Temp\\\\%' THEN 40\n        WHEN s.path LIKE '%\\\\Users\\\\%\\\\Downloads\\\\%' THEN 35\n        WHEN s.path LIKE '%\\\\AppData\\\\Local\\\\%' THEN 35\n        WHEN s.path LIKE '%\\\\AppData\\\\Roaming\\\\%' THEN 30\n        WHEN s.path LIKE '%\\\\Users\\\\%\\\\Documents\\\\%' THEN 30\n        WHEN s.path LIKE '%\\\\Users\\\\Public\\\\%' THEN 25\n        WHEN s.path LIKE '%\\\\ProgramData\\\\%' AND s.path NOT LIKE '%\\\\ProgramData\\\\Microsoft\\\\%' THEN 20\n        ELSE 5\n      END) +\n      (CASE\n        WHEN a.result IS NULL OR a.result = '' THEN 25\n        WHEN a.result != 'trusted' THEN 25\n        WHEN a.subject_name NOT LIKE '%Microsoft%' AND a.subject_name NOT LIKE '%Windows%' THEN 15\n        ELSE 0\n      END) +\n      (CASE\n        WHEN s.user_account IN ('LocalSystem', 'NT AUTHORITY\\\\SYSTEM', 'SYSTEM') AND\n             (s.path LIKE '%\\\\Temp\\\\%' OR s.path LIKE '%\\\\AppData\\\\%' OR s.path LIKE '%\\\\Users\\\\%') THEN 20\n        WHEN s.user_account IN ('LocalSystem', 'NT AUTHORITY\\\\SYSTEM', 'SYSTEM') THEN 10\n        WHEN s.user_account LIKE '%Administrator%' THEN 5\n        ELSE 0\n      END) +\n      (CASE\n        WHEN LOWER(s.name) IN ('service', 'svc', 'system', 'update', 'windows', 'microsoft', 'security', 'monitor', 'agent', 'helper') THEN 10\n        WHEN LENGTH(s.name) <= 5 THEN 8\n        WHEN s.display_name = s.name OR s.display_name IS NULL THEN 5\n        ELSE 0\n      END) +\n      (CASE\n        WHEN r1.data IS NOT NULL AND r1.data != '' AND h_dll.sha256 IS NULL THEN 5\n        WHEN r1.data LIKE '%\\\\Temp\\\\%' OR r1.data LIKE '%\\\\AppData\\\\%' THEN 5\n        WHEN a_dll.result IS NOT NULL AND a_dll.result != 'trusted' THEN 5\n        ELSE 0\n      END)\n    ) >= 70 THEN 'CRITICAL'\n    WHEN (\n      (CASE\n        WHEN s.path LIKE '%\\\\Temp\\\\%' THEN 40\n        WHEN s.path LIKE '%\\\\Users\\\\%\\\\AppData\\\\Local\\\\Temp\\\\%' THEN 40\n        WHEN s.path LIKE '%\\\\Users\\\\%\\\\Downloads\\\\%' THEN 35\n        WHEN s.path LIKE '%\\\\AppData\\\\Local\\\\%' THEN 35\n        WHEN s.path LIKE '%\\\\AppData\\\\Roaming\\\\%' THEN 30\n        WHEN s.path LIKE '%\\\\Users\\\\%\\\\Documents\\\\%' THEN 30\n        WHEN s.path LIKE '%\\\\Users\\\\Public\\\\%' THEN 25\n        WHEN s.path LIKE '%\\\\ProgramData\\\\%' AND s.path NOT LIKE '%\\\\ProgramData\\\\Microsoft\\\\%' THEN 20\n        ELSE 5\n      END) +\n      (CASE\n        WHEN a.result IS NULL OR a.result = '' THEN 25\n        WHEN a.result != 'trusted' THEN 25\n        WHEN a.subject_name NOT LIKE '%Microsoft%' AND a.subject_name NOT LIKE '%Windows%' THEN 15\n        ELSE 0\n      END) +\n      (CASE\n        WHEN s.user_account IN ('LocalSystem', 'NT AUTHORITY\\\\SYSTEM', 'SYSTEM') AND\n             (s.path LIKE '%\\\\Temp\\\\%' OR s.path LIKE '%\\\\AppData\\\\%' OR s.path LIKE '%\\\\Users\\\\%') THEN 20\n        WHEN s.user_account IN ('LocalSystem', 'NT AUTHORITY\\\\SYSTEM', 'SYSTEM') THEN 10\n        WHEN s.user_account LIKE '%Administrator%' THEN 5\n        ELSE 0\n      END) +\n      (CASE\n        WHEN LOWER(s.name) IN ('service', 'svc', 'system', 'update', 'windows', 'microsoft', 'security', 'monitor', 'agent', 'helper') THEN 10\n        WHEN LENGTH(s.name) <= 5 THEN 8\n        WHEN s.display_name = s.name OR s.display_name IS NULL THEN 5\n        ELSE 0\n      END) +\n      (CASE\n        WHEN r1.data IS NOT NULL AND r1.data != '' AND h_dll.sha256 IS NULL THEN 5\n        WHEN r1.data LIKE '%\\\\Temp\\\\%' OR r1.data LIKE '%\\\\AppData\\\\%' THEN 5\n        WHEN a_dll.result IS NOT NULL AND a_dll.result != 'trusted' THEN 5\n        ELSE 0\n      END)\n    ) >= 50 THEN 'HIGH'\n    WHEN (\n      (CASE\n        WHEN s.path LIKE '%\\\\Temp\\\\%' THEN 40\n        WHEN s.path LIKE '%\\\\Users\\\\%\\\\AppData\\\\Local\\\\Temp\\\\%' THEN 40\n        WHEN s.path LIKE '%\\\\Users\\\\%\\\\Downloads\\\\%' THEN 35\n        WHEN s.path LIKE '%\\\\AppData\\\\Local\\\\%' THEN 35\n        WHEN s.path LIKE '%\\\\AppData\\\\Roaming\\\\%' THEN 30\n        WHEN s.path LIKE '%\\\\Users\\\\%\\\\Documents\\\\%' THEN 30\n        WHEN s.path LIKE '%\\\\Users\\\\Public\\\\%' THEN 25\n        WHEN s.path LIKE '%\\\\ProgramData\\\\%' AND s.path NOT LIKE '%\\\\ProgramData\\\\Microsoft\\\\%' THEN 20\n        ELSE 5\n      END) +\n      (CASE\n        WHEN a.result IS NULL OR a.result = '' THEN 25\n        WHEN a.result != 'trusted' THEN 25\n        WHEN a.subject_name NOT LIKE '%Microsoft%' AND a.subject_name NOT LIKE '%Windows%' THEN 15\n        ELSE 0\n      END) +\n      (CASE\n        WHEN s.user_account IN ('LocalSystem', 'NT AUTHORITY\\\\SYSTEM', 'SYSTEM') AND\n             (s.path LIKE '%\\\\Temp\\\\%' OR s.path LIKE '%\\\\AppData\\\\%' OR s.path LIKE '%\\\\Users\\\\%') THEN 20\n        WHEN s.user_account IN ('LocalSystem', 'NT AUTHORITY\\\\SYSTEM', 'SYSTEM') THEN 10\n        WHEN s.user_account LIKE '%Administrator%' THEN 5\n        ELSE 0\n      END) +\n      (CASE\n        WHEN LOWER(s.name) IN ('service', 'svc', 'system', 'update', 'windows', 'microsoft', 'security', 'monitor', 'agent', 'helper') THEN 10\n        WHEN LENGTH(s.name) <= 5 THEN 8\n        WHEN s.display_name = s.name OR s.display_name IS NULL THEN 5\n        ELSE 0\n      END) +\n      (CASE\n        WHEN r1.data IS NOT NULL AND r1.data != '' AND h_dll.sha256 IS NULL THEN 5\n        WHEN r1.data LIKE '%\\\\Temp\\\\%' OR r1.data LIKE '%\\\\AppData\\\\%' THEN 5\n        WHEN a_dll.result IS NOT NULL AND a_dll.result != 'trusted' THEN 5\n        ELSE 0\n      END)\n    ) >= 30 THEN 'MEDIUM'\n    ELSE 'LOW'\n  END) AS risk_level\nFROM services s\nLEFT JOIN registry r1 ON r1.path = 'HKEY_LOCAL_MACHINE\\\\System\\\\CurrentControlSet\\\\Services\\\\' || s.name || '\\\\Parameters' AND r1.name = 'ServiceDll'\nLEFT JOIN registry r2 ON r2.path = 'HKEY_LOCAL_MACHINE\\\\System\\\\CurrentControlSet\\\\Services\\\\' || s.name AND r2.name = 'FailureCommand'\nLEFT JOIN hash h ON h.path = s.path\nLEFT JOIN authenticode a ON a.path = s.path\nLEFT JOIN hash h_dll ON h_dll.path = r1.data\nLEFT JOIN authenticode a_dll ON a_dll.path = r1.data\nLEFT JOIN registry r_service_key ON r_service_key.path = 'HKEY_LOCAL_MACHINE\\\\System\\\\CurrentControlSet\\\\Services\\\\' || s.name\nWHERE\n  s.start_type IN ('AUTO_START', 'DEMAND_START', 'BOOT_START', 'SYSTEM_START')\n  AND (\n    s.path LIKE '%\\\\Temp\\\\%'\n    OR s.path LIKE '%\\\\Users\\\\%\\\\AppData\\\\%'\n    OR s.path LIKE '%\\\\Users\\\\%\\\\Documents\\\\%'\n    OR s.path LIKE '%\\\\Users\\\\%\\\\Downloads\\\\%'\n    OR s.path LIKE '%\\\\Users\\\\Public\\\\%'\n    OR (s.path LIKE '%\\\\ProgramData\\\\%' AND s.path NOT LIKE '%\\\\ProgramData\\\\Microsoft\\\\%')\n    OR (r1.data IS NOT NULL AND r1.data != '' AND r1.data NOT LIKE 'C:\\\\Windows\\\\System32\\\\%' AND r1.data NOT LIKE 'C:\\\\Windows\\\\SysWOW64\\\\%')\n    OR (r2.data IS NOT NULL AND r2.data != '')\n    OR (a.result IS NOT NULL AND a.result != 'trusted')\n  )\n  AND s.path NOT LIKE 'C:\\\\Windows\\\\System32\\\\%'\n  AND s.path NOT LIKE 'C:\\\\Windows\\\\SysWOW64\\\\%'\n  AND s.name NOT IN ('wuauserv', 'BITS', 'TrustedInstaller', 'WinDefend', 'Spooler')\nORDER BY risk_score DESC\nLIMIT 200;",
+    "updated_at": "2025-11-05T09:19:01.000Z",
+    "updated_by": "elastic"
+  },
+  "coreMigrationVersion": "9.2.0",
+  "id": "osquery_manager-892ee425-60e7-4eb6-ba25-6e97dc3e2ea0",
+  "references": [],
+  "type": "osquery-saved-query",
+  "updated_at": "2025-11-05T09:19:01.000Z",
+  "version": "WzgzLDJd"
+}

--- a/packages/osquery_manager/kibana/osquery_saved_query/osquery_manager-f8b0894b-772d-4242-8e19-dbc5d7ae2e06.json
+++ b/packages/osquery_manager/kibana/osquery_saved_query/osquery_manager-f8b0894b-772d-4242-8e19-dbc5d7ae2e06.json
@@ -1,0 +1,65 @@
+{
+  "attributes": {
+    "created_at": "2025-11-06T00:00:00.000Z",
+    "created_by": "elastic",
+    "description": "Detects suspicious systemd persistence on Linux with multi-factor risk scoring. Monitors /etc/systemd/system/ (80% of malware), /etc/systemd/user/, /run/systemd/system/, ~/.config/systemd/user/, /tmp, and /var/tmp. Prioritizes socket/timer units, enabled services, and recently created units. Risk levels: CRITICAL (70+), HIGH (50-69), MEDIUM (30-49), LOW (<30). Returns entries with risk_score >= 30 (MEDIUM+) or created within last 7 days.",
+    "ecs_mapping": [
+      {
+        "key": "service.name",
+        "value": {
+          "field": "id"
+        }
+      },
+      {
+        "key": "service.state",
+        "value": {
+          "field": "active_state"
+        }
+      },
+      {
+        "key": "file.path",
+        "value": {
+          "field": "fragment_path"
+        }
+      },
+      {
+        "key": "event.category",
+        "value": {
+          "value": [
+            "configuration"
+          ]
+        }
+      },
+      {
+        "key": "event.type",
+        "value": {
+          "value": [
+            "info"
+          ]
+        }
+      },
+      {
+        "key": "tags",
+        "value": {
+          "value": [
+            "persistence",
+            "systemd",
+            "linux"
+          ]
+        }
+      }
+    ],
+    "id": "suspicious_systemd_linux_elastic",
+    "interval": "3600",
+    "platform": "linux",
+    "query": "WITH systemd_base AS (\n  SELECT\n    su.id,\n    su.description,\n    su.load_state,\n    su.active_state,\n    su.sub_state,\n    su.fragment_path,\n    su.unit_file_state,\n    f.ctime,\n    f.mtime,\n    CASE\n      WHEN su.id LIKE '%.socket' THEN 'SOCKET'\n      WHEN su.id LIKE '%.timer' THEN 'TIMER'\n      WHEN su.id LIKE '%.service' THEN 'SERVICE'\n      WHEN su.id LIKE '%.target' THEN 'TARGET'\n      WHEN su.id LIKE '%.path' THEN 'PATH'\n      ELSE 'OTHER'\n    END AS unit_type\n  FROM systemd_units su\n  LEFT JOIN file f ON f.path = su.fragment_path\n  WHERE (\n    su.fragment_path LIKE '/etc/systemd/system/%'\n    OR su.fragment_path LIKE '/etc/systemd/user/%'\n    OR su.fragment_path LIKE '/run/systemd/system/%'\n    OR su.fragment_path LIKE '%/.config/systemd/user/%'\n    OR su.fragment_path LIKE '/tmp/%'\n    OR su.fragment_path LIKE '/var/tmp/%'\n  )\n  AND su.fragment_path NOT LIKE '/lib/systemd/%'\n  AND su.fragment_path NOT LIKE '/usr/lib/systemd/%'\n),\nsystemd_risk AS (\n  SELECT\n    id,\n    description,\n    load_state,\n    active_state,\n    sub_state,\n    fragment_path,\n    unit_file_state,\n    unit_type,\n    ctime,\n    mtime,\n    CASE\n      WHEN fragment_path LIKE '/tmp/%' OR fragment_path LIKE '/var/tmp/%' THEN 40\n      WHEN fragment_path LIKE '/etc/systemd/system/%' THEN 30\n      WHEN fragment_path LIKE '%/.config/systemd/user/%' THEN 25\n      WHEN fragment_path LIKE '/run/systemd/system/%' THEN 20\n      WHEN fragment_path LIKE '/etc/systemd/user/%' THEN 15\n      ELSE 0\n    END AS location_risk,\n    CASE\n      WHEN unit_file_state = 'enabled' AND active_state = 'active' THEN 35\n      WHEN unit_file_state = 'enabled' AND active_state = 'inactive' THEN 25\n      WHEN unit_file_state = 'static' AND active_state = 'active' THEN 20\n      WHEN load_state = 'error' THEN 15\n      WHEN load_state = 'masked' THEN 0\n      ELSE 10\n    END AS state_risk,\n    CASE\n      WHEN unit_type = 'SOCKET' THEN 25\n      WHEN unit_type = 'TIMER' THEN 20\n      WHEN unit_type = 'SERVICE' THEN 10\n      ELSE 0\n    END AS type_risk\n  FROM systemd_base\n)\nSELECT\n  id,\n  description,\n  fragment_path,\n  unit_file_state,\n  active_state,\n  load_state,\n  unit_type,\n  location_risk,\n  state_risk,\n  type_risk,\n  (location_risk + state_risk + type_risk) AS risk_score,\n  CASE\n    WHEN (location_risk + state_risk + type_risk) >= 70 THEN 'CRITICAL'\n    WHEN (location_risk + state_risk + type_risk) >= 50 THEN 'HIGH'\n    WHEN (location_risk + state_risk + type_risk) >= 30 THEN 'MEDIUM'\n    ELSE 'LOW'\n  END AS risk_level,\n  CASE\n    WHEN unit_type = 'SOCKET' THEN 'HIGH: Socket unit detected - potential network backdoor listener'\n    WHEN unit_type = 'TIMER' THEN 'MEDIUM: Timer unit detected - potential C2 beaconing mechanism'\n    WHEN fragment_path LIKE '/tmp/%' OR fragment_path LIKE '/var/tmp/%' THEN 'CRITICAL: Unit file in temporary directory - likely malware persistence'\n    WHEN fragment_path LIKE '/etc/systemd/system/%' AND unit_file_state = 'enabled' THEN 'HIGH: Enabled system unit - review configuration for suspicious commands'\n    WHEN unit_file_state = 'enabled' AND active_state = 'active' THEN 'MEDIUM: Enabled and active unit - validate legitimacy'\n    ELSE 'Review unit configuration and validate against baseline'\n  END AS analyst_guidance,\n  datetime(ctime, 'unixepoch', 'localtime') AS file_created,\n  datetime(mtime, 'unixepoch', 'localtime') AS file_modified,\n  CAST((strftime('%s', 'now') - COALESCE(mtime, strftime('%s', 'now'))) / 86400 AS INTEGER) AS age_days\nFROM systemd_risk\nWHERE (\n  (location_risk + state_risk + type_risk) >= 30\n  OR CAST((strftime('%s', 'now') - COALESCE(mtime, strftime('%s', 'now'))) / 86400 AS INTEGER) <= 7\n  OR unit_type IN ('SOCKET', 'TIMER')\n)\nORDER BY (location_risk + state_risk + type_risk) DESC, CAST((strftime('%s', 'now') - COALESCE(mtime, strftime('%s', 'now'))) / 86400 AS INTEGER) ASC, id\nLIMIT 200;",
+    "updated_at": "2025-11-06T00:00:00.000Z",
+    "updated_by": "elastic"
+  },
+  "coreMigrationVersion": "9.2.0",
+  "id": "osquery_manager-f8b0894b-772d-4242-8e19-dbc5d7ae2e06",
+  "references": [],
+  "type": "osquery-saved-query",
+  "updated_at": "2025-11-05T09:19:01.000Z",
+  "version": "Wzk2LDJd"
+}

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: osquery_manager
 title: Osquery Manager
-version: 1.19.1
+version: 1.20.0
 description: Deploy Osquery with Elastic Agent, then run and schedule queries in Kibana
 type: integration
 categories:


### PR DESCRIPTION
## Core Forensic Artifacts Coverage

| # | Artifact                | ✓ | OS | Query | File | Description |
|:-:|-------------------------|:-:|:--:|-------|:----:|-------------|
| 1 | Services                | ✅ | Win | suspicious_services | [003](kibana/osquery_saved_query/osquery_manager-892ee425-60e7-4eb6-ba25-6e97dc3e2ea0.json) | Detect suspicious services running from user-writable directories or with generic names commonly used by malware |
| 1a | Services                | ✅ | Mac | suspicious_launchd_macos | [043](kibana/osquery_saved_query/osquery_manager-5823a22e-5add-416d-a142-de323400edb0.json) | Detect suspicious launch daemons and agents on macOS, excluding system paths but flagging user-writable directories |
| 1b | Services                | ✅ | Linux | suspicious_systemd_linux | [044](kibana/osquery_saved_query/osquery_manager-f8b0894b-772d-4242-8e19-dbc5d7ae2e06.json) | Detect suspicious systemd units on Linux, excluding system paths but flagging user-writable directories and unusual locations |


## Queries by Platform

<details>
<summary><b>🪟 Windows - Suspicious Services</b></summary>

### Description
Detects suspicious Windows services with comprehensive risk scoring (0-100). Identifies services in user-writable directories, unsigned/untrusted binaries, ServiceDLL hijacking, failure command persistence, and privilege escalation patterns.

**Query returned No results,** not sure if my query is wrong (should not be ;) ) , or I just do not have suspicious services running on my VM :P Can somebody help validate this?

### Platform
`windows`

### Interval
`3600` seconds (1 hour)

### SQL Query

```sql
SELECT
  s.name,
  s.display_name,
  s.status,
  s.start_type,
  s.path,
  s.user_account,
  r1.data AS service_dll,
  r2.data AS failure_command,
  h.sha256,
  h.md5,
  a.subject_name AS cert_subject,
  a.issuer_name AS cert_issuer,
  a.result AS signature_status,
  h_dll.sha256 AS servicedll_sha256,
  h_dll.md5 AS servicedll_md5,
  a_dll.subject_name AS servicedll_cert_subject,
  a_dll.result AS servicedll_signature_status,
  r_service_key.mtime AS service_registry_mtime,
  CAST((strftime('%s', 'now') - r_service_key.mtime) / 86400 AS INTEGER) AS days_since_creation,
  (
    (CASE
      WHEN s.path LIKE '%\\Temp\\%' THEN 40
      WHEN s.path LIKE '%\\Users\\%\\AppData\\Local\\Temp\\%' THEN 40
      WHEN s.path LIKE '%\\Users\\%\\Downloads\\%' THEN 35
      WHEN s.path LIKE '%\\AppData\\Local\\%' THEN 35
      WHEN s.path LIKE '%\\AppData\\Roaming\\%' THEN 30
      WHEN s.path LIKE '%\\Users\\%\\Documents\\%' THEN 30
      WHEN s.path LIKE '%\\Users\\Public\\%' THEN 25
      WHEN s.path LIKE '%\\ProgramData\\%' AND s.path NOT LIKE '%\\ProgramData\\Microsoft\\%' THEN 20
      ELSE 5
    END) +
    (CASE
      WHEN a.result IS NULL OR a.result = '' THEN 25
      WHEN a.result != 'trusted' THEN 25
      WHEN a.subject_name NOT LIKE '%Microsoft%' AND a.subject_name NOT LIKE '%Windows%' THEN 15
      ELSE 0
    END) +
    (CASE
      WHEN s.user_account IN ('LocalSystem', 'NT AUTHORITY\\SYSTEM', 'SYSTEM') AND
           (s.path LIKE '%\\Temp\\%' OR s.path LIKE '%\\AppData\\%' OR s.path LIKE '%\\Users\\%') THEN 20
      WHEN s.user_account IN ('LocalSystem', 'NT AUTHORITY\\SYSTEM', 'SYSTEM') THEN 10
      WHEN s.user_account LIKE '%Administrator%' THEN 5
      ELSE 0
    END) +
    (CASE
      WHEN LOWER(s.name) IN ('service', 'svc', 'system', 'update', 'windows', 'microsoft', 'security', 'monitor', 'agent', 'helper') THEN 10
      WHEN LENGTH(s.name) <= 5 THEN 8
      WHEN s.display_name = s.name OR s.display_name IS NULL THEN 5
      ELSE 0
    END) +
    (CASE
      WHEN r1.data IS NOT NULL AND r1.data != '' AND h_dll.sha256 IS NULL THEN 5
      WHEN r1.data LIKE '%\\Temp\\%' OR r1.data LIKE '%\\AppData\\%' THEN 5
      WHEN a_dll.result IS NOT NULL AND a_dll.result != 'trusted' THEN 5
      ELSE 0
    END)
  ) AS risk_score,
  (CASE
    WHEN (
      (CASE
        WHEN s.path LIKE '%\\Temp\\%' THEN 40
        WHEN s.path LIKE '%\\Users\\%\\AppData\\Local\\Temp\\%' THEN 40
        WHEN s.path LIKE '%\\Users\\%\\Downloads\\%' THEN 35
        WHEN s.path LIKE '%\\AppData\\Local\\%' THEN 35
        WHEN s.path LIKE '%\\AppData\\Roaming\\%' THEN 30
        WHEN s.path LIKE '%\\Users\\%\\Documents\\%' THEN 30
        WHEN s.path LIKE '%\\Users\\Public\\%' THEN 25
        WHEN s.path LIKE '%\\ProgramData\\%' AND s.path NOT LIKE '%\\ProgramData\\Microsoft\\%' THEN 20
        ELSE 5
      END) +
      (CASE
        WHEN a.result IS NULL OR a.result = '' THEN 25
        WHEN a.result != 'trusted' THEN 25
        WHEN a.subject_name NOT LIKE '%Microsoft%' AND a.subject_name NOT LIKE '%Windows%' THEN 15
        ELSE 0
      END) +
      (CASE
        WHEN s.user_account IN ('LocalSystem', 'NT AUTHORITY\\SYSTEM', 'SYSTEM') AND
             (s.path LIKE '%\\Temp\\%' OR s.path LIKE '%\\AppData\\%' OR s.path LIKE '%\\Users\\%') THEN 20
        WHEN s.user_account IN ('LocalSystem', 'NT AUTHORITY\\SYSTEM', 'SYSTEM') THEN 10
        WHEN s.user_account LIKE '%Administrator%' THEN 5
        ELSE 0
      END) +
      (CASE
        WHEN LOWER(s.name) IN ('service', 'svc', 'system', 'update', 'windows', 'microsoft', 'security', 'monitor', 'agent', 'helper') THEN 10
        WHEN LENGTH(s.name) <= 5 THEN 8
        WHEN s.display_name = s.name OR s.display_name IS NULL THEN 5
        ELSE 0
      END) +
      (CASE
        WHEN r1.data IS NOT NULL AND r1.data != '' AND h_dll.sha256 IS NULL THEN 5
        WHEN r1.data LIKE '%\\Temp\\%' OR r1.data LIKE '%\\AppData\\%' THEN 5
        WHEN a_dll.result IS NOT NULL AND a_dll.result != 'trusted' THEN 5
        ELSE 0
      END)
    ) >= 70 THEN 'CRITICAL'
    WHEN (
      (CASE
        WHEN s.path LIKE '%\\Temp\\%' THEN 40
        WHEN s.path LIKE '%\\Users\\%\\AppData\\Local\\Temp\\%' THEN 40
        WHEN s.path LIKE '%\\Users\\%\\Downloads\\%' THEN 35
        WHEN s.path LIKE '%\\AppData\\Local\\%' THEN 35
        WHEN s.path LIKE '%\\AppData\\Roaming\\%' THEN 30
        WHEN s.path LIKE '%\\Users\\%\\Documents\\%' THEN 30
        WHEN s.path LIKE '%\\Users\\Public\\%' THEN 25
        WHEN s.path LIKE '%\\ProgramData\\%' AND s.path NOT LIKE '%\\ProgramData\\Microsoft\\%' THEN 20
        ELSE 5
      END) +
      (CASE
        WHEN a.result IS NULL OR a.result = '' THEN 25
        WHEN a.result != 'trusted' THEN 25
        WHEN a.subject_name NOT LIKE '%Microsoft%' AND a.subject_name NOT LIKE '%Windows%' THEN 15
        ELSE 0
      END) +
      (CASE
        WHEN s.user_account IN ('LocalSystem', 'NT AUTHORITY\\SYSTEM', 'SYSTEM') AND
             (s.path LIKE '%\\Temp\\%' OR s.path LIKE '%\\AppData\\%' OR s.path LIKE '%\\Users\\%') THEN 20
        WHEN s.user_account IN ('LocalSystem', 'NT AUTHORITY\\SYSTEM', 'SYSTEM') THEN 10
        WHEN s.user_account LIKE '%Administrator%' THEN 5
        ELSE 0
      END) +
      (CASE
        WHEN LOWER(s.name) IN ('service', 'svc', 'system', 'update', 'windows', 'microsoft', 'security', 'monitor', 'agent', 'helper') THEN 10
        WHEN LENGTH(s.name) <= 5 THEN 8
        WHEN s.display_name = s.name OR s.display_name IS NULL THEN 5
        ELSE 0
      END) +
      (CASE
        WHEN r1.data IS NOT NULL AND r1.data != '' AND h_dll.sha256 IS NULL THEN 5
        WHEN r1.data LIKE '%\\Temp\\%' OR r1.data LIKE '%\\AppData\\%' THEN 5
        WHEN a_dll.result IS NOT NULL AND a_dll.result != 'trusted' THEN 5
        ELSE 0
      END)
    ) >= 50 THEN 'HIGH'
    WHEN (
      (CASE
        WHEN s.path LIKE '%\\Temp\\%' THEN 40
        WHEN s.path LIKE '%\\Users\\%\\AppData\\Local\\Temp\\%' THEN 40
        WHEN s.path LIKE '%\\Users\\%\\Downloads\\%' THEN 35
        WHEN s.path LIKE '%\\AppData\\Local\\%' THEN 35
        WHEN s.path LIKE '%\\AppData\\Roaming\\%' THEN 30
        WHEN s.path LIKE '%\\Users\\%\\Documents\\%' THEN 30
        WHEN s.path LIKE '%\\Users\\Public\\%' THEN 25
        WHEN s.path LIKE '%\\ProgramData\\%' AND s.path NOT LIKE '%\\ProgramData\\Microsoft\\%' THEN 20
        ELSE 5
      END) +
      (CASE
        WHEN a.result IS NULL OR a.result = '' THEN 25
        WHEN a.result != 'trusted' THEN 25
        WHEN a.subject_name NOT LIKE '%Microsoft%' AND a.subject_name NOT LIKE '%Windows%' THEN 15
        ELSE 0
      END) +
      (CASE
        WHEN s.user_account IN ('LocalSystem', 'NT AUTHORITY\\SYSTEM', 'SYSTEM') AND
             (s.path LIKE '%\\Temp\\%' OR s.path LIKE '%\\AppData\\%' OR s.path LIKE '%\\Users\\%') THEN 20
        WHEN s.user_account IN ('LocalSystem', 'NT AUTHORITY\\SYSTEM', 'SYSTEM') THEN 10
        WHEN s.user_account LIKE '%Administrator%' THEN 5
        ELSE 0
      END) +
      (CASE
        WHEN LOWER(s.name) IN ('service', 'svc', 'system', 'update', 'windows', 'microsoft', 'security', 'monitor', 'agent', 'helper') THEN 10
        WHEN LENGTH(s.name) <= 5 THEN 8
        WHEN s.display_name = s.name OR s.display_name IS NULL THEN 5
        ELSE 0
      END) +
      (CASE
        WHEN r1.data IS NOT NULL AND r1.data != '' AND h_dll.sha256 IS NULL THEN 5
        WHEN r1.data LIKE '%\\Temp\\%' OR r1.data LIKE '%\\AppData\\%' THEN 5
        WHEN a_dll.result IS NOT NULL AND a_dll.result != 'trusted' THEN 5
        ELSE 0
      END)
    ) >= 30 THEN 'MEDIUM'
    ELSE 'LOW'
  END) AS risk_level
FROM services s
LEFT JOIN registry r1 ON r1.path = 'HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Services\\' || s.name || '\\Parameters' AND r1.name = 'ServiceDll'
LEFT JOIN registry r2 ON r2.path = 'HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Services\\' || s.name AND r2.name = 'FailureCommand'
LEFT JOIN hash h ON h.path = s.path
LEFT JOIN authenticode a ON a.path = s.path
LEFT JOIN hash h_dll ON h_dll.path = r1.data
LEFT JOIN authenticode a_dll ON a_dll.path = r1.data
LEFT JOIN registry r_service_key ON r_service_key.path = 'HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Services\\' || s.name
WHERE
  s.start_type IN ('AUTO_START', 'DEMAND_START', 'BOOT_START', 'SYSTEM_START')
  AND (
    s.path LIKE '%\\Temp\\%'
    OR s.path LIKE '%\\Users\\%\\AppData\\%'
    OR s.path LIKE '%\\Users\\%\\Documents\\%'
    OR s.path LIKE '%\\Users\\%\\Downloads\\%'
    OR s.path LIKE '%\\Users\\Public\\%'
    OR (s.path LIKE '%\\ProgramData\\%' AND s.path NOT LIKE '%\\ProgramData\\Microsoft\\%')
    OR (r1.data IS NOT NULL AND r1.data != '' AND r1.data NOT LIKE 'C:\\Windows\\System32\\%' AND r1.data NOT LIKE 'C:\\Windows\\SysWOW64\\%')
    OR (r2.data IS NOT NULL AND r2.data != '')
    OR (a.result IS NOT NULL AND a.result != 'trusted')
  )
  AND s.path NOT LIKE 'C:\\Windows\\System32\\%'
  AND s.path NOT LIKE 'C:\\Windows\\SysWOW64\\%'
  AND s.name NOT IN ('wuauserv', 'BITS', 'TrustedInstaller', 'WinDefend', 'Spooler')
ORDER BY risk_score DESC
LIMIT 200;
```

### Key Detection Capabilities
- User-writable directory execution (Temp, AppData, Downloads)
- Unsigned or untrusted code signatures
- ServiceDLL hijacking attempts
- Privilege escalation (SYSTEM account with suspicious paths)
- Generic service name masquerading

</details>

<details>
<summary><b>🍎 macOS - Suspicious Launch Daemons/Agents</b></summary>

### Description
Detects suspicious launchd persistence on macOS with multi-factor risk scoring. Monitors all standard LaunchAgents/LaunchDaemons locations, analyzes program paths, detects label masquerading, and prioritizes high-risk entries.

<img width="1727" height="87" alt="Screenshot 2025-11-06 at 15 26 42" src="https://github.com/user-attachments/assets/13a91d96-5003-4c51-82d2-f6ca9a00c394" />


### Platform
`darwin` (macOS)

### Interval
`3600` seconds (1 hour)

### SQL Query

```sql
WITH launchd_base AS (
  SELECT
    l.name,
    l.label,
    l.path,
    -- Extract executable from program_arguments (NO l.program column exists!)
    CASE
      WHEN l.program_arguments LIKE '<%' THEN
        -- Handle XML array format: <string>/path/to/exe</string>
        RTRIM(LTRIM(SUBSTR(l.program_arguments, INSTR(l.program_arguments, '<string>') + 8, INSTR(l.program_arguments, '</string>') - INSTR(l.program_arguments, '<string>') - 8)))
      WHEN l.program_arguments != '' THEN
        -- Use program_arguments as-is (might be a simple string or first element)
        l.program_arguments
      ELSE NULL
    END AS program,
    l.program_arguments,
    l.run_at_load,
    l.keep_alive,
    -- Infer username from plist location (NO l.username column exists!)
    CASE
      WHEN l.path LIKE '/Library/LaunchDaemons/%' THEN 'root'
      WHEN l.path LIKE '/Users/%/Library/LaunchAgents/%' THEN
        -- Extract username from path: /Users/USERNAME/Library/LaunchAgents/...
        SUBSTR(l.path, 8, INSTR(SUBSTR(l.path, 8), '/') - 1)
      WHEN l.path LIKE '/Users/%/Library/LaunchDaemons/%' THEN
        -- Extract username from path: /Users/USERNAME/Library/LaunchDaemons/...
        SUBSTR(l.path, 8, INSTR(SUBSTR(l.path, 8), '/') - 1)
      WHEN l.path LIKE '/Library/LaunchAgents/%' THEN 'system'
      ELSE NULL
    END AS username,
    l.disabled,
    f.ctime AS file_created,
    f.mtime AS file_modified,
    CAST((strftime('%s', 'now') - COALESCE(f.ctime, strftime('%s', 'now'))) / 86400 AS INTEGER) AS age_days,
    -- Program risk category (use program_arguments directly)
    CASE
      WHEN l.program_arguments LIKE '/tmp/%' OR l.program_arguments LIKE '/var/tmp/%' THEN 'TEMP_EXECUTION'
      WHEN l.program_arguments LIKE '/Users/%/Downloads/%' OR l.program_arguments LIKE '/Users/%/Desktop/%' THEN 'USER_DOWNLOAD'
      WHEN l.program_arguments LIKE '/dev/shm/%' THEN 'SHARED_MEMORY'
      WHEN l.program_arguments LIKE '/Users/%/.%' OR l.program_arguments LIKE '%/.hidden/%' THEN 'HIDDEN_PROGRAM'
      WHEN l.program_arguments NOT LIKE '/usr/%' AND l.program_arguments NOT LIKE '/bin/%' AND l.program_arguments NOT LIKE '/sbin/%' AND l.program_arguments NOT LIKE '/Applications/%.app/%' AND l.program_arguments NOT LIKE '/System/%' THEN 'NON_STANDARD_LOCATION'
      WHEN l.program_arguments LIKE '/usr/bin/python%' OR l.program_arguments LIKE '/bin/sh' OR l.program_arguments LIKE '/bin/bash' OR l.program_arguments LIKE '/usr/bin/perl%' OR l.program_arguments LIKE '/usr/bin/ruby%' THEN 'INTERPRETER'
      WHEN l.program_arguments LIKE '/Applications/%.app/%' THEN 'APPLICATION'
      ELSE 'SYSTEM_BINARY'
    END AS program_risk_category,
    CASE
      WHEN l.path LIKE '/Library/LaunchDaemons/%' THEN 'ROOT_DAEMON'
      WHEN l.path LIKE '/Library/LaunchAgents/%' THEN 'SYSTEM_AGENT'
      WHEN l.path LIKE '/Users/%/Library/LaunchAgents/%' THEN 'USER_AGENT'
      WHEN l.path LIKE '/Users/%/Library/LaunchDaemons/%' THEN 'USER_DAEMON'
      WHEN l.path LIKE '/tmp/%' OR l.path LIKE '/var/tmp/%' THEN 'TEMP_PLIST'
      WHEN l.path LIKE '/Users/%/Downloads/%' THEN 'DOWNLOADS'
      WHEN l.path LIKE '/Users/%/Desktop/%' THEN 'DESKTOP'
      ELSE 'OTHER'
    END AS plist_location_type
  FROM launchd l
  LEFT JOIN file f ON f.path = l.path
  WHERE (
    l.path LIKE '/Library/LaunchAgents/%'
    OR l.path LIKE '/Library/LaunchDaemons/%'
    OR l.path LIKE '/Users/%/Library/LaunchAgents/%'
    OR l.path LIKE '/Users/%/Library/LaunchDaemons/%'
    OR l.path LIKE '/tmp/%'
    OR l.path LIKE '/var/tmp/%'
    OR l.path LIKE '/Users/%/Downloads/%'
    OR l.path LIKE '/Users/%/Desktop/%'
  )
  AND l.path NOT LIKE '/System/Library/%'
  AND l.path NOT LIKE '/Library/Apple/%'
  AND l.path NOT LIKE '/Applications/Xcode.app/%'
),
scored_launchd AS (
  SELECT
    *,
    (
      CASE
        WHEN path LIKE '/Library/LaunchDaemons/%' THEN 30
        WHEN path LIKE '/tmp/%' OR path LIKE '/var/tmp/%' THEN 30
        WHEN path LIKE '/Users/%/Library/LaunchAgents/%' THEN 25
        WHEN path LIKE '/Users/%/Library/LaunchDaemons/%' THEN 25
        WHEN path LIKE '/Users/%/Downloads/%' OR path LIKE '/Users/%/Desktop/%' THEN 20
        WHEN path LIKE '/Library/LaunchAgents/%' THEN 20
        ELSE 0
      END +
      CASE
        WHEN program_risk_category IN ('TEMP_EXECUTION', 'SHARED_MEMORY') THEN 30
        WHEN program_risk_category IN ('USER_DOWNLOAD', 'HIDDEN_PROGRAM') THEN 25
        WHEN program_risk_category = 'NON_STANDARD_LOCATION' THEN 20
        WHEN program_risk_category = 'INTERPRETER' THEN 15
        ELSE 0
      END +
      CASE
        WHEN label LIKE 'com.apple.%' AND path NOT LIKE '/System/Library/%' AND path NOT LIKE '/Library/Apple/%' THEN 20
        WHEN label LIKE 'com.google.%' AND program NOT LIKE '/Applications/Google%' AND program NOT LIKE '/Library/Google/%' THEN 20
        WHEN label LIKE '%malware%' OR label LIKE '%trojan%' OR label LIKE '%backdoor%' OR label LIKE '%virus%' THEN 20
        WHEN label LIKE '%update%' OR label LIKE '%check%' OR label LIKE '%sync%' OR label LIKE '%agent%' THEN 15
        WHEN label NOT LIKE '%.%' THEN 10
        ELSE 0
      END +
      CASE
        WHEN run_at_load = 1 AND keep_alive = 1 THEN 20
        WHEN keep_alive = 1 THEN 15
        WHEN run_at_load = 1 THEN 10
        ELSE 0
      END
    ) AS risk_score
  FROM launchd_base
)
SELECT
  name,
  label,
  path,
  program,
  program_arguments,
  run_at_load,
  keep_alive,
  username,
  disabled,
  datetime(file_created, 'unixepoch', 'localtime') AS created_time,
  datetime(file_modified, 'unixepoch', 'localtime') AS modified_time,
  age_days,
  plist_location_type,
  program_risk_category,
  risk_score,
  CASE
    WHEN risk_score >= 70 THEN 'CRITICAL'
    WHEN risk_score >= 50 THEN 'HIGH'
    WHEN risk_score >= 30 THEN 'MEDIUM'
    ELSE 'LOW'
  END AS risk_level
FROM scored_launchd
WHERE risk_score >= 30 OR age_days <= 7
ORDER BY risk_score DESC, age_days ASC, label
LIMIT 200;
```

### Key Detection Capabilities
- Temporary directory persistence (/tmp, /var/tmp)
- User Downloads/Desktop execution
- Label masquerading (com.apple.*, com.google.*)
- Hidden program execution
- Non-standard binary locations
- RunAtLoad + KeepAlive persistence patterns

</details>

<details>
<summary><b>🐧 Linux - Suspicious Systemd Units</b></summary>

### Description
Detects suspicious systemd persistence on Linux with multi-factor risk scoring. Monitors /etc/systemd/system/ (80% of malware), user systemd units, runtime units, and temporary locations. Prioritizes socket/timer units and recently created entries.

<img width="1728" height="244" alt="Screenshot 2025-11-06 at 15 26 29" src="https://github.com/user-attachments/assets/4667c174-2952-49fc-ac46-52c5f0966008" />

### Platform
`linux`

### Interval
`3600` seconds (1 hour)

### SQL Query

```sql
WITH systemd_base AS (
  SELECT
    su.id,
    su.description,
    su.load_state,
    su.active_state,
    su.sub_state,
    su.fragment_path,
    su.unit_file_state,
    f.ctime,
    f.mtime,
    CASE
      WHEN su.id LIKE '%.socket' THEN 'SOCKET'
      WHEN su.id LIKE '%.timer' THEN 'TIMER'
      WHEN su.id LIKE '%.service' THEN 'SERVICE'
      WHEN su.id LIKE '%.target' THEN 'TARGET'
      WHEN su.id LIKE '%.path' THEN 'PATH'
      ELSE 'OTHER'
    END AS unit_type
  FROM systemd_units su
  LEFT JOIN file f ON f.path = su.fragment_path
  WHERE (
    su.fragment_path LIKE '/etc/systemd/system/%'
    OR su.fragment_path LIKE '/etc/systemd/user/%'
    OR su.fragment_path LIKE '/run/systemd/system/%'
    OR su.fragment_path LIKE '%/.config/systemd/user/%'
    OR su.fragment_path LIKE '/tmp/%'
    OR su.fragment_path LIKE '/var/tmp/%'
  )
  AND su.fragment_path NOT LIKE '/lib/systemd/%'
  AND su.fragment_path NOT LIKE '/usr/lib/systemd/%'
),
systemd_risk AS (
  SELECT
    id,
    description,
    load_state,
    active_state,
    sub_state,
    fragment_path,
    unit_file_state,
    unit_type,
    ctime,
    mtime,
    CASE
      WHEN fragment_path LIKE '/tmp/%' OR fragment_path LIKE '/var/tmp/%' THEN 40
      WHEN fragment_path LIKE '/etc/systemd/system/%' THEN 30
      WHEN fragment_path LIKE '%/.config/systemd/user/%' THEN 25
      WHEN fragment_path LIKE '/run/systemd/system/%' THEN 20
      WHEN fragment_path LIKE '/etc/systemd/user/%' THEN 15
      ELSE 0
    END AS location_risk,
    CASE
      WHEN unit_file_state = 'enabled' AND active_state = 'active' THEN 35
      WHEN unit_file_state = 'enabled' AND active_state = 'inactive' THEN 25
      WHEN unit_file_state = 'static' AND active_state = 'active' THEN 20
      WHEN load_state = 'error' THEN 15
      WHEN load_state = 'masked' THEN 0
      ELSE 10
    END AS state_risk,
    CASE
      WHEN unit_type = 'SOCKET' THEN 25
      WHEN unit_type = 'TIMER' THEN 20
      WHEN unit_type = 'SERVICE' THEN 10
      ELSE 0
    END AS type_risk
  FROM systemd_base
)
SELECT
  id,
  description,
  fragment_path,
  unit_file_state,
  active_state,
  load_state,
  unit_type,
  location_risk,
  state_risk,
  type_risk,
  (location_risk + state_risk + type_risk) AS risk_score,
  CASE
    WHEN (location_risk + state_risk + type_risk) >= 70 THEN 'CRITICAL'
    WHEN (location_risk + state_risk + type_risk) >= 50 THEN 'HIGH'
    WHEN (location_risk + state_risk + type_risk) >= 30 THEN 'MEDIUM'
    ELSE 'LOW'
  END AS risk_level,
  CASE
    WHEN unit_type = 'SOCKET' THEN 'HIGH: Socket unit detected - potential network backdoor listener'
    WHEN unit_type = 'TIMER' THEN 'MEDIUM: Timer unit detected - potential C2 beaconing mechanism'
    WHEN fragment_path LIKE '/tmp/%' OR fragment_path LIKE '/var/tmp/%' THEN 'CRITICAL: Unit file in temporary directory - likely malware persistence'
    WHEN fragment_path LIKE '/etc/systemd/system/%' AND unit_file_state = 'enabled' THEN 'HIGH: Enabled system unit - review configuration for suspicious commands'
    WHEN unit_file_state = 'enabled' AND active_state = 'active' THEN 'MEDIUM: Enabled and active unit - validate legitimacy'
    ELSE 'Review unit configuration and validate against baseline'
  END AS analyst_guidance,
  datetime(ctime, 'unixepoch', 'localtime') AS file_created,
  datetime(mtime, 'unixepoch', 'localtime') AS file_modified,
  CAST((strftime('%s', 'now') - COALESCE(mtime, strftime('%s', 'now'))) / 86400 AS INTEGER) AS age_days
FROM systemd_risk
WHERE (
  (location_risk + state_risk + type_risk) >= 30
  OR CAST((strftime('%s', 'now') - COALESCE(mtime, strftime('%s', 'now'))) / 86400 AS INTEGER) <= 7
  OR unit_type IN ('SOCKET', 'TIMER')
)
ORDER BY (location_risk + state_risk + type_risk) DESC, CAST((strftime('%s', 'now') - COALESCE(mtime, strftime('%s', 'now'))) / 86400 AS INTEGER) ASC, id
LIMIT 200;
```

### Key Detection Capabilities
- Socket units (network backdoor listeners)
- Timer units (C2 beaconing mechanisms)
- Temporary directory persistence (/tmp, /var/tmp)
- User systemd units (~/.config/systemd/user/)
- Enabled and active suspicious units
- Recently created units (within 7 days)

</details>

---

## Risk Score Interpretation

| Risk Level | Score Range | Action Required |
|------------|-------------|-----------------|
| **CRITICAL** | 70-100 | Immediate investigation required - likely active threat |
| **HIGH** | 50-69 | Review within 24 hours - potential persistence mechanism |
| **MEDIUM** | 30-49 | Weekly review - may be legitimate but unusual |
| **LOW** | 0-29 | Baseline monitoring - context-dependent assessment |

---

