### PR TITLE
tenable_ot_security: change assets fingerprint to id plus timestamps

### DIFF
--- a/packages/microsoft_exchange_online_message_trace/manifest.yml
+++ b/packages/microsoft_exchange_online_message_trace/manifest.yml
@@ -9,7 +9,7 @@ categories:
   - email_security
 conditions:
   kibana:
-    version: "^8.19.4 || ^9.1.4"
+    version: "^8.19.4 || ~9.0.7 || ^9.1.4"
   elastic:
     subscription: "basic"
 icons:

--- a/packages/microsoft_exchange_online_message_trace/manifest.yml
+++ b/packages/microsoft_exchange_online_message_trace/manifest.yml
@@ -9,7 +9,7 @@ categories:
   - email_security
 conditions:
   kibana:
-    version: "^8.19.4 || ~9.0.7 || ^9.1.4"
+    version: "^8.19.4 || ^9.1.4"
   elastic:
     subscription: "basic"
 icons:

--- a/packages/tenable_ot_security/changelog.yml
+++ b/packages/tenable_ot_security/changelog.yml
@@ -8,11 +8,17 @@
       type: enhancement
       link: https://github.com/elastic/integrations/pull/17670
     - description: >-
+        Change assets risk.total_risk field type from keyword to double.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/17670
+    - description: >-
         The _id scheme change means every existing asset document will be
-        duplicated until lifecycle policy removes the old versions. Customers
-        upgrading from 1.0.0 should install 1.1.0 first and allow at least
-        one successful asset collection interval before upgrading to this
-        version.
+        duplicated until lifecycle policy removes the old versions. Where
+        possible, upgrade to 1.1.0 first and allow at least one successful
+        asset collection interval before upgrading to this version. Where
+        this is not possible, the risk.total_risk field type change triggers
+        an automatic data stream rollover on upgrade, so the old backing
+        index begins aging out immediately without manual intervention.
       type: breaking-change
       link: https://github.com/elastic/integrations/pull/17670
 - version: "1.1.1"

--- a/packages/tenable_ot_security/changelog.yml
+++ b/packages/tenable_ot_security/changelog.yml
@@ -1,3 +1,20 @@
+- version: "2.0.0"
+  changes:
+    - description: >-
+        Change assets document fingerprint from full-body hash to id plus
+        timestamps. Assets now produce a new document only when a timestamp
+        field changes, preserving update history without creating duplicates
+        from non-temporal field noise.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/17670
+    - description: >-
+        The _id scheme change means every existing asset document will be
+        duplicated until lifecycle policy removes the old versions. Customers
+        upgrading from 1.0.0 should install 1.1.0 first and allow at least
+        one successful asset collection interval before upgrading to this
+        version.
+      type: breaking-change
+      link: https://github.com/elastic/integrations/pull/17670
 - version: "1.1.1"
   changes:
     - description: >-

--- a/packages/tenable_ot_security/data_stream/assets/_dev/test/pipeline/test-assets.json-expected.json
+++ b/packages/tenable_ot_security/data_stream/assets/_dev/test/pipeline/test-assets.json-expected.json
@@ -60,7 +60,7 @@
                     "name": "OT Device #966",
                     "purdue_level": "Level2",
                     "risk": {
-                        "total_risk": "35.40130597317059"
+                        "total_risk": 35.40130597317059
                     },
                     "run_status": "Unknown",
                     "run_status_time": "0001-01-01T00:00:00Z",

--- a/packages/tenable_ot_security/data_stream/assets/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/tenable_ot_security/data_stream/assets/elasticsearch/ingest_pipeline/default.yml
@@ -8,9 +8,16 @@ processors:
 
   - fingerprint:
       fields:
-        - tenable_ot_security.assets
+        - tenable_ot_security.assets.id
+        - tenable_ot_security.assets.firstSeen
+        - tenable_ot_security.assets.lastSeen
+        - tenable_ot_security.assets.lastHit
+        - tenable_ot_security.assets.lastSnapshot
+        - tenable_ot_security.assets.lastUpdate
+        - tenable_ot_security.assets.runStatusTime
       tag: fingerprinting
       target_field: "_id"
+      ignore_missing: true
       on_failure:
         - append:
             field: error.message

--- a/packages/tenable_ot_security/data_stream/assets/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/tenable_ot_security/data_stream/assets/elasticsearch/ingest_pipeline/default.yml
@@ -108,6 +108,18 @@ processors:
           ctx.tenable_ot_security.assets = normalize(ctx.tenable_ot_security.assets);
         }
 
