### PR TITLE
[doc] Update number_of_workers in aws integration to align with cloudwatch api rate limit

### DIFF
--- a/packages/aws/_dev/build/docs/cloudtrail.md
+++ b/packages/aws/_dev/build/docs/cloudtrail.md
@@ -57,7 +57,7 @@ The CloudWatch integration offers the `latency` setting to address this scenario
 
 If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
 
-The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS). If more workers run concurrently than the rate limit allows, you will see `ThrottlingException: Rate exceeded` errors and the integration may report a DEGRADED status in Fleet.
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS) per AWS account and per region; this limit is shared across all API callers in that account and region. If you run multiple integrations or data streams that collect CloudWatch logs from the same account and region, their workers share the same 5 TPS—so even 5 workers per data stream can cause throttling when combined. Exceeding the limit causes `ThrottlingException: Rate exceeded` errors and may report DEGRADED status in Fleet.
 
 **Recommendation:** Set `number_of_workers` to **5 or less** and `scan_frequency` to **5m or more**, regardless of how many log groups match `log_group_name_prefix`. Workers will iterate through the matching log groups within each scan interval. The default value is `1`.
 

--- a/packages/aws/_dev/build/docs/cloudwatch.md
+++ b/packages/aws/_dev/build/docs/cloudwatch.md
@@ -52,7 +52,7 @@ The CloudWatch integration offers the `latency` setting to address this scenario
 
 If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
 
-The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS). If more workers run concurrently than the rate limit allows, you will see `ThrottlingException: Rate exceeded` errors and the integration may report a DEGRADED status in Fleet.
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS) per AWS account and per region; this limit is shared across all API callers in that account and region. If you run multiple integrations or data streams that collect CloudWatch logs from the same account and region, their workers share the same 5 TPS—so even 5 workers per data stream can cause throttling when combined. Exceeding the limit causes `ThrottlingException: Rate exceeded` errors and may report DEGRADED status in Fleet.
 
 **Recommendation:** Set `number_of_workers` to **5 or less** and `scan_frequency` to **5m or more**, regardless of how many log groups match `log_group_name_prefix`. Workers will iterate through the matching log groups within each scan interval. The default value is `1`.
 

--- a/packages/aws/_dev/build/docs/ec2.md
+++ b/packages/aws/_dev/build/docs/ec2.md
@@ -55,7 +55,7 @@ The CloudWatch integration offers the `latency` setting to address this scenario
 
 If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
 
-The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS). If more workers run concurrently than the rate limit allows, you will see `ThrottlingException: Rate exceeded` errors and the integration may report a DEGRADED status in Fleet.
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS) per AWS account and per region; this limit is shared across all API callers in that account and region. If you run multiple integrations or data streams that collect CloudWatch logs from the same account and region, their workers share the same 5 TPS—so even 5 workers per data stream can cause throttling when combined. Exceeding the limit causes `ThrottlingException: Rate exceeded` errors and may report DEGRADED status in Fleet.
 
 **Recommendation:** Set `number_of_workers` to **5 or less** and `scan_frequency` to **5m or more**, regardless of how many log groups match `log_group_name_prefix`. Workers will iterate through the matching log groups within each scan interval. The default value is `1`.
 

--- a/packages/aws/_dev/build/docs/elb.md
+++ b/packages/aws/_dev/build/docs/elb.md
@@ -62,7 +62,7 @@ The CloudWatch integration offers the `latency` setting to address this scenario
 
 If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
 
-The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS). If more workers run concurrently than the rate limit allows, you will see `ThrottlingException: Rate exceeded` errors and the integration may report a DEGRADED status in Fleet.
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS) per AWS account and per region; this limit is shared across all API callers in that account and region. If you run multiple integrations or data streams that collect CloudWatch logs from the same account and region, their workers share the same 5 TPS—so even 5 workers per data stream can cause throttling when combined. Exceeding the limit causes `ThrottlingException: Rate exceeded` errors and may report DEGRADED status in Fleet.
 
 **Recommendation:** Set `number_of_workers` to **5 or less** and `scan_frequency` to **5m or more**, regardless of how many log groups match `log_group_name_prefix`. Workers will iterate through the matching log groups within each scan interval. The default value is `1`.
 

