### PR TITLE
Migrate the eset_protect package to the links panel

### DIFF
--- a/packages/eset_protect/changelog.yml
+++ b/packages/eset_protect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: "Change the Dashboards to use the links panel"
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.11.1"
   changes:
     - description: "Fix 404 Not Found responses caused by a stale cached `response-id` header. Clear `cursor.response_id` on 200 OK and only include the header after 202 Accepted."

--- a/packages/eset_protect/kibana/dashboard/eset_protect-186ccfba-ed02-4f7a-a46d-a58ec636688a.json
+++ b/packages/eset_protect/kibana/dashboard/eset_protect-186ccfba-ed02-4f7a-a46d-a58ec636688a.json
@@ -27,6 +27,48 @@
             {
                 "embeddableConfig": {
                     "enhancements": {},
+                    "attributes": {
+                        "title": "links",
+                        "layout": "vertical",
+                        "links": [
+                            {
+                                "label": "Event",
+                                "type": "dashboardLink",
+                                "id": "eset_protect-186ccfba-ed02-4f7a-a46d-a58ec636688a",
+                                "order": 0,
+                                "destinationRefName": "link_eset_protect-186ccfba-ed02-4f7a-a46d-a58ec636688a_dashboard"
+                            },
+                            {
+                                "label": "Detection",
+                                "type": "dashboardLink",
+                                "id": "eset_protect-99f893a6-1b3d-412f-9a03-46035f2fa9d5",
+                                "order": 1,
+                                "destinationRefName": "link_eset_protect-99f893a6-1b3d-412f-9a03-46035f2fa9d5_dashboard"
+                            },
+                            {
+                                "label": "Device Task",
+                                "type": "dashboardLink",
+                                "id": "eset_protect-dbe9ff1e-44c4-4cd9-8475-f04309279577",
+                                "order": 2,
+                                "destinationRefName": "link_eset_protect-dbe9ff1e-44c4-4cd9-8475-f04309279577_dashboard"
+                            }
+                        ]
+                    }
+                },
+                "gridData": {
+                    "h": 6,
+                    "i": "d47b24ca-dfc2-4715-bd9d-03013432cd96",
+                    "w": 10,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "d47b24ca-dfc2-4715-bd9d-03013432cd96",
+                "title": "Table of Contents",
+                "type": "links"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
                     "hidePanelTitles": false,
                     "savedVis": {
                         "data": {
@@ -43,7 +85,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**ESET PROTECT**  \n\n**[Event](#/dashboard/eset_protect-186ccfba-ed02-4f7a-a46d-a58ec636688a)**  \n[Detection](#/dashboard/eset_protect-99f893a6-1b3d-412f-9a03-46035f2fa9d5)  \n[Device Task](#/dashboard/eset_protect-dbe9ff1e-44c4-4cd9-8475-f04309279577)  \n\n**Event**\n\nThis dashboard provides an overview of syslog events received from ESET PROTECT, categorized as:\n\n- Threat Event\n- Firewall Aggregated Event\n- HIPS Aggregated Event\n- Audit Event\n- Filtered Websites Event\n- Enterprise Inspector Alert Event\n- Blocked Files Event\n\n[**Integration Page**](/app/integrations/detail/eset_protect/overview)\n\n\n",
+                            "markdown": "**ESET PROTECT**\n\nThis dashboard provides an overview of syslog events received from ESET PROTECT, categorized as:\n\n- Threat Event\n- Firewall Aggregated Event\n- HIPS Aggregated Event\n- Audit Event\n- Filtered Websites Event\n- Enterprise Inspector Alert Event\n- Blocked Files Event\n\n[**Integration Page**](/app/integrations/detail/eset_protect/overview)\n\n\n",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -52,14 +94,14 @@
                     }
                 },
                 "gridData": {
-                    "h": 30,
+                    "h": 24,
                     "i": "d47b24ca-dfc2-4715-bd9d-03013432cd96",
                     "w": 10,
                     "x": 0,
-                    "y": 0
+                    "y": 6
                 },
-                "panelIndex": "d47b24ca-dfc2-4715-bd9d-03013432cd96",
-                "title": "Table of Contents",
+                "panelIndex": "d47b24ca-dfc2-4715-bd9d-03013432cd96_1",
+                "title": "Contents",
                 "type": "visualization"
             },
             {
@@ -212,7 +254,7 @@
                     "y": 0
                 },
                 "panelIndex": "981e4637-6331-4136-88eb-a2acfd835315",
-                "title": "Events by Threat Type [Logs ESET PROTECT]",
+                "title": "Events by Threat Type",
                 "type": "lens"
             },
             {
@@ -365,7 +407,7 @@
                     "y": 0
                 },
                 "panelIndex": "d6415dc2-c420-46c2-9a95-1baf41a32509",
-                "title": "Events by Severity [Logs ESET PROTECT]",
+                "title": "Events by Severity",
                 "type": "lens"
             },
             {
@@ -521,7 +563,7 @@
                     "y": 14
                 },
                 "panelIndex": "76855fa1-403d-4866-9daa-24a22c96e0ea",
