### PR TITLE
Chargeback dashboard: ECU/ERU wording in Configuration Information

### DIFF
--- a/packages/chargeback/kibana/dashboard/chargeback-39a39857-746c-4a29-adca-3c2fcb6bcfb6.json
+++ b/packages/chargeback/kibana/dashboard/chargeback-39a39857-746c-4a29-adca-3c2fcb6bcfb6.json
@@ -4085,7 +4085,7 @@
                         "version": 1,
                         "visualizationType": "lnsDatatable"
                     },
-                    "description": "ECU rates and units configured over time",
+                    "description": "Consumption unit (ECU or ERU) rates and currency units configured over time",
                     "enhancements": {
                         "dynamicActions": {
                             "events": []
@@ -4098,7 +4098,7 @@
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "ECU Rates"
+                    "title": "Consumption unit rates (ECU / ERU)"
                 },
                 "gridData": {
                     "h": 8,
@@ -4282,7 +4282,7 @@
             },
             {
                 "embeddableConfig": {
-                    "content": "## Blended weight calculation\n\nThe chargeback integration calculates a blended cost value by combining indexing time (hot tier only), query time, and storage size with configurable weights set in `chargeback_conf_lookup` (default: indexing=20, query=20, storage=40). Each weight is a percentage representing how much that activity contributes to the total cost, allowing you to prioritize storage-heavy vs compute-heavy workloads based on your organization's usage patterns. Adjust weights by updating the lookup index to match your cost model (e.g., increase query weight for analytics-heavy teams, increase storage weight for archival use cases).",
+                    "content": "## Blended weight calculation\n\nThe chargeback integration calculates a blended cost value (from consumption units: ECU or ERU) by combining indexing time (hot tier only), query time, and storage size with configurable weights set in `chargeback_conf_lookup` (default: indexing=20, query=20, storage=40). Each weight is a percentage representing how much that activity contributes to the total cost, allowing you to prioritize storage-heavy vs compute-heavy workloads based on your organization's usage patterns. Adjust weights by updating the lookup index to match your cost model (e.g., increase query weight for analytics-heavy teams, increase storage weight for archival use cases).",
                     "title": ""
                 },
                 "gridData": {
@@ -4314,7 +4314,7 @@
             },
             {
                 "embeddableConfig": {
-                    "content": "## Normalised cost\nNormalised cost is calculated as ECU (Elastic Consumption Units) multiplied by the conversion rate (`conf_ecu_rate`) from the `chargeback_conf_lookup` index, where the rate is selected based on the time window being queried. This allows you to convert raw ECU consumption into your preferred currency (e.g., EUR, USD) and apply different rates for different time periods. You can adjust this by updating the lookup index with period-specific rates."
+                    "content": "## Normalised cost\nNormalised cost is calculated as consumption units (ECU — Elastic Consumption Units — or ERU — Elastic Resource Units, depending on your billing source) multiplied by the conversion rate (`conf_ecu_rate`) from the `chargeback_conf_lookup` index, where the rate is selected based on the time window being queried. This allows you to convert raw consumption (ECU or ERU) into your preferred currency (e.g., EUR, USD) and apply different rates for different time periods. You can adjust this by updating the lookup index with period-specific rates."
                 },
                 "gridData": {
                     "h": 10,
@@ -4329,7 +4329,7 @@
             },
             {
                 "embeddableConfig": {
-                    "content": "## Configuration date span\nThe `chargeback_conf_lookup` index supports time-windowed configuration using `conf_start_date` and `conf_end_date` fields, allowing you to set different ECU rates and weights for specific time periods. Create multiple configuration documents with different date ranges (e.g., Q1 rates vs Q2 rates) and the dashboard will apply the appropriate configuration based on the query time window. This enables historical cost analysis with period-accurate pricing and weight adjustments.",
+                    "content": "## Configuration date span\nThe `chargeback_conf_lookup` index supports time-windowed configuration using `conf_start_date` and `conf_end_date` fields, allowing you to set different consumption unit (ECU or ERU) rates and weights for specific time periods. Create multiple configuration documents with different date ranges (e.g., Q1 rates vs Q2 rates) and the dashboard will apply the appropriate configuration based on the query time window. This enables historical cost analysis with period-accurate pricing and weight adjustments.",
                     "title": ""
                 },
                 "gridData": {


### PR DESCRIPTION
## Summary
Updates the Chargeback Configuration Information section at the bottom of the dashboard so wording supports both ECU (Elastic Consumption Units) and ERU (Elastic Resource Units).

## Changes
- **Normalised cost:** Consumption units (ECU or ERU depending on billing source), `conf_ecu_rate` applies to both.
- **Configuration date span:** "Consumption unit (ECU or ERU) rates".
- **Blended weight calculation:** Cost value (from consumption units: ECU or ERU).
- **Panel title:** "ECU Rates" → "Consumption unit rates (ECU / ERU)".
- **Panel description:** "Consumption unit (ECU or ERU) rates and currency units configured over time".

Layout unchanged.