--- a/packages/aws/_dev/build/docs/firewall.md
+++ b/packages/aws/_dev/build/docs/firewall.md
@@ -56,7 +56,7 @@ The CloudWatch integration offers the `latency` setting to address this scenario
 
 If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
 
-The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS). If more workers run concurrently than the rate limit allows, you will see `ThrottlingException: Rate exceeded` errors and the integration may report a DEGRADED status in Fleet.
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS) per AWS account and per region; this limit is shared across all API callers in that account and region. If you run multiple integrations or data streams that collect CloudWatch logs from the same account and region, their workers share the same 5 TPS—so even 5 workers per data stream can cause throttling when combined. Exceeding the limit causes `ThrottlingException: Rate exceeded` errors and may report DEGRADED status in Fleet.
 
 **Recommendation:** Set `number_of_workers` to **5 or less** and `scan_frequency` to **5m or more**, regardless of how many log groups match `log_group_name_prefix`. Workers will iterate through the matching log groups within each scan interval. The default value is `1`.
 

--- a/packages/aws/_dev/build/docs/route53.md
+++ b/packages/aws/_dev/build/docs/route53.md
@@ -52,7 +52,7 @@ The CloudWatch integration offers the `latency` setting to address this scenario
 
 If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
 
-The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS). If more workers run concurrently than the rate limit allows, you will see `ThrottlingException: Rate exceeded` errors and the integration may report a DEGRADED status in Fleet.
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS) per AWS account and per region; this limit is shared across all API callers in that account and region. If you run multiple integrations or data streams that collect CloudWatch logs from the same account and region, their workers share the same 5 TPS—so even 5 workers per data stream can cause throttling when combined. Exceeding the limit causes `ThrottlingException: Rate exceeded` errors and may report DEGRADED status in Fleet.
 
 **Recommendation:** Set `number_of_workers` to **5 or less** and `scan_frequency` to **5m or more**, regardless of how many log groups match `log_group_name_prefix`. Workers will iterate through the matching log groups within each scan interval. The default value is `1`.
 

--- a/packages/aws/_dev/build/docs/vpcflow.md
+++ b/packages/aws/_dev/build/docs/vpcflow.md
@@ -77,7 +77,7 @@ The CloudWatch integration offers the `latency` setting to address this scenario
 
 If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
 
-The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS). If more workers run concurrently than the rate limit allows, you will see `ThrottlingException: Rate exceeded` errors and the integration may report a DEGRADED status in Fleet.
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS) per AWS account and per region; this limit is shared across all API callers in that account and region. If you run multiple integrations or data streams that collect CloudWatch logs from the same account and region, their workers share the same 5 TPS—so even 5 workers per data stream can cause throttling when combined. Exceeding the limit causes `ThrottlingException: Rate exceeded` errors and may report DEGRADED status in Fleet.
 
 **Recommendation:** Set `number_of_workers` to **5 or less** and `scan_frequency` to **5m or more**, regardless of how many log groups match `log_group_name_prefix`. Workers will iterate through the matching log groups within each scan interval. The default value is `1`.
 

--- a/packages/aws/_dev/build/docs/waf.md
+++ b/packages/aws/_dev/build/docs/waf.md
@@ -56,7 +56,7 @@ The CloudWatch integration offers the `latency` setting to address this scenario
 
 If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
 
-The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS). If more workers run concurrently than the rate limit allows, you will see `ThrottlingException: Rate exceeded` errors and the integration may report a DEGRADED status in Fleet.
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS) per AWS account and per region; this limit is shared across all API callers in that account and region. If you run multiple integrations or data streams that collect CloudWatch logs from the same account and region, their workers share the same 5 TPS—so even 5 workers per data stream can cause throttling when combined. Exceeding the limit causes `ThrottlingException: Rate exceeded` errors and may report DEGRADED status in Fleet.
 
 **Recommendation:** Set `number_of_workers` to **5 or less** and `scan_frequency` to **5m or more**, regardless of how many log groups match `log_group_name_prefix`. Workers will iterate through the matching log groups within each scan interval. The default value is `1`.
 

