### PR TITLE
add custom filestream options to oracle integration

### DIFF
--- a/packages/oracle/changelog.yml
+++ b/packages/oracle/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.31.2"
+  changes:
+    - description: Add custom filestream options to database_audit datastream
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/16974
 - version: "1.31.1"
   changes:
     - description: Update the Oracle Integration documentation.

--- a/packages/oracle/data_stream/database_audit/agent/stream/stream.yml.hbs
+++ b/packages/oracle/data_stream/database_audit/agent/stream/stream.yml.hbs
@@ -26,3 +26,7 @@ processors:
 {{processors}}
 {{/if}}
 - add_locale: ~
+
+{{#if custom}}
+{{custom}}
+{{/if}}

--- a/packages/oracle/data_stream/database_audit/manifest.yml
+++ b/packages/oracle/data_stream/database_audit/manifest.yml
@@ -36,6 +36,12 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
-
+      - name: custom
+        type: yaml
+        title: Custom Filestream Configuration Options
+        description: >-
+          YAML configuration options for filestream input. Be careful, this may break the integration.
+        required: false
+        show_user: false
     title: Oracle Audit Log
     description: Collect Oracle audit logs

--- a/packages/oracle/manifest.yml
+++ b/packages/oracle/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: oracle
 title: "Oracle"
-version: "1.31.1"
+version: "1.31.2"
 description: Collect Oracle Audit Log, Performance metrics, Tablespace metrics, Sysmetrics metrics, System statistics metrics, memory metrics from Oracle database.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Add ability to add custom filestream configuration options to the `database_audit` datastream in the oracle integration.

This is necessary to allow modifying things like prospector scan interval.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #16968

## Screenshots
<img width="845" height="1129" alt="Screenshot 2026-01-15 at 14 42 51" src="https://github.com/user-attachments/assets/739cf48c-8a8c-4a74-b2ac-f00350aaa255" />


<img width="745" height="490" alt="Screenshot 2026-01-15 at 14 44 33" src="https://github.com/user-attachments/assets/4ae3b734-b386-4500-982f-5844e7749008" />

