### PR TITLE
[backport 3.2] GCP infra manager link

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -17,6 +17,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "3.2.1"
+  changes:
+    - description: GCP infra manager link
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/17036
 - version: "3.2.0"
   changes:
     - description: Bump up pre-release version

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "3.2.0"
+version: "3.2.1"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"
@@ -169,7 +169,7 @@ policy_templates:
             required: true
             show_user: false
             description: A URL to CloudShell for creating a new deployment
-            default: https://shell.cloud.google.com/cloudshell/?ephemeral=true&cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Felastic%2Fcloudbeat&cloudshell_git_branch=9.2&cloudshell_workspace=deploy%2Fdeployment-manager&show=terminal
+            default: https://shell.cloud.google.com/cloudshell/?ephemeral=true&cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Felastic%2Fcloudbeat&cloudshell_git_branch=main&cloudshell_workspace=deploy%2Finfrastructure-manager%2Fgcp-elastic-agent&show=terminal
       - type: cloudbeat/cis_azure
         title: Azure
         description: CIS Benchmark for Microsoft Azure Foundations


### PR DESCRIPTION
Backport of #17036 to cloud_security_posture 3.2.x (Kibana 9.3.x)

## Summary
- Updated CloudShell URL to use main branch and infrastructure-manager workspace path

## Original PR
https://github.com/elastic/integrations/pull/17036

Made with [Cursor](https://cursor.com)