### PR TITLE
fix pipeline flaky test by adding regex to match dynamic date values

### DIFF
--- a/packages/haproxy/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/haproxy/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,5 @@
 fields:
   tags:
     - preserve_original_event
+dynamic_fields:
+  "@timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}"

--- a/packages/pps/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/pps/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,6 @@
 fields:
   tags:
     - preserve_original_event
+dynamic_fields:
+  "@timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}"
+  "event.created": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}"

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-common-config.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-common-config.yml
@@ -5,3 +5,5 @@ fields:
   _conf:
     reroute:
       - dns
+dynamic_fields:
+  "sentinel_one_cloud_funnel.event.timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}"

--- a/packages/trendmicro/data_stream/deep_security/_dev/test/pipeline/test-common-config.yml
+++ b/packages/trendmicro/data_stream/deep_security/_dev/test/pipeline/test-common-config.yml
@@ -2,3 +2,5 @@ fields:
   tags:
     - preserve_original_event
     - preserve_duplicate_custom_fields
+dynamic_fields:
+  "@timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}"

--- a/packages/vsphere/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/vsphere/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,5 @@
 fields:
   tags:
     - preserve_original_event
+dynamic_fields:
+  "@timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}"

--- a/packages/watchguard_firebox/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/watchguard_firebox/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -4,3 +4,6 @@ fields:
     - preserve_duplicate_custom_fields
   _conf:
     tz_offset: +05:30
+dynamic_fields:
+  "@timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}"
+  "watchguard_firebox.log.syslog_timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}"

--- a/packages/zscaler_zia/data_stream/alerts/_dev/test/pipeline/test-common-config.yml
+++ b/packages/zscaler_zia/data_stream/alerts/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,6 @@
 dynamic_fields:
   "@timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}"
+  "zscaler_zia.alerts.timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}"
 fields:
   tags:
     - preserve_original_event


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
fix pipeline flaky tests by adding regex to match dynamic date values.

Timestamps that are parsed without a year (such as those on BSD-style syslog messages) will have
their expected values inherit the year the expected files are generated in. This means that
tests will only pass in the year that the expected files are generated.

The relevant timestamp field (@timestamp, for example) has been added to the pipeline test config
as a dynamic field, and a regex pattern is used to match the expected format of the timestamp.

Fixes the tests for the following packages:
- haproxy
- pps
- sentinel_one_cloud_funnel
- trendmicro
- vsphere
- watchguard_firebox
- zscaler_zia
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/<integration_name> directory.
- Run the following command to run tests.
> elastic-package test