### PR TITLE
chore: Backport AWS integration 3.13.x stack supported Kibana version 

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.13.5"
+  changes:
+    - description: Update Kibana compatibility to start from 8.19.x and above
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/16975
 - version: "3.13.4"
   changes:
     - description: Add description on lastSync start_position configuration for CloudWatch.

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: aws
 title: AWS
-version: 3.13.4
+version: 3.13.5
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:
@@ -11,7 +11,7 @@ conditions:
   elastic:
     subscription: basic
   kibana:
-    version: "~8.16.6 || ~8.17.4 || ^8.18.0 || ^9.0.0"
+    version: "^8.19.0 || ^9.0.0"
 screenshots:
   - src: /img/metricbeat-aws-overview.png
     title: metricbeat aws overview


### PR DESCRIPTION
## Proposed commit message

Backport for AWS integration 3.13.x track to update compatible Kibana version.

This is to correct the CloudWatch `lastSync` option introduced at `3.13.4`. The feature is only available on 8.19.x and newer release tracks.

## Related issues

Addressed AWS integration concern of https://github.com/elastic/integrations/issues/16333 
Original PR - https://github.com/elastic/integrations/pull/14733 