+  - convert:
+      tag: convert_total_risk_to_double
+      field: tenable_ot_security.assets.risk.total_risk
+      type: double
+      if: ctx.tenable_ot_security?.assets?.risk?.total_risk != null
+      on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+        - remove:
+            field: tenable_ot_security.assets.risk.total_risk
+
   ##################### ECS Fields #####################
 
   - set:

--- a/packages/tenable_ot_security/data_stream/assets/fields/tenable-assets-fields.yml
+++ b/packages/tenable_ot_security/data_stream/assets/fields/tenable-assets-fields.yml
@@ -90,7 +90,7 @@
           format: ISO8601
           description: The timestamp when the run status was last updated.
         - name: risk.total_risk
-          type: keyword
+          type: double
           description: The overall risk score of the asset.
         - name: criticality
           type: keyword

--- a/packages/tenable_ot_security/data_stream/assets/sample_event.json
+++ b/packages/tenable_ot_security/data_stream/assets/sample_event.json
@@ -78,7 +78,7 @@
             "name": "DeviceNet_L81",
             "purdue_level": "Level1",
             "risk": {
-                "total_risk": "72.8374829734034"
+                "total_risk": 72.8374829734034
             },
             "run_status": "Unknown",
             "run_status_time": "0001-01-01T00:00:00Z",

--- a/packages/tenable_ot_security/docs/README.md
+++ b/packages/tenable_ot_security/docs/README.md
@@ -114,7 +114,7 @@ An example event for `assets` looks as following:
             "name": "DeviceNet_L81",
             "purdue_level": "Level1",
             "risk": {
-                "total_risk": "72.8374829734034"
+                "total_risk": 72.8374829734034
             },
             "run_status": "Unknown",
             "run_status_time": "0001-01-01T00:00:00Z",
@@ -160,7 +160,7 @@ The following non-ECS fields are used in assets documents:
 | tenable_ot_security.assets.macs | A list of MAC addresses associated with the asset. | keyword |
 | tenable_ot_security.assets.name | The name of the asset. | keyword |
 | tenable_ot_security.assets.purdue_level | The Purdue level classification of the asset. | keyword |
-| tenable_ot_security.assets.risk.total_risk | The overall risk score of the asset. | keyword |
+| tenable_ot_security.assets.risk.total_risk | The overall risk score of the asset. | double |
 | tenable_ot_security.assets.run_status | The current operational status of the asset. | keyword |
 | tenable_ot_security.assets.run_status_time | The timestamp when the run status was last updated. | date |
 | tenable_ot_security.assets.segments.archived | Indicates whether the segment is archived. | boolean |

--- a/packages/tenable_ot_security/manifest.yml
+++ b/packages/tenable_ot_security/manifest.yml
@@ -10,7 +10,7 @@ categories:
   - security
 conditions:
   kibana:
-    version: "^8.16.1 || ^9.0.0"
+    version: "^8.16.1 || ^9.1.4"
   elastic:
     subscription: "basic"
 screenshots:

--- a/packages/tenable_ot_security/manifest.yml
+++ b/packages/tenable_ot_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.0
 name: tenable_ot_security
 title: Tenable OT Security
-version: 1.1.1
+version: 2.0.0
 source:
   license: "Elastic-2.0"
 description: Tenable OT Security


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
tenable_ot_security: change assets fingerprint to id plus timestamps

Change the assets document fingerprint from a full-body hash to a hash
of the asset id and all timestamp fields (firstSeen, lastSeen, lastHit,
lastSnapshot, lastUpdate, runStatusTime). This preserves update history;
a new document is created whenever a timestamp changes without the
duplicate-on-every-poll problem caused by the full-body hash.

Change the risk.total_risk field type from keyword to double. The field
carries a floating-point risk score and double is the correct type.
This type change also causes Fleet to trigger an automatic data stream
rollover on upgrade: the putMapping call fails with an
illegal_argument_exception when it tries to change the field type in
the existing backing index, and Fleet responds by rolling over. The
rollover starts the life-cycle clock on the old backing index so
duplicate documents from the _id scheme change age out without manual
intervention.

The Kibana version constraint is tightened to ^8.16.1 || ^9.1.4 so
that 9.x users see the breaking-change call-out. Where possible,
upgrading to 1.1.0 first and allowing at least one asset collection
interval before upgrading to 2.0.0 avoids the overlap period entirely.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Depends #17669 (not to be merged before and only to be merged after reasonable interval)
- Closes #17628

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