--- a/packages/aws/data_stream/apigateway_logs/manifest.yml
+++ b/packages/aws/data_stream/apigateway_logs/manifest.yml
@@ -253,7 +253,7 @@ streams:
         title: Number of workers
         required: false
         show_user: false
-        description: The number of workers assigned to reading from log groups. Do not exceed 5 (AWS CloudWatch Logs API rate limit for DescribeLogGroups/FilterLogEvents). Use number_of_workers ≤ 5 and scan_frequency ≥ 5m regardless of how many log groups match. Default is 1.
+        description: The number of workers assigned to reading from log groups. Do not exceed 5. The 5 TPS limit is per AWS account per region and shared across all CloudWatch log inputs in that account/region; with multiple data streams or integrations, keep total workers ≤ 5. Use number_of_workers ≤ 5 and scan_frequency ≥ 5m. Default is 1.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws/data_stream/cloudtrail/manifest.yml
+++ b/packages/aws/data_stream/cloudtrail/manifest.yml
@@ -312,7 +312,7 @@ streams:
         title: Number of workers
         required: false
         show_user: false
-        description: The number of workers assigned to reading from log groups. Do not exceed 5 (AWS CloudWatch Logs API rate limit for DescribeLogGroups/FilterLogEvents). Use number_of_workers ≤ 5 and scan_frequency ≥ 5m regardless of how many log groups match. Default is 1.
+        description: The number of workers assigned to reading from log groups. Do not exceed 5. The 5 TPS limit is per AWS account per region and shared across all CloudWatch log inputs in that account/region; with multiple data streams or integrations, keep total workers ≤ 5. Use number_of_workers ≤ 5 and scan_frequency ≥ 5m. Default is 1.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws/data_stream/cloudwatch_logs/manifest.yml
+++ b/packages/aws/data_stream/cloudwatch_logs/manifest.yml
@@ -100,7 +100,7 @@ streams:
         title: Number of workers
         required: false
         show_user: false
-        description: The number of workers assigned to reading from log groups. Do not exceed 5 (AWS CloudWatch Logs API rate limit for DescribeLogGroups/FilterLogEvents). Use number_of_workers ≤ 5 and scan_frequency ≥ 5m regardless of how many log groups match. Default is 1.
+        description: The number of workers assigned to reading from log groups. Do not exceed 5. The 5 TPS limit is per AWS account per region and shared across all CloudWatch log inputs in that account/region; with multiple data streams or integrations, keep total workers ≤ 5. Use number_of_workers ≤ 5 and scan_frequency ≥ 5m. Default is 1.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws/data_stream/ec2_logs/manifest.yml
+++ b/packages/aws/data_stream/ec2_logs/manifest.yml
@@ -253,7 +253,7 @@ streams:
         title: Number of workers
         required: false
         show_user: false
-        description: The number of workers assigned to reading from log groups. Do not exceed 5 (AWS CloudWatch Logs API rate limit for DescribeLogGroups/FilterLogEvents). Use number_of_workers ≤ 5 and scan_frequency ≥ 5m regardless of how many log groups match. Default is 1.
+        description: The number of workers assigned to reading from log groups. Do not exceed 5. The 5 TPS limit is per AWS account per region and shared across all CloudWatch log inputs in that account/region; with multiple data streams or integrations, keep total workers ≤ 5. Use number_of_workers ≤ 5 and scan_frequency ≥ 5m. Default is 1.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws/data_stream/elb_logs/manifest.yml
+++ b/packages/aws/data_stream/elb_logs/manifest.yml
@@ -253,7 +253,7 @@ streams:
         title: Number of workers
         required: false
         show_user: false