-                "title": "Audit Events by Domain [Logs ESET PROTECT]",
+                "title": "Audit Events by Domain",
                 "type": "lens"
             },
             {
@@ -668,7 +710,7 @@
                     "y": 30
                 },
                 "panelIndex": "655d0a51-7501-4e1e-8db3-567025d497c3",
-                "title": "Top 10 Process Executable [Logs ESET PROTECT]",
+                "title": "Top 10 Process Executable",
                 "type": "lens"
             },
             {
@@ -815,7 +857,7 @@
                     "y": 30
                 },
                 "panelIndex": "68350342-7a2a-416b-b6b2-e0b07347ee48",
-                "title": "Top 10 Threat Name [Logs ESET PROTECT]",
+                "title": "Top 10 Threat Name",
                 "type": "lens"
             },
             {
@@ -962,7 +1004,7 @@
                     "y": 45
                 },
                 "panelIndex": "e86ac2a4-8e8e-4931-9d1d-2f34ea8af59e",
-                "title": "Top 10 Source IP [Logs ESET PROTECT]",
+                "title": "Top 10 Source IP",
                 "type": "lens"
             },
             {
@@ -1110,7 +1152,7 @@
                     "y": 45
                 },
                 "panelIndex": "ba7776e9-d708-4256-8d4d-0bfb99d05b16",
-                "title": "Top 10 Destination IP [Logs ESET PROTECT]",
+                "title": "Top 10 Destination IP",
                 "type": "lens"
             },
             {
@@ -1258,7 +1300,7 @@
                     "y": 60
                 },
                 "panelIndex": "0f217f1b-c2ba-4cbb-96ca-ea3985ec1370",
-                "title": "Top 10 Rule Name [Logs ESET PROTECT]",
+                "title": "Top 10 Rule Name",
                 "type": "lens"
             },
             {
@@ -1406,7 +1448,7 @@
                     "y": 60
                 },
                 "panelIndex": "596e098a-d8e0-4c42-9b20-96f449cc99ae",
-                "title": "Top 10 Users Associated with Event [Logs ESET PROTECT]",
+                "title": "Top 10 Users Associated with Event",
                 "type": "lens"
             },
             {
@@ -1548,6 +1590,21 @@
             "id": "logs-*",
             "name": "controlGroup_4c961bf1-c98e-47eb-87f0-a8d1131105a8:optionsListDataView",
             "type": "index-pattern"
+        },
+        {
+            "name": "d47b24ca-dfc2-4715-bd9d-03013432cd96:link_eset_protect-186ccfba-ed02-4f7a-a46d-a58ec636688a_dashboard",
+            "type": "dashboard",
+            "id": "eset_protect-186ccfba-ed02-4f7a-a46d-a58ec636688a"
+        },
+        {
+            "name": "d47b24ca-dfc2-4715-bd9d-03013432cd96:link_eset_protect-99f893a6-1b3d-412f-9a03-46035f2fa9d5_dashboard",
+            "type": "dashboard",
+            "id": "eset_protect-99f893a6-1b3d-412f-9a03-46035f2fa9d5"
+        },
+        {
+            "name": "d47b24ca-dfc2-4715-bd9d-03013432cd96:link_eset_protect-dbe9ff1e-44c4-4cd9-8475-f04309279577_dashboard",
+            "type": "dashboard",
+            "id": "eset_protect-dbe9ff1e-44c4-4cd9-8475-f04309279577"
         }
     ],
     "type": "dashboard",

