### PR TITLE
[docker_input_otel] Update system test assertion about number of docs

### DIFF
--- a/packages/docker_input_otel/_dev/test/system/test-default-config.yml
+++ b/packages/docker_input_otel/_dev/test/system/test-default-config.yml
@@ -5,4 +5,4 @@ vars:
   # Use a safe API version for the dind image
   api_version: "1.41"
 assert:
-  hit_count: 10
+  min_count: 10


### PR DESCRIPTION
## Proposed commit message

Fix the assertion about the number of docs to be inserted into Elasticsearch introduced in #17726 .

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] ~I have added an entry to my package's `changelog.yml` file.~
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] ~I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~

## Related issues

- Relates https://github.com/elastic/integrations/pull/17726
- Relates https://github.com/elastic/integrations/issues/17606

