### PR TITLE
[CI] Avoid reading secret from vault in steps testing packages - local stacks

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -110,11 +110,6 @@ if [[ "${BUILDKITE_PIPELINE_SLUG}" =~ ^(integrations|integrations-test-stack)$ ]
         BUILDKITE_API_TOKEN=$(retry 5 vault kv get -field buildkite_token "${BUILDKITE_API_TOKEN_PATH}")
         export BUILDKITE_API_TOKEN
     fi
-
-    if [[ "${BUILDKITE_STEP_KEY}" =~ ^test-integrations- ]]; then
-        BUILDKITE_API_TOKEN=$(retry 5 vault kv get -field buildkite_token "${BUILDKITE_API_TOKEN_PATH}")
-        export BUILDKITE_API_TOKEN
-    fi
 fi
 
 if [[ "${BUILDKITE_PIPELINE_SLUG}" == "integrations-serverless" ]]; then


### PR DESCRIPTION
## Proposed commit message

After the refactor in Buildkite scripts done in #13410 , `BUILDKITE_API_TOKEN` is not used in Buildkite stesps with id `test-integrations-*`. 



