### PR TITLE
Adds missing manifest value to DGA integration 

### DIFF
--- a/packages/dga/changelog.yml
+++ b/packages/dga/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add serverless security capability to manifest
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/17444
 - version: "2.3.5"
   changes:
     - description: Update package docs with customization steps for ML jobs and transforms

--- a/packages/dga/changelog.yml
+++ b/packages/dga/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.6"
+  changes:
+    - description: Add serverless security capability to manifest
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "2.3.5"
   changes:
     - description: Update package docs with customization steps for ML jobs and transforms

--- a/packages/dga/manifest.yml
+++ b/packages/dga/manifest.yml
@@ -15,6 +15,8 @@ conditions:
     version: "^8.9.0 || ^9.0.0"
   elastic:
     subscription: platinum
+    capabilities:
+      - security
 screenshots:
   - src: /img/sample-screenshot.png
     title: Sample screenshot

--- a/packages/dga/manifest.yml
+++ b/packages/dga/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.4
 name: dga
 title: "Domain Generation Algorithm Detection"
-version: 2.3.5
+version: 2.3.6
 source:
   license: "Elastic-2.0"
 description: "ML solution package to detect domain generation algorithm (DGA) activity in your network data."


### PR DESCRIPTION
## Proposed commit message

Adds serverless security capability to `manifest.yml` file. 

>[!NOTE]
For the Kibana team, the DGA integration appears in the `excludePackages` list [here](https://github.com/elastic/kibana/blob/main/config/serverless.security.yml#L212). Shouldn't this be removed if it's serverless supported? 🤔 

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## How to test this PR locally

Commands I guess? 

## Related issues

- Closes [#123](https://github.com/elastic/docs-content-internal/issues/753)