-        description: The number of workers assigned to reading from log groups. Do not exceed 5 (AWS CloudWatch Logs API rate limit for DescribeLogGroups/FilterLogEvents). Use number_of_workers ≤ 5 and scan_frequency ≥ 5m regardless of how many log groups match. Default is 1.
+        description: The number of workers assigned to reading from log groups. Do not exceed 5. The 5 TPS limit is per AWS account per region and shared across all CloudWatch log inputs in that account/region; with multiple data streams or integrations, keep total workers ≤ 5. Use number_of_workers ≤ 5 and scan_frequency ≥ 5m. Default is 1.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws/data_stream/emr_logs/manifest.yml
+++ b/packages/aws/data_stream/emr_logs/manifest.yml
@@ -255,7 +255,7 @@ streams:
         title: Number of workers
         required: false
         show_user: false
-        description: The number of workers assigned to reading from log groups. Do not exceed 5 (AWS CloudWatch Logs API rate limit for DescribeLogGroups/FilterLogEvents). Use number_of_workers ≤ 5 and scan_frequency ≥ 5m regardless of how many log groups match. Default is 1.
+        description: The number of workers assigned to reading from log groups. Do not exceed 5. The 5 TPS limit is per AWS account per region and shared across all CloudWatch log inputs in that account/region; with multiple data streams or integrations, keep total workers ≤ 5. Use number_of_workers ≤ 5 and scan_frequency ≥ 5m. Default is 1.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws/data_stream/firewall_logs/manifest.yml
+++ b/packages/aws/data_stream/firewall_logs/manifest.yml
@@ -253,7 +253,7 @@ streams:
         title: Number of workers
         required: false
         show_user: false
-        description: The number of workers assigned to reading from log groups. Do not exceed 5 (AWS CloudWatch Logs API rate limit for DescribeLogGroups/FilterLogEvents). Use number_of_workers ≤ 5 and scan_frequency ≥ 5m regardless of how many log groups match. Default is 1.
+        description: The number of workers assigned to reading from log groups. Do not exceed 5. The 5 TPS limit is per AWS account per region and shared across all CloudWatch log inputs in that account/region; with multiple data streams or integrations, keep total workers ≤ 5. Use number_of_workers ≤ 5 and scan_frequency ≥ 5m. Default is 1.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws/data_stream/lambda_logs/manifest.yml
+++ b/packages/aws/data_stream/lambda_logs/manifest.yml
@@ -100,7 +100,7 @@ streams:
         title: Number of workers
         required: false
         show_user: false
-        description: The number of workers assigned to reading from log groups. Do not exceed 5 (AWS CloudWatch Logs API rate limit for DescribeLogGroups/FilterLogEvents). Use number_of_workers ≤ 5 and scan_frequency ≥ 5m regardless of how many log groups match. Default is 1.
+        description: The number of workers assigned to reading from log groups. Do not exceed 5. The 5 TPS limit is per AWS account per region and shared across all CloudWatch log inputs in that account/region; with multiple data streams or integrations, keep total workers ≤ 5. Use number_of_workers ≤ 5 and scan_frequency ≥ 5m. Default is 1.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws/data_stream/route53_public_logs/manifest.yml
+++ b/packages/aws/data_stream/route53_public_logs/manifest.yml
@@ -97,7 +97,7 @@ streams:
         title: Number of workers
         required: false
         show_user: false
-        description: The number of workers assigned to reading from log groups. Do not exceed 5 (AWS CloudWatch Logs API rate limit for DescribeLogGroups/FilterLogEvents). Use number_of_workers ≤ 5 and scan_frequency ≥ 5m regardless of how many log groups match. Default is 1.
+        description: The number of workers assigned to reading from log groups. Do not exceed 5. The 5 TPS limit is per AWS account per region and shared across all CloudWatch log inputs in that account/region; with multiple data streams or integrations, keep total workers ≤ 5. Use number_of_workers ≤ 5 and scan_frequency ≥ 5m. Default is 1.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws/data_stream/route53_resolver_logs/manifest.yml
+++ b/packages/aws/data_stream/route53_resolver_logs/manifest.yml
@@ -97,7 +97,7 @@ streams:
         title: Number of workers
         required: false
         show_user: false
