### PR TITLE
qualys_gav: fix pagination crash on empty asset page

### DIFF
--- a/packages/qualys_gav/_dev/deploy/docker/files/config.yml
+++ b/packages/qualys_gav/_dev/deploy/docker/files/config.yml
@@ -2990,3 +2990,80 @@ rules:
               }
           }
           `}}
+  # Edge-case test: hasMore=1 with an empty asset list on page 2.
+  # First page returns two assets normally.
+  - path: /rest/2.0/search/am/asset
+    methods: ['POST']
+    query_params:
+      lastSeenAssetId: 0
+      pageSize: 5
+    request_headers:
+      Authorization:
+        - 'Bearer xxxx'
+    responses:
+      - status_code: 200
+        headers:
+          x-ratelimit-limit: ["100"]
+          x-ratelimit-remaining: ["98"]
+          x-ratelimit-window-sec: ["3600"]
+          x-ratelimit-towait-sec: ["0"]
+        body: |
+          {{ minify_json `
+          {
+              "responseMessage": "Valid API Access",
+              "count": 2,
+              "responseCode": "SUCCESS",
+              "lastSeenAssetId": 90000002,
+              "hasMore": 1,
+              "assetListData": {
+                  "asset": [
+                      {
+                          "assetId": 90000001,
+                          "assetUUID": "aaaaaaaa-0001-0001-0001-000000000001",
+                          "lastModifiedDate": "2025-07-11T14:21:10.000Z",
+                          "createdDate": "2025-07-09T14:21:12.000Z",
+                          "assetType": "HOST",
+                          "assetName": "empty-page-test-1"
+                      },
+                      {
+                          "assetId": 90000002,
+                          "assetUUID": "aaaaaaaa-0002-0002-0002-000000000002",
+                          "lastModifiedDate": "2025-07-11T14:21:10.000Z",
+                          "createdDate": "2025-07-09T14:21:12.000Z",
+                          "assetType": "HOST",
+                          "assetName": "empty-page-test-2"
+                      }
+                  ]
+              }
+          }
+          `}}
+  # Second page: API says hasMore=1 but returns an empty asset list.
+  # Without the size() guard, .max() throws "no extremum of empty list".
+  - path: /rest/2.0/search/am/asset
+    methods: ['POST']
+    query_params:
+      lastSeenAssetId: 90000002
+      pageSize: 5
+    request_headers:
+      Authorization:
+        - 'Bearer xxxx'
+    responses:
+      - status_code: 200
+        headers:
+          x-ratelimit-limit: ["100"]
+          x-ratelimit-remaining: ["98"]
+          x-ratelimit-window-sec: ["3600"]
+          x-ratelimit-towait-sec: ["0"]
+        body: |
+          {{ minify_json `
+          {
+              "responseMessage": "Valid API Access",
+              "count": 0,
+              "responseCode": "SUCCESS",
+              "lastSeenAssetId": 90000002,
+              "hasMore": 1,
+              "assetListData": {
+                  "asset": []
+              }
+          }
+          `}}

--- a/packages/qualys_gav/changelog.yml
+++ b/packages/qualys_gav/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.7.2"
+  changes:
+    - description: Fix pagination failure when Qualys API returns an empty asset list with hasMore set.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/17627
 - version: "0.7.1"
   changes:
     - description: Remove rate-limit headers from authentication API call.

--- a/packages/qualys_gav/data_stream/asset/_dev/test/system/test-empty-page-config.yml
+++ b/packages/qualys_gav/data_stream/asset/_dev/test/system/test-empty-page-config.yml
@@ -1,0 +1,13 @@
+input: cel
+service: qualys_gav
+vars:
+  url: http://{{Hostname}}:{{Port}}
+  username: xxxx
+  password: xxxx
+data_stream:
+  vars:
+    preserve_original_event: true
+    preserve_duplicate_custom_fields: true
+    batch_size: 5
+assert:
+  hit_count: 2

--- a/packages/qualys_gav/data_stream/asset/agent/stream/cel.yml.hbs
+++ b/packages/qualys_gav/data_stream/asset/agent/stream/cel.yml.hbs
@@ -92,10 +92,10 @@ program: |
                 "interval_start": state.interval.start,
                 "interval_id": state.interval.id,
               }),
-              "want_more": body.hasMore != 0,
+              "want_more": body.hasMore != 0 && size(body.assetListData.asset) != 0,
               "access_token": token.access_token,
               "expiry": token.expiry,
-              "asset_id": body.hasMore != 0 ? body.assetListData.asset.map(e, e.assetId).max() : 0,
+              "asset_id": (body.hasMore != 0 && size(body.assetListData.asset) != 0) ? body.assetListData.asset.map(e, e.assetId).max() : 0,
             })
           :
             (resp.StatusCode == 204) ?

--- a/packages/qualys_gav/manifest.yml
+++ b/packages/qualys_gav/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: qualys_gav
 title: Qualys Global AssetView
-version: 0.7.1
+version: 0.7.2
 description: Collect logs from Qualys Global AssetView with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
qualys_gav: fix pagination crash on empty asset page

The Qualys API occasionally returns hasMore=1 with an empty asset
list. The CEL program called .max() on the mapped asset IDs without
checking for an empty list, causing "no extremum of empty list".

Guard both want_more and the asset_id calculation with a size check
so pagination stops cleanly when the asset list is empty.

The system test is templated from the existing test-default-config
and mock rules, using a distinct pageSize (5) to route to its own
mock sequence. The second mock page returns an empty asset array
with hasMore=1, reproducing the edge case from the bug report.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #17603

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
