### PR TITLE
[tines] correct next_page value in system test rule config

### DIFF
--- a/packages/tines/_dev/deploy/docker/config.yml
+++ b/packages/tines/_dev/deploy/docker/config.yml
@@ -537,7 +537,7 @@ rules:
               "meta": {
                   "current_page": "https://your-tenant-1234.tines.com/api/v1/audit_logs?per_page=20&page=1",
                   "previous_page": null,
-                  "next_page": "null",
+                  "next_page": null,
                   "per_page": 20,
                   "pages": 1,
                   "count": 123
@@ -1096,7 +1096,7 @@ rules:
               "meta": {
                   "current_page": "https://your-tenant-1234.tines.com/api/v1/audit_logs?per_page=20&page=1",
                   "previous_page": null,
-                  "next_page": "null",
+                  "next_page": null,
                   "per_page": 20,
                   "pages": 1,
                   "count": 123


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->
```
tines: correct `next_page` value in system test rule config to prevent updating
the fleet health status to degraded

Previously, the `next_page` value was incorrectly set to the string "null", so during system testing
it attempted to perform a new request with that URL (with the value `null`), resulting in an error.

Actually, it should be `"next_page": null` as mentioned in the (documentation)[1].

[1] https://www.tines.com/api/welcome/#the-meta-object
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/tines directory.
- Run the following command to run tests.
> elastic-package test
