### PR TITLE
[ti_anomali] Fix tags variable in threatstream policy test

### DIFF
--- a/packages/ti_anomali/data_stream/threatstream/_dev/test/policy/test-all.expected
+++ b/packages/ti_anomali/data_stream/threatstream/_dev/test/policy/test-all.expected
@@ -37,7 +37,8 @@ inputs:
             certificate: /etc/pki/client/cert.pem
             enabled: false
             key: /etc/pki/client/cert.key
-          tags: null
+          tags:
+            - custom-ti_anomali
           type: http_endpoint
           url: /
       type: http_endpoint

--- a/packages/ti_anomali/data_stream/threatstream/_dev/test/policy/test-all.yml
+++ b/packages/ti_anomali/data_stream/threatstream/_dev/test/policy/test-all.yml
@@ -11,6 +11,7 @@ data_stream:
       key: "/etc/pki/client/cert.key"
     ioc_expiration_duration: "90d"
     tags:
+      - custom-ti_anomali
     preserve_original_event: false
     processors: |
       - add_fields:


### PR DESCRIPTION
## Proposed commit message

Fix policy test in `ti_anomali` test package for `threatstream` data stream (relates https://github.com/elastic/integrations/pull/17428).
Currently, the value set in the policy is null, but this should not be possible since `tags` is a required variable.

- Current policy test configuration:
https://github.com/elastic/integrations/blob/579e9a3cbbdfb54a838a8bb410dab08066c8ca46/packages/ti_anomali/data_stream/threatstream/_dev/test/policy/test-all.yml#L12-L14

- Current expected policy:
https://github.com/elastic/integrations/blob/579e9a3cbbdfb54a838a8bb410dab08066c8ca46/packages/ti_anomali/data_stream/threatstream/_dev/test/policy/test-all.expected#L40

In the next `elastic-package` release, this process to create the policy with the variables from the test will be updated and this test will fail.

This Pull Request updates the value set in `tags` (defining one tag) and the corresponding expected file:

```yaml
    tags:
      - custom-ti_anomali
```


## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- ~[ ] I have added an entry to my package's `changelog.yml` file.~
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- ~[ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~
## Author's Checklist

- [x] Run tests with the upcoming changes in elastic-package https://buildkite.com/elastic/integrations/builds/38941

## How to test this PR locally

```bash
elastic-package stack up -v -d --version 8.18.0
cd packages/ti_anomali
elastic-package test policy -v
elastic-package stack down -v
```

## Related issues

- Follows https://github.com/elastic/integrations/pull/17428
- Relates https://github.com/elastic/elastic-package/pull/3318
- Relates https://github.com/elastic/elastic-package/pull/3299