### PR TITLE
[ESET Protect] bugfix: hardcoded error message

### DIFF
--- a/packages/eset_protect/changelog.yml
+++ b/packages/eset_protect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.0.1"
+  changes:
+    - description: Change error handling to dynamically determine whether v1 or v2 api is called.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/17447
 - version: "2.0.0"
   changes:
     - description: |

--- a/packages/eset_protect/data_stream/detection/agent/stream/cel.yml.hbs
+++ b/packages/eset_protect/data_stream/detection/agent/stream/cel.yml.hbs
@@ -131,7 +131,7 @@ program: |
                 "error": {
                   "code": string(resp.StatusCode),
                   "id": string(resp.Status),
-                  "message": "GET " + state.url.trim_right("/") + "/v1/detections :" + (
+                  "message": "GET " + state.url.trim_right("/") + "/" + state.api_version + "/detections :" + (
                     size(resp.Body) != 0 ?
                       string(resp.Body)
                     :

--- a/packages/eset_protect/manifest.yml
+++ b/packages/eset_protect/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: eset_protect
 title: ESET PROTECT
-version: "2.0.0"
+version: "2.0.1"
 description: Collect logs from ESET PROTECT with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```bash
eset_protect: fix hardcoded v1 API version in detection error message
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:
- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## WHAT

This PR fixes the error handler in the `detection` data stream CEL program to dynamically reference the configured API version instead of hardcoding `/v1/detections`.

## WHY
In version `2.0.0`, support was added for selecting between the v1 and v2 detections API via the `api_version` variable ([#17447](https://github.com/elastic/integrations/pull/17447)). The actual HTTP request URL correctly uses `state.api_version` to build the path:

```cel
state.url.trim_right("/") + "/" + state.api_version + "/detections?"
```

However, the error handler still had a hardcoded reference to `/v1/detections`:

```cel
"message": "GET " + state.url.trim_right("/") + "/v1/detections :" + (
```

This means that when running with `api_version: v2`, any non-200/non-202 error response would incorrectly report the URL as `/v1/detections` in the error message, making it appear as if the v1 API is being called when it is not. This is misleading during troubleshooting and makes it difficult to determine which API version is actually in use.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots
<img width="3032" height="270" alt="image" src="https://github.com/user-attachments/assets/a2e4d0a3-3548-459b-bf26-529a0437e19f" />


<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
