### PR TITLE
Test elastic-package#3330 - DO NOT MERGE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -253,4 +253,4 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/elastic/elastic-package => github.com/mrodm/elastic-package v0.53.1-0.20260303124820-3a6142f2fce6
+replace github.com/elastic/elastic-package => github.com/mrodm/elastic-package v0.53.1-0.20260303140041-138d221fad25

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWu
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/2gBQ3RWajuToeY6ZtZTIKv2v7ThUy5KKusIT0yc0=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
-github.com/mrodm/elastic-package v0.53.1-0.20260303124820-3a6142f2fce6 h1:I3jC8oEFiX4eFurdu0i7Ki7aRoL1FAQ1EWaGvVIW+WE=
-github.com/mrodm/elastic-package v0.53.1-0.20260303124820-3a6142f2fce6/go.mod h1:vP+xRGbtptIkrDjGE8PRjU8ofHL7014tJhpAjE/Xo24=
+github.com/mrodm/elastic-package v0.53.1-0.20260303140041-138d221fad25 h1:iDizczPkm80PS2HG/lDclujDB8o8jFg+BO6voUQwWcQ=
+github.com/mrodm/elastic-package v0.53.1-0.20260303140041-138d221fad25/go.mod h1:Wnp81NkonfBhgkTp5NPh5jo12k4OTZAkTYNpI38+EC0=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 h1:ZK8zHtRHOkbHy6Mmr5D264iyp3TiX5OmNcI5cIARiQI=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6/go.mod h1:CJlz5H+gyd6CUWT45Oy4q24RdLyn7Md9Vj2/ldJBSIo=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=


### PR DESCRIPTION
Update elastic-package reference to https://github.com/elastic/elastic-package/commit/138d221f.

This PR is related to https://github.com/elastic/integrations/pull/17636 , but includes also the revert of `go-ucfg` to v0.8.8

Relates: https://github.com/elastic/elastic-package/pull/3330