### PR TITLE
[system] stop starting unnecessary log input on Windows

### DIFF
--- a/dev/codeowners/codeowners.go
+++ b/dev/codeowners/codeowners.go
@@ -20,11 +20,11 @@ const DefaultCodeownersPath = ".github/CODEOWNERS"
 func Check() error {
 	codeowners, err := readGithubOwners(DefaultCodeownersPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("error reading %s: %w", DefaultCodeownersPath, err)
 	}
 	const packagesDir = "packages"
 	if err := validatePackages(codeowners, packagesDir); err != nil {
-		return err
+		return fmt.Errorf("error validating packages in directory '%s': %w", packagesDir, err)
 	}
 
 	return nil
@@ -65,7 +65,7 @@ type githubOwners struct {
 func validatePackages(codeowners *githubOwners, packagesDir string) error {
 	packageDirEntries, err := os.ReadDir(packagesDir)
 	if err != nil {
-		return err
+		return fmt.Errorf("error reading directory '%s': %w", packagesDir, err)
 	}
 
 	if len(packageDirEntries) == 0 {
@@ -83,12 +83,12 @@ func validatePackages(codeowners *githubOwners, packagesDir string) error {
 		packageManifestPath := path.Join(packagePath, "manifest.yml")
 		err = codeowners.checkManifest(packageManifestPath)
 		if err != nil {
-			return err
+			return fmt.Errorf("error checking manifest '%s': %w", packageManifestPath, err)
 		}
 
 		err = codeowners.checkDataStreams(packagePath)
 		if err != nil {
-			return err
+			return fmt.Errorf("error checking data streams from '%s': %w", packagePath, err)
 		}
 
 	}

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.12.3"
+  changes:
+    - description: Stop starting unnecessary log input on Windows
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/16337
 - version: "2.12.2"
   changes:
     - description: Improve documentation

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: system
 title: System
-version: "2.12.2"
+version: "2.12.3"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:
@@ -54,24 +54,24 @@ policy_templates:
         vars:
           - name: condition
             title: Condition
-            description: "Condition to filter when to apply this input. Refer to\n[Host provider](https://www.elastic.co/guide/en/fleet/current/host-provider.html)\nto find the available keys and to\n[Conditions](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html#conditions)\non how to use the available keys in conditions. It defaults to\n'${host.os_version} != \"12 (bookworm)\" and ${host.os_version} != \"13 (trixie)\" and (${host.os_platform} != \"amzn\" or ${host.os_version} != \"2023\") and (${host.os_platform} != \"sles\" and ${host.os_version} != \"15 SP1\" \nand ${host.os_version} != \"15 SP2\" and ${host.os_version} != \"15 SP3\" and ${host.os_version} != \"15 SP4\" and ${host.os_version} != \"15 SP5\" and ${host.os_version} != \"15 SP6\" and ${host.os_version} != \"15 SP7\")'\n"
+            description: "Condition to filter when to apply this input. Refer to\n[Host provider](https://www.elastic.co/guide/en/fleet/current/host-provider.html)\nto find the available keys and to\n[Conditions](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html#conditions)\non how to use the available keys in conditions. It defaults to\n'(${host.platform} != \"windows\") and (${host.os_version} != \"12 (bookworm)\" and ${host.os_version} != \"13 (trixie)\" and (${host.os_platform} != \"amzn\" or ${host.os_version} != \"2023\") and (${host.os_platform} != \"sles\" and ${host.os_version} != \"15 SP1\" \nand ${host.os_version} != \"15 SP2\" and ${host.os_version} != \"15 SP3\" and ${host.os_version} != \"15 SP4\" and ${host.os_version} != \"15 SP5\" and ${host.os_version} != \"15 SP6\" and ${host.os_version} != \"15 SP7\"))'\n"
             type: text
             multi: false
             required: false
             show_user: true
-            default: ${host.os_version} != "12 (bookworm)" and ${host.os_version} != "13 (trixie)" and (${host.os_platform} != "amzn" or ${host.os_version} != "2023") and (${host.os_platform} != "sles" and ${host.os_version} != "15 SP1" and ${host.os_version} != "15 SP2" and ${host.os_version} != "15 SP3" and ${host.os_version} != "15 SP4" and ${host.os_version} != "15 SP5" and ${host.os_version} != "15 SP6" and ${host.os_version} != "15 SP7")
+            default: (${host.platform} != "windows") and (${host.os_version} != "12 (bookworm)" and ${host.os_version} != "13 (trixie)" and (${host.os_platform} != "amzn" or ${host.os_version} != "2023") and (${host.os_platform} != "sles" and ${host.os_version} != "15 SP1" and ${host.os_version} != "15 SP2" and ${host.os_version} != "15 SP3" and ${host.os_version} != "15 SP4" and ${host.os_version} != "15 SP5" and ${host.os_version} != "15 SP6" and ${host.os_version} != "15 SP7"))
       - type: journald
         title: Collect logs from System instances using Journald
         description: Collecting System auth and syslog logs using Journald
         vars:
           - name: condition
             title: Condition
-            description: "Condition to filter when to apply this input. Refer to\n[Host provider](https://www.elastic.co/guide/en/fleet/current/host-provider.html)\nto find the available keys and to\n[Conditions](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html#conditions)\non how to use the available keys in conditions. It defaults to\n'${host.os_version} == \"12 (bookworm)\" or ${host.os_version} == \"13 (trixie)\" or (${host.os_platform} == \"amzn\" and ${host.os_version} == \"2023\") or (${host.os_platform} == \"sles\" and (${host.os_version} == \"15 SP1\" \nor ${host.os_version} == \"15 SP2\" or ${host.os_version} == \"15 SP3\" or ${host.os_version} == \"15 SP4\" or ${host.os_version} == \"15 SP5\" or ${host.os_version} == \"15 SP6\" or ${host.os_version} == \"15 SP7\"))'\n"
+            description: "Condition to filter when to apply this input. Refer to\n[Host provider](https://www.elastic.co/guide/en/fleet/current/host-provider.html)\nto find the available keys and to\n[Conditions](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html#conditions)\non how to use the available keys in conditions. It defaults to\n'(${host.platform} != \"windows\") and (${host.os_version} == \"12 (bookworm)\" or ${host.os_version} == \"13 (trixie)\" or (${host.os_platform} == \"amzn\" and ${host.os_version} == \"2023\") or (${host.os_platform} == \"sles\" and (${host.os_version} == \"15 SP1\" \nor ${host.os_version} == \"15 SP2\" or ${host.os_version} == \"15 SP3\" or ${host.os_version} == \"15 SP4\" or ${host.os_version} == \"15 SP5\" or ${host.os_version} == \"15 SP6\" or ${host.os_version} == \"15 SP7\")))'\n"
             type: text
             multi: false
             required: false
             show_user: true
-            default: ${host.os_version} == "12 (bookworm)" or ${host.os_version} == "13 (trixie)" or (${host.os_platform} == "amzn" and ${host.os_version} == "2023") or (${host.os_platform} == "sles" and (${host.os_version} == "15 SP1" or ${host.os_version} == "15 SP2" or ${host.os_version} == "15 SP3" or ${host.os_version} == "15 SP4" or ${host.os_version} == "15 SP5" or ${host.os_version} == "15 SP6" or ${host.os_version} == "15 SP7"))
+            default: (${host.platform} != "windows") and (${host.os_version} == "12 (bookworm)" or ${host.os_version} == "13 (trixie)" or (${host.os_platform} == "amzn" and ${host.os_version} == "2023") or (${host.os_platform} == "sles" and (${host.os_version} == "15 SP1" or ${host.os_version} == "15 SP2" or ${host.os_version} == "15 SP3" or ${host.os_version} == "15 SP4" or ${host.os_version} == "15 SP5" or ${host.os_version} == "15 SP6" or ${host.os_version} == "15 SP7")))
       - type: winlog
         title: "Collect events from the Windows event log"
         description: "Collecting events from Windows event log"


### PR DESCRIPTION
## Proposed commit message

Stop starting unnecessary log input on Windows.

This is done by changing the conditional around the log input &
journald inputs.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

1. Install on Windows
2. Should only be 2 agentbeats running for the system integration

## Related issues

- Closes #16236

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
