### PR TITLE
Osquery docs cleanup

### DIFF
--- a/packages/osquery_manager/docs/README.md
+++ b/packages/osquery_manager/docs/README.md
@@ -12,7 +12,7 @@ This integration adds an Osquery UI in Kibana where you can:
 Osquery results are stored in Elasticsearch, so that you can use the power of the stack to search, analyze, and visualize Osquery data.
 
 ## Investigate with Osquery
-For information about using Osquery, see the [Osquery Kibana documentation](https://www.elastic.co/guide/en/kibana/current/osquery.html). 
+For information about using Osquery, refer to the [Osquery Kibana documentation](https://www.elastic.co/docs/solutions/security/investigate/osquery). 
 This includes information about required privileges; how to run, schedule, and save queries; how to map osquery fields to ECS; and other useful information about managing Osquery with this integration.
 
 For information about Osquery tables, refer to the [Osquery schema documentation](https://osquery.io/schema) and [Osquery Extension for Elastic](https://github.com/elastic/beats/blob/main/x-pack/osquerybeat/ext/osquery-extension/README.md).


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/4207.

- Renames the Documentation heading to Investigate with Osquery
- Removes the Exported Fields section and link, since that page is being removed in https://github.com/elastic/kibana/pull/247551
- Adds the link to the official Osquery schema and additional Elastic-specific tables