### PR TITLE
Fix invalid integrations:// cross-link path in Citrix ADC docs

### DIFF
--- a/packages/citrix_adc/_dev/build/docs/README.md
+++ b/packages/citrix_adc/_dev/build/docs/README.md
@@ -43,7 +43,7 @@ Example Host Configuration: `http://example.com:9090`
 
 ## Setup
   
-For step-by-step instructions on how to set up an integration, check the [quick start](integrations://docs/extend/quick-start.md).
+For step-by-step instructions on how to set up an integration, check the [quick start](integrations://extend/quick-start.md).
 
 **NOTE:** It is recommended to configure the application firewall to enable CEF-formatted logs.
 

--- a/packages/citrix_adc/changelog.yml
+++ b/packages/citrix_adc/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.3"
+  changes:
+    - description: "Fix invalid integrations:// cross-link path in documentation."
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/17432
 - version: "1.18.2"
   changes:
     - description: "Fix grok processing in native pipeline for headers with timezone."

--- a/packages/citrix_adc/docs/README.md
+++ b/packages/citrix_adc/docs/README.md
@@ -43,7 +43,7 @@ Example Host Configuration: `http://example.com:9090`
 
 ## Setup
   
-For step-by-step instructions on how to set up an integration, check the [quick start](integrations://docs/extend/quick-start.md).
+For step-by-step instructions on how to set up an integration, check the [quick start](integrations://extend/quick-start.md).
 
 **NOTE:** It is recommended to configure the application firewall to enable CEF-formatted logs.
 

--- a/packages/citrix_adc/manifest.yml
+++ b/packages/citrix_adc/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: citrix_adc
 title: Citrix ADC
-version: "1.18.2"
+version: "1.18.3"
 description: This Elastic integration collects logs and metrics from Citrix ADC product.
 type: integration
 categories:


### PR DESCRIPTION
## Summary
- Remove erroneous `docs/` prefix from the `integrations://` cross-link in the Citrix ADC setup section
- The link index path is `extend/quick-start.md`, not `docs/extend/quick-start.md`
- This fixes a doc build error in [elastic/integration-docs#1065](https://github.com/elastic/integration-docs/pull/1065)

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/guide/en/integrations-developer/current/tips-for-building-integrations.html) and this pull request is aligned with them

🤖 Generated with [Claude Code](https://claude.com/claude-code)