--- a/packages/eset_protect/kibana/dashboard/eset_protect-99f893a6-1b3d-412f-9a03-46035f2fa9d5.json
+++ b/packages/eset_protect/kibana/dashboard/eset_protect-99f893a6-1b3d-412f-9a03-46035f2fa9d5.json
@@ -27,6 +27,48 @@
             {
                 "embeddableConfig": {
                     "enhancements": {},
+                    "attributes": {
+                        "title": "links",
+                        "layout": "vertical",
+                        "links": [
+                            {
+                                "label": "Event",
+                                "type": "dashboardLink",
+                                "id": "eset_protect-186ccfba-ed02-4f7a-a46d-a58ec636688a",
+                                "order": 0,
+                                "destinationRefName": "link_eset_protect-186ccfba-ed02-4f7a-a46d-a58ec636688a_dashboard"
+                            },
+                            {
+                                "label": "Detection",
+                                "type": "dashboardLink",
+                                "id": "eset_protect-99f893a6-1b3d-412f-9a03-46035f2fa9d5",
+                                "order": 1,
+                                "destinationRefName": "link_eset_protect-99f893a6-1b3d-412f-9a03-46035f2fa9d5_dashboard"
+                            },
+                            {
+                                "label": "Device Task",
+                                "type": "dashboardLink",
+                                "id": "eset_protect-dbe9ff1e-44c4-4cd9-8475-f04309279577",
+                                "order": 2,
+                                "destinationRefName": "link_eset_protect-dbe9ff1e-44c4-4cd9-8475-f04309279577_dashboard"
+                            }
+                        ]
+                    }
+                },
+                "gridData": {
+                    "h": 6,
+                    "i": "5f4e6970-8643-47cb-a70d-924e19a5389b",
+                    "w": 10,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "5f4e6970-8643-47cb-a70d-924e19a5389b",
+                "title": "Table of Contents",
+                "type": "links"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
                     "hidePanelTitles": false,
                     "savedVis": {
                         "data": {
@@ -43,7 +85,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**ESET PROTECT**  \n\n[Event](#/dashboard/eset_protect-186ccfba-ed02-4f7a-a46d-a58ec636688a)  \n**[Detection](#/dashboard/eset_protect-99f893a6-1b3d-412f-9a03-46035f2fa9d5)**  \n[Device Task](#/dashboard/eset_protect-dbe9ff1e-44c4-4cd9-8475-f04309279577)  \n\n**Detection**\n\nThis dashboard provides an overview of detection events received from ESET PROTECT.\n\n\n[**Integration Page**](/app/integrations/detail/eset_protect/overview)\n",
+                            "markdown": "**ESET PROTECT**\n\nThis dashboard provides an overview of detection events received from ESET PROTECT.\n\n\n[**Integration Page**](/app/integrations/detail/eset_protect/overview)\n",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -52,14 +94,14 @@
                     }
                 },
                 "gridData": {
-                    "h": 27,
+                    "h": 21,
                     "i": "5f4e6970-8643-47cb-a70d-924e19a5389b",
                     "w": 10,
                     "x": 0,
-                    "y": 0
+                    "y": 14
                 },
-                "panelIndex": "5f4e6970-8643-47cb-a70d-924e19a5389b",
-                "title": "Table of Contents",
+                "panelIndex": "5f4e6970-8643-47cb-a70d-924e19a5389b_1",
+                "title": "Contents",
                 "type": "visualization"
             },
             {
@@ -171,7 +213,7 @@
                     "y": 0
                 },
                 "panelIndex": "3fc43ac8-ba2a-4811-8292-e4fd700c7dc8",
-                "title": "Total Detection [Logs ESET PROTECT]",
+                "title": "Total Detection",
                 "type": "lens"
             },
             {
@@ -348,7 +390,7 @@
                     "y": 0
                 },
                 "panelIndex": "2dd92a4b-5067-469e-bf92-d1c8686022a8",
-                "title": "Detection by Object Type [Logs ESET PROTECT]",
+                "title": "Detection by Object Type",
                 "type": "lens"
             },
             {
@@ -502,7 +544,7 @@
                     "y": 13
                 },
                 "panelIndex": "ab2fbd6f-e055-40bd-9e53-e25d4ea900c2",