-        description: The number of workers assigned to reading from log groups. Do not exceed 5 (AWS CloudWatch Logs API rate limit for DescribeLogGroups/FilterLogEvents). Use number_of_workers ≤ 5 and scan_frequency ≥ 5m regardless of how many log groups match. Default is 1.
+        description: The number of workers assigned to reading from log groups. Do not exceed 5. The 5 TPS limit is per AWS account per region and shared across all CloudWatch log inputs in that account/region; with multiple data streams or integrations, keep total workers ≤ 5. Use number_of_workers ≤ 5 and scan_frequency ≥ 5m. Default is 1.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws/data_stream/vpcflow/manifest.yml
+++ b/packages/aws/data_stream/vpcflow/manifest.yml
@@ -253,7 +253,7 @@ streams:
         title: Number of workers
         required: false
         show_user: false
-        description: The number of workers assigned to reading from log groups. Do not exceed 5 (AWS CloudWatch Logs API rate limit for DescribeLogGroups/FilterLogEvents). Use number_of_workers ≤ 5 and scan_frequency ≥ 5m regardless of how many log groups match. Default is 1.
+        description: The number of workers assigned to reading from log groups. Do not exceed 5. The 5 TPS limit is per AWS account per region and shared across all CloudWatch log inputs in that account/region; with multiple data streams or integrations, keep total workers ≤ 5. Use number_of_workers ≤ 5 and scan_frequency ≥ 5m. Default is 1.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws/data_stream/waf/manifest.yml
+++ b/packages/aws/data_stream/waf/manifest.yml
@@ -253,7 +253,7 @@ streams:
         title: Number of workers
         required: false
         show_user: false
-        description: The number of workers assigned to reading from log groups. Do not exceed 5 (AWS CloudWatch Logs API rate limit for DescribeLogGroups/FilterLogEvents). Use number_of_workers ≤ 5 and scan_frequency ≥ 5m regardless of how many log groups match. Default is 1.
+        description: The number of workers assigned to reading from log groups. Do not exceed 5. The 5 TPS limit is per AWS account per region and shared across all CloudWatch log inputs in that account/region; with multiple data streams or integrations, keep total workers ≤ 5. Use number_of_workers ≤ 5 and scan_frequency ≥ 5m. Default is 1.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws/docs/cloudtrail.md
+++ b/packages/aws/docs/cloudtrail.md
@@ -57,7 +57,7 @@ The CloudWatch integration offers the `latency` setting to address this scenario
 
 If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
 
-The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS). If more workers run concurrently than the rate limit allows, you will see `ThrottlingException: Rate exceeded` errors and the integration may report a DEGRADED status in Fleet.
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS) per AWS account and per region; this limit is shared across all API callers in that account and region. If you run multiple integrations or data streams that collect CloudWatch logs from the same account and region, their workers share the same 5 TPS—so even 5 workers per data stream can cause throttling when combined. Exceeding the limit causes `ThrottlingException: Rate exceeded` errors and may report DEGRADED status in Fleet.
 
 **Recommendation:** Set `number_of_workers` to **5 or less** and `scan_frequency` to **5m or more**, regardless of how many log groups match `log_group_name_prefix`. Workers will iterate through the matching log groups within each scan interval. The default value is `1`.
 

--- a/packages/aws/docs/cloudwatch.md
+++ b/packages/aws/docs/cloudwatch.md
@@ -52,7 +52,7 @@ The CloudWatch integration offers the `latency` setting to address this scenario
 
 If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
 
-The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS). If more workers run concurrently than the rate limit allows, you will see `ThrottlingException: Rate exceeded` errors and the integration may report a DEGRADED status in Fleet.
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS) per AWS account and per region; this limit is shared across all API callers in that account and region. If you run multiple integrations or data streams that collect CloudWatch logs from the same account and region, their workers share the same 5 TPS—so even 5 workers per data stream can cause throttling when combined. Exceeding the limit causes `ThrottlingException: Rate exceeded` errors and may report DEGRADED status in Fleet.
 
 **Recommendation:** Set `number_of_workers` to **5 or less** and `scan_frequency` to **5m or more**, regardless of how many log groups match `log_group_name_prefix`. Workers will iterate through the matching log groups within each scan interval. The default value is `1`.
 

