### PR TITLE
[Kibana] Make condition option available in http metricset

### DIFF
--- a/packages/kibana/changelog.yml
+++ b/packages/kibana/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.8.1"
+  changes:
+    - description: Add condition to HTTP Metrics metricset
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/123
 - version: "2.8.0"
   changes:
     - description: Update package spec to 3.0.0

--- a/packages/kibana/changelog.yml
+++ b/packages/kibana/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add condition to HTTP Metrics metricset
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/123
+      link: https://github.com/elastic/integrations/pull/17522
 - version: "2.8.0"
   changes:
     - description: Update package spec to 3.0.0

--- a/packages/kibana/data_stream/background_task_utilization/agent/stream/stream.yml.hbs
+++ b/packages/kibana/data_stream/background_task_utilization/agent/stream/stream.yml.hbs
@@ -16,6 +16,9 @@ period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}
 {{/if}}
+{{#if condition }}
+condition: {{ condition }}
+{{/if}}
 namespace: "background_task_utilization"
 path: "/api/task_manager/_background_task_utilization"
 method: "GET"

--- a/packages/kibana/data_stream/task_manager_metrics/agent/stream/stream.yml.hbs
+++ b/packages/kibana/data_stream/task_manager_metrics/agent/stream/stream.yml.hbs
@@ -16,6 +16,9 @@ period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}
 {{/if}}
+{{#if condition }}
+condition: {{ condition }}
+{{/if}}
 namespace: "task_manager_metrics"
 path: "/api/task_manager/metrics"
 method: "GET"

--- a/packages/kibana/manifest.yml
+++ b/packages/kibana/manifest.yml
@@ -1,6 +1,6 @@
 name: kibana
 title: Kibana
-version: "2.8.0"
+version: "2.8.1"
 description: Collect logs and metrics from Kibana with Elastic Agent.
 type: integration
 icons:
@@ -77,6 +77,13 @@ policy_templates:
               #certificate_authorities: ["/etc/ca.crt"]
               #certificate: "/etc/client.crt"
               #key: "/etc/client.key"
+          - name: condition
+            title: Condition
+            description: Condition to filter when to collect this input
+            type: text
+            multi: false
+            required: false
+            show_user: false
       - type: kibana/metrics
         title: "Metrics (Stack Monitoring)"
         description: "Collect stats, status and alert metrics from Kibana instances to power the Stack Monitoring application in Kibana"


### PR DESCRIPTION
## Proposed commit message
Expose `Condition` in UI to allow dynamically enabling/disabling data collection for HTTP Metrics. This option is already available in the Stack Monitoring metricset

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

Add a valid condition to the integration and check if data collection is/is not enabled, e.g. `${host.platform} == "windows"` on a linux host should not enable the input.

## Screenshots
<img width="360" height="103" alt="image" src="https://github.com/user-attachments/assets/5f9038f9-d21a-43e7-ba4e-a30db5eb5795" />
