### PR TITLE
Add Grok pattern for PANW Audit Logs 

### DIFF
--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
@@ -39,6 +39,7 @@ processors:
       patterns:
         - "^%{DATA},%{TIMESTAMP:_temp_.received_time},%{FIELD:observer.serial_number},%{FIELD:panw.panos.type},(?:%{FIELD:panw.panos.sub_type})?,%{FIELD:_temp_.config_version},%{TIMESTAMP:_temp_.generated_time},%{GREEDYDATA:message}$"
         - "^(?:<\\d+>)?%{SYSLOGTIMESTAMP:_temp_.syslog_time} %{IPORHOST:observer.hostname} %{NOTSPACE:observer.serial_number},%{PANW_DATE:_temp_.generated_time},%{FIELD:panw.panos.type},%{GREEDYDATA:message}$"
+        - "^%{DATA} - - - - %{FIELD:observer.serial_number},%{TIMESTAMP:_temp_.generated_time},%{FIELD:panw.panos.type},%{GREEDYDATA:message}$"
       pattern_definitions:
         TIMESTAMP: "%{PANW_DATE}|%{TIMESTAMP_ISO8601}"
         PANW_DATE: "%{YEAR}/%{MONTHNUM}/%{MONTHDAY} %{TIME}"


### PR DESCRIPTION
I added an additional Grok pattern to the list available in the default ingest pipeline. I did this because the PANW audit logs were failing to parse. I have tested these changes in production and verified their efficacy in parsing the panw audit logs. 

To test, the reviewer could install the PANW integration, try to ingest some PANW audit logs and verify this pattern is required to parse audit logs and that adding this pattern does in fact parse them correctly

## Related issues
https://github.com/elastic/integrations/issues/14912