--- a/packages/aws/docs/ec2.md
+++ b/packages/aws/docs/ec2.md
@@ -55,7 +55,7 @@ The CloudWatch integration offers the `latency` setting to address this scenario
 
 If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
 
-The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS). If more workers run concurrently than the rate limit allows, you will see `ThrottlingException: Rate exceeded` errors and the integration may report a DEGRADED status in Fleet.
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS) per AWS account and per region; this limit is shared across all API callers in that account and region. If you run multiple integrations or data streams that collect CloudWatch logs from the same account and region, their workers share the same 5 TPS—so even 5 workers per data stream can cause throttling when combined. Exceeding the limit causes `ThrottlingException: Rate exceeded` errors and may report DEGRADED status in Fleet.
 
 **Recommendation:** Set `number_of_workers` to **5 or less** and `scan_frequency` to **5m or more**, regardless of how many log groups match `log_group_name_prefix`. Workers will iterate through the matching log groups within each scan interval. The default value is `1`.
 

--- a/packages/aws/docs/elb.md
+++ b/packages/aws/docs/elb.md
@@ -62,7 +62,7 @@ The CloudWatch integration offers the `latency` setting to address this scenario
 
 If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
 
-The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS). If more workers run concurrently than the rate limit allows, you will see `ThrottlingException: Rate exceeded` errors and the integration may report a DEGRADED status in Fleet.
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS) per AWS account and per region; this limit is shared across all API callers in that account and region. If you run multiple integrations or data streams that collect CloudWatch logs from the same account and region, their workers share the same 5 TPS—so even 5 workers per data stream can cause throttling when combined. Exceeding the limit causes `ThrottlingException: Rate exceeded` errors and may report DEGRADED status in Fleet.
 
 **Recommendation:** Set `number_of_workers` to **5 or less** and `scan_frequency` to **5m or more**, regardless of how many log groups match `log_group_name_prefix`. Workers will iterate through the matching log groups within each scan interval. The default value is `1`.
 

--- a/packages/aws/docs/firewall.md
+++ b/packages/aws/docs/firewall.md
@@ -56,7 +56,7 @@ The CloudWatch integration offers the `latency` setting to address this scenario
 
 If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
 
-The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS). If more workers run concurrently than the rate limit allows, you will see `ThrottlingException: Rate exceeded` errors and the integration may report a DEGRADED status in Fleet.
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS) per AWS account and per region; this limit is shared across all API callers in that account and region. If you run multiple integrations or data streams that collect CloudWatch logs from the same account and region, their workers share the same 5 TPS—so even 5 workers per data stream can cause throttling when combined. Exceeding the limit causes `ThrottlingException: Rate exceeded` errors and may report DEGRADED status in Fleet.
 
 **Recommendation:** Set `number_of_workers` to **5 or less** and `scan_frequency` to **5m or more**, regardless of how many log groups match `log_group_name_prefix`. Workers will iterate through the matching log groups within each scan interval. The default value is `1`.
 

--- a/packages/aws/docs/route53.md
+++ b/packages/aws/docs/route53.md
@@ -52,7 +52,7 @@ The CloudWatch integration offers the `latency` setting to address this scenario
 
 If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
 
-The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS). If more workers run concurrently than the rate limit allows, you will see `ThrottlingException: Rate exceeded` errors and the integration may report a DEGRADED status in Fleet.
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS) per AWS account and per region; this limit is shared across all API callers in that account and region. If you run multiple integrations or data streams that collect CloudWatch logs from the same account and region, their workers share the same 5 TPS—so even 5 workers per data stream can cause throttling when combined. Exceeding the limit causes `ThrottlingException: Rate exceeded` errors and may report DEGRADED status in Fleet.
 
 **Recommendation:** Set `number_of_workers` to **5 or less** and `scan_frequency` to **5m or more**, regardless of how many log groups match `log_group_name_prefix`. Workers will iterate through the matching log groups within each scan interval. The default value is `1`.
 

--- a/packages/aws/docs/vpcflow.md
+++ b/packages/aws/docs/vpcflow.md
@@ -77,7 +77,7 @@ The CloudWatch integration offers the `latency` setting to address this scenario
 
 If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
 
