### PR TITLE
[cloud_security_posture] Remove dynamic: false from misconfiguration transform

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -18,6 +18,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "3.3.0-preview08"
+  changes:
+    - description: "Remove `dynamic: false` from misconfiguration transform to allow `ecs@mappings` dynamic templates to evaluate."
+      type: bugfix
+      link: TBD
 - version: "3.3.0-preview07"
   changes:
     - description: Removed ECS field definitions from misconfiguration transform, now covered by ecs@mappings component template on transform destination index templates.

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -22,7 +22,7 @@
   changes:
     - description: "Remove `dynamic: false` from misconfiguration transform to allow `ecs@mappings` dynamic templates to evaluate."
       type: bugfix
-      link: TBD
+      link: https://github.com/elastic/integrations/pull/17637
 - version: "3.3.0-preview07"
   changes:
     - description: Removed ECS field definitions from misconfiguration transform, now covered by ecs@mappings component template on transform destination index templates.

--- a/packages/cloud_security_posture/elasticsearch/transform/misconfiguration/manifest.yml
+++ b/packages/cloud_security_posture/elasticsearch/transform/misconfiguration/manifest.yml
@@ -8,11 +8,4 @@ destination_index_template:
         order:
           - desc
   mappings:
-    dynamic: false
-    dynamic_templates:
-      - strings_as_keyword:
-          match_mapping_type: string
-          mapping:
-            ignore_above: 1024
-            type: keyword
     date_detection: false

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "3.3.0-preview07"
+version: "3.3.0-preview08"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
PR #17552 removed explicit ECS field definitions from CDR integration transform destinations, relying on the `ecs@mappings` component template. This broke ECS field searchability and Group-by in the Kibana CSP Findings data grid because the CSP misconfiguration transform had `dynamic: false`, which completely prevents `ecs@mappings` dynamic templates from evaluating.

This PR removes `dynamic: false` and the redundant `strings_as_keyword` dynamic template, keeping only the index sort settings and `date_detection: false`.

The `dynamic: false` setting is also not inline with other CDR related transforms, `cloud_security_posture` integration is the only integration with this setting

Fixes:
- https://github.com/elastic/security-team/issues/16212

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/guide/en/integrations-developer/current/tips-for-building-integrations.html) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version conditions are aligned across all changed packages.

## Author's Checklist

- [x] Changes are limited to a single package

## How to test this PR locally

1. Install the integration in local Kibana
2. Verify destination index template has `ecs@mappings` and no `dynamic: false`:
   ```bash
   curl -s "http://localhost:9200/_index_template/security_solution-cloud_security_posture.misconfiguration_latest*" -u elastic:changeme | jq '.index_templates[].index_template'
   ```
3. Wait for transform to run, then check destination index mapping has ECS fields:
   ```bash
   curl -s "http://localhost:9200/security_solution-cloud_security_posture.misconfiguration_latest-*/_mapping" -u elastic:changeme | jq '.[] .mappings.properties.cloud'
   ```
4. In Findings page: verify Group by Cloud Account ID works
5. Verify search bar autocompletes ECS field names (cloud.account.id, event.category, etc.)

## Related issues

Fixes the regression introduced in https://github.com/elastic/integrations/pull/17552