-                "title": "Detection by Severity Level [Logs ESET PROTECT]",
+                "title": "Detection by Severity Level",
                 "type": "lens"
             },
             {
@@ -656,7 +698,7 @@
                     "y": 13
                 },
                 "panelIndex": "b43180d3-bfdb-4ed5-89dc-88585acbd36a",
-                "title": "Detection by Category [Logs ESET PROTECT]",
+                "title": "Detection by Category",
                 "type": "lens"
             },
             {
@@ -804,7 +846,7 @@
                     "y": 27
                 },
                 "panelIndex": "9c1d4b11-8620-41c6-b77d-866b4a078369",
-                "title": "Top 10 Circumstances for Detection [Logs ESET PROTECT]",
+                "title": "Top 10 Circumstances for Detection",
                 "type": "lens"
             },
             {
@@ -952,7 +994,7 @@
                     "y": 27
                 },
                 "panelIndex": "fefdc44f-03b9-4d0e-abc3-903ffd51bb4d",
-                "title": "Top 10 Process Executables for Detection [Logs ESET PROTECT]",
+                "title": "Top 10 Process Executables for Detection",
                 "type": "lens"
             },
             {
@@ -1099,7 +1141,7 @@
                     "y": 42
                 },
                 "panelIndex": "b6b2bf22-2455-4d10-9231-2ecde81b0ac0",
-                "title": "Top 10 Source IP [Logs ESET PROTECT]",
+                "title": "Top 10 Source IP",
                 "type": "lens"
             },
             {
@@ -1247,7 +1289,7 @@
                     "y": 42
                 },
                 "panelIndex": "061a2ce7-80ff-49be-8004-344270ba6ccc",
-                "title": "Top 10 Destination IP [Logs ESET PROTECT]",
+                "title": "Top 10 Destination IP",
                 "type": "lens"
             },
             {
@@ -1422,7 +1464,7 @@
                     "y": 57
                 },
                 "panelIndex": "9bd9c00f-14df-4389-bd80-3a13c9068a79",
-                "title": "Detection by Type [Logs ESET PROTECT]",
+                "title": "Detection by Type",
                 "type": "lens"
             },
             {
@@ -1570,7 +1612,7 @@
                     "y": 57
                 },
                 "panelIndex": "02f99d8e-6d57-46ab-9339-4ce86cd2ebfb",
-                "title": "Top 10 Usernames for Detection [Logs ESET PROTECT]",
+                "title": "Top 10 Usernames for Detection",
                 "type": "lens"
             },
             {
@@ -1717,6 +1759,21 @@
             "id": "logs-*",
             "name": "controlGroup_ddc90976-c139-4a6d-9349-42b0a3ae40aa:optionsListDataView",
             "type": "index-pattern"
+        },
+        {
+            "name": "5f4e6970-8643-47cb-a70d-924e19a5389b:link_eset_protect-186ccfba-ed02-4f7a-a46d-a58ec636688a_dashboard",
+            "type": "dashboard",
+            "id": "eset_protect-186ccfba-ed02-4f7a-a46d-a58ec636688a"
+        },
+        {
+            "name": "5f4e6970-8643-47cb-a70d-924e19a5389b:link_eset_protect-99f893a6-1b3d-412f-9a03-46035f2fa9d5_dashboard",
+            "type": "dashboard",
+            "id": "eset_protect-99f893a6-1b3d-412f-9a03-46035f2fa9d5"
+        },
+        {
+            "name": "5f4e6970-8643-47cb-a70d-924e19a5389b:link_eset_protect-dbe9ff1e-44c4-4cd9-8475-f04309279577_dashboard",
+            "type": "dashboard",
+            "id": "eset_protect-dbe9ff1e-44c4-4cd9-8475-f04309279577"
         }
     ],
     "type": "dashboard",

