### PR TITLE
[Qualys VMDR] Fix duplicate fields in transform

### DIFF
--- a/packages/qualys_vmdr/elasticsearch/transform/latest_cdr_vulnerabilities/fields/fields.yml
+++ b/packages/qualys_vmdr/elasticsearch/transform/latest_cdr_vulnerabilities/fields/fields.yml
@@ -139,8 +139,6 @@
           type: keyword
         - name: severity
           type: long
-        - name: source
-          type: keyword
         - name: ssl
           type: keyword
         - name: status
@@ -152,8 +150,6 @@
         - name: trurisk_elimination_status
           type: keyword
         - name: type
-          type: keyword
-        - name: trurisk_elimination_status
           type: keyword
         - name: unique_vuln_id
           type: keyword


### PR DESCRIPTION
## Proposed commit message

```
qualys_vmdr: remove duplicate fields in transform as per the comment [1] in this PR [2]. 

Also, remove unsupported field `source` from the fields definition. The pipeline currently does not 
parse this field. This was incorrectly added into the transform fields inside the PR [2].

- [1] https://github.com/elastic/integrations/pull/16727#issuecomment-3719541508
- [2] https://github.com/elastic/integrations/pull/16727
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Relates #16640