### PR TITLE
[GCP Cloud Connectors] Declare audience and service account as raw text fields

### DIFF
--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -7,7 +7,7 @@
 # 1.1.x - 9.2.x
 # 1.0.x - 9.1.x
 # 0.1.x - 8.15.x
-- version: "1.5.0-preview03"
+- version: "1.5.0-preview04"
   changes:
     - description: Mark gcp_credentials_cloud_connector_id as secret
       type: enhancement

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/manifest.yml
@@ -415,14 +415,12 @@ streams:
         multi: false
         required: false
         show_user: true
-        secret: true
       - name: gcp.credentials.audience
         type: text
         title: Audience
         multi: false
         required: false
         show_user: true
-        secret: true
       - name: gcp_credentials_cloud_connector_id
         type: text
         title: Elastic Cloud Connector ID

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_asset_inventory
 title: "Cloud Asset Discovery"
-version: "1.5.0-preview03"
+version: "1.5.0-preview04"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Discovery"

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -18,7 +18,7 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
-- version: "3.3.0-preview05"
+- version: "3.3.0-preview06"
   changes:
     - description: Add gcp_credentials_cloud_connector_id to GCP stream template and mark as secret
       type: enhancement

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -312,14 +312,12 @@ streams:
         multi: false
         required: false
         show_user: true
-        secret: true
       - name: gcp.credentials.audience
         type: text
         title: Audience
         multi: false
         required: false
         show_user: true
-        secret: true
       - name: gcp_credentials_cloud_connector_id
         type: text
         title: Elastic Cloud Connector ID

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "3.3.0-preview05"
+version: "3.3.0-preview06"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Stops marking two GCP credential inputs as secrets in both Cloud Asset Inventory and Cloud Security Posture integrations:
* gcp.credentials.audience
* gcp.credentials.service_account_email

secret: true is removed from these fields in the stream manifests so they are no longer treated as secret inputs.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