--- a/packages/eset_protect/kibana/dashboard/eset_protect-dbe9ff1e-44c4-4cd9-8475-f04309279577.json
+++ b/packages/eset_protect/kibana/dashboard/eset_protect-dbe9ff1e-44c4-4cd9-8475-f04309279577.json
@@ -27,6 +27,48 @@
             {
                 "embeddableConfig": {
                     "enhancements": {},
+                    "attributes": {
+                        "title": "links",
+                        "layout": "vertical",
+                        "links": [
+                            {
+                                "label": "Event",
+                                "type": "dashboardLink",
+                                "id": "eset_protect-186ccfba-ed02-4f7a-a46d-a58ec636688a",
+                                "order": 0,
+                                "destinationRefName": "link_eset_protect-186ccfba-ed02-4f7a-a46d-a58ec636688a_dashboard"
+                            },
+                            {
+                                "label": "Detection",
+                                "type": "dashboardLink",
+                                "id": "eset_protect-99f893a6-1b3d-412f-9a03-46035f2fa9d5",
+                                "order": 1,
+                                "destinationRefName": "link_eset_protect-99f893a6-1b3d-412f-9a03-46035f2fa9d5_dashboard"
+                            },
+                            {
+                                "label": "Device Task",
+                                "type": "dashboardLink",
+                                "id": "eset_protect-dbe9ff1e-44c4-4cd9-8475-f04309279577",
+                                "order": 2,
+                                "destinationRefName": "link_eset_protect-dbe9ff1e-44c4-4cd9-8475-f04309279577_dashboard"
+                            }
+                        ]
+                    }
+                },
+                "gridData": {
+                    "h": 6,
+                    "i": "eef299e7-8d41-4001-999b-a9b80efd84e7",
+                    "w": 10,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "eef299e7-8d41-4001-999b-a9b80efd84e7",
+                "title": "Table of Contents",
+                "type": "links"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
                     "hidePanelTitles": false,
                     "savedVis": {
                         "data": {
@@ -43,7 +85,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**ESET PROTECT**  \n\n[Event](#/dashboard/eset_protect-186ccfba-ed02-4f7a-a46d-a58ec636688a)  \n[Detection](#/dashboard/eset_protect-99f893a6-1b3d-412f-9a03-46035f2fa9d5)  \n**[Device Task](#/dashboard/eset_protect-dbe9ff1e-44c4-4cd9-8475-f04309279577)**  \n\n**Device Task**\n\nThis dashboard provides an overview of device task events received from ESET PROTECT.\n\n\n[**Integration Page**](/app/integrations/detail/eset_protect/overview)\n",
+                            "markdown": "**ESET PROTECT**\n\nThis dashboard provides an overview of device task events received from ESET PROTECT.\n\n\n[**Integration Page**](/app/integrations/detail/eset_protect/overview)\n",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -52,14 +94,14 @@
                     }
                 },
                 "gridData": {
-                    "h": 27,
+                    "h": 21,
                     "i": "eef299e7-8d41-4001-999b-a9b80efd84e7",
                     "w": 10,
                     "x": 0,
-                    "y": 0
+                    "y": 6
                 },
-                "panelIndex": "eef299e7-8d41-4001-999b-a9b80efd84e7",
-                "title": "Table of Contents",
+                "panelIndex": "eef299e7-8d41-4001-999b-a9b80efd84e7_1",
+                "title": "Contents",
                 "type": "visualization"
             },
             {
@@ -171,7 +213,7 @@
                     "y": 0
                 },
                 "panelIndex": "83d7c810-40e6-4cdd-a1c5-a1d905d779e0",
-                "title": "Total Device Task [Logs ESET PROTECT]",
+                "title": "Total Device Task",
                 "type": "lens"
             },
             {
@@ -317,7 +359,7 @@
                     "y": 0
                 },
                 "panelIndex": "46e11ee5-4045-4e1a-98da-da5bdba4694c",
-                "title": "Top Action Name [Logs ESET PROTECT]",
+                "title": "Top Action Name",
                 "type": "lens"
             },
             {
@@ -463,7 +505,7 @@
                     "y": 13
                 },
                 "panelIndex": "601846f0-196f-4b9b-9206-28f6762b91ea",