-The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS). If more workers run concurrently than the rate limit allows, you will see `ThrottlingException: Rate exceeded` errors and the integration may report a DEGRADED status in Fleet.
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS) per AWS account and per region; this limit is shared across all API callers in that account and region. If you run multiple integrations or data streams that collect CloudWatch logs from the same account and region, their workers share the same 5 TPS—so even 5 workers per data stream can cause throttling when combined. Exceeding the limit causes `ThrottlingException: Rate exceeded` errors and may report DEGRADED status in Fleet.
 
 **Recommendation:** Set `number_of_workers` to **5 or less** and `scan_frequency` to **5m or more**, regardless of how many log groups match `log_group_name_prefix`. Workers will iterate through the matching log groups within each scan interval. The default value is `1`.
 

--- a/packages/aws/docs/waf.md
+++ b/packages/aws/docs/waf.md
@@ -56,7 +56,7 @@ The CloudWatch integration offers the `latency` setting to address this scenario
 
 If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
 
-The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS). If more workers run concurrently than the rate limit allows, you will see `ThrottlingException: Rate exceeded` errors and the integration may report a DEGRADED status in Fleet.
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. **Do not set `number_of_workers` higher than the AWS API rate limit.** The CloudWatch Logs APIs (DescribeLogGroups, FilterLogEvents) are limited to 5 transactions per second (TPS) per AWS account and per region; this limit is shared across all API callers in that account and region. If you run multiple integrations or data streams that collect CloudWatch logs from the same account and region, their workers share the same 5 TPS—so even 5 workers per data stream can cause throttling when combined. Exceeding the limit causes `ThrottlingException: Rate exceeded` errors and may report DEGRADED status in Fleet.
 
 **Recommendation:** Set `number_of_workers` to **5 or less** and `scan_frequency` to **5m or more**, regardless of how many log groups match `log_group_name_prefix`. Workers will iterate through the matching log groups within each scan interval. The default value is `1`.
 

--- a/packages/aws_bedrock_agentcore/data_stream/gateway_application_logs/manifest.yml
+++ b/packages/aws_bedrock_agentcore/data_stream/gateway_application_logs/manifest.yml
@@ -49,7 +49,7 @@ streams:
         default: 1
         required: false
         show_user: false
-        description: The number of workers assigned to read from log groups. Do not exceed 5 (AWS CloudWatch Logs API rate limit for DescribeLogGroups/FilterLogEvents). Use number_of_workers ≤ 5 and scan_frequency ≥ 5m regardless of how many log groups match. Default is 1.
+        description: The number of workers assigned to read from log groups. Do not exceed 5. The 5 TPS limit is per AWS account per region and shared across all CloudWatch log inputs in that account/region; with multiple data streams or integrations, keep total workers ≤ 5. Use number_of_workers ≤ 5 and scan_frequency ≥ 5m. Default is 1.
       - name: log_streams
         type: text
         title: Log Streams

--- a/packages/aws_bedrock_agentcore/data_stream/memory_application_logs/manifest.yml
+++ b/packages/aws_bedrock_agentcore/data_stream/memory_application_logs/manifest.yml
@@ -49,7 +49,7 @@ streams:
         default: 1
         required: false
         show_user: false
-        description: The number of workers assigned to read from log groups. Do not exceed 5 (AWS CloudWatch Logs API rate limit for DescribeLogGroups/FilterLogEvents). Use number_of_workers ≤ 5 and scan_frequency ≥ 5m regardless of how many log groups match. Default is 1.
+        description: The number of workers assigned to read from log groups. Do not exceed 5. The 5 TPS limit is per AWS account per region and shared across all CloudWatch log inputs in that account/region; with multiple data streams or integrations, keep total workers ≤ 5. Use number_of_workers ≤ 5 and scan_frequency ≥ 5m. Default is 1.
       - name: log_streams
         type: text
         title: Log Streams

