### PR TITLE
filestream: adjust decompression toggle text

### DIFF
--- a/packages/filestream/changelog.yml
+++ b/packages/filestream/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.1"
+  changes:
+    - description: Adjust GZIP decompression docs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/16647
 - version: "2.3.0"
   changes:
     - description: Promote GZIP decompression to GA

--- a/packages/filestream/manifest.yml
+++ b/packages/filestream/manifest.yml
@@ -3,7 +3,7 @@ name: filestream
 title: Custom Logs (Filestream)
 description: Collect log data using filestream with Elastic Agent.
 type: input
-version: 2.3.0
+version: 2.3.1
 conditions:
   kibana:
     version: "^9.2.0"
@@ -37,7 +37,7 @@ policy_templates:
         show_user: true
         default: false
         description: |
-          When enabled, filestream will decompress GZIP-compressed files (.gz) as they are read. For full details, see the [documentation](https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-filestream#reading-gzip-files). If enabled, you **must** also remove the '\.gz$' pattern from the "Exclude Files" setting to ensure `.gz` files are ingested. Available for Elastic Agent 9.2.0 in beta and for Elastic Agent 9.3.0 or newer in GA.
+          When enabled, filestream will decompress GZIP-compressed files (.gz) as they are read. For full details, see the [documentation](https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-filestream#reading-gzip-files). If enabled, you **must** also remove the '\.gz$' pattern from the "Exclude Files" setting to ensure `.gz` files are ingested. Available for Elastic Agent 9.2.0 in beta.
       - name: use_logs_stream
         type: bool
         title: Use the "logs" data stream


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
filestream: adjust decompression toggle text
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- ~~[ ] I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
- ~~[ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~~
- ~~[ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

 - Install the integration
 - check the text from `Decompress GZIP files` does not contain ` and for Elastic Agent 9.3.0 or newer in GA`

## Related issues

- Relates https://github.com/elastic/integrations/issues/16219

## Screenshots

<img width="513" height="193" alt="Screenshot from 2025-12-19 20-11-41" src="https://github.com/user-attachments/assets/98dc698b-e927-4743-968b-28fe68d0e8c9" />

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
