### PR TITLE
[backport 1.1] GCP infra manager link

### DIFF
--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -3,6 +3,11 @@
 # 1.1.x - 9.2.x
 # 1.0.x - 9.1.x
 # 0.1.x - 8.15.x
+- version: "1.1.7"
+  changes:
+    - description: GCP infra manager link
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/17036
 - version: "1.1.6"
   changes:
     - description: Bumped links for Cloud Formation, ARM and GCP Deployment Manager to 9.2.0

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_asset_inventory
 title: "Cloud Asset Discovery"
-version: "1.1.6"
+version: "1.1.7"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Discovery"
@@ -111,7 +111,7 @@ policy_templates:
             required: true
             show_user: false
             description: A URL to CloudShell for creating a new deployment
-            default: https://shell.cloud.google.com/cloudshell/?ephemeral=true&cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Felastic%2Fcloudbeat&cloudshell_git_branch=9.2&cloudshell_workspace=deploy%2Fdeployment-manager&show=terminal
+            default: https://shell.cloud.google.com/cloudshell/?ephemeral=true&cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Felastic%2Fcloudbeat&cloudshell_git_branch=main&cloudshell_workspace=deploy%2Finfrastructure-manager%2Fgcp-elastic-agent&show=terminal
     categories:
       - security
       - cloud


### PR DESCRIPTION
Backport of #17036 to cloud_asset_inventory 1.1.x (Kibana 9.2.x)

## Summary
- Updated CloudShell URL to use main branch and infrastructure-manager workspace path

## Original PR
https://github.com/elastic/integrations/pull/17036

Made with [Cursor](https://cursor.com)