### PR TITLE
chore: remove CloudWatch lastSync option from older tracks as it is incompatible with Kibana versions below 9.x

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.17.1"
+  changes:
+    - description: Disable lastSync start_position configuration for CloudWatch as it's incompatible with versions below 9.x.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/16998
 - version: "3.17.0"
   changes:
     - description: Enable Agentless deployment for AWS GuardDuty.

--- a/packages/aws/data_stream/apigateway_logs/manifest.yml
+++ b/packages/aws/data_stream/apigateway_logs/manifest.yml
@@ -216,7 +216,7 @@ streams:
         required: false
         default: beginning
         show_user: true
-        description: Specify whether the input should start reading logs from the `beginning` (oldest log entry), `end` (newest log entry), or `lastSync` (last successful read timestamp if input ran before).
+        description: Allows user to specify if this input should read log files from the beginning or from the end.
       - name: scan_frequency
         type: text
         title: Scan Frequency

--- a/packages/aws/data_stream/cloudtrail/manifest.yml
+++ b/packages/aws/data_stream/cloudtrail/manifest.yml
@@ -275,7 +275,7 @@ streams:
         required: false
         default: beginning
         show_user: true
-        description: Specify whether the input should start reading logs from the `beginning` (oldest log entry), `end` (newest log entry), or `lastSync` (last successful read timestamp if input ran before).
+        description: Allows user to specify if this input should read log files from the beginning or from the end.
       - name: scan_frequency
         type: text
         title: Scan Frequency

--- a/packages/aws/data_stream/cloudwatch_logs/manifest.yml
+++ b/packages/aws/data_stream/cloudwatch_logs/manifest.yml
@@ -63,7 +63,7 @@ streams:
         required: false
         default: beginning
         show_user: true
-        description: Specify whether the input should start reading logs from the `beginning` (oldest log entry), `end` (newest log entry), or `lastSync` (last successful read timestamp if input ran before).
+        description: Allows user to specify if this input should read log files from the beginning or from the end.
       - name: scan_frequency
         type: text
         title: Scan Frequency

--- a/packages/aws/data_stream/ec2_logs/manifest.yml
+++ b/packages/aws/data_stream/ec2_logs/manifest.yml
@@ -216,7 +216,7 @@ streams:
         required: false
         default: beginning
         show_user: true
-        description: Specify whether the input should start reading logs from the `beginning` (oldest log entry), `end` (newest log entry), or `lastSync` (last successful read timestamp if input ran before).
+        description: Allows user to specify if this input should read log files from the beginning or from the end.
       - name: scan_frequency
         type: text
         title: Scan Frequency

--- a/packages/aws/data_stream/elb_logs/manifest.yml
+++ b/packages/aws/data_stream/elb_logs/manifest.yml
@@ -216,7 +216,7 @@ streams:
         required: false
         default: beginning
         show_user: true
-        description: Specify whether the input should start reading logs from the `beginning` (oldest log entry), `end` (newest log entry), or `lastSync` (last successful read timestamp if input ran before).
+        description: Allows user to specify if this input should read log files from the beginning or from the end.
       - name: scan_frequency
         type: text
         title: Scan Frequency

--- a/packages/aws/data_stream/emr_logs/manifest.yml
+++ b/packages/aws/data_stream/emr_logs/manifest.yml
@@ -218,7 +218,7 @@ streams:
         required: false
         default: beginning
         show_user: true
-        description: Specify whether the input should start reading logs from the `beginning` (oldest log entry), `end` (newest log entry), or `lastSync` (last successful read timestamp if input ran before).
+        description: Allows user to specify if this input should read log files from the beginning or from the end.
       - name: scan_frequency
         type: text
         title: Scan Frequency

--- a/packages/aws/data_stream/firewall_logs/manifest.yml
+++ b/packages/aws/data_stream/firewall_logs/manifest.yml
@@ -216,7 +216,7 @@ streams:
         required: false
         default: beginning
         show_user: true
-        description: Specify whether the input should start reading logs from the `beginning` (oldest log entry), `end` (newest log entry), or `lastSync` (last successful read timestamp if input ran before).
+        description: Allows user to specify if this input should read log files from the beginning or from the end.
       - name: scan_frequency
         type: text
         title: Scan Frequency

--- a/packages/aws/data_stream/lambda_logs/manifest.yml
+++ b/packages/aws/data_stream/lambda_logs/manifest.yml
@@ -63,7 +63,7 @@ streams:
         required: false
         default: beginning
         show_user: true
-        description: Specify whether the input should start reading logs from the `beginning` (oldest log entry), `end` (newest log entry), or `lastSync` (last successful read timestamp if input ran before).
+        description: Allows user to specify if this input should read log files from the beginning or from the end.
       - name: scan_frequency
         type: text
         title: Scan Frequency

--- a/packages/aws/data_stream/route53_public_logs/manifest.yml
+++ b/packages/aws/data_stream/route53_public_logs/manifest.yml
@@ -58,7 +58,7 @@ streams:
       - name: start_position
         type: text
         title: Start Position
-        description: Specify whether the input should start reading logs from the `beginning` (oldest log entry), `end` (newest log entry), or `lastSync` (last successful read timestamp if input ran before).
+        description: Allows user to specify if this input should read log files from the beginning or from the end.
         multi: false
         show_user: false
         required: true

--- a/packages/aws/data_stream/route53_resolver_logs/manifest.yml
+++ b/packages/aws/data_stream/route53_resolver_logs/manifest.yml
@@ -58,7 +58,7 @@ streams:
       - name: start_position
         type: text
         title: Start Position
-        description: Specify whether the input should start reading logs from the `beginning` (oldest log entry), `end` (newest log entry), or `lastSync` (last successful read timestamp if input ran before).
+        description: Allows user to specify if this input should read log files from the beginning or from the end.
         multi: false
         show_user: false
         required: true

--- a/packages/aws/data_stream/vpcflow/manifest.yml
+++ b/packages/aws/data_stream/vpcflow/manifest.yml
@@ -216,7 +216,7 @@ streams:
         required: false
         default: beginning
         show_user: true
-        description: Specify whether the input should start reading logs from the `beginning` (oldest log entry), `end` (newest log entry), or `lastSync` (last successful read timestamp if input ran before).
+        description: Allows user to specify if this input should read log files from the beginning or from the end.
       - name: scan_frequency
         type: text
         title: Scan Frequency

--- a/packages/aws/data_stream/waf/manifest.yml
+++ b/packages/aws/data_stream/waf/manifest.yml
@@ -216,7 +216,7 @@ streams:
         required: false
         default: beginning
         show_user: true
-        description: Specify whether the input should start reading logs from the `beginning` (oldest log entry), `end` (newest log entry), or `lastSync` (last successful read timestamp if input ran before).
+        description: Allows user to specify if this input should read log files from the beginning or from the end.
       - name: scan_frequency
         type: text
         title: Scan Frequency

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: aws
 title: AWS
-version: 3.17.0
+version: 3.17.1
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Backport for AWS integration 3.17.x track to disable `lastSync` start_position configuration option for CloudWatch

This is incompatible with Kibana versions lower than 9.x

## Related issues

Addressed AWS integration concern of https://github.com/elastic/integrations/issues/16333 
Original PR - https://github.com/elastic/integrations/pull/14733 