### PR TITLE
fix actionable-obs-team ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -447,8 +447,8 @@
 /packages/swimlane @elastic/security-service-integrations
 /packages/symantec_endpoint @elastic/security-service-integrations
 /packages/symantec_endpoint_security @elastic/security-service-integrations
-/packages/synthetics @elastic/obs-ux-management-team
-/packages/synthetics_dashboards @elastic/obs-ux-management-team
+/packages/synthetics @elastic/actionable-obs-team
+/packages/synthetics_dashboards @elastic/actionable-obs-team
 /packages/sysdig @elastic/security-service-integrations
 /packages/syslog_router @elastic/integration-experience
 /packages/sysmon_linux @elastic/sec-linux-platform

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -85,7 +85,7 @@ spec:
           access_level: BUILD_AND_READ
         obs-infraobs-integrations:
           access_level: BUILD_AND_READ
-        obs-ux-management-team:
+        actionable-obs-team:
           access_level: BUILD_AND_READ
         profiling:
           access_level: BUILD_AND_READ

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -39,5 +39,5 @@ icons:
     size: 16x16
     type: image/svg+xml
 owner:
-  github: elastic/obs-ux-management-team
+  github: elastic/actionable-obs-team
   type: elastic

--- a/packages/synthetics_dashboards/manifest.yml
+++ b/packages/synthetics_dashboards/manifest.yml
@@ -20,4 +20,4 @@ icons:
     type: image/svg+xml
 owner:
   type: elastic
-  github: elastic/obs-ux-management-team
+  github: elastic/actionable-obs-team


### PR DESCRIPTION
## Proposed commit message

Rename `elastic/obs-ux-management-team` to `elastic/actionable-obs-team` across the repo to reflect the team rename. Updates owner references in the `synthetics` and `synthetics_dashboards` package manifests, CODEOWNERS, and CI pipeline access configuration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

- [x] All instances of `obs-ux-management-team` have been replaced with `actionable-obs-team`
- [x] No stale references remain (verified via repo-wide search)

## How to test this PR locally

Verify no instances of the old team name remain:

```bash
grep -r "obs-ux-management-team" .
```

Expected: no results.

## Related issues

N/A

## Screenshots

N/A
