### PR TITLE
Add an optional monitoring-indices@custom pipeline

### DIFF
--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.2"
+  changes:
+    - description: Add optional monitoring-indices@custom pipeline
+      type: enhancement
+      link: "https://github.com/elastic/integrations/pull/17275"
 - version: "1.19.1"
   changes:
     - description: Fix role filter in Cluster Node View Dashboards

--- a/packages/elasticsearch/elasticsearch/ingest_pipeline/monitoring_indices.yml
+++ b/packages/elasticsearch/elasticsearch/ingest_pipeline/monitoring_indices.yml
@@ -132,6 +132,11 @@ processors:
         - start
         - end
       tag: remove_start_end_fields
+  - pipeline:
+      name: 'monitoring-indices@custom'
+      tag: pipeline_custom
+      ignore_missing_pipeline: true
+      description: 'Executes a custom ingest pipeline if defined by the user. This allows users to add custom transformations without modifying the default pipeline.'
 
 on_failure:
   - set:

--- a/packages/elasticsearch/elasticsearch/transform/index_pivot/transform.yml
+++ b/packages/elasticsearch/elasticsearch/transform/index_pivot/transform.yml
@@ -119,7 +119,7 @@ pivot:
         script: "Math.max(0, params.end-params.start)"
 dest:
   index: "monitoring-indices"
-  pipeline: "1.19.1-monitoring_indices"
+  pipeline: "1.19.2-monitoring_indices"
 description: This transform runs every 10 minutes to compute extra metrics for the Elasticsearch indices.
 frequency: 10m
 settings:

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 1.19.1
+version: 1.19.2
 description: Elasticsearch Integration
 type: integration
 icons:


### PR DESCRIPTION


## Proposed commit message
Add an optional monitoring-indices@custom pipeline

For example to override the destination index to be per-month.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
