### PR TITLE
SKU based chargeback

### DIFF
--- a/packages/chargeback/_dev/build/build.yml
+++ b/packages/chargeback/_dev/build/build.yml
@@ -1,3 +1,0 @@
-dependencies:
-  ecs:
-    reference: git@v8.17.0

--- a/packages/chargeback/elasticsearch/transform/cluster_tier_and_ds_contribution/transform.yml
+++ b/packages/chargeback/elasticsearch/transform/cluster_tier_and_ds_contribution/transform.yml
@@ -25,6 +25,12 @@ pivot:
           lang: painless
           source: >
             if (doc.containsKey('elasticsearch.index.tier') && !doc['elasticsearch.index.tier'].empty) {
+              def itier = doc.containsKey('elasticsearch.index.tier') && !doc['elasticsearch.index.tier'].empty ? doc['elasticsearch.index.tier'].value : null;
+              if (itier == null) return 'unknown';
+              if (itier.contains('hot') || itier.contains('hot/content') || itier.contains('content')) return 'datahot/datacontent';
+              if (itier.contains('warm')) return 'datawarm';
+              if (itier.contains('cold')) return 'datacold';
+              if (itier.contains('frozen')) return 'datafrozen';
               return doc['elasticsearch.index.tier'].value;
             }
             def pref = doc.containsKey('elasticsearch.index.tier_preference') && !doc['elasticsearch.index.tier_preference'].empty ? doc['elasticsearch.index.tier_preference'].value : null;

--- a/packages/chargeback/elasticsearch/transform/cluster_tier_contribution/transform.yml
+++ b/packages/chargeback/elasticsearch/transform/cluster_tier_contribution/transform.yml
@@ -25,6 +25,12 @@ pivot:
           lang: painless
           source: >
             if (doc.containsKey('elasticsearch.index.tier') && !doc['elasticsearch.index.tier'].empty) {
+              def itier = doc.containsKey('elasticsearch.index.tier') && !doc['elasticsearch.index.tier'].empty ? doc['elasticsearch.index.tier'].value : null;
+              if (itier == null) return 'unknown';
+              if (itier.contains('hot') || itier.contains('hot/content') || itier.contains('content')) return 'datahot/datacontent';
+              if (itier.contains('warm')) return 'datawarm';
+              if (itier.contains('cold')) return 'datacold';
+              if (itier.contains('frozen')) return 'datafrozen';
               return doc['elasticsearch.index.tier'].value;
             }
             


### PR DESCRIPTION
## Proposed commit message
Moving from weighted cost attributed to only the data tiers to a sku and utilization based attribution of cost.

- Split dashboard into *overview*, *data tier* and *features*
- Deployment statistics per `cost_type`
- changed `cluster_tier_contribution` and `cluster_tier_and_ds_contribution` transforms to align `tier` with billing info. (`hot/content` --> `datahot/datacontent`, `cold` --> `datacold`, etc)


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

## Screenshots
<img width="1967" height="613" alt="image" src="https://github.com/user-attachments/assets/6c49abc0-b15f-4a0e-96cb-d13e80d97f75" />
