### PR TITLE
[kafka] consumergroup test

### DIFF
--- a/packages/kafka/data_stream/consumergroup/_dev/test/system/test-default-config.yml
+++ b/packages/kafka/data_stream/consumergroup/_dev/test/system/test-default-config.yml
@@ -1,5 +1,7 @@
 vars:
   hosts:
-    - '{{Hostname}}:9092'
+    - "{{Hostname}}:8780"
+  metrics_path:
+    - /jolokia
 data_stream:
   vars: ~


### PR DESCRIPTION
The kafka consumergroup  package is missing docker based system tests. This PR adds them, similar to Metricbeat’s tests.


Relates https://github.com/elastic/integrations/issues/15905