### PR TITLE
[CI] Add retries to build elastic-package binary

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -261,7 +261,7 @@ check_git_diff() {
 use_elastic_package() {
     echo "--- Installing elastic-package"
     mkdir -p build
-    go build -o "${ELASTIC_PACKAGE_BIN}" github.com/elastic/elastic-package
+    retry 5 go build -o "${ELASTIC_PACKAGE_BIN}" github.com/elastic/elastic-package
 }
 
 elastic_package_verbosity() {


### PR DESCRIPTION
## Proposed commit message

Add retries to run the command that builds the elastic-package binary:
```
go build -o "${ELASTIC_PACKAGE_BIN}" github.com/elastic/elastic-package
```

This will help us to retry that installation/building process if there are some temporal failures like the one happened in this build:
https://buildkite.com/elastic/integrations/builds/34786#019acb08-9282-45ca-97b0-7529333e9cbf/340-498