--- a/packages/aws_bedrock_agentcore/data_stream/runtime_application_logs/manifest.yml
+++ b/packages/aws_bedrock_agentcore/data_stream/runtime_application_logs/manifest.yml
@@ -49,7 +49,7 @@ streams:
         default: 1
         required: false
         show_user: false
-        description: The number of workers assigned to read from log groups. Do not exceed 5 (AWS CloudWatch Logs API rate limit for DescribeLogGroups/FilterLogEvents). Use number_of_workers ≤ 5 and scan_frequency ≥ 5m regardless of how many log groups match. Default is 1.
+        description: The number of workers assigned to read from log groups. Do not exceed 5. The 5 TPS limit is per AWS account per region and shared across all CloudWatch log inputs in that account/region; with multiple data streams or integrations, keep total workers ≤ 5. Use number_of_workers ≤ 5 and scan_frequency ≥ 5m. Default is 1.
       - name: log_streams
         type: text
         title: Log Streams

--- a/packages/aws_mq/data_stream/activemq_audit_logs/manifest.yml
+++ b/packages/aws_mq/data_stream/activemq_audit_logs/manifest.yml
@@ -100,7 +100,7 @@ streams:
       title: Number of workers
       required: false
       show_user: false
-      description: The number of workers assigned to reading from log groups. Do not exceed 5 (AWS CloudWatch Logs API rate limit for DescribeLogGroups/FilterLogEvents). Use number_of_workers ≤ 5 and scan_frequency ≥ 5m regardless of how many log groups match. Default is 1.
+      description: The number of workers assigned to reading from log groups. Do not exceed 5. The 5 TPS limit is per AWS account per region and shared across all CloudWatch log inputs in that account/region; with multiple data streams or integrations, keep total workers ≤ 5. Use number_of_workers ≤ 5 and scan_frequency ≥ 5m. Default is 1.
     - name: tags
       type: text
       title: Tags

--- a/packages/aws_mq/data_stream/activemq_general_logs/manifest.yml
+++ b/packages/aws_mq/data_stream/activemq_general_logs/manifest.yml
@@ -100,7 +100,7 @@ streams:
       title: Number of workers
       required: false
       show_user: false
-      description: The number of workers assigned to reading from log groups. Do not exceed 5 (AWS CloudWatch Logs API rate limit for DescribeLogGroups/FilterLogEvents). Use number_of_workers ≤ 5 and scan_frequency ≥ 5m regardless of how many log groups match. Default is 1.
+      description: The number of workers assigned to reading from log groups. Do not exceed 5. The 5 TPS limit is per AWS account per region and shared across all CloudWatch log inputs in that account/region; with multiple data streams or integrations, keep total workers ≤ 5. Use number_of_workers ≤ 5 and scan_frequency ≥ 5m. Default is 1.
     - name: tags
       type: text
       title: Tags

--- a/packages/aws_mq/data_stream/rabbitmq_general_logs/manifest.yml
+++ b/packages/aws_mq/data_stream/rabbitmq_general_logs/manifest.yml
@@ -100,7 +100,7 @@ streams:
       title: Number of workers
       required: false
       show_user: false
-      description: The number of workers assigned to reading from log groups. Do not exceed 5 (AWS CloudWatch Logs API rate limit for DescribeLogGroups/FilterLogEvents). Use number_of_workers ≤ 5 and scan_frequency ≥ 5m regardless of how many log groups match. Default is 1.
+      description: The number of workers assigned to reading from log groups. Do not exceed 5. The 5 TPS limit is per AWS account per region and shared across all CloudWatch log inputs in that account/region; with multiple data streams or integrations, keep total workers ≤ 5. Use number_of_workers ≤ 5 and scan_frequency ≥ 5m. Default is 1.
     - name: tags
       type: text
       title: Tags


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->
Updates AWS CloudWatch–related documentation and integration UI text so `number_of_workers` is no longer described as “one per log group.” The previous guidance led users with many log groups to set a high worker count, which triggers AWS DescribeLogGroups/FilterLogEvents rate limits (5 TPS) and causes `ThrottlingException: Rate exceeded` and DEGRADED status in Fleet (especially after 8.19.x unit health reporting).

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
