### PR TITLE
cloud_security_posture: Add gcp_credentials_cloud_connector_id to GCP stream and mark as secret

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -18,6 +18,10 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "3.3.0-preview05"
+  changes:
+    - description: Add gcp_credentials_cloud_connector_id to GCP stream template and mark as secret
+      type: enhancement
 - version: "3.3.0-preview04"
   changes:
     - description: Fix GCP Cloud Connector validation

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -22,6 +22,7 @@
   changes:
     - description: Add gcp_credentials_cloud_connector_id to GCP stream template and mark as secret
       type: enhancement
+      link: https://github.com/elastic/integrations/pull/17378
 - version: "3.3.0-preview04"
   changes:
     - description: Fix GCP Cloud Connector validation

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/gcp.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/gcp.yml.hbs
@@ -32,6 +32,9 @@ config:
         {{#if gcp.credentials.audience}}
         audience: {{gcp.credentials.audience}}
         {{/if}}
+        {{#if gcp_credentials_cloud_connector_id}}
+        cloud_connector_id: {{gcp_credentials_cloud_connector_id}}
+        {{/if}}
 {{#if condition}}
 condition: {{ condition }}
 {{/if}}

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -326,6 +326,7 @@ streams:
         multi: false
         required: false
         show_user: true
+        secret: true
         description: Required when using Cloud Connectors Managed Identity
       - name: gcp.supports_cloud_connectors
         type: bool

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "3.3.0-preview04"
+version: "3.3.0-preview05"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
## Summary
- Add `gcp_credentials_cloud_connector_id` to `data_stream/findings/agent/stream/gcp.yml.hbs` (cloud_connector_id in credentials).
- Mark `gcp_credentials_cloud_connector_id` as secret in findings manifest.
- Bump version to 3.3.0-preview05.