### PR TITLE
kafka_log: clarify default protocol version in description

### DIFF
--- a/packages/kafka_log/changelog.yml
+++ b/packages/kafka_log/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.9.1"
+  changes:
+    - description: Updated the version field description to clarify default protocol versions.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/16516
 - version: "1.9.0"
   changes:
     - description: Add SASL mechanism configuration.

--- a/packages/kafka_log/data_stream/generic/manifest.yml
+++ b/packages/kafka_log/data_stream/generic/manifest.yml
@@ -52,7 +52,7 @@ streams:
       - name: version
         type: text
         title: Version
-        description: The version of the Kafka protocol to use (defaults to "1.0.0").
+        description: The version of the Kafka protocol to use (defaults to "1.0.0" in 8.x and "2.1.0" in 9.0+).
         required: false
         show_user: true
       - name: expand_event_list_from_field

--- a/packages/kafka_log/manifest.yml
+++ b/packages/kafka_log/manifest.yml
@@ -3,7 +3,7 @@ name: kafka_log
 title: Custom Kafka Logs
 description: Collect data from kafka topic with Elastic Agent.
 type: integration
-version: "1.9.0"
+version: "1.9.1"
 conditions:
   kibana:
     version: "^8.13.0 || ^9.0.0"


### PR DESCRIPTION
## Proposed commit message

The default Kafka protocol version depends on the filebeat version. For 8.x it defaults to 1.0.0, and for 9.0+ it defaults to 2.1.0. Update the description to clarify this.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 