### PR TITLE
[Enhancement][Synthetics] Add base64 encoding option for inline browser monitors

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Add base64 encoding option for inline browser monitors
+      type: enhancement
+      link: https://github.com/elastic/beats/pull/45100
 - version: "1.4.2"
   changes:
     - description: New version for 8.19.0 Maintenance windows

--- a/packages/synthetics/data_stream/browser/agent/stream/browser.yml.hbs
+++ b/packages/synthetics/data_stream/browser/agent/stream/browser.yml.hbs
@@ -26,6 +26,9 @@ tags: {{tags}}
 {{#if source.inline.script}}
 source.inline.script: {{source.inline.script}}
 {{/if}}
+{{#if source.inline.encoding}}
+source.inline.encoding: {{source.inline.encoding}}
+{{/if}}
 {{#if source.project.content}}
 source.project.content: {{source.project.content}}
 {{/if}}

--- a/packages/synthetics/data_stream/browser/manifest.yml
+++ b/packages/synthetics/data_stream/browser/manifest.yml
@@ -79,6 +79,12 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: source.inline.encoding
+        type: text
+        title: Encoding type for inline script
+        multi: false
+        required: false
+        show_user: false
       - name: source.project.content
         type: text
         title: Project monitor script

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 3.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Internal Elastic integration for providing access to private locations.
-version: 1.4.2
+version: 1.5.0
 categories: 
   - observability
   # Added monitoring category as Synthetics provides synthetic monitoring capabilities


### PR DESCRIPTION
## Summary

Add support for `source.inline.encoding` option in browser monitors, enabling base64-encoded inline scripts. This allows inline monitor scripts to contain special characters that would otherwise break YAML format.

Related to: https://github.com/elastic/beats/pull/45100

## Changes

- Add `source.inline.encoding` variable to browser data stream manifest
- Add encoding field to browser handlebar template
- Bump package version to `1.5.0`
- Update Kibana version constraint to `^8.19.0 || ^9.1.0`

## Usage

When creating a browser monitor, the inline script can now be base64-encoded:
```json
{
  "source": {
    "inline": {
      "script": "c3RlcCgnR28gdG8gaG9tZXBhZ2UnLCBhc3luYyAoKSA9PiB7IC4uLiB9KQ==",
      "encoding": "base64"
    }
  }
}
```