### PR TITLE
[docs CI] Fix kibana condition rendering in ci pipeline docs

### DIFF
--- a/docs/ci_pipelines.md
+++ b/docs/ci_pipelines.md
@@ -76,12 +76,12 @@ More details about this CI pipeline:
   In the following table, there are some examples:
     
   | STACK_VERSION env | Kibana Condition Package | Released | Elastic stack run |
-  | :---:    | :---:                | :---: | :---:             |
-  | ""       | `^7.16.0 || ^8.0.0`  | Yes   | `7.16.0`          |
-  | ""       | `^8.12.0`            | Yes   | `8.12.0`          |
-  | ""       | `^8.14.1`            | Yes   | `8.14.1`          |
-  | ""       | `^8.15.0`            | No    | `8.15.0-SNAPSHOT` |
-  | `8.14.0` | `^8.13.0`            | Yes   | `8.14.0`          |
+  | :---:    | :---:                  | :---: | :---:             |
+  | ""       | `^7.16.0 \|\| ^8.0.0`  | Yes   | `7.16.0`          |
+  | ""       | `^8.12.0`              | Yes   | `8.12.0`          |
+  | ""       | `^8.14.1`              | Yes   | `8.14.1`          |
+  | ""       | `^8.15.0`              | No    | `8.15.0-SNAPSHOT` |
+  | `8.14.0` | `^8.13.0`              | Yes   | `8.14.0`          |
 
   If the STACK_VERSION environment variable is defined, just the packages supporting that stack version are tested. For instance:
 


### PR DESCRIPTION
## Proposed commit message

Fix markdown error in ci pipelines documentation to show Kibana constraints containing `||`.

Link to rendered doc: https://github.com/mrodm/integrations/blob/29961bd5d43bbaef1ac13ab064e9c03cbf8fd1c5/docs/ci_pipelines.md

## Screenshots

- Before

<img width="732" height="255" alt="Screenshot from 2025-12-17 12-23-06" src="https://github.com/user-attachments/assets/b91f4c79-d7e3-46c3-b925-01466321ed71" />

- After
<img width="729" height="226" alt="Screenshot from 2025-12-17 12-23-13" src="https://github.com/user-attachments/assets/1d52f394-0859-49a0-9511-75fbb28d1787" />