-                "title": "Top Devices with Highest Device Task [Logs ESET PROTECT]",
+                "title": "Top Devices with Highest Device Task",
                 "type": "lens"
             },
             {
@@ -535,6 +577,21 @@
             "id": "logs-*",
             "name": "controlGroup_3d42ec16-f72a-4097-80fe-ae789a51c991:optionsListDataView",
             "type": "index-pattern"
+        },
+        {
+            "name": "eef299e7-8d41-4001-999b-a9b80efd84e7:link_eset_protect-186ccfba-ed02-4f7a-a46d-a58ec636688a_dashboard",
+            "type": "dashboard",
+            "id": "eset_protect-186ccfba-ed02-4f7a-a46d-a58ec636688a"
+        },
+        {
+            "name": "eef299e7-8d41-4001-999b-a9b80efd84e7:link_eset_protect-99f893a6-1b3d-412f-9a03-46035f2fa9d5_dashboard",
+            "type": "dashboard",
+            "id": "eset_protect-99f893a6-1b3d-412f-9a03-46035f2fa9d5"
+        },
+        {
+            "name": "eef299e7-8d41-4001-999b-a9b80efd84e7:link_eset_protect-dbe9ff1e-44c4-4cd9-8475-f04309279577_dashboard",
+            "type": "dashboard",
+            "id": "eset_protect-dbe9ff1e-44c4-4cd9-8475-f04309279577"
         }
     ],
     "type": "dashboard",

--- a/packages/eset_protect/kibana/search/eset_protect-1235fac4-e101-4844-9c12-c929ae25ec08.json
+++ b/packages/eset_protect/kibana/search/eset_protect-1235fac4-e101-4844-9c12-c929ae25ec08.json
@@ -51,7 +51,7 @@
             ]
         ],
         "timeRestore": false,
-        "title": "Device Task Essential Details [Logs ESET PROTECT]",
+        "title": "Device Task Essential Details",
         "usesAdHocDataView": false
     },
     "coreMigrationVersion": "8.8.0",

--- a/packages/eset_protect/kibana/search/eset_protect-c68400bb-870a-451d-b0cd-247ceb201ad5.json
+++ b/packages/eset_protect/kibana/search/eset_protect-c68400bb-870a-451d-b0cd-247ceb201ad5.json
@@ -51,7 +51,7 @@
             ]
         ],
         "timeRestore": false,
-        "title": "Event Essential Details [Logs ESET PROTECT]",
+        "title": "Event Essential Details",
         "usesAdHocDataView": false
     },
     "coreMigrationVersion": "8.8.0",

--- a/packages/eset_protect/kibana/search/eset_protect-f3c0f0c5-d165-48a4-aafa-6451bdda548f.json
+++ b/packages/eset_protect/kibana/search/eset_protect-f3c0f0c5-d165-48a4-aafa-6451bdda548f.json
@@ -51,7 +51,7 @@
             ]
         ],
         "timeRestore": false,
-        "title": "Detection Essential Details [Logs ESET PROTECT]",
+        "title": "Detection Essential Details",
         "usesAdHocDataView": false
     },
     "coreMigrationVersion": "8.8.0",

--- a/packages/eset_protect/manifest.yml
+++ b/packages/eset_protect/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: eset_protect
 title: ESET PROTECT
-version: "1.11.1"
+version: "1.12.0"
 description: Collect logs from ESET PROTECT with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Migrate the eset_protect package to use the links panel to make the links work in a serverless and different space

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

When I have time I will update the